### PR TITLE
Gamemode chunk delete

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/addons/GameModeAddon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/GameModeAddon.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.api.addons;
 
 import java.util.Optional;
 
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.generator.ChunkGenerator;
@@ -129,4 +130,11 @@ public abstract class GameModeAddon extends Addon {
 	 * @since 1.4.0
 	 */
 	public abstract void saveWorldSettings();
+	
+	/**
+	 * When called, the game mode must regenerate the chunk to its original state.
+	 * Used when an island is deleted.
+	 * @param chunk - chunk to regenerate
+	 */
+	public abstract void regerateChunk(Chunk chunk);
 }

--- a/src/main/java/world/bentobox/bentobox/util/DeleteIslandChunks.java
+++ b/src/main/java/world/bentobox/bentobox/util/DeleteIslandChunks.java
@@ -15,43 +15,45 @@ import world.bentobox.bentobox.database.objects.IslandDeletion;
  */
 public class DeleteIslandChunks {
 
-    /**
-     * This is how many chunks per world will be done in one tick.
-     */
-    private static final int SPEED = 5;
-    private int x;
-    private int z;
-    private BukkitTask task;
+	/**
+	 * This is how many chunks per world will be done in one tick.
+	 */
+	private static final int SPEED = 5;
+	private int x;
+	private int z;
+	private BukkitTask task;
 
-    @SuppressWarnings({"deprecation", "squid:CallToDeprecatedMethod"})
-    public DeleteIslandChunks(BentoBox plugin, IslandDeletion di) {
-        // Fire event
-        IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETE_CHUNKS).build();
-        x = di.getMinXChunk();
-        z = di.getMinZChunk();
-        // Run through all chunks of the islands and regenerate them.
-        task = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
-            for (int i = 0; i < SPEED; i++) {
-                // World#regenerateChunk(int, int) from Bukkit is deprecated because it may not regenerate decoration correctly
-                di.getWorld().regenerateChunk(x, z); 
-                if (plugin.getIWM().isNetherGenerate(di.getWorld()) && plugin.getIWM().isNetherIslands(di.getWorld())) {
-                    plugin.getIWM().getNetherWorld(di.getWorld()).regenerateChunk(x, z);
-                }
-                if (plugin.getIWM().isEndGenerate(di.getWorld()) && plugin.getIWM().isEndIslands(di.getWorld())) {
-                    plugin.getIWM().getEndWorld(di.getWorld()).regenerateChunk(x, z);
-                }
-                z++;
-                if (z > di.getMaxZChunk()) {
-                    z = di.getMinZChunk();
-                    x++;
-                    if (x > di.getMaxXChunk()) {
-                        // We're done
-                        task.cancel();
-                        // Fire event
-                        IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETED).build();
-                    }
-                }
-            }
-        }, 0L, 1L);
-    }
+	public DeleteIslandChunks(BentoBox plugin, IslandDeletion di) {
+		// Fire event
+		IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETE_CHUNKS).build();
+		x = di.getMinXChunk();
+		z = di.getMinZChunk();
+		// Run through all chunks of the islands and regenerate them.
+		task = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+			for (int i = 0; i < SPEED; i++) {
+				plugin.getIWM().getAddon(di.getWorld()).ifPresent(gm -> {
+					
+					gm.regerateChunk(di.getWorld().getChunkAt(x, z));
+					
+					if (plugin.getIWM().isNetherGenerate(di.getWorld()) && plugin.getIWM().isNetherIslands(di.getWorld())) {
+						gm.regerateChunk(gm.getNetherWorld().getChunkAt(x, z));
+					}
+					if (plugin.getIWM().isEndGenerate(di.getWorld()) && plugin.getIWM().isEndIslands(di.getWorld())) {
+						gm.regerateChunk(gm.getEndWorld().getChunkAt(x, z));
+					}
+					z++;
+					if (z > di.getMaxZChunk()) {
+						z = di.getMinZChunk();
+						x++;
+						if (x > di.getMaxXChunk()) {
+							// We're done
+							task.cancel();
+							// Fire event
+							IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETED).build();
+						}
+					}
+				});
+			}
+		}, 0L, 1L);
+	}
 }


### PR DESCRIPTION
This is required for 1.14 compatibility and will work on 1.13 as well.

BentoBox handles the deletion by calling a chunk regeneration method in the game mode. It is simple to reuse the same code that was used for the generation. See the related BSkyBlock PR.

I'm open to discussion on improvements to this.