### PR TITLE
Fix issue where TeamMembers could not set island home.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
@@ -24,7 +24,7 @@ public class IslandSethomeCommand extends ConfirmableCommand {
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
         // Check island
-        if (!getPlugin().getIslands().hasIsland(getWorld(), user)) {
+        if (!getPlugin().getIslands().hasIsland(getWorld(), user) && !getPlugin().getIslands().inTeam(getWorld(), user.getUniqueId())) {
             user.sendMessage("general.errors.no-island");
             return false;
         }


### PR DESCRIPTION
Continues fix of issue #538.

It happened because IslandManager#hasIsland(World,User) returns true only if island is owned by player, team members will always gets false, as they do not directly own an island.