### PR TITLE
Fixes incorrect sethome if an island was locked

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -79,16 +79,16 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
             Island island = getIslands().getIsland(getWorld(), playerUUID);
             // Get the team's island
             Island teamIsland = getIslands().getIsland(getWorld(), prospectiveOwnerUUID);
-            // Move player to team's island
-            User prospectiveOwner = User.getInstance(prospectiveOwnerUUID);
-            Location newHome = getIslands().getSafeHomeLocation(getWorld(), prospectiveOwner, 1);
-            user.teleport(newHome);
             // Remove player as owner of the old island
             getIslands().removePlayer(getWorld(), playerUUID);
             // Remove money inventory etc. for leaving
             cleanPlayer(user);
             // Add the player as a team member of the new island
             getIslands().setJoinTeam(teamIsland, playerUUID);
+            //Move player to team's island
+            User prospectiveOwner = User.getInstance(prospectiveOwnerUUID);
+            Location newHome = getIslands().getSafeHomeLocation(getWorld(), prospectiveOwner, 1);
+            user.teleport(newHome);
             // Set the player's home
             getPlayers().setHomeLocation(playerUUID, user.getLocation());
             // Delete the old island
@@ -132,5 +132,4 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
             getPlugin().getVault().ifPresent(vault -> vault.withdraw(user, vault.getBalance(user)));
         }
     }
-
 }


### PR DESCRIPTION
-for visitor/ coops/ trusted players. I think this reorder of execution fixs this, correct me if I'm wrong.

Issue #665 : Teleport > Sethome > Add 
(Sets incorrect if the island was locked for visitor as the member was not yet added to the island so the teleportation failed, therefore it will take the location of user from where he was standing when he typed /is team accept) 

Fix: Add > Teleport > Set