### PR TITLE
Adds ability for gamemodes to override locale references

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -236,19 +236,24 @@ public class User {
     }
 
     /**
-     * Gets a translation of this reference for this user.
+     * Gets a translation of this reference for this user. Translations may be overridden by Addons
+     * by using the same reference prefixed by the addon name (from the Addon Description) in lower case.
      * @param reference - reference found in a locale file
      * @param variables - variables to insert into translated string. Variables go in pairs, for example
      *                  "[name]", "tastybento"
      * @return Translated string with colors converted, or the reference if nothing has been found
      */
     public String getTranslation(String reference, String... variables) {
-        // Get translation
-        String translation = plugin.getLocalesManager().get(this, reference);
+        // Get translation.
+        String addonPrefix = plugin.getIWM().getAddon(getWorld()).map(a -> a.getDescription().getName().toLowerCase() + ".").orElse("");
+        String translation = plugin.getLocalesManager().get(addonPrefix + reference);
 
-        // If no translation has been found, return the reference for debug purposes.
         if (translation == null) {
-            return reference;
+            translation = plugin.getLocalesManager().get(reference);
+            if (translation == null) {
+                // If no translation has been found, return the reference for debug purposes.
+                return reference;
+            }
         }
 
         // Then replace variables
@@ -327,10 +332,10 @@ public class User {
 
     /**
      * Gets the current world this entity resides in
-     * @return World
+     * @return World - world or null
      */
     public World getWorld() {
-        return player.getWorld();
+        return player == null ? null : player.getWorld();
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -245,11 +245,12 @@ public class User {
      */
     public String getTranslation(String reference, String... variables) {
         // Get translation.
-        String addonPrefix = plugin.getIWM().getAddon(getWorld()).map(a -> a.getDescription().getName().toLowerCase() + ".").orElse("");
-        String translation = plugin.getLocalesManager().get(addonPrefix + reference);
+        String addonPrefix = plugin.getIWM()
+                .getAddon(getWorld()).map(a -> a.getDescription().getName().toLowerCase() + ".").orElse("");
+        String translation = plugin.getLocalesManager().get(this, addonPrefix + reference);
 
         if (translation == null) {
-            translation = plugin.getLocalesManager().get(reference);
+            translation = plugin.getLocalesManager().get(this, reference);
             if (translation == null) {
                 // If no translation has been found, return the reference for debug purposes.
                 return reference;

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/EnterExitListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/EnterExitListener.java
@@ -65,17 +65,17 @@ public class EnterExitListener extends FlagListener {
         islandFrom.ifPresent(i -> {
             // Fire the IslandExitEvent
             new IslandEvent.IslandEventBuilder()
-                    .island(i)
-                    .involvedPlayer(user.getUniqueId())
-                    .reason(IslandEvent.Reason.EXIT)
-                    .admin(false)
-                    .location(user.getLocation())
-                    .build();
+            .island(i)
+            .involvedPlayer(user.getUniqueId())
+            .reason(IslandEvent.Reason.EXIT)
+            .admin(false)
+            .location(user.getLocation())
+            .build();
 
             // Send message if island is owned by someone
             if (i.getOwner() != null) {
                 user.notify("protection.flags.ENTER_EXIT_MESSAGES.now-leaving", TextVariables.NAME, (i.getName() != null) ? i.getName() :
-                        user.getTranslation("protection.flags.ENTER_EXIT_MESSAGES.island", TextVariables.NAME, getPlugin().getPlayers().getName(i.getOwner())));
+                    user.getTranslation("protection.flags.ENTER_EXIT_MESSAGES.island", TextVariables.NAME, getPlugin().getPlayers().getName(i.getOwner())));
             }
             // Send message if island is unowned, but has a name
             else if (i.getName() != null) {
@@ -86,17 +86,17 @@ public class EnterExitListener extends FlagListener {
         islandTo.ifPresent(i -> {
             // Fire the IslandEnterEvent
             new IslandEvent.IslandEventBuilder()
-                    .island(i)
-                    .involvedPlayer(user.getUniqueId())
-                    .reason(IslandEvent.Reason.ENTER)
-                    .admin(false)
-                    .location(user.getLocation())
-                    .build();
+            .island(i)
+            .involvedPlayer(user.getUniqueId())
+            .reason(IslandEvent.Reason.ENTER)
+            .admin(false)
+            .location(user.getLocation())
+            .build();
 
             // Send message if island is owned by someone
             if (i.getOwner() != null) {
                 user.notify("protection.flags.ENTER_EXIT_MESSAGES.now-entering", TextVariables.NAME, (i.getName() != null) ? i.getName() :
-                        user.getTranslation("protection.flags.ENTER_EXIT_MESSAGES.island", TextVariables.NAME, getPlugin().getPlayers().getName(i.getOwner())));
+                    user.getTranslation("protection.flags.ENTER_EXIT_MESSAGES.island", TextVariables.NAME, getPlugin().getPlayers().getName(i.getOwner())));
             }
             // Send message if island is unowned, but has a name
             else if (i.getName() != null) {

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -168,8 +168,11 @@ public class AddonsManager {
     private void handleAddonError(Addon addon, Throwable throwable) {
         // Set the AddonState as "ERROR".
         addon.setState(Addon.State.ERROR);
-        plugin.log("Skipping " + addon.getDescription().getName() + " due to an unhandled exception...");
-        plugin.log("STACKTRACE: " + throwable.getClass().getSimpleName() + " - " + throwable.getMessage() + " - " + throwable.getCause());
+        plugin.logError("Skipping " + addon.getDescription().getName() + " due to an unhandled exception...");
+        plugin.logError("STACKTRACE: " + throwable.getClass().getSimpleName() + " - " + throwable.getMessage() + " - " + throwable.getCause());
+        if (plugin.getConfig().getBoolean("debug")) {
+            throwable.printStackTrace();
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -15,6 +15,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.entity.EntityType;
+import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -549,8 +550,8 @@ public class IslandWorldManager {
      *            - world
      * @return GameModeAddon, or empty
      */
-    public Optional<GameModeAddon> getAddon(World world) {
-        return Optional.ofNullable(gameModes.get(Util.getWorld(world)));
+    public Optional<GameModeAddon> getAddon(@Nullable World world) {
+        return world == null ? Optional.empty() : Optional.ofNullable(gameModes.get(Util.getWorld(world)));
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
@@ -113,6 +113,10 @@ public class AdminInfoCommandTest {
         LocalesManager lm = mock(LocalesManager.class);
         when(lm.get(Mockito.any(), Mockito.any())).thenReturn("mock translation");
         when(plugin.getLocalesManager()).thenReturn(lm);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommandTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -101,8 +102,11 @@ public class AdminRangeCommandTest {
         // Locales
         LocalesManager lm = mock(LocalesManager.class);
         Answer<String> answer = invocation -> invocation.getArgumentAt(1, String.class);
-            when(lm.get(Mockito.any(), Mockito.any())).thenAnswer(answer );
-            when(plugin.getLocalesManager()).thenReturn(lm);
+        when(lm.get(Mockito.any(), Mockito.any())).thenAnswer(answer );
+        when(plugin.getLocalesManager()).thenReturn(lm);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
@@ -6,7 +6,12 @@ package world.bentobox.bentobox.api.commands.admin.range;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -117,6 +122,8 @@ public class AdminRangeResetCommandTest {
         when(lm.get(Mockito.any(), Mockito.any())).thenAnswer(answer );
         when(plugin.getLocalesManager()).thenReturn(lm);
 
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
@@ -6,7 +6,12 @@ package world.bentobox.bentobox.api.commands.admin.range;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -119,6 +124,8 @@ public class AdminRangeSetCommandTest {
         when(lm.get(Mockito.any(), Mockito.any())).thenAnswer(answer );
         when(plugin.getLocalesManager()).thenReturn(lm);
 
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -110,6 +111,9 @@ public class AdminTeamAddCommandTest {
         IslandWorldManager iwm = mock(IslandWorldManager.class);
         when(iwm.getFriendlyName(Mockito.any())).thenReturn("BSkyBlock");
         when(plugin.getIWM()).thenReturn(iwm);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -110,6 +111,9 @@ public class AdminTeamDisbandCommandTest {
         LocalesManager lm = mock(LocalesManager.class);
         when(lm.get(Mockito.any(), Mockito.any())).thenReturn("mock translation");
         when(plugin.getLocalesManager()).thenReturn(lm);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -112,6 +113,9 @@ public class AdminTeamKickCommandTest {
         LocalesManager lm = mock(LocalesManager.class);
         when(lm.get(Mockito.any(), Mockito.any())).thenReturn("mock translation");
         when(plugin.getLocalesManager()).thenReturn(lm);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
@@ -121,6 +121,9 @@ public class IslandTeamKickCommandTest {
         iwm = mock(IslandWorldManager.class);
         when(iwm.getFriendlyName(Mockito.any())).thenReturn("BSkyBlock");
         when(plugin.getIWM()).thenReturn(iwm);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -40,6 +40,8 @@ import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.api.addons.AddonDescription;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
@@ -54,6 +56,7 @@ public class UserTest {
     private BentoBox plugin;
     private LocalesManager lm;
     private User user;
+    private IslandWorldManager iwm;
 
     @Before
     public void setUp() throws Exception {
@@ -82,7 +85,7 @@ public class UserTest {
         when(Bukkit.getPlayer(Mockito.any(UUID.class))).thenReturn(player);
         when(Bukkit.getLogger()).thenReturn(Logger.getAnonymousLogger());
 
-        IslandWorldManager iwm = mock(IslandWorldManager.class);
+        iwm = mock(IslandWorldManager.class);
         when(plugin.getIWM()).thenReturn(iwm);
         // Addon
         when(iwm .getAddon(Mockito.any())).thenReturn(Optional.empty());
@@ -251,6 +254,20 @@ public class UserTest {
     public void testSendMessage() {
         user.sendMessage("a.reference");
         Mockito.verify(player).sendMessage(Mockito.eq(TEST_TRANSLATION));
+    }
+
+    @Test
+    public void testSendMessageOverrideWithAddon() {
+        GameModeAddon addon = mock(GameModeAddon.class);
+        AddonDescription desc = new AddonDescription.Builder("mock", "name").build();
+        when(addon.getDescription()).thenReturn(desc);
+        Optional<GameModeAddon> optionalAddon = Optional.of(addon);
+        when(iwm .getAddon(any())).thenReturn(optionalAddon);
+        when(lm.get(any(), Mockito.eq("name.a.reference"))).thenReturn("mockmockmock");
+        //user = User.getInstance(player);
+        user.sendMessage("a.reference");
+        Mockito.verify(player, Mockito.never()).sendMessage(Mockito.eq(TEST_TRANSLATION));
+        Mockito.verify(player).sendMessage(Mockito.eq("mockmockmock"));
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -264,7 +264,6 @@ public class UserTest {
         Optional<GameModeAddon> optionalAddon = Optional.of(addon);
         when(iwm .getAddon(any())).thenReturn(optionalAddon);
         when(lm.get(any(), Mockito.eq("name.a.reference"))).thenReturn("mockmockmock");
-        //user = User.getInstance(player);
         user.sendMessage("a.reference");
         Mockito.verify(player, Mockito.never()).sendMessage(Mockito.eq(TEST_TRANSLATION));
         Mockito.verify(player).sendMessage(Mockito.eq("mockmockmock"));

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
@@ -27,26 +28,40 @@ import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.PluginManager;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 
 
 @RunWith(PowerMockRunner.class)
+@PrepareForTest({ BentoBox.class, Bukkit.class })
 public class UserTest {
 
-    private static Player player;
+    private static final String TEST_TRANSLATION = "mock translation [test]";
+    private Player player;
+    private BentoBox plugin;
+    private LocalesManager lm;
+    private User user;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+    @Before
+    public void setUp() throws Exception {
+        // Set up plugin
+        plugin = mock(BentoBox.class);
+        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        User.setPlugin(plugin);
+
         Server server = mock(Server.class);
         World world = mock(World.class);
         when(server.getLogger()).thenReturn(Logger.getAnonymousLogger());
@@ -62,21 +77,35 @@ public class UserTest {
         ItemFactory itemFactory = mock(ItemFactory.class);
         when(server.getItemFactory()).thenReturn(itemFactory);
 
-        Bukkit.setServer(server);
-
+        PowerMockito.mockStatic(Bukkit.class);
+        when(Bukkit.getServer()).thenReturn(server);
+        when(Bukkit.getPlayer(Mockito.any(UUID.class))).thenReturn(player);
         when(Bukkit.getLogger()).thenReturn(Logger.getAnonymousLogger());
 
+        IslandWorldManager iwm = mock(IslandWorldManager.class);
+        when(plugin.getIWM()).thenReturn(iwm);
+        // Addon
+        when(iwm .getAddon(Mockito.any())).thenReturn(Optional.empty());
 
+        sender = mock(CommandSender.class);
+
+        user = User.getInstance(player);
+
+        // Locales
+        lm = mock(LocalesManager.class);
+        when(plugin.getLocalesManager()).thenReturn(lm);
+        when(lm.get(any(), any())).thenReturn(TEST_TRANSLATION);
+        when(lm.get(any())).thenReturn(TEST_TRANSLATION);
+
+    }
+
+    @After
+    public void cleanUp() {
+        User.clearUsers();
     }
 
     private CommandSender sender;
 
-    @Before
-    public void setUp() throws Exception {
-        sender = mock(CommandSender.class);
-        User.clearUsers();
-        User.setPlugin(null);
-    }
 
     @Test
     public void testGetInstanceCommandSender() {
@@ -87,9 +116,6 @@ public class UserTest {
 
     @Test
     public void testGetInstancePlayer() {
-        Player player = mock(Player.class);
-        User user = User.getInstance(player);
-        assertNotNull(user);
         assertEquals(player,user.getPlayer());
     }
 
@@ -175,14 +201,13 @@ public class UserTest {
     public void testGetUniqueId() {
         UUID uuid = UUID.randomUUID();
         when(player.getUniqueId()).thenReturn(uuid);
-        User user = User.getInstance(player);
+        user = User.getInstance(player);
         assertEquals(uuid, user.getUniqueId());
     }
 
     @Test
     public void testHasPermission() {
         when(player.hasPermission(Mockito.anyString())).thenReturn(true);
-        User user = User.getInstance(player);
         assertTrue(user.hasPermission(""));
         assertTrue(user.hasPermission("perm"));
     }
@@ -190,27 +215,18 @@ public class UserTest {
     @Test
     public void testIsOnline() {
         when(player.isOnline()).thenReturn(true);
-        User user = User.getInstance(player);
         assertTrue(user.isOnline());
     }
 
     @Test
     public void testIsOp() {
         when(player.isOp()).thenReturn(true);
-        User user = User.getInstance(player);
         assertTrue(user.isOp());
     }
 
     @Test
     public void testGetTranslation() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
         // Locales - final
-        LocalesManager lm = mock(LocalesManager.class);
-        when(plugin.getLocalesManager()).thenReturn(lm);
-        when(lm.get(any(), any())).thenReturn("mock translation [test]");
-
-        User user = User.getInstance(player);
         assertEquals("mock translation [test]", user.getTranslation("a.reference"));
         assertEquals("mock translation variable", user.getTranslation("a.reference", "[test]", "variable"));
 
@@ -222,13 +238,9 @@ public class UserTest {
 
     @Test
     public void testGetTranslationOrNothing() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
-        // Locales - final
-        LocalesManager lm = mock(LocalesManager.class);
-        when(plugin.getLocalesManager()).thenReturn(lm);
         // Return the original string to pretend that a translation could not be found
         when(lm.get(any(), any())).thenReturn("fake.reference");
+        when(lm.get(any())).thenReturn("fake.reference");
 
         User user = User.getInstance(player);
         assertEquals("", user.getTranslationOrNothing("fake.reference"));
@@ -237,67 +249,21 @@ public class UserTest {
 
     @Test
     public void testSendMessage() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
-        // Locales - final
-        LocalesManager lm = mock(LocalesManager.class);
-        when(plugin.getLocalesManager()).thenReturn(lm);
-        String translation = ChatColor.RED + "" + ChatColor.BOLD + "test translation";
-        when(lm.get(any(), any())).thenReturn(translation);
-
-        Player pl = mock(Player.class);
-
-        User user = User.getInstance(pl);
         user.sendMessage("a.reference");
-        Mockito.verify(pl).sendMessage(translation);
-    }
-
-    @Test
-    public void testSendMessageNullUser() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
-        // Locales - final
-        LocalesManager lm = mock(LocalesManager.class);
-        when(plugin.getLocalesManager()).thenReturn(lm);
-        String translation = ChatColor.RED + "" + ChatColor.BOLD + "test translation";
-        when(lm.get(any(), any())).thenReturn(translation);
-
-        Player pl = mock(Player.class);
-
-        User user = User.getInstance(UUID.randomUUID());
-        user.sendMessage("a.reference");
-        Mockito.verify(pl, Mockito.never()).sendMessage(Mockito.anyString());
-
+        Mockito.verify(player).sendMessage(Mockito.eq(TEST_TRANSLATION));
     }
 
     @Test
     public void testSendMessageBlankTranslation() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
-        // Locales - final
-        LocalesManager lm = mock(LocalesManager.class);
         // Nothing - blank translation
         when(lm.get(any(), any())).thenReturn("");
-        when(plugin.getLocalesManager()).thenReturn(lm);
-
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
         user.sendMessage("a.reference");
-        Mockito.verify(pl, Mockito.never()).sendMessage(Mockito.anyString());
+        Mockito.verify(player, Mockito.never()).sendMessage(Mockito.anyString());
 
     }
 
     @Test
     public void testSendMessageOnlyColors() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
-        // Locales - final
-        LocalesManager lm = mock(LocalesManager.class);
-        when(plugin.getLocalesManager()).thenReturn(lm);
-
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
-
         // Nothing - just color codes
         StringBuilder allColors = new StringBuilder();
         for (ChatColor cc : ChatColor.values()) {
@@ -305,57 +271,36 @@ public class UserTest {
         }
         when(lm.get(any(), any())).thenReturn(allColors.toString());
         user.sendMessage("a.reference");
-        Mockito.verify(pl, Mockito.never()).sendMessage(Mockito.anyString());
+        Mockito.verify(player, Mockito.never()).sendMessage(Mockito.anyString());
 
     }
 
     @Test
     public void testSendRawMessage() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
         String raw = ChatColor.RED + "" + ChatColor.BOLD + "test message";
-
-        Player pl = mock(Player.class);
-
-        User user = User.getInstance(pl);
         user.sendRawMessage(raw);
-        Mockito.verify(pl).sendMessage(raw);
-
-
+        Mockito.verify(player).sendMessage(raw);
     }
 
     @Test
     public void testSendRawMessageNullUser() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
         String raw = ChatColor.RED + "" + ChatColor.BOLD + "test message";
-
-        Player pl = mock(Player.class);
-
-        User user = User.getInstance(UUID.randomUUID());
+        user = User.getInstance((CommandSender)null);
         user.sendRawMessage(raw);
-        Mockito.verify(pl, Mockito.never()).sendMessage(Mockito.anyString());
+        Mockito.verify(player, Mockito.never()).sendMessage(Mockito.anyString());
 
     }
 
     @Test
     public void testNotifyStringStringArrayNotifyOK() {
-        BentoBox plugin = mock(BentoBox.class);
         Notifier notifier = mock(Notifier.class);
 
         when(plugin.getNotifier()).thenReturn(notifier);
-        User.setPlugin(plugin);
-        // Locales - final
-        LocalesManager lm = mock(LocalesManager.class);
-        when(plugin.getLocalesManager()).thenReturn(lm);
         String translation = ChatColor.RED + "" + ChatColor.BOLD + "test translation";
         when(lm.get(any(), any())).thenReturn(translation);
 
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
-
         // Set notify
-        when(notifier.notify(Mockito.any(), Mockito.eq(translation))).thenReturn(true);
+        when(notifier.notify(any(), Mockito.eq(translation))).thenReturn(true);
 
         user.notify("a.reference");
         Mockito.verify(notifier).notify(user, translation);
@@ -365,63 +310,49 @@ public class UserTest {
 
     @Test
     public void testSetGameMode() {
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
         for (GameMode gm: GameMode.values()) {
             user.setGameMode(gm);
         }
-        Mockito.verify(pl, Mockito.times(GameMode.values().length)).setGameMode(Mockito.any());
+        Mockito.verify(player, Mockito.times(GameMode.values().length)).setGameMode(Mockito.any());
 
     }
 
     @Test
     public void testTeleport() {
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
-        when(pl.teleport(Mockito.any(Location.class))).thenReturn(true);
+        when(player.teleport(Mockito.any(Location.class))).thenReturn(true);
         Location loc = mock(Location.class);
         user.teleport(loc);
-        Mockito.verify(pl).teleport(loc);
+        Mockito.verify(player).teleport(loc);
 
     }
 
     @Test
     public void testGetWorld() {
-        Player pl = mock(Player.class);
         World world = mock(World.class);
-        when(pl.getWorld()).thenReturn(world);
-        User user = User.getInstance(pl);
+        when(player.getWorld()).thenReturn(world);
+        User user = User.getInstance(player);
         assertEquals(world, user.getWorld());
 
     }
 
     @Test
     public void testCloseInventory() {
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
         user.closeInventory();
-        Mockito.verify(pl).closeInventory();
+        Mockito.verify(player).closeInventory();
     }
 
     @Test
     public void testGetLocalePlayer() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
         PlayersManager pm = mock(PlayersManager.class);
         when(plugin.getPlayers()).thenReturn(pm);
         when(pm.getLocale(Mockito.any())).thenReturn("en-US");
 
         // Confirm that Locale object is correctly obtained
-        Locale locale = Locale.US;
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
-        assertEquals(locale, user.getLocale());
+        assertEquals(Locale.US, user.getLocale());
     }
 
     @Test
     public void testGetLocaleConsole() {
-        BentoBox plugin = mock(BentoBox.class);
-        User.setPlugin(plugin);
         PlayersManager pm = mock(PlayersManager.class);
         when(plugin.getPlayers()).thenReturn(pm);
         when(pm.getLocale(Mockito.any())).thenReturn("en-US");
@@ -438,18 +369,14 @@ public class UserTest {
 
     @Test
     public void testUpdateInventory() {
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
         user.updateInventory();
-        Mockito.verify(pl).updateInventory();
+        Mockito.verify(player).updateInventory();
     }
 
     @Test
     public void testPerformCommand() {
-        Player pl = mock(Player.class);
-        User user = User.getInstance(pl);
         user.performCommand("test");
-        Mockito.verify(pl).performCommand("test");
+        Mockito.verify(player).performCommand("test");
     }
 
     @SuppressWarnings("unlikely-arg-type")

--- a/src/test/java/world/bentobox/bentobox/listeners/BannedVisitorCommandsTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/BannedVisitorCommandsTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -91,6 +92,9 @@ public class BannedVisitorCommandsTest {
         // Notifier
         Notifier notifier = mock(Notifier.class);
         when(plugin.getNotifier()).thenReturn(notifier);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
 
 
     }

--- a/src/test/java/world/bentobox/bentobox/listeners/NetherPortalsTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/NetherPortalsTest.java
@@ -148,6 +148,10 @@ public class NetherPortalsTest {
 
         // Normally in world
         Util.setPlugin(plugin);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     private void wrongWorld() {

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/BreedingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/BreedingListenerTest.java
@@ -182,6 +182,10 @@ public class BreedingListenerTest {
 
         PowerMockito.mockStatic(Util.class);
         when(Util.getWorld(Mockito.any())).thenReturn(mock(World.class));
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/EnderChestListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/EnderChestListenerTest.java
@@ -131,6 +131,9 @@ public class EnderChestListenerTest {
         item = mock(ItemStack.class);
         clickedBlock = mock(Block.class);
 
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     @After

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/EnterExitListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/EnterExitListenerTest.java
@@ -170,6 +170,10 @@ public class EnterExitListenerTest {
         when(iwm.getWorldSettings(Mockito.any())).thenReturn(ws);
         Map<String, Boolean> worldFlags = new HashMap<>();
         when(ws.getWorldFlags()).thenReturn(worldFlags);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/ExperiencePickupListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/ExperiencePickupListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package world.bentobox.bentobox.listeners.flags;
 
@@ -55,7 +55,7 @@ import world.bentobox.bentobox.util.Util;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest( {Bukkit.class, BentoBox.class, Flags.class, Util.class} )
 public class ExperiencePickupListenerTest {
-    
+
     private EntityTargetLivingEntityEvent e;
     private ExperiencePickupListener epl;
     private World world;
@@ -73,10 +73,10 @@ public class ExperiencePickupListenerTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
-        
+
         // World
         world = mock(World.class);
-        
+
         //FlagsManager flagsManager = new FlagsManager(plugin);
         //when(plugin.getFlagsManager()).thenReturn(flagsManager);
 
@@ -85,7 +85,7 @@ public class ExperiencePickupListenerTest {
         when(iwm.inWorld(any(World.class))).thenReturn(true);
         when(iwm.inWorld(any(Location.class))).thenReturn(true);
         when(plugin.getIWM()).thenReturn(iwm);
-        
+
         // Fake players
         Settings settings = mock(Settings.class);
         Mockito.when(plugin.getSettings()).thenReturn(settings);
@@ -124,16 +124,20 @@ public class ExperiencePickupListenerTest {
         when(location.getBlockX()).thenReturn(0);
         when(location.getBlockY()).thenReturn(0);
         when(location.getBlockZ()).thenReturn(0);
-        
-        // Set up as valid        
+
+        // Set up as valid
         entity = mock(ExperienceOrb.class);
         targetEntity = mock(Player.class);
         when(targetEntity.getLocation()).thenReturn(location);
         when(entity.getLocation()).thenReturn(location);
-        
+
         TargetReason reason = TargetReason.CLOSEST_PLAYER;
         e = new EntityTargetLivingEntityEvent(entity, targetEntity, reason);
         epl = new ExperiencePickupListener();
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     /**
@@ -147,17 +151,17 @@ public class ExperiencePickupListenerTest {
         assertNull(e.getTarget());
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.eq("protection.protected"));
     }
-    
+
     /**
      * Test method for {@link world.bentobox.bentobox.listeners.flags.ExperiencePickupListener#onExperienceOrbTargetPlayer(org.bukkit.event.entity.EntityTargetLivingEntityEvent)}.
      */
     @Test
-    public void testOnExperienceOrbTargetPlayerAllowed() {        
+    public void testOnExperienceOrbTargetPlayerAllowed() {
         epl.onExperienceOrbTargetPlayer(e);
         assertNotNull(e.getTarget());
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
     }
-    
+
     /**
      * Test method for {@link world.bentobox.bentobox.listeners.flags.ExperiencePickupListener#onExperienceOrbTargetPlayer(org.bukkit.event.entity.EntityTargetLivingEntityEvent)}.
      */
@@ -168,7 +172,7 @@ public class ExperiencePickupListenerTest {
         assertNotNull(e.getTarget());
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
     }
-    
+
     /**
      * Test method for {@link world.bentobox.bentobox.listeners.flags.ExperiencePickupListener#onExperienceOrbTargetPlayer(org.bukkit.event.entity.EntityTargetLivingEntityEvent)}.
      */

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/HurtingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/HurtingListenerTest.java
@@ -149,6 +149,9 @@ public class HurtingListenerTest {
         notifier = mock(Notifier.class);
         when(plugin.getNotifier()).thenReturn(notifier);
 
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/LockAndBanListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/LockAndBanListenerTest.java
@@ -69,20 +69,20 @@ public class LockAndBanListenerTest {
      */
     @Before
     public void setUp() throws Exception {
-        
+
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
 
         // World
         world = mock(World.class);
-        
+
         // Island world manager
         IslandWorldManager iwm = mock(IslandWorldManager.class);
         when(iwm.getPermissionPrefix(Mockito.any())).thenReturn("bskyblock");
-        
+
         when(plugin.getIWM()).thenReturn(iwm);
-        
+
         // Settings
         Settings s = mock(Settings.class);
         when(plugin.getSettings()).thenReturn(s);
@@ -117,12 +117,12 @@ public class LockAndBanListenerTest {
         sch = mock(BukkitScheduler.class);
         PowerMockito.mockStatic(Bukkit.class);
         when(Bukkit.getScheduler()).thenReturn(sch);
-        
-        // Locales      
+
+        // Locales
         LocalesManager lm = mock(LocalesManager.class);
         when(plugin.getLocalesManager()).thenReturn(lm);
         when(lm.get(any(), any())).thenReturn("mock translation");
-        
+
         // Notifier
         notifier = mock(Notifier.class);
         when(plugin.getNotifier()).thenReturn(notifier);
@@ -142,35 +142,39 @@ public class LockAndBanListenerTest {
         when(island.isAllowed(Mockito.any(), Mockito.any())).thenReturn(true);
 
         when(im.getIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(island);
-        
+
         // Create the listener object
         listener = new LockAndBanListener();
-        
+
         // Common from to's
         outside = mock(Location.class);
         when(outside.getWorld()).thenReturn(world);
         when(outside.getBlockX()).thenReturn(X + PROTECTION_RANGE + 1);
         when(outside.getBlockY()).thenReturn(Y);
         when(outside.getBlockZ()).thenReturn(Z);
-        
+
         inside = mock(Location.class);
         when(inside.getWorld()).thenReturn(world);
         when(inside.getBlockX()).thenReturn(X + PROTECTION_RANGE - 1);
         when(inside.getBlockY()).thenReturn(Y);
         when(inside.getBlockZ()).thenReturn(Z);
-        
+
         inside2 = mock(Location.class);
         when(inside.getWorld()).thenReturn(world);
         when(inside.getBlockX()).thenReturn(X + PROTECTION_RANGE - 2);
         when(inside.getBlockY()).thenReturn(Y);
         when(inside.getBlockZ()).thenReturn(Z);
-        
+
         Optional<Island> opIsland = Optional.ofNullable(island);
         when(im.getProtectedIslandAt(Mockito.eq(inside))).thenReturn(opIsland);
         when(im.getProtectedIslandAt(Mockito.eq(inside2))).thenReturn(opIsland);
         when(im.getProtectedIslandAt(Mockito.eq(outside))).thenReturn(Optional.empty());
-        }
-    
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
+    }
+
     @Test
     public void testTeleportToNotBannedIsland() {
         // Setup location outside island, one inside banned island
@@ -186,7 +190,7 @@ public class LockAndBanListenerTest {
         // User should see no message from this class
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.any());
     }
-    
+
     @Test
     public void testTeleportToBannedIsland() {
         // Make player
@@ -195,7 +199,7 @@ public class LockAndBanListenerTest {
 
         // Add player to the ban list
         when(island.isBanned(Mockito.eq(uuid))).thenReturn(true);
-        
+
         // Simulate a teleport into an island
         PlayerTeleportEvent e = new PlayerTeleportEvent(player, outside, inside);
         // Pass to event listener
@@ -215,15 +219,15 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player on the island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Add player to the ban list
         when(island.isBanned(Mockito.eq(uuid))).thenReturn(true);
-        
+
         // Log them in
         listener.onPlayerLogin(new PlayerJoinEvent(player, "join message"));
         // User should see a message
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
-        // User should be teleported somewhere 
+        // User should be teleported somewhere
         Mockito.verify(im).homeTeleport(Mockito.any(), Mockito.eq(player));
         // Call teleport event
         PlayerTeleportEvent e = new PlayerTeleportEvent(player, inside, outside);
@@ -232,7 +236,7 @@ public class LockAndBanListenerTest {
         // Should not be cancelled
         assertFalse(e.isCancelled());
     }
-    
+
     @Test
     public void testVerticalMoveOnly() {
         // Move vertically only
@@ -252,7 +256,7 @@ public class LockAndBanListenerTest {
         // Confirm no check is done on the island
         Mockito.verify(im, Mockito.never()).getProtectedIslandAt(Mockito.any());
     }
-    
+
     @Test
     public void testVerticalVehicleMoveOnly() {
         // Move vertically only
@@ -278,7 +282,7 @@ public class LockAndBanListenerTest {
         // Confirm no check is done on the island
         Mockito.verify(im, Mockito.never()).getProtectedIslandAt(Mockito.any());
     }
-    
+
     @Test
     public void testPlayerMoveIntoBannedIsland() {
         // Make player
@@ -288,7 +292,7 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player just outside island
         when(player.getLocation()).thenReturn(outside);
-        
+
         // Add player to the ban list
         when(island.isBanned(Mockito.eq(uuid))).thenReturn(true);
 
@@ -301,7 +305,7 @@ public class LockAndBanListenerTest {
         // User should NOT be teleported somewhere
         Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
     }
-    
+
     @Test
     public void testPlayerMoveInsideBannedIsland() {
         // Make player
@@ -311,9 +315,9 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player inside island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Add player to the ban list
-        when(island.isBanned(Mockito.eq(uuid))).thenReturn(true);        
+        when(island.isBanned(Mockito.eq(uuid))).thenReturn(true);
         // Move player
         PlayerMoveEvent e = new PlayerMoveEvent(player, inside, inside2);
         listener.onPlayerMove(e);
@@ -329,7 +333,7 @@ public class LockAndBanListenerTest {
         // Should not be cancelled
         assertFalse(ev.isCancelled());
     }
- 
+
     @Test
     public void testVehicleMoveIntoBannedIsland() {
         // Make player
@@ -337,13 +341,13 @@ public class LockAndBanListenerTest {
         when(player.getUniqueId()).thenReturn(uuid);
         // Give player an island
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
-        
+
         // Add player to the ban list
         when(island.isBanned(Mockito.eq(uuid))).thenReturn(true);
 
         // Add the user to the ban list
         when(island.isBanned(Mockito.eq(uuid))).thenReturn(true);
-        
+
         // Create vehicle and put two players in it. One is banned, the other is not
         Vehicle vehicle = mock(Vehicle.class);
         Player player2 = mock(Player.class);
@@ -366,12 +370,12 @@ public class LockAndBanListenerTest {
         // Should not be cancelled
         assertFalse(ev.isCancelled());
     }
-    
+
     /*
      * Island lock tests
      */
- 
-    
+
+
     @Test
     public void testTeleportToLockedIsland() {
         // Make player
@@ -388,7 +392,7 @@ public class LockAndBanListenerTest {
         // Player should see a message
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.any());
     }
-    
+
     @Test
     public void testTeleportToLockedIslandAsMember() {
         // Make player
@@ -413,15 +417,15 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player on the island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
-        
+
         // Log them in
         listener.onPlayerLogin(new PlayerJoinEvent(player, "join message"));
         // User should see a message
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
-        // User should be teleported somewhere 
+        // User should be teleported somewhere
         Mockito.verify(im).homeTeleport(Mockito.any(), Mockito.eq(player));
         // Call teleport event
         PlayerTeleportEvent e = new PlayerTeleportEvent(player, inside, outside);
@@ -430,54 +434,54 @@ public class LockAndBanListenerTest {
         // Should not be cancelled
         assertFalse(e.isCancelled());
     }
-    
+
     @Test
     public void testLoginToLockedIslandAsOp() {
         // Make player
         Player player = mock(Player.class);
         when(player.isOp()).thenReturn(true);
-        
+
         when(player.getUniqueId()).thenReturn(uuid);
         // Give player an island
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player on the island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
-        
+
         // Log them in
         listener.onPlayerLogin(new PlayerJoinEvent(player, "join message"));
         // User should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
-        // User should not be teleported somewhere 
+        // User should not be teleported somewhere
         Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
     }
-    
+
     @Test
     public void testLoginToLockedIslandWithBypassPerm() {
         // Make player
         Player player = mock(Player.class);
         when(player.isOp()).thenReturn(false);
         when(player.hasPermission(Mockito.anyString())).thenReturn(true);
-        
+
         when(player.getUniqueId()).thenReturn(uuid);
         // Give player an island
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player on the island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
-        
+
         // Log them in
         listener.onPlayerLogin(new PlayerJoinEvent(player, "join message"));
         // User should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
-        // User should not be teleported somewhere 
+        // User should not be teleported somewhere
         Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
     }
-    
+
     @Test
     public void testLoginToLockedIslandAsMember() {
         // Make player
@@ -491,10 +495,10 @@ public class LockAndBanListenerTest {
         listener.onPlayerLogin(new PlayerJoinEvent(player, "join message"));
         // User should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
-        // User should not be teleported somewhere 
+        // User should not be teleported somewhere
         Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
     }
-        
+
     @Test
     public void testPlayerMoveIntoLockedIsland() {
         // Make player
@@ -504,7 +508,7 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player just outside island
         when(player.getLocation()).thenReturn(outside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
 
@@ -517,19 +521,19 @@ public class LockAndBanListenerTest {
         // User should NOT be teleported somewhere
         Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
     }
-    
+
     @Test
     public void testPlayerMoveIntoLockedIslandAsOp() {
         // Make player
         Player player = mock(Player.class);
         when(player.isOp()).thenReturn(true);
-        
+
         when(player.getUniqueId()).thenReturn(uuid);
         // Give player an island
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player just outside island
         when(player.getLocation()).thenReturn(outside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
 
@@ -538,20 +542,20 @@ public class LockAndBanListenerTest {
         listener.onPlayerMove(e);
         assertFalse(e.isCancelled());
     }
-    
+
     @Test
     public void testPlayerMoveIntoLockedIslandWithBypass() {
         // Make player
         Player player = mock(Player.class);
         when(player.isOp()).thenReturn(false);
         when(player.hasPermission(Mockito.anyString())).thenReturn(true);
-        
+
         when(player.getUniqueId()).thenReturn(uuid);
         // Give player an island
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player just outside island
         when(player.getLocation()).thenReturn(outside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
 
@@ -560,8 +564,8 @@ public class LockAndBanListenerTest {
         listener.onPlayerMove(e);
         assertFalse(e.isCancelled());
     }
-    
-    
+
+
     @Test
     public void testPlayerMoveIntoLockedIslandAsMember() {
         // Make player
@@ -581,7 +585,7 @@ public class LockAndBanListenerTest {
         // User should NOT be teleported somewhere
         Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
     }
-    
+
     @Test
     public void testPlayerMoveInsideLockedIsland() {
         // Make player
@@ -591,7 +595,7 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player inside island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
 
@@ -610,7 +614,7 @@ public class LockAndBanListenerTest {
         // Should not be cancelled
         assertFalse(ev.isCancelled());
     }
-    
+
     @Test
     public void testPlayerMoveInsideLockedIslandAsOp() {
         // Make player
@@ -621,7 +625,7 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player inside island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
 
@@ -630,7 +634,7 @@ public class LockAndBanListenerTest {
         listener.onPlayerMove(e);
         assertFalse(e.isCancelled());
     }
-    
+
     @Test
     public void testPlayerMoveInsideLockedIslandWithBypass() {
         // Make player
@@ -642,7 +646,7 @@ public class LockAndBanListenerTest {
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         // Place the player inside island
         when(player.getLocation()).thenReturn(inside);
-        
+
         // Lock island for player
         when(island.isAllowed(Mockito.any(), Mockito.eq(Flags.LOCK))).thenReturn(false);
 
@@ -651,8 +655,8 @@ public class LockAndBanListenerTest {
         listener.onPlayerMove(e);
         assertFalse(e.isCancelled());
     }
-    
-    
+
+
     @Test
     public void testPlayerMoveInsideLockedIslandAsMember() {
         // Make player
@@ -671,7 +675,7 @@ public class LockAndBanListenerTest {
         // User should not be teleported somewhere
         Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
     }
- 
+
     @Test
     public void testVehicleMoveIntoLockedIsland() {
         // Make player
@@ -682,10 +686,10 @@ public class LockAndBanListenerTest {
         Player player2 = mock(Player.class);
         UUID uuid2 = UUID.randomUUID();
         when(player2.getUniqueId()).thenReturn(uuid2);
-        
+
         // Player 1 is not a member, player 2 is an island member
         when(island.isAllowed(Mockito.any(User.class), Mockito.any())).thenAnswer((Answer<Boolean>) invocation -> invocation.getArgumentAt(0, User.class).getUniqueId().equals(uuid2));
-       
+
         // Create vehicle and put two players in it. One is a member, the other is not
         Vehicle vehicle = mock(Vehicle.class);
         List<Entity> passengers = new ArrayList<>();
@@ -707,5 +711,5 @@ public class LockAndBanListenerTest {
         // Should not be cancelled
         assertFalse(ev.isCancelled());
     }
-    
+
 }

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/ObsidianScoopingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/ObsidianScoopingListenerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.bukkit.GameMode;
@@ -142,6 +143,10 @@ public class ObsidianScoopingListenerTest {
         Map<String, Boolean> map = new HashMap<>();
         map.put("OBSIDIAN_SCOOPING", true);
         when(ws.getWorldFlags()).thenReturn(map);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/PVPListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/PVPListenerTest.java
@@ -193,6 +193,10 @@ public class PVPListenerTest {
         // Notifier
         notifier = mock(Notifier.class);
         when(plugin.getNotifier()).thenReturn(notifier);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     private void wrongWorld() {

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/PhysicalInteractionListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/PhysicalInteractionListenerTest.java
@@ -99,7 +99,6 @@ public class PhysicalInteractionListenerTest {
 
         PowerMockito.mockStatic(Bukkit.class);
         when(Bukkit.getServer()).thenReturn(server);
-        //Bukkit.setServer(server);
 
         SkullMeta skullMeta = mock(SkullMeta.class);
         when(itemFactory.getItemMeta(any())).thenReturn(skullMeta);
@@ -181,6 +180,10 @@ public class PhysicalInteractionListenerTest {
         // Item and clicked block
         item = mock(ItemStack.class);
         clickedBlock = mock(Block.class);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
 
     }
 

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/TNTListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/TNTListenerTest.java
@@ -91,7 +91,6 @@ public class TNTListenerTest {
 
         PowerMockito.mockStatic(Bukkit.class);
         when(Bukkit.getServer()).thenReturn(server);
-        //Bukkit.setServer(server);
 
         SkullMeta skullMeta = mock(SkullMeta.class);
         when(itemFactory.getItemMeta(any())).thenReturn(skullMeta);
@@ -164,6 +163,10 @@ public class TNTListenerTest {
 
         PowerMockito.mockStatic(Util.class);
         when(Util.getWorld(Mockito.any())).thenReturn(mock(World.class));
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -182,6 +182,10 @@ public class IslandsManagerTest {
         when(Bukkit.getServer()).thenReturn(server);
         pim = mock(PluginManager.class);
         when(server.getPluginManager()).thenReturn(pim);
+
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportBuilderTest.java
@@ -1,5 +1,13 @@
 package world.bentobox.bentobox.util.teleport;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.junit.Before;
@@ -7,19 +15,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.LocalesManager;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(SafeSpotTeleport.Builder.class)
@@ -46,6 +51,11 @@ public class SafeSpotTeleportBuilderTest {
         LocalesManager lm = mock(LocalesManager.class);
         when(plugin.getLocalesManager()).thenReturn(lm);
         when(lm.get(any(), any())).thenReturn("mock translation");
+        // Addon
+        IslandWorldManager iwm = mock(IslandWorldManager.class);
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+        when(plugin.getIWM()).thenReturn(iwm);
+
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportTest.java
@@ -95,6 +95,10 @@ public class SafeSpotTeleportTest {
         sch = mock(BukkitScheduler.class);
         when(server.getScheduler()).thenReturn(sch);
 
+        // Addon
+        when(iwm.getAddon(Mockito.any())).thenReturn(Optional.empty());
+
+
     }
 
     /**


### PR DESCRIPTION
The default BentoBox locale text is geared towards island games. When
writing the SkyGrid addon I am using the standard protection flags, but
I need to reference a "protection area" instead of an "island". This
enables me to do that by having the same reference but prefixed in the
locale file by the name of the addon (in lower case), as written in the
addon's addon.yml.

Example from SkyGrid's locale file:

```
skygrid:
  protection:
    flags:
      ENTER_EXIT_MESSAGES: 
        description: "Display entry and exit messages"
        island: "[name]'s protected area"
        name: "Enter/Exit messages"
        now-entering: "&bNow entering [name]"
        now-leaving: "&bNow leaving [name]"
```

This overrides the default ENTER_EXIT_MESSAGES flag text.
