### PR TITLE
Develop island schematics support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
 			<id>vault-repo</id>
 			<url>http://nexus.hc.to/content/repositories/pub_releases</url>
 		</repository>
+		<repository>
+			<id>placeholderapi</id>
+			<url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -106,6 +110,13 @@
 			<groupId>net.milkbowl.vault</groupId>
 			<artifactId>VaultAPI</artifactId>
 			<version>1.7</version>
+			<scope>provided</scope>
+		</dependency>
+		<!-- Placeholders -->
+		<dependency>
+			<groupId>me.clip</groupId>
+			<artifactId>placeholderapi</artifactId>
+			<version>2.9.2</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>world.bentobox</groupId>
 	<artifactId>bentobox</artifactId>
-	<version>0.12.0-SNAPSHOT</version>
+	<version>0.13.0-SNAPSHOT</version>
 
 	<name>BentoBox</name>
 	<description>BentoBox is an expandable Minecraft Spigot plugin for island-type games like ASkyBlock or AcidIsland.</description>

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -345,4 +345,10 @@ public class BentoBox extends JavaPlugin {
         return Optional.ofNullable((VaultHook) hooksManager.getHook("Vault").orElse(null));
     }
 
+    /**
+     * @return the PlaceholdersManager.
+     */
+    public PlaceholdersManager getPlaceholdersManager() {
+        return placeholdersManager;
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -12,6 +12,7 @@ import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.events.BentoBoxReadyEvent;
 import world.bentobox.bentobox.api.user.Notifier;
 import world.bentobox.bentobox.commands.BentoBoxCommand;
+import world.bentobox.bentobox.hooks.PlaceholderAPIHook;
 import world.bentobox.bentobox.hooks.VaultHook;
 import world.bentobox.bentobox.listeners.BannedVisitorCommands;
 import world.bentobox.bentobox.listeners.BlockEndDragon;
@@ -27,6 +28,7 @@ import world.bentobox.bentobox.managers.HooksManager;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
+import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.managers.SchemsManager;
@@ -52,6 +54,7 @@ public class BentoBox extends JavaPlugin {
     private RanksManager ranksManager;
     private SchemsManager schemsManager;
     private HooksManager hooksManager;
+    private PlaceholdersManager placeholdersManager;
 
     // Settings
     private Settings settings;
@@ -143,6 +146,10 @@ public class BentoBox extends JavaPlugin {
             // Load hooks
             hooksManager = new HooksManager(this);
             hooksManager.registerHook(new VaultHook());
+            hooksManager.registerHook(new PlaceholderAPIHook());
+
+            // Setup the Placeholders manager
+            placeholdersManager = new PlaceholdersManager(this);
 
             // Fire plugin ready event
             isLoaded = true;

--- a/src/main/java/world/bentobox/bentobox/api/placeholders/PlaceholderReplacer.java
+++ b/src/main/java/world/bentobox/bentobox/api/placeholders/PlaceholderReplacer.java
@@ -1,0 +1,8 @@
+package world.bentobox.bentobox.api.placeholders;
+
+import world.bentobox.bentobox.api.user.User;
+
+public interface PlaceholderReplacer {
+
+    String onReplace(User user);
+}

--- a/src/main/java/world/bentobox/bentobox/hooks/PlaceholderAPIHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/PlaceholderAPIHook.java
@@ -1,0 +1,128 @@
+package world.bentobox.bentobox.hooks;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.hooks.Hook;
+import world.bentobox.bentobox.api.placeholders.PlaceholderReplacer;
+import world.bentobox.bentobox.api.user.User;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Provides implementations and interfacing needed to register and get placeholders from PlaceholderAPI.
+ *
+ * @author Poslovitch
+ */
+public class PlaceholderAPIHook extends Hook {
+
+    private BentoBoxPlaceholderExpansion bentoboxExpansion;
+    private Map<Addon, AddonPlaceholderExpansion> addonsExpansions;
+
+    public PlaceholderAPIHook() {
+        super("PlaceholderAPI");
+        this.bentoboxExpansion = new BentoBoxPlaceholderExpansion(BentoBox.getInstance());
+        this.addonsExpansions = new HashMap<>();
+    }
+
+    @Override
+    public boolean hook() {
+        return bentoboxExpansion.canRegister() && bentoboxExpansion.register();
+    }
+
+    @Override
+    public String getFailureCause() {
+        return "could not register BentoBox's expansion";
+    }
+
+    public void registerBentoBoxPlaceholder(String placeholder, PlaceholderReplacer replacer) {
+        bentoboxExpansion.registerPlaceholder(placeholder, replacer);
+    }
+
+    public void registerAddonPlaceholder(Addon addon, String placeholder, PlaceholderReplacer replacer) {
+        // Check if the addon expansion does not exist
+        if (!addonsExpansions.containsKey(addon)) {
+            AddonPlaceholderExpansion addonPlaceholderExpansion = new AddonPlaceholderExpansion(addon);
+            addonPlaceholderExpansion.register();
+            addonsExpansions.put(addon, addonPlaceholderExpansion);
+        }
+
+        addonsExpansions.get(addon).registerPlaceholder(placeholder, replacer);
+    }
+
+    abstract class BasicPlaceholderExpansion extends PlaceholderExpansion {
+        private Map<String, PlaceholderReplacer> placeholders;
+
+        BasicPlaceholderExpansion() {
+            this.placeholders = new HashMap<>();
+        }
+
+        @Override
+        public String getIdentifier() {
+            return getName().toLowerCase(Locale.ENGLISH);
+        }
+
+        void registerPlaceholder(String placeholder, PlaceholderReplacer replacer) {
+            placeholders.putIfAbsent(placeholder, replacer);
+        }
+
+        @Override
+        public String onPlaceholderRequest(Player p, String placeholder) {
+            User user = User.getInstance(p);
+
+            if (placeholders.containsKey(placeholder)) {
+                return placeholders.get(placeholder).onReplace(user);
+            }
+            return null;
+        }
+    }
+
+    class BentoBoxPlaceholderExpansion extends BasicPlaceholderExpansion {
+        private BentoBox plugin;
+
+        BentoBoxPlaceholderExpansion(BentoBox plugin) {
+            this.plugin = plugin;
+        }
+
+        @Override
+        public String getName() {
+            return plugin.getName();
+        }
+
+        @Override
+        public String getAuthor() {
+            return "Tastybento and Poslovitch";
+        }
+
+        @Override
+        public String getVersion() {
+            return plugin.getDescription().getVersion();
+        }
+    }
+
+    class AddonPlaceholderExpansion extends BasicPlaceholderExpansion {
+        private Addon addon;
+
+        AddonPlaceholderExpansion(Addon addon) {
+            this.addon = addon;
+        }
+
+        @Override
+        public String getName() {
+            return addon.getDescription().getName();
+        }
+
+        @Override
+        public String getAuthor() {
+            return addon.getDescription().getAuthors().get(0);
+        }
+
+        @Override
+        public String getVersion() {
+            return addon.getDescription().getVersion();
+        }
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/managers/HooksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/HooksManager.java
@@ -26,7 +26,7 @@ public class HooksManager {
             if (hook.hook()) {
                 hooks.add(hook);
             } else {
-                plugin.log("Could not hook with " + hook.getPluginName() + " because: " + hook.getFailureCause() + ". Skipping...");
+                plugin.log("Could not hook with " + hook.getPluginName() + ((hook.getFailureCause() != null) ? " because: " + hook.getFailureCause() : "") + ". Skipping...");
             }
         }
     }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -623,18 +623,20 @@ public class IslandsManager {
     }
 
     /**
-     * Checks if an online player is in the protected area of their island, a team island or a
-     * coop island in the specific world in the arguments.
+     * Checks if an online player is in the protected area of an island he owns or he is part of.
      *
-     * @param world - the world to check
-     * @param user - the user
-     * @return true if on their island in world, false if not
+     * @param world the World to check, if null the method will always return {@code false}.
+     * @param user the User to check, if null or if this is not a Player the method will always return {@code false}.
+     *
+     * @return {@code true} if this User is located within the protected area of an island he owns or he is part of,
+     *          {@code false} otherwise or if this User is not located in this World.
      */
     public boolean userIsOnIsland(World world, User user) {
-        if (user == null) {
+        if (user == null || !user.isPlayer() || world == null) {
             return false;
         }
-        return getProtectedIslandAt(user.getLocation())
+        return (user.getLocation().getWorld() == world)
+               && getProtectedIslandAt(user.getLocation())
                 .map(i -> i.getMembers().entrySet().stream()
                         .anyMatch(en -> en.getKey().equals(user.getUniqueId()) && en.getValue() > RanksManager.VISITOR_RANK))
                 .orElse(false);

--- a/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
@@ -5,6 +5,11 @@ import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.placeholders.PlaceholderReplacer;
 import world.bentobox.bentobox.hooks.PlaceholderAPIHook;
 
+/**
+ * Manages placeholder integration.
+ *
+ * @author Poslovitch
+ */
 public class PlaceholdersManager {
 
     private BentoBox plugin;
@@ -13,6 +18,11 @@ public class PlaceholdersManager {
         this.plugin = plugin;
     }
 
+    /**
+     * Registers the placeholder on the behalf on BentoBox.
+     * @param placeholder the placeholder to register. It will be appended with {@code "bentobox_"} by the placeholder plugin.
+     * @param replacer the expression that will return a {@code String} when executed, which will replace the placeholder.
+     */
     public void registerPlaceholder(String placeholder, PlaceholderReplacer replacer) {
         // Register it in PlaceholderAPI
         plugin.getHooks().getHook("PlaceholderAPI").ifPresent(hook -> {
@@ -21,6 +31,11 @@ public class PlaceholdersManager {
         });
     }
 
+    /**
+     * Registers the placeholder on the behalf of the specified addon.
+     * @param placeholder the placeholder to register. It will be appended with the addon's name by the placeholder plugin.
+     * @param replacer the expression that will return a {@code String} when executed, which will replace the placeholder.
+     */
     public void registerPlaceholder(Addon addon, String placeholder, PlaceholderReplacer replacer) {
         if (addon == null) {
             registerPlaceholder(placeholder, replacer);

--- a/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
@@ -1,0 +1,35 @@
+package world.bentobox.bentobox.managers;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.placeholders.PlaceholderReplacer;
+import world.bentobox.bentobox.hooks.PlaceholderAPIHook;
+
+public class PlaceholdersManager {
+
+    private BentoBox plugin;
+
+    public PlaceholdersManager(BentoBox plugin) {
+        this.plugin = plugin;
+    }
+
+    public void registerPlaceholder(String placeholder, PlaceholderReplacer replacer) {
+        // Register it in PlaceholderAPI
+        plugin.getHooks().getHook("PlaceholderAPI").ifPresent(hook -> {
+            PlaceholderAPIHook placeholderAPIHook = (PlaceholderAPIHook) hook;
+            placeholderAPIHook.registerBentoBoxPlaceholder(placeholder, replacer);
+        });
+    }
+
+    public void registerPlaceholder(Addon addon, String placeholder, PlaceholderReplacer replacer) {
+        if (addon == null) {
+            registerPlaceholder(placeholder, replacer);
+            return;
+        }
+        // Register it in PlaceholderAPI
+        plugin.getHooks().getHook("PlaceholderAPI").ifPresent(hook -> {
+            PlaceholderAPIHook placeholderAPIHook = (PlaceholderAPIHook) hook;
+            placeholderAPIHook.registerAddonPlaceholder(addon, placeholder, replacer);
+        });
+    }
+}


### PR DESCRIPTION
Hi, I tried to replace the island.schem file in the BentoBox\addons\AcidIsland\schems folder with another type of island (which I already used in the old version of AcidIsland) but when it has to create the island in console it exits this error and l island is not created

`[19:51:45 ERROR]: [BentoBox] Tried to paste schem for AcidIsland_world but it is not loaded!`

What's the problem?