### PR TITLE
Load blueprints with non-lowercase names

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
@@ -135,7 +135,7 @@ public class BlueprintsManager {
      * @param addon the {@link GameModeAddon} to get the blueprint bundles.
      */
     public Map<String, BlueprintBundle> getBlueprintBundles(@NonNull GameModeAddon addon) {
-        return blueprintBundles.getOrDefault(addon, new HashMap<>());
+        return blueprintBundles.getOrDefault(addon, new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
     }
 
     /**
@@ -153,7 +153,7 @@ public class BlueprintsManager {
      * @param addon the {@link GameModeAddon} to load the blueprints of.
      */
     public void loadBlueprintBundles(@NonNull GameModeAddon addon) {
-        blueprintBundles.put(addon, new HashMap<>());
+        blueprintBundles.put(addon, new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
 
         // See if there are any schems that need converting
         new SchemToBlueprint(plugin).convertSchems(addon);


### PR DESCRIPTION
 Restore the possibility to load blueprints with non-lowercase names, see https://github.com/BentoBoxWorld/BentoBox/pull/496