### PR TITLE
Unnecessary getPermissionPrefix()

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommand.java
@@ -22,7 +22,7 @@ public class AdminTeleportCommand extends CompositeCommand {
     @Override
     public void setup() {
         // Permission
-        setPermission(getPermissionPrefix() + "admin.tp");
+        setPermission("admin.tp");
         setOnlyPlayer(true);
         setParametersHelp("commands.admin.tp.parameters");
         setDescription("commands.admin.tp.description");


### PR DESCRIPTION
Kryniowesegryderiusz <3 in Support noticed that Admin tp command has double bskyblock.bskyblock, and I found reason in code.
This getPermissionPrefix() is not necessary, as setPermission() will also add prefix.