### PR TITLE
Handle Mooshroom "milking"

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BucketListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BucketListener.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.listeners.flags.protection;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.MushroomCow;
 import org.bukkit.entity.TropicalFish;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -57,6 +58,18 @@ public class BucketListener extends FlagListener {
     public void onTropicalFishScooping(final PlayerInteractEntityEvent e) {
         if (e.getRightClicked() instanceof TropicalFish && e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.WATER_BUCKET)) {
             checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.FISH_SCOOPING);
+        }
+    }
+
+
+    /**
+     * Prevents collecting mushroom strew from MushroomCow if player does not have access to Milking flag.
+     * @param e - event
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onBowlFill(final PlayerInteractEntityEvent e) {
+        if (e.getRightClicked() instanceof MushroomCow && e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.BOWL)) {
+            checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.MILKING);
         }
     }
 }


### PR DESCRIPTION
Add extra PlayerInteractEntityEvent handling that prevents from using bowl on mooshrooms without MILKING protection flag.

