### PR TITLE
Fix issue with offline players that kept inventory

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -79,7 +79,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
             }
             else {
                 getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
-                this.getAddon().getPlayers().save(targetUUID);
+                getPlayers().save(targetUUID);
             }
         }
         if (getIWM().isOnLeaveResetInventory(getWorld())) {
@@ -87,8 +87,8 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
                 target.getPlayer().getInventory().clear();
             }
             else {
-                this.getAddon().getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
-                this.getAddon().getPlayers().save(targetUUID);
+                getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
+                getPlayers().save(targetUUID);
 
             }
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -13,6 +13,7 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 
+
 public class IslandTeamKickCommand extends ConfirmableCommand {
 
     public IslandTeamKickCommand(CompositeCommand islandTeamCommand) {
@@ -76,13 +77,20 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
             if (target.isOnline()) {
                 target.getPlayer().getEnderChest().clear();
             }
-            // FIXME need some special handling here if the target's offline.
+            else {
+                this.getAddon().getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
+                this.getAddon().getPlayers().save(targetUUID);
+            }
         }
         if (getIWM().isOnLeaveResetInventory(getWorld())) {
             if (target.isOnline()) {
                 target.getPlayer().getInventory().clear();
             }
-            // FIXME need some special handling here if the target's offline.
+            else {
+                this.getAddon().getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
+                this.getAddon().getPlayers().save(targetUUID);
+
+            }
         }
         if (getSettings().isUseEconomy() && getIWM().isOnLeaveResetMoney(getWorld())) {
             getPlugin().getVault().ifPresent(vault -> vault.withdraw(target, vault.getBalance(target)));

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -78,7 +78,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
                 target.getPlayer().getEnderChest().clear();
             }
             else {
-                getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
+                getPlayers().getPlayer(targetUUID).addToPendingKick(getWorld());
                 getPlayers().save(targetUUID);
             }
         }
@@ -87,7 +87,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
                 target.getPlayer().getInventory().clear();
             }
             else {
-                getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
+                getPlayers().getPlayer(targetUUID).addToPendingKick(getWorld());
                 getPlayers().save(targetUUID);
 
             }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -78,7 +78,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
                 target.getPlayer().getEnderChest().clear();
             }
             else {
-                this.getAddon().getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
+                getPlayers().getPlayer(targetUUID).addQuarantinedWorld(getWorld());
                 this.getAddon().getPlayers().save(targetUUID);
             }
         }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Players.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Players.java
