### PR TITLE
Java 10 Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.10</java.version>
+		<java.version>1.8</java.version>
 		<powermock.version>1.7.4</powermock.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.7.0</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.1.0</version>
 				<configuration>
 					<minimizeJar>true</minimizeJar>
 					<relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>1.10</java.version>
 		<powermock.version>1.7.4</powermock.version>
 	</properties>
 
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
@@ -142,6 +142,7 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.1.0</version>
 			</plugin>
+			<!--
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -159,7 +160,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -173,10 +174,11 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.0</version>
 				<configuration>
 					<minimizeJar>true</minimizeJar>
 					<relocations>
@@ -199,7 +201,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,6 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.1.0</version>
 			</plugin>
-			<!--
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -160,7 +159,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin> -->
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -174,11 +173,10 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.1.1</version>
 				<configuration>
 					<minimizeJar>true</minimizeJar>
 					<relocations>
@@ -201,7 +199,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin> -->
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -130,11 +130,12 @@ public class BentoBox extends JavaPlugin {
             instance.log("#############################################");
 
             // Load metrics
+            /*
             if (settings.isMetrics()) {
                 BStats bStats = new BStats(this);
                 bStats.registerMetrics();
             }
-
+             */
             // Fire plugin ready event
             Bukkit.getServer().getPluginManager().callEvent(new BentoBoxReadyEvent());
         });

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -130,12 +130,12 @@ public class BentoBox extends JavaPlugin {
             instance.log("#############################################");
 
             // Load metrics
-            /*
+
             if (settings.isMetrics()) {
                 BStats bStats = new BStats(this);
                 bStats.registerMetrics();
             }
-             */
+
             // Fire plugin ready event
             Bukkit.getServer().getPluginManager().callEvent(new BentoBoxReadyEvent());
         });

