### PR TITLE
Add color translation for Panel and PanelItem names.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelBuilder.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.api.panels.builders;
 
+import org.bukkit.ChatColor;
 import java.util.TreeMap;
 
 import world.bentobox.bentobox.api.panels.Panel;
@@ -15,7 +16,7 @@ public class PanelBuilder {
     private PanelListener listener;
 
     public PanelBuilder name(String name) {
-        this.name = name;
+        this.name = ChatColor.translateAlternateColorCodes('&', name);
         return this;
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilder.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -44,7 +45,7 @@ public class PanelItemBuilder {
 
 
     public PanelItemBuilder name(String name) {
-        this.name = name;
+        this.name = ChatColor.translateAlternateColorCodes('&', name);
         return this;
     }
 


### PR DESCRIPTION
I had a issue in Biomes and Challenges addon with panel and panelItem names.

These names does not translate chat colors, so it was necessary to translate them before passing it to PanelItemBuilder or PanelBuilder. 
But it would be more convenient if builders do it them-self, as it is done with code that translate messages.

