### PR TITLE
Fixes user being spawned instead of target on /island expel

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
@@ -119,7 +119,7 @@ public class IslandExpelCommand extends CompositeCommand {
         } else if (getIslands().getSpawn(getWorld()).isPresent()){
             // Success
             user.sendMessage(SUCCESS);
-            getIslands().spawnTeleport(getWorld(), user.getPlayer());
+            getIslands().spawnTeleport(getWorld(), target.getPlayer());
             return true;
         } else if (getIWM().getAddon(getWorld())
                 .map(gm -> gm.getPlayerCommand()


### PR DESCRIPTION
If target had no island to be expelled to, second if statement would expel User (executor) itself