### PR TITLE
Append build number to builds compiled by the CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,14 @@
     </dependencies>
 
     <build>
+        <!-- By default ${revision} is ${build.version}-SNAPSHOT -->
+        <!-- If GIT_BRANCH variable is set to origin/master, then it will be only ${build.version}. -->
+
+        <!-- By default ${build.number} is -LOCAL. -->
+        <!-- If the BUILD_NUMBER variable is set, then it will be -b[number]. -->
+        <!-- If GIT_BRANCH variable is set to origin/master, then it will be the empty string. -->
+        <finalName>${project.name}-${revision}${build.number}</finalName>
+        
         <defaultGoal>clean package</defaultGoal>
         <resources>
             <resource>


### PR DESCRIPTION
By default ${revision} is ${build.version}-SNAPSHOT
- If GIT_BRANCH variable is set to origin/master, then it will be only ${build.version}.

By default ${build.number} is -LOCAL.
- If the BUILD_NUMBER variable is set, then it will be -b[number]. 
- If GIT_BRANCH variable is set to origin/master, then it will be the empty string.

So, in the end, we can get 3 different names:
1. `BentoBox-1.5.0-SNAPSHOT-LOCAL.jar` - if you package 1.5.0 locally;
2. `BentoBox-1.5.0-SNAPSHOT-b222.jar` - if package is running in Jenkins and **not** from the master branch;
3. `BentoBox-1.5.0.jar` - if package is run in Jenkins and from the master branch;

Be aware that with this change BentoBox output jar will contain capital letters. 