@@ -1,7 +1,9 @@
 package world.bentobox.bentobox.database.objects;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -33,6 +35,13 @@ public class Players implements DataObject {
     private String locale = "";
     @Expose
     private Map<String, Integer> deaths = new HashMap<>();
+
+    /**
+     * This variable stores set of worlds where user inventory is quarantined.
+     */
+    @Expose
+    private Set<String> quarantineWorld = new HashSet<>();
+
 
     /**
      * This is required for database storage
@@ -271,4 +280,33 @@ public class Players implements DataObject {
         this.deaths = deaths;
     }
 
+
+    /**
+     * This method returns the quarantineWorld value.
+     * @return the value of quarantineWorld.
+     */
+    public Set<String> getQuarantineWorld()
+    {
+        return quarantineWorld;
+    }
+
+
+    /**
+     * This method sets the quarantineWorld value.
+     * @param quarantineWorld the quarantineWorld new value.
+     */
+    public void setQuarantineWorld(Set<String> quarantineWorld)
+    {
+        this.quarantineWorld = quarantineWorld;
+    }
+
+
+    /**
+     * This mehtod adds given world in quarantined world set.
+     * @param world World that must be added to quarantined set.
+     */
+    public void addQuarantinedWorld(World world)
+    {
+        this.quarantineWorld.add(Util.getWorld(world).getName());
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Players.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Players.java
@@ -37,10 +37,11 @@ public class Players implements DataObject {
     private Map<String, Integer> deaths = new HashMap<>();
 
     /**
-     * This variable stores set of worlds where user inventory is quarantined.
+     * This variable stores set of worlds where user inventory must be cleared.
+     * @since 1.3.0
      */
     @Expose
-    private Set<String> quarantineWorld = new HashSet<>();
+    private Set<String> pendingKicks = new HashSet<>();
 
 
     /**
@@ -282,31 +283,31 @@ public class Players implements DataObject {
 
 
     /**
-     * This method returns the quarantineWorld value.
-     * @return the value of quarantineWorld.
+     * This method returns the pendingKicks value.
+     * @return the value of pendingKicks.
      */
-    public Set<String> getQuarantineWorld()
+    public Set<String> getPendingKicks()
     {
-        return quarantineWorld;
+        return pendingKicks;
     }
 
 
     /**
-     * This method sets the quarantineWorld value.
-     * @param quarantineWorld the quarantineWorld new value.
+     * This method sets the pendingKicks value.
+     * @param pendingKicks the pendingKicks new value.
      */
-    public void setQuarantineWorld(Set<String> quarantineWorld)
+    public void setPendingKicks(Set<String> pendingKicks)
     {
-        this.quarantineWorld = quarantineWorld;
+        this.pendingKicks = pendingKicks;
     }
 
 
     /**
-     * This mehtod adds given world in quarantined world set.
-     * @param world World that must be added to quarantined set.
+     * This method adds given world in pendingKicks world set.
+     * @param world World that must be added to pendingKicks set.
      */
-    public void addQuarantinedWorld(World world)
+    public void addToPendingKick(World world)
     {
-        this.quarantineWorld.add(Util.getWorld(world).getName());
+        this.pendingKicks.add(Util.getWorld(world).getName());
     }
 }

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -6,9 +6,11 @@ import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.eclipse.jdt.annotation.NonNull;
@@ -17,6 +19,7 @@ import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.database.objects.Players;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
@@ -73,8 +76,56 @@ public class JoinLeaveListener implements Listener {
             if (plugin.getIWM().inWorld(user.getLocation()) && Flags.REMOVE_MOBS.isSetForWorld(user.getWorld())) {
                 plugin.getIslands().clearArea(user.getLocation());
             }
+
+            // Clear inventory if required
+            this.clearPlayersInventory(Util.getWorld(event.getPlayer().getWorld()),
+                User.getInstance(event.getPlayer()));
         }
     }
+
+
+    /**
+     * This event will clean players inventor
+     * @param event SwitchWorld event.
+     */
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerSwitchWorld(final PlayerChangedWorldEvent event)
+    {
+        // Clear inventory if required
+        this.clearPlayersInventory(Util.getWorld(event.getPlayer().getWorld()),
+            User.getInstance(event.getPlayer()));
+    }
+
+
+    /**
+     * This method clears player inventory and ender chest if given world is quarantined
+     * in user data file and it is required by plugin settings.
+     * @param world World where cleaning must occur.
+     * @param user Targeted user.
+     */
+    private void clearPlayersInventory(World world, User user)
+    {
+        // Clear inventory if required
+        Players players = this.players.getPlayer(user.getUniqueId());
+
+        if (!players.getQuarantineWorld().isEmpty() &&
+            players.getQuarantineWorld().contains(world.getName()))
+        {
+            if (plugin.getIWM().isOnLeaveResetEnderChest(world))
+            {
+                user.getPlayer().getEnderChest().clear();
+            }
+
+            if (plugin.getIWM().isOnLeaveResetInventory(world))
+            {
+                user.getPlayer().getInventory().clear();
+            }
+
+            players.getQuarantineWorld().remove(world.getName());
+            this.players.save(user.getUniqueId());
+        }
+    }
+
 
     private void runAutomatedOwnershipTransfer(User user) {
         plugin.getIWM().getOverWorlds().stream()

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -88,7 +88,7 @@ public class JoinLeaveListener implements Listener {
      * This event will clean players inventor
      * @param event SwitchWorld event.
      */
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerSwitchWorld(final PlayerChangedWorldEvent event)
     {
         // Clear inventory if required
@@ -108,8 +108,8 @@ public class JoinLeaveListener implements Listener {
         // Clear inventory if required
         Players players = this.players.getPlayer(user.getUniqueId());
 
-        if (!players.getQuarantineWorld().isEmpty() &&
-            players.getQuarantineWorld().contains(world.getName()))
+        if (!players.getPendingKicks().isEmpty() &&
+            players.getPendingKicks().contains(world.getName()))
         {
             if (plugin.getIWM().isOnLeaveResetEnderChest(world))
             {
@@ -121,7 +121,7 @@ public class JoinLeaveListener implements Listener {
                 user.getPlayer().getInventory().clear();
             }
 
-            players.getQuarantineWorld().remove(world.getName());
+            players.getPendingKicks().remove(world.getName());
             this.players.save(user.getUniqueId());
         }
     }


### PR DESCRIPTION
Not sure if this works, but it should work...
Basically, I introduce a new Set in Players Database Object that holds Quarantined Worlds.

And in JoinLeaveListener I add a method that clears players inventory. This method is called in PlayerJoinEvent and PlayerChangedWorldEvent (that was added).
Off course, after inventory has been cleared, the world is removed from the quarantined set. 