### PR TITLE
Fix issue when Owners could not kick team members

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -34,7 +34,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.no-team");
             return false;
         }
-        if (user.getUniqueId() != getOwner(getWorld(), user)) {
+        if (!user.getUniqueId().equals(getOwner(getWorld(), user))) {
             user.sendMessage("general.errors.not-owner");
             return false;
         }


### PR DESCRIPTION
So, UUID cannot be compared with == and !=. It should be always use UUID#equals(UUID) method.