--- a/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.api.addons;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -35,7 +36,7 @@ public class AddonClassLoader extends URLClassLoader {
             MalformedURLException,
             InvalidDescriptionException,
             InstantiationException,
-            IllegalAccessException {
+            IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
         super(new URL[]{path.toURI().toURL()}, parent);
 
         loader = addonsManager;
@@ -58,7 +59,7 @@ public class AddonClassLoader extends URLClassLoader {
             throw new InvalidAddonInheritException("Main class doesn't not extends super class 'Addon'");
         }
 
-        addon = addonClass.newInstance();
+        addon = addonClass.getDeclaredConstructor().newInstance();
         addon.setDescription(asDescription(data));
         // Set permissions
         if (data.isConfigurationSection("permissions")) {

--- a/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
@@ -113,20 +113,24 @@ public class AddonClassLoader extends URLClassLoader {
         if (name.startsWith("world.bentobox.bentobox")) {
             return null;
         }
+        Class<?> result = classes.get(name);
+        if (result == null) {
+            if (checkGlobal) {
+                result = loader.getClassByName(name);
+            }
 
-        Class<?> result = classes.computeIfAbsent(name, k -> {
-            if (checkGlobal && loader.getClassByName(name) != null) {
-                return loader.getClassByName(name);
-            } else {
+            if (result == null) {
                 try {
-                    return super.findClass(name);
+                    result = super.findClass(name);
                 } catch (ClassNotFoundException e) {
-                    return null;
+                    result = null;
+                }
+                if (result != null) {
+                    loader.setClass(name, result);
+
                 }
             }
-        });
-        if (result != null) {
-            loader.setClass(name, result);
+            classes.put(name, result);
         }
         return result;
     }

--- a/src/main/java/world/bentobox/bentobox/api/configuration/Config.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/Config.java
@@ -41,7 +41,8 @@ public class Config<T> {
         try {
             result = handler.loadObjects();
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-                | InvocationTargetException | ClassNotFoundException | IntrospectionException e) {
+                | InvocationTargetException | ClassNotFoundException | IntrospectionException
+                | NoSuchMethodException | SecurityException e) {
             logger.severe(() -> "Could not load config! Error: " + e.getMessage());
         }
         return result;
@@ -56,7 +57,7 @@ public class Config<T> {
         try {
             return handler.loadObject(uniqueId);
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
-                | ClassNotFoundException | IntrospectionException e) {
+                | ClassNotFoundException | IntrospectionException | NoSuchMethodException | SecurityException e) {
             logger.severe(() -> "Could not load config object! " + e.getMessage());
         }
 

--- a/src/main/java/world/bentobox/bentobox/database/AbstractDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/AbstractDatabaseHandler.java
@@ -48,16 +48,22 @@ public abstract class AbstractDatabaseHandler<T> {
     /**
      * Loads all the records in this table and returns a list of them
      * @return list of <T>
+     * @throws SecurityException
+     * @throws NoSuchMethodException
+     * @throws IllegalArgumentException
      */
-    public abstract List<T> loadObjects() throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, IntrospectionException;
+    public abstract List<T> loadObjects() throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, IntrospectionException, IllegalArgumentException, NoSuchMethodException, SecurityException;
 
     /**
      * Creates a <T> filled with values from the corresponding
      * database file
      * @param uniqueId - unique ID
      * @return <T>
+     * @throws SecurityException
+     * @throws NoSuchMethodException
+     * @throws IllegalArgumentException
      */
-    public abstract T loadObject(String uniqueId) throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, IntrospectionException;
+    public abstract T loadObject(String uniqueId) throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, IntrospectionException, IllegalArgumentException, NoSuchMethodException, SecurityException;
 
     /**
      * Save T into the corresponding database

--- a/src/main/java/world/bentobox/bentobox/database/Database.java
+++ b/src/main/java/world/bentobox/bentobox/database/Database.java
@@ -49,7 +49,8 @@ public class Database<T> {
         try {
             result = handler.loadObjects();
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-                | InvocationTargetException | ClassNotFoundException | IntrospectionException e) {
+                | InvocationTargetException | ClassNotFoundException | IntrospectionException
+                | NoSuchMethodException | SecurityException e) {
             logger.severe(() -> "Could not load objects from database! Error: " + e.getMessage());
         }
         return result;
@@ -65,7 +66,7 @@ public class Database<T> {
         try {
             result = handler.loadObject(uniqueId);
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
-                | ClassNotFoundException | IntrospectionException e) {
+                | ClassNotFoundException | IntrospectionException | NoSuchMethodException | SecurityException e) {
             logger.severe(() -> "Could not load object from database! " + e.getMessage());
         }
         return result;

--- a/src/main/java/world/bentobox/bentobox/database/flatfile/ConfigHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/flatfile/ConfigHandler.java
@@ -25,7 +25,7 @@ public class ConfigHandler<T> extends FlatFileDatabaseHandler<T> {
         saveObject(instance);
     }
 
-    public T loadSettings(String uniqueId, T dbConfig) throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, IntrospectionException {
+    public T loadSettings(String uniqueId, T dbConfig) throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, IntrospectionException, IllegalArgumentException, NoSuchMethodException, SecurityException {
         if (dbConfig == null) {
             return loadObject(uniqueId);
         }

--- a/src/main/java/world/bentobox/bentobox/database/mysql/MySQLDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/mysql/MySQLDatabaseConnector.java
@@ -24,12 +24,12 @@ public class MySQLDatabaseConnector implements DatabaseConnector {
     public MySQLDatabaseConnector(DatabaseConnectionSettingsImpl dbSettings) {
         this.dbSettings = dbSettings;
         try {
-            Class.forName("com.mysql.jdbc.Driver").newInstance();
+            Class.forName("com.mysql.jdbc.Driver").getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             Bukkit.getLogger().severe("Could not instantiate JDBC driver! " + e.getMessage());
         }
-        // jdbc:mysql://localhost:3306/Peoples?autoReconnect=true&useSSL=false
-        connectionUrl = "jdbc:mysql://" + dbSettings.getHost() + ":" + dbSettings.getPort() + "/" + dbSettings.getDatabaseName() + "?autoReconnect=true&useSSL=false&allowMultiQueries=true";
+        connectionUrl = "jdbc:mysql://" + dbSettings.getHost() + ":" + dbSettings.getPort() + "/" + dbSettings.getDatabaseName()
+        + "?autoReconnect=true&useSSL=false&allowMultiQueries=true";
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a bug that was being highlighted by running the plugin under Java 10 but keeps it compiling as Java 8 for maximum compatibility. 

The bug was that classes were being loaded from the Jar continuously instead of being cached and so Java 10 complained about duplicate classes. I fixed that and also upgraded the use of some methods to be non-deprecated in Java 10. The code that fixes it can still probably be refactored to be more Java 8-ish. Trying to do this is what caused the bug in the first place.

Other changes are that I use addonClass.getDeclaredConstructor().newInstance(); instead of addonClass.newInstance(); This works in Java 8 too and is apparently better because it propagates exceptions. Making this change removes the only depreciation error I saw in Java 10.

Note that Java 11 is actually going to be the next LTS (long term stable) release and it's due out next month, so lets revisit this when it comes out.

