### PR TITLE
Added addon request system to request data from an addon in spigot plugins

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
@@ -3,6 +3,8 @@ package world.bentobox.bentobox.api.addons;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -15,6 +17,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.request.AddonRequestHandler;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 
@@ -32,6 +35,7 @@ public abstract class Addon {
     private FileConfiguration config;
     private File dataFolder;
     private File file;
+    private Map<String, AddonRequestHandler> requestHandlers = new HashMap<>();
 
     public Addon() {
         state = State.DISABLED;
@@ -358,5 +362,29 @@ public abstract class Addon {
      */
     public String getPermissionPrefix() {
         return this.getDescription().getName().toLowerCase() + ".";
+    }
+
+    /**
+     * Register request handler to answer requests from plugins.
+     * @param handler
+     */
+    public void registerRequestHandler(AddonRequestHandler handler) {
+        requestHandlers.put(handler.getLabel(), handler);
+    }
+
+    /**
+     * Send request to addon.
+     * @param label
+     * @param metaData
+     * @return request response, null if no response.
+     */
+    public Object request(String label, Map<String, Object> metaData) {
+        label = label.toLowerCase();
+        AddonRequestHandler handler = requestHandlers.get(label);
+        if(handler != null) {
+            return handler.handle(metaData);
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/addons/exceptions/AddonRequestException.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/exceptions/AddonRequestException.java
@@ -1,0 +1,14 @@
+package world.bentobox.bentobox.api.addons.exceptions;
+
+import world.bentobox.bentobox.api.addons.request.AddonRequestBuilder;
+
+import java.util.UUID;
+
+public class AddonRequestException extends AddonException
+{
+	private static final long serialVersionUID = -5698456013070166174L;
+
+	public AddonRequestException(String errorMessage) {
+		super(errorMessage);
+	}
+}

--- a/src/main/java/world/bentobox/bentobox/api/addons/request/AddonRequestBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/request/AddonRequestBuilder.java
@@ -1,0 +1,64 @@
+package world.bentobox.bentobox.api.addons.request;
+
+import org.apache.commons.lang.Validate;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.Addon;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class AddonRequestBuilder
+{
+	private String addonName;
+	private String requestLabel;
+	private Map<String, Object> metaData = new HashMap<>();
+
+	/**
+	 * Define the addon you wish to request.
+	 *
+	 * @param addonName
+	 */
+	public AddonRequestBuilder addon(String addonName) {
+		this.addonName = addonName;
+		return this;
+	}
+
+	/**
+	 * Define label for addon request.
+	 *
+	 * @param requestLabel
+	 */
+	public AddonRequestBuilder label(String requestLabel) {
+		this.requestLabel = requestLabel;
+		return this;
+	}
+
+	/**
+	 * Add meta data to addon request.
+	 *
+	 * @param key
+	 * @param value
+	 */
+	public AddonRequestBuilder addMetaData(String key, Object value) {
+		metaData.put(key, value);
+		return this;
+	}
+
+	/**
+	 * Send request to addon.
+	 *
+	 * @return request response, null if no response.
+	 */
+	public Object request() {
+		Validate.notNull(addonName);
+		Validate.notNull(requestLabel);
+
+		Optional<Addon> addonOptional = BentoBox.getInstance().getAddonsManager().getAddonByName(addonName);
+		if(addonOptional.isPresent()) {
+			Addon addon = addonOptional.get();
+			return addon.request(requestLabel, metaData);
+		}
+		return null;
+	}
+}

--- a/src/main/java/world/bentobox/bentobox/api/addons/request/AddonRequestHandler.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/request/AddonRequestHandler.java
@@ -1,0 +1,31 @@
+package world.bentobox.bentobox.api.addons.request;
+
+import java.util.Map;
+
+public abstract class AddonRequestHandler
+{
+	private String label;
+
+	public AddonRequestHandler(String label) {
+		this.label = label.toLowerCase();
+	}
+
+	/**
+	 * Get request handler label.
+	 *
+	 * @return label
+	 */
+	public String getLabel() {
+		return label;
+	}
+
+	/**
+	 * Handle an addon request.
+	 * This is used only for Addons to respond to addon requests from plugins.
+	 * Example: request island level from Levels addon.
+	 *
+	 * @param metaData
+	 * @return request response
+	 */
+	public abstract Object handle(Map<String, Object> metaData);
+}


### PR DESCRIPTION
So I've been trying to directly get a players island level from one of my plugins but I've been having issues because spigot plugins can not use classes from Addons. (This was discussed in this issue: https://github.com/BentoBoxWorld/bentobox/issues/352)

I see there is an option to listen for AddonEvent to receive data, but this would requiring caching of any data received, and this could be a struggle if wanting to obtain offline player levels (as it was in my case)

I've added this system so that you can request data from Addons, and Addons can add handlers for these requests. 

**Here is an example of a request handler (to be put in an Addons code), for responding to a level request. This code would be ran through the main class of the Addon using #registerRequestHandler.**

![image](https://user-images.githubusercontent.com/17110585/50060800-6866d980-0190-11e9-9ee4-503b59102d64.png)


**Here is an example of request to an Addon (to be put in a spigot plugin), to request a player's island level.**

![image](https://user-images.githubusercontent.com/17110585/50060797-55eca000-0190-11e9-95b7-687be3ed7bce.png)


I've tested this myself and it works perfectly. This would be an amazing help for developers trying to obtain data from Addons as it would remove the need to cache data after listening through AddonEvent.

I made an effort to maintain the code style of your plugin, there shouldn't be any inconsistencies.

I hope you consider my pull request.