### PR TITLE
Implement Blueprint Bundles GUI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,24 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.1</version>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <show>private</show>
+                    <failOnError>false</failOnError>
+                    <additionalJOption>-Xdoclint:none</additionalJOption>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -275,37 +275,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.1</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <show>private</show>
-                    <failOnError>false</failOnError>
-                    <additionalJOption>-Xdoclint:none</additionalJOption>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCommand.java
@@ -3,11 +3,14 @@ package world.bentobox.bentobox.api.commands.admin.blueprints;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Particle;
+
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.blueprints.BlueprintClipboard;
 import world.bentobox.bentobox.managers.BlueprintsManager;
+import world.bentobox.bentobox.panels.BlueprintManagementPanel;
 
 import java.io.File;
 import java.util.HashMap;
@@ -50,7 +53,7 @@ public class AdminBlueprintCommand extends ConfirmableCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        showHelp(this, user);
+        new BlueprintManagementPanel(getPlugin()).openPanel(user, (GameModeAddon)getAddon());
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/blueprints/Blueprint.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/Blueprint.java
@@ -21,7 +21,7 @@ import world.bentobox.bentobox.blueprints.dataobjects.BlueprintEntity;
  * @author tastybento
  *
  */
-public class Blueprint {
+public class Blueprint implements Comparable<Blueprint> {
 
     /**
      * Unique name for this blueprint. The filename will be this plus the blueprint suffix
@@ -196,6 +196,10 @@ public class Blueprint {
      */
     public void setBedrock(Vector bedrock) {
         this.bedrock = bedrock;
+    }
+    @Override
+    public int compareTo(Blueprint o) {
+        return this.name.compareToIgnoreCase(o.name);
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/blueprints/Blueprint.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/Blueprint.java
@@ -3,6 +3,7 @@
  */
 package world.bentobox.bentobox.blueprints;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -56,8 +57,9 @@ public class Blueprint {
     /**
      * @param name the name to set
      */
-    public void setName(String name) {
+    public Blueprint setName(String name) {
         this.name = name;
+        return this;
     }
     /**
      * @return the displayName
@@ -68,8 +70,9 @@ public class Blueprint {
     /**
      * @param displayName the displayName to set
      */
-    public void setDisplayName(String displayName) {
+    public Blueprint setDisplayName(String displayName) {
         this.displayName = displayName;
+        return this;
     }
     /**
      * @return the icon
@@ -79,9 +82,11 @@ public class Blueprint {
     }
     /**
      * @param icon the icon to set
+     * @return
      */
-    public void setIcon(Material icon) {
+    public Blueprint setIcon(Material icon) {
         this.icon = icon;
+        return this;
     }
     /**
      * @return the description
@@ -92,8 +97,17 @@ public class Blueprint {
     /**
      * @param description the description to set
      */
-    public void setDescription(List<String> description) {
+    public Blueprint setDescription(List<String> description) {
         this.description = description;
+        return this;
+    }
+    /**
+     * @param description the description to set
+     */
+    public Blueprint setDescription(String description) {
+        if (this.description == null) this.description = new ArrayList<>();
+        this.description.add(description);
+        return this;
     }
     /**
      * @return the attached

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionPrompt.java
@@ -1,0 +1,60 @@
+package world.bentobox.bentobox.blueprints.conversation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.Prompt;
+import org.bukkit.conversations.StringPrompt;
+
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
+
+/**
+ * Collects a description
+ * @author tastybento
+ *
+ */
+public class DescriptionPrompt extends StringPrompt {
+
+    private GameModeAddon addon;
+    private BlueprintBundle bb;
+
+    public DescriptionPrompt(GameModeAddon addon, BlueprintBundle bb) {
+        this.addon = addon;
+        this.bb = bb;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public String getPromptText(ConversationContext context) {
+        if (context.getSessionData("description") != null) {
+            StringBuilder sb = new StringBuilder();
+            for (String line : ((List<String>) context.getSessionData("description"))) {
+                sb.append(ChatColor.DARK_PURPLE);
+                sb.append(line);
+                sb.append(System.getProperty("line.separator"));
+            }
+            return sb.toString();
+        }
+        return "Enter a multi line description for " + bb.getDisplayName() + System.getProperty("line.separator")
+        + ChatColor.GOLD + " and 'quit' on a line by itself to finish.";
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Prompt acceptInput(ConversationContext context, String input) {
+        if (input.equals("quit")) {
+            return new DescriptionSuccessPrompt(addon, bb);
+        }
+        List<String> desc = new ArrayList<>();
+        if (context.getSessionData("description") != null) {
+            desc = ((List<String>) context.getSessionData("description"));
+        }
+        desc.add(ChatColor.translateAlternateColorCodes('&', input));
+        context.setSessionData("description", desc);
+        return this;
+    }
+}
+

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionSuccessPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionSuccessPrompt.java
@@ -1,0 +1,52 @@
+package world.bentobox.bentobox.blueprints.conversation;
+
+import java.util.List;
+
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.MessagePrompt;
+import org.bukkit.conversations.Prompt;
+import org.bukkit.entity.Player;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
+import world.bentobox.bentobox.panels.BlueprintManagementPanel;
+
+public class DescriptionSuccessPrompt extends MessagePrompt {
+
+    private GameModeAddon addon;
+    private BlueprintBundle bb;
+
+    /**
+     * @param addon
+     * @param bb
+     */
+    public DescriptionSuccessPrompt(GameModeAddon addon, BlueprintBundle bb) {
+        this.addon = addon;
+        this.bb = bb;
+    }
+
+    @Override
+    public String getPromptText(ConversationContext context) {
+        @SuppressWarnings("unchecked")
+        List<String> description = (List<String>)context.getSessionData("description");
+        if (description != null) {
+            bb.setDescription(description);
+            BentoBox.getInstance().getBlueprintsManager().addBlueprintBundle(addon, bb);
+            BentoBox.getInstance().getBlueprintsManager().saveBlueprintBundle(addon, bb);
+            new BlueprintManagementPanel(BentoBox.getInstance()).openBB(User.getInstance((Player)context.getForWhom()), addon, bb);
+            // Set the name
+            // if successfully
+            return "Success!";
+        } else {
+            return "Cancelling";
+        }
+    }
+
+    @Override
+    protected Prompt getNextPrompt(ConversationContext context) {
+        return Prompt.END_OF_CONVERSATION;
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameConversationPrefix.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameConversationPrefix.java
@@ -1,9 +1,8 @@
 package world.bentobox.bentobox.blueprints.conversation;
 
+import org.bukkit.ChatColor;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.ConversationPrefix;
-
-import net.md_5.bungee.api.ChatColor;
 
 public class NameConversationPrefix implements ConversationPrefix {
 

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameConversationPrefix.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameConversationPrefix.java
@@ -1,0 +1,14 @@
+package world.bentobox.bentobox.blueprints.conversation;
+
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.ConversationPrefix;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class NameConversationPrefix implements ConversationPrefix {
+
+    @Override
+    public String getPrefix(ConversationContext conversationContext) {
+        return ChatColor.GOLD + "> ";
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
@@ -1,0 +1,36 @@
+package world.bentobox.bentobox.blueprints.conversation;
+
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.Prompt;
+import org.bukkit.conversations.StringPrompt;
+
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
+
+public class NamePrompt extends StringPrompt {
+
+    private GameModeAddon addon;
+    private BlueprintBundle bb;
+
+    public NamePrompt(GameModeAddon addon, BlueprintBundle bb) {
+        this.addon = addon;
+        this.bb = bb;
+    }
+
+    @Override
+    public String getPromptText(ConversationContext context) {
+        return "Enter a name, or 'quit' to quit";
+    }
+
+    @Override
+    public Prompt acceptInput(ConversationContext context, String input) {
+        if (input.length() > 32) {
+            context.getForWhom().sendRawMessage("Too long");
+            return this;
+        }
+        context.setSessionData("name", input);
+        return new NameSuccessPrompt(addon, bb);
+    }
+
+}
+

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
@@ -4,6 +4,7 @@ import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.StringPrompt;
 
+import net.md_5.bungee.api.ChatColor;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 
 public class NamePrompt extends StringPrompt {
@@ -21,12 +22,14 @@ public class NamePrompt extends StringPrompt {
 
     @Override
     public Prompt acceptInput(ConversationContext context, String input) {
-        if (input.length() > 32) {
+        // Convert color codes
+        input = ChatColor.translateAlternateColorCodes('&', input);
+        if (ChatColor.stripColor(input).length() > 32) {
             context.getForWhom().sendRawMessage("Too long");
             return this;
         }
         // Make a uniqueid
-        StringBuilder uniqueId = new StringBuilder(input.toLowerCase().replace(" ", "_"));
+        StringBuilder uniqueId = new StringBuilder(ChatColor.stripColor(input).toLowerCase().replace(" ", "_"));
         // Check if this name is unique
         int max = 0;
         while (max++ < 32 && addon.getPlugin().getBlueprintsManager().getBlueprintBundles(addon).containsKey(uniqueId.toString())) {

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
@@ -5,16 +5,13 @@ import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.StringPrompt;
 
 import world.bentobox.bentobox.api.addons.GameModeAddon;
-import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
 
 public class NamePrompt extends StringPrompt {
 
     private GameModeAddon addon;
-    private BlueprintBundle bb;
 
-    public NamePrompt(GameModeAddon addon, BlueprintBundle bb) {
+    public NamePrompt(GameModeAddon addon) {
         this.addon = addon;
-        this.bb = bb;
     }
 
     @Override
@@ -28,8 +25,20 @@ public class NamePrompt extends StringPrompt {
             context.getForWhom().sendRawMessage("Too long");
             return this;
         }
+        // Make a uniqueid
+        StringBuilder uniqueId = new StringBuilder(input.toLowerCase().replace(" ", "_"));
+        // Check if this name is unique
+        int max = 0;
+        while (max++ < 32 && addon.getPlugin().getBlueprintsManager().getBlueprintBundles(addon).containsKey(uniqueId.toString())) {
+            uniqueId.append("x");
+        }
+        if (max == 32) {
+            context.getForWhom().sendRawMessage("Please pick a more unique name");
+            return this;
+        }
+        context.setSessionData("uniqueId", uniqueId.toString());
         context.setSessionData("name", input);
-        return new NameSuccessPrompt(addon, bb);
+        return new NameSuccessPrompt(addon);
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameSuccessPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameSuccessPrompt.java
@@ -1,0 +1,42 @@
+package world.bentobox.bentobox.blueprints.conversation;
+
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.MessagePrompt;
+import org.bukkit.conversations.Prompt;
+import org.bukkit.entity.Player;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
+import world.bentobox.bentobox.panels.BlueprintManagementPanel;
+
+public class NameSuccessPrompt extends MessagePrompt {
+
+    private GameModeAddon addon;
+    private BlueprintBundle bb;
+
+    public NameSuccessPrompt(GameModeAddon addon, BlueprintBundle bb) {
+        this.addon = addon;
+        this.bb = bb;
+    }
+
+    @Override
+    public String getPromptText(ConversationContext context) {
+        String name = (String) context.getSessionData("name");
+        bb.setDisplayName(name);
+        BentoBox.getInstance().getBlueprintsManager().addBlueprintBundle(addon, bb);
+        BentoBox.getInstance().getBlueprintsManager().saveBlueprintBundle(addon, bb);
+        new BlueprintManagementPanel(BentoBox.getInstance()).openPanel(User.getInstance((Player)context.getForWhom()), addon);
+        // Set the name
+        // if successfully
+        return "Success!";
+        // Else return failure
+    }
+
+    @Override
+    protected Prompt getNextPrompt(ConversationContext context) {
+        return Prompt.END_OF_CONVERSATION;
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameSuccessPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameSuccessPrompt.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.blueprints.conversation;
 
+import org.bukkit.Material;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.MessagePrompt;
 import org.bukkit.conversations.Prompt;
@@ -14,16 +15,18 @@ import world.bentobox.bentobox.panels.BlueprintManagementPanel;
 public class NameSuccessPrompt extends MessagePrompt {
 
     private GameModeAddon addon;
-    private BlueprintBundle bb;
 
-    public NameSuccessPrompt(GameModeAddon addon, BlueprintBundle bb) {
+    public NameSuccessPrompt(GameModeAddon addon) {
         this.addon = addon;
-        this.bb = bb;
     }
 
     @Override
     public String getPromptText(ConversationContext context) {
         String name = (String) context.getSessionData("name");
+        String uniqueId = (String) context.getSessionData("uniqueId");
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setIcon(Material.RED_WOOL);
+        bb.setUniqueId(uniqueId);
         bb.setDisplayName(name);
         BentoBox.getInstance().getBlueprintsManager().addBlueprintBundle(addon, bb);
         BentoBox.getInstance().getBlueprintsManager().saveBlueprintBundle(addon, bb);

--- a/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintBundle.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintBundle.java
@@ -126,6 +126,14 @@ public class BlueprintBundle implements DataObject {
     }
 
     /**
+     * Removes a blueprint from this environment slot
+     * @param env - the world environment
+     */
+    public void clearBlueprint(World.Environment env) {
+        this.blueprints.remove(env);
+    }
+
+    /**
      * Get the blueprint for the environment type
      * @param env - {@link World#Environment} type
      * @return Blueprint or null if one does not exist

--- a/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
@@ -6,6 +6,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -226,6 +227,7 @@ public class BlueprintsManager {
                 plugin.logStacktrace(e);
             }
         }
+        plugin.logDebug("There are bp " + blueprints.get(addon).size());
     }
 
     /**
@@ -288,6 +290,15 @@ public class BlueprintsManager {
     }
 
     /**
+     * Get blueprints for this game mode
+     * @param addon - game mdoe addon
+     * @return Map of name and blueprint or empty map
+     */
+    public Map<String, Blueprint> getBlueprints(GameModeAddon addon) {
+        return blueprints.getOrDefault(addon, new HashMap<>());
+    }
+
+    /**
      * Paste the islands to world
      * @param addon - GameModeAddon
      * @param island - island
@@ -316,8 +327,18 @@ public class BlueprintsManager {
             return false;
         }
         Blueprint bp = blueprints.get(addon).get(bb.getBlueprint(World.Environment.NORMAL));
+        if (bp == null) {
+            // Oops, no overworld
+            bp = blueprints.get(addon).get("island");
+            plugin.logError("Blueprint bundle has no normal world blueprint, using default");
+            if (bp == null) {
+                plugin.logError("NO DEFAULT BLUEPRINT FOUND! Make sure 'island.blu' exists!");
+            }
+        }
         // Paste overworld
-        new BlueprintPaster(plugin, bp, addon.getOverWorld(), island, task);
+        if (bp != null) {
+            new BlueprintPaster(plugin, bp, addon.getOverWorld(), island, task);
+        }
         // Make nether island
         if (bb.getBlueprint(World.Environment.NETHER) != null
                 && addon.getWorldSettings().isNetherGenerate()
@@ -381,6 +402,24 @@ public class BlueprintsManager {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Removes a blueprint bundle
+     * @param addon - Game Mode Addon
+     * @param bb - Blueprint Bundle to delete
+     */
+    public void deleteBlueprintBundle(@NonNull GameModeAddon addon, BlueprintBundle bb) {
+        if (blueprintBundles.containsKey(addon)) {
+            blueprintBundles.get(addon).keySet().removeIf(k -> k.equals(bb.getUniqueId()));
+        }
+        File bpf = getBlueprintsFolder(addon);
+        File fileName = new File(bpf, bb.getUniqueId() + BLUEPRINT_BUNDLE_SUFFIX);
+        try {
+            Files.deleteIfExists(fileName.toPath());
+        } catch (IOException e) {
+            plugin.logError("Could not delete Blueprint Bundle " + e.getLocalizedMessage());
+        }
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
@@ -227,7 +227,6 @@ public class BlueprintsManager {
                 plugin.logStacktrace(e);
             }
         }
-        plugin.logDebug("There are bp " + blueprints.get(addon).size());
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/panels/BlueprintManagementPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/BlueprintManagementPanel.java
@@ -1,27 +1,226 @@
 package world.bentobox.bentobox.panels;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.conversations.Conversable;
+import org.bukkit.conversations.ConversationFactory;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.inventory.ClickType;
 import org.eclipse.jdt.annotation.NonNull;
+
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.panels.Panel;
+import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.blueprints.Blueprint;
+import world.bentobox.bentobox.blueprints.conversation.NameConversationPrefix;
+import world.bentobox.bentobox.blueprints.conversation.NamePrompt;
+import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
 
 /**
- * @author tastybento, Poslovitch
+ * @author tastybento
  * @since 1.5.0
  */
 public class BlueprintManagementPanel {
 
-    private static final String LOCALE_REF = "blueprint-management";
+    private static final String INFO = "Click on blueprint then click here";
+    private BentoBox plugin;
+    private final Blueprint overWorld = new Blueprint().setIcon(Material.GREEN_STAINED_GLASS_PANE).setName("Overworld").setDescription(INFO);
+    private final Blueprint netherWorld = new Blueprint().setIcon(Material.RED_STAINED_GLASS_PANE).setName("Nether").setDescription(INFO);
+    private final Blueprint endWorld = new Blueprint().setIcon(Material.YELLOW_STAINED_GLASS_PANE).setName("The End").setDescription(INFO);
+    private Entry<Integer, Blueprint> selected;
+    private Map<Integer, Blueprint> blueprints = new HashMap<>();
 
-    private BlueprintManagementPanel() {}
-
-    public static void openPanel(@NonNull User user, @NonNull GameModeAddon addon) {
-        PanelBuilder builder = new PanelBuilder()
-                .name(user.getTranslation(LOCALE_REF + "title"))
-                .size(54);
-
-
-
-        builder.build().open(user);
+    public BlueprintManagementPanel(BentoBox plugin) {
+        this.plugin = plugin;
     }
+
+    private PanelItem trashIcon = new PanelItemBuilder()
+            .name("Trash")
+            .description("Click to delete")
+            .icon(Material.TNT)
+            .clickHandler(this::trashBundle)
+            .build();
+
+    public void openPanel(@NonNull User user, @NonNull GameModeAddon addon) {
+        // Show panel of blueprint bundles
+        // Clicking on a bundle opens up the bundle edit panel
+
+        // Create the panel
+        PanelBuilder pb = new PanelBuilder().name("Blueprint Manager").user(user).size(45);
+        // Get the bundles
+        plugin.getBlueprintsManager().getBlueprintBundles(addon).values().stream().limit(36)
+        .forEach(bb -> pb.item(new PanelItemBuilder()
+                .name(bb.getDisplayName())
+                .description("Click to edit")
+                .icon(bb.getIcon())
+                .clickHandler((panel, u, clickType, slot) -> {
+                    u.closeInventory();
+                    openBB(u, addon, bb);
+                    return true;
+                })
+                .build()));
+
+        // Panel has New Blueprint Bundle button - clicking in creates a new bundle
+        pb.item(36, getNewBundle(user, addon));
+        // Panel has a Trash icon. If a bundle is dragged to the trash icon then it is discarded
+        pb.item(44, trashIcon);
+        pb.build();
+    }
+
+    private void openBB(User user, @NonNull GameModeAddon addon, BlueprintBundle bb) {
+        int index = 18;
+        for (Blueprint bp : plugin.getBlueprintsManager().getBlueprints().getOrDefault(addon, new HashMap<>()).values()) {
+            blueprints.put(index++, bp);
+        }
+        // Create the panel
+        PanelBuilder pb = new PanelBuilder().name(bb.getDisplayName()).user(user).size(45);
+        // Display bundle icon
+        pb.item(0, new PanelItemBuilder()
+                .name("Click to edit description")
+                .description(bb.getDescription())
+                .icon(bb.getIcon())
+                .clickHandler((panel, u, clickType, slot) -> {
+                    // Description conversation
+                    return true;
+                })
+                .build());
+
+        pb.item(2, getBlueprintItem(bb, blueprints.getOrDefault(bb.getBlueprint(World.Environment.NORMAL), overWorld)));
+        pb.item(3, getBlueprintItem(bb, blueprints.getOrDefault(bb.getBlueprint(World.Environment.NETHER), netherWorld)));
+        pb.item(4, getBlueprintItem(bb, blueprints.getOrDefault(bb.getBlueprint(World.Environment.THE_END), endWorld)));
+        for (int i = 9; i < 18; i++) {
+            pb.item(i, new PanelItemBuilder().icon(Material.BLACK_STAINED_GLASS_PANE).name("-").build());
+        }
+        blueprints.values().stream().sorted().limit(18).forEach(b -> pb.item(getBlueprintItem(bb, b)));
+        // Panel has a Back icon.
+        pb.item(44, new PanelItemBuilder().icon(Material.ARROW).name("Back").build());
+        pb.build();
+
+    }
+
+    private PanelItem getBlueprintItem(BlueprintBundle bb, Blueprint blueprint) {
+
+        return new PanelItemBuilder()
+                .name(blueprint.getDisplayName() == null ? blueprint.getName() : blueprint.getDisplayName())
+                .description(blueprint.getDescription() == null ? new ArrayList<>() : blueprint.getDescription())
+                .icon(blueprint.getIcon() == null ? Material.PAPER : blueprint.getIcon())
+                .clickHandler((panel, u, clickType, slot) -> {
+                    // Handle the world squares
+                    if (slot > 1 && slot < 5) {
+                        if (selected == null) {
+                            u.sendRawMessage("Select Blueprint first");
+                            u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_ANVIL_HIT, 1F, 1F);
+
+                        } else if (clickType.equals(ClickType.RIGHT)) {
+                            u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
+                            // Remove the item and replace with the blank
+                            if (slot == 2) {
+                                // Overworld
+                                bb.clearBlueprint(World.Environment.NORMAL);
+                                panel.getItems().put(2, getBlueprintItem(bb, overWorld));
+                            } else if (slot == 3) {
+                                // Nether
+                                bb.clearBlueprint(World.Environment.NETHER);
+                                panel.getItems().put(3, getBlueprintItem(bb, netherWorld));
+                            } else if (slot == 4) {
+                                // Overworld
+                                bb.clearBlueprint(World.Environment.THE_END);
+                                panel.getItems().put(4, getBlueprintItem(bb, endWorld));
+                            }
+                        } else {
+                            // Add
+                            u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
+                            // make slot the chosen one
+                            if (slot == 2) {
+                                // Overworld
+                                bb.setBlueprint(World.Environment.NORMAL, selected.getValue());
+                                panel.getItems().put(2, getBlueprintItem(bb, blueprint));
+                                panel.getInventory().setItem(2, getBlueprintItem(bb, blueprint).getItem());
+                            } else if (slot == 3) {
+                                // Nether
+                                bb.setBlueprint(World.Environment.NETHER, selected.getValue());
+                                panel.getItems().put(3, getBlueprintItem(bb, blueprint));
+                                panel.getInventory().setItem(3, getBlueprintItem(bb, blueprint).getItem());
+                            } else if (slot == 4) {
+                                // Overworld
+                                bb.setBlueprint(World.Environment.THE_END, selected.getValue());
+                                panel.getItems().put(4, getBlueprintItem(bb, blueprint));
+                                panel.getInventory().setItem(4, getBlueprintItem(bb, blueprint).getItem());
+                            }
+                        }
+                    } else {
+                        // Select blueprint
+                        if (blueprints.containsKey(slot)) {
+                            if (selected == null) {
+                                // Nothing selected
+                                u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 2F);
+                                selected = new AbstractMap.SimpleEntry<>(slot, blueprints.get(slot));
+                                panel.getInventory().getItem(slot).addUnsafeEnchantment(Enchantment.ARROW_DAMAGE, 1);
+                            } else if (slot == selected.getKey()){
+                                // Clicked on same item
+                                u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
+                                selected = null;
+                                panel.getInventory().getItem(slot).removeEnchantment(Enchantment.ARROW_DAMAGE);
+                            } else {
+                                // Another item already selected
+                                panel.getInventory().getItem(selected.getKey()).removeEnchantment(Enchantment.ARROW_DAMAGE);
+                                u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 2F);
+                                selected = new AbstractMap.SimpleEntry<>(slot, blueprints.get(slot));
+                                panel.getInventory().getItem(slot).addUnsafeEnchantment(Enchantment.ARROW_DAMAGE, 1);
+                            }
+                        }
+
+                    }
+
+                    return true;
+                })
+                .build();
+    }
+
+    private PanelItem getNewBundle(@NonNull User user, @NonNull GameModeAddon addon) {
+        return new PanelItemBuilder()
+                .name("New Bundle")
+                .description("Click to make a new bundle")
+                .icon(Material.GREEN_BANNER)
+                .clickHandler((panel, u, clickType, slot) -> {
+                    u.closeInventory();
+                    BlueprintBundle bb = new BlueprintBundle();
+                    bb.setIcon(Material.SNOW_BLOCK);
+                    bb.setUniqueId(UUID.randomUUID().toString());
+                    bb.setDisplayName("New Bundle");
+                    askForName(u.getPlayer(), addon, bb);
+                    return true;
+                })
+                .build();
+    }
+
+    public boolean trashBundle(Panel panel, User user, ClickType clickType, int slot ) {
+        return true;
+    }
+
+    public void askForName(Conversable whom, GameModeAddon addon, BlueprintBundle bb) {
+        new ConversationFactory(BentoBox.getInstance())
+        .withModality(true)
+        .withLocalEcho(false)
+        .withPrefix(new NameConversationPrefix())
+        .withTimeout(90)
+        .withFirstPrompt(new NamePrompt(addon, bb))
+        .withEscapeSequence("exit")
+        .withEscapeSequence("quit")
+        .buildConversation(whom).begin();
+    }
+
+
 }

--- a/src/main/java/world/bentobox/bentobox/panels/BlueprintManagementPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/BlueprintManagementPanel.java
@@ -28,6 +28,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.blueprints.Blueprint;
+import world.bentobox.bentobox.blueprints.conversation.DescriptionPrompt;
 import world.bentobox.bentobox.blueprints.conversation.NameConversationPrefix;
 import world.bentobox.bentobox.blueprints.conversation.NamePrompt;
 import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
@@ -80,7 +81,7 @@ public class BlueprintManagementPanel {
         pb.build();
     }
 
-    private void openBB(User user, @NonNull GameModeAddon addon, BlueprintBundle bb) {
+    public void openBB(User user, @NonNull GameModeAddon addon, BlueprintBundle bb) {
         int index = 18;
         for (Blueprint bp : plugin.getBlueprintsManager().getBlueprints(addon).values()) {
             blueprints.put(index++, bp);
@@ -93,7 +94,9 @@ public class BlueprintManagementPanel {
                 .description(bb.getDescription())
                 .icon(bb.getIcon())
                 .clickHandler((panel, u, clickType, slot) -> {
+                    u.closeInventory();
                     // Description conversation
+                    askForDescription(u.getPlayer(), addon, bb);
                     return true;
                 })
                 .build());
@@ -106,7 +109,6 @@ public class BlueprintManagementPanel {
         for (int i = 9; i < 18; i++) {
             pb.item(i, new PanelItemBuilder().icon(Material.BLACK_STAINED_GLASS_PANE).name("-").build());
         }
-        plugin.logDebug("There are " + blueprints.size() + " blueprints");
         blueprints.entrySet().stream().limit(18).forEach(b -> pb.item(getBlueprintItem(addon, b.getKey(), bb, b.getValue())));
         // Buttons for non-default bundle
         if (!bb.getUniqueId().equals("default")) {
@@ -257,6 +259,16 @@ public class BlueprintManagementPanel {
         .withFirstPrompt(new NamePrompt(addon))
         .withEscapeSequence("exit")
         .withEscapeSequence("quit")
+        .buildConversation(whom).begin();
+    }
+
+    public void askForDescription(Conversable whom, GameModeAddon addon, BlueprintBundle bb) {
+        new ConversationFactory(BentoBox.getInstance())
+        .withModality(true)
+        .withLocalEcho(false)
+        .withPrefix(new NameConversationPrefix())
+        .withTimeout(90)
+        .withFirstPrompt(new DescriptionPrompt(addon, bb))
         .buildConversation(whom).begin();
     }
 

--- a/src/main/java/world/bentobox/bentobox/panels/BlueprintManagementPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/BlueprintManagementPanel.java
@@ -3,19 +3,23 @@ package world.bentobox.bentobox.panels;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.UUID;
 
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.World;
+import org.bukkit.World.Environment;
 import org.bukkit.conversations.Conversable;
 import org.bukkit.conversations.ConversationFactory;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.inventory.ClickType;
 import org.eclipse.jdt.annotation.NonNull;
 
+import com.google.common.collect.ImmutableMap;
+
+import net.md_5.bungee.api.ChatColor;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.panels.Panel;
@@ -27,6 +31,7 @@ import world.bentobox.bentobox.blueprints.Blueprint;
 import world.bentobox.bentobox.blueprints.conversation.NameConversationPrefix;
 import world.bentobox.bentobox.blueprints.conversation.NamePrompt;
 import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -36,9 +41,13 @@ public class BlueprintManagementPanel {
 
     private static final String INFO = "Click on blueprint then click here";
     private BentoBox plugin;
-    private final Blueprint overWorld = new Blueprint().setIcon(Material.GREEN_STAINED_GLASS_PANE).setName("Overworld").setDescription(INFO);
-    private final Blueprint netherWorld = new Blueprint().setIcon(Material.RED_STAINED_GLASS_PANE).setName("Nether").setDescription(INFO);
-    private final Blueprint endWorld = new Blueprint().setIcon(Material.YELLOW_STAINED_GLASS_PANE).setName("The End").setDescription(INFO);
+    private final static Blueprint NORMAL_BP = new Blueprint().setIcon(Material.GREEN_STAINED_GLASS_PANE).setName("Normal").setDescription(INFO);
+    private final static Blueprint NETHER_BP = new Blueprint().setIcon(Material.RED_STAINED_GLASS_PANE).setName("Nether").setDescription(INFO);
+    private final static Blueprint END_BP = new Blueprint().setIcon(Material.YELLOW_STAINED_GLASS_PANE).setName("The End").setDescription(INFO);
+    private final static Map<Integer, World.Environment> SLOT_TO_ENV = ImmutableMap.of(3, World.Environment.NORMAL, 5, World.Environment.NETHER, 7, World.Environment.THE_END);
+    private final static Map<World.Environment, Blueprint> ENV_TO_BP = ImmutableMap.of(World.Environment.NORMAL, NORMAL_BP, World.Environment.NETHER, NETHER_BP, World.Environment.THE_END, END_BP);
+    private static final int MAX_WORLD_SLOT = 9;
+    private static final int MIN_WORLD_SLOT = 0;
     private Entry<Integer, Blueprint> selected;
     private Map<Integer, Blueprint> blueprints = new HashMap<>();
 
@@ -46,19 +55,12 @@ public class BlueprintManagementPanel {
         this.plugin = plugin;
     }
 
-    private PanelItem trashIcon = new PanelItemBuilder()
-            .name("Trash")
-            .description("Click to delete")
-            .icon(Material.TNT)
-            .clickHandler(this::trashBundle)
-            .build();
-
     public void openPanel(@NonNull User user, @NonNull GameModeAddon addon) {
         // Show panel of blueprint bundles
         // Clicking on a bundle opens up the bundle edit panel
 
         // Create the panel
-        PanelBuilder pb = new PanelBuilder().name("Blueprint Manager").user(user).size(45);
+        PanelBuilder pb = new PanelBuilder().name("Blueprint Bundle Manager").user(user).size(45);
         // Get the bundles
         plugin.getBlueprintsManager().getBlueprintBundles(addon).values().stream().limit(36)
         .forEach(bb -> pb.item(new PanelItemBuilder()
@@ -74,14 +76,13 @@ public class BlueprintManagementPanel {
 
         // Panel has New Blueprint Bundle button - clicking in creates a new bundle
         pb.item(36, getNewBundle(user, addon));
-        // Panel has a Trash icon. If a bundle is dragged to the trash icon then it is discarded
-        pb.item(44, trashIcon);
+
         pb.build();
     }
 
     private void openBB(User user, @NonNull GameModeAddon addon, BlueprintBundle bb) {
         int index = 18;
-        for (Blueprint bp : plugin.getBlueprintsManager().getBlueprints().getOrDefault(addon, new HashMap<>()).values()) {
+        for (Blueprint bp : plugin.getBlueprintsManager().getBlueprints(addon).values()) {
             blueprints.put(index++, bp);
         }
         // Create the panel
@@ -96,69 +97,113 @@ public class BlueprintManagementPanel {
                     return true;
                 })
                 .build());
+        SLOT_TO_ENV.forEach((k,v) -> {
+            String bpName = bb.getBlueprint(v);
+            pb.item(k-1, getWorldInstrTile(v));
+            pb.item(k, getBlueprintItem(addon, k, bb, plugin.getBlueprintsManager().getBlueprints(addon).getOrDefault(bpName, ENV_TO_BP.get(v))));
+        });
 
-        pb.item(2, getBlueprintItem(bb, blueprints.getOrDefault(bb.getBlueprint(World.Environment.NORMAL), overWorld)));
-        pb.item(3, getBlueprintItem(bb, blueprints.getOrDefault(bb.getBlueprint(World.Environment.NETHER), netherWorld)));
-        pb.item(4, getBlueprintItem(bb, blueprints.getOrDefault(bb.getBlueprint(World.Environment.THE_END), endWorld)));
         for (int i = 9; i < 18; i++) {
             pb.item(i, new PanelItemBuilder().icon(Material.BLACK_STAINED_GLASS_PANE).name("-").build());
         }
-        blueprints.values().stream().sorted().limit(18).forEach(b -> pb.item(getBlueprintItem(bb, b)));
+        plugin.logDebug("There are " + blueprints.size() + " blueprints");
+        blueprints.entrySet().stream().limit(18).forEach(b -> pb.item(getBlueprintItem(addon, b.getKey(), bb, b.getValue())));
+        // Buttons for non-default bundle
+        if (!bb.getUniqueId().equals("default")) {
+            // Panel has a Trash icon. If right clicked it is discarded
+            pb.item(36, getTrashIcon(addon, bb));
+            // Toggle permission - default is always allowed
+            pb.item(39, getPermissionIcon(addon, bb));
+        }
         // Panel has a Back icon.
-        pb.item(44, new PanelItemBuilder().icon(Material.ARROW).name("Back").build());
+        pb.item(44, new PanelItemBuilder().icon(Material.ARROW).name("Back").clickHandler((panel, u, clickType, slot) -> {
+            openPanel(u,addon);
+            return true;
+        }).build());
+
         pb.build();
 
     }
 
-    private PanelItem getBlueprintItem(BlueprintBundle bb, Blueprint blueprint) {
+    private PanelItem getWorldInstrTile(Environment env) {
+        return new PanelItemBuilder()
+                .name(Util.prettifyText(env.name()) + " world")
+                .description("Place bluprint", "to right to set")
+                .icon(Material.GRAY_STAINED_GLASS_PANE)
+                .build();
+    }
 
+    private PanelItem getTrashIcon(@NonNull GameModeAddon addon, BlueprintBundle bb) {
+        return new PanelItemBuilder()
+                .name("Trash")
+                .description("Right click here to delete")
+                .icon(Material.TNT)
+                .clickHandler((panel, u, clickType, slot) -> {
+                    if (clickType.equals(ClickType.RIGHT)) {
+                        u.getPlayer().playSound(u.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1F, 1F);
+                        plugin.getBlueprintsManager().deleteBlueprintBundle(addon, bb);
+                        openPanel(u,addon);
+                    }
+                    return true;
+                })
+                .build();
+    }
+
+    private PanelItem getPermissionIcon(@NonNull GameModeAddon addon, BlueprintBundle bb) {
+        return new PanelItemBuilder().icon(Material.PAINTING).name("Permission")
+                .description(bb.isRequirePermission() ? ChatColor.RED + "Required" : ChatColor.GREEN + "Not required")
+                .description(bb.isRequirePermission() ? addon.getPermissionPrefix() + "island.create."  + bb.getUniqueId() : "")
+                .clickHandler((panel, u, clickType, slot) -> {
+                    // Toggle permission
+                    u.getPlayer().playSound(u.getLocation(), Sound.UI_BUTTON_CLICK, 1F, 1F);
+                    bb.setRequirePermission(!bb.isRequirePermission());
+                    // Save
+                    plugin.getBlueprintsManager().saveBlueprintBundle(addon, bb);
+                    panel.getInventory().setItem(39, getPermissionIcon(addon, bb).getItem());
+                    return true;
+                }).build();
+    }
+
+    private PanelItem getBlueprintItem(GameModeAddon addon, int pos, BlueprintBundle bb, Blueprint blueprint) {
+        // Create description
+        List<String> desc = blueprint.getDescription() == null ? new ArrayList<>() : blueprint.getDescription();
+        if ((!blueprint.equals(END_BP) && !blueprint.equals(NORMAL_BP) && !blueprint.equals(NETHER_BP))) {
+            if ((pos > MIN_WORLD_SLOT && pos < MAX_WORLD_SLOT)) {
+                desc.add(ChatColor.RED + "Right click to remove");
+            } else {
+                desc.add(ChatColor.GREEN + "Click to select, then add to bundle");
+            }
+        }
         return new PanelItemBuilder()
                 .name(blueprint.getDisplayName() == null ? blueprint.getName() : blueprint.getDisplayName())
-                .description(blueprint.getDescription() == null ? new ArrayList<>() : blueprint.getDescription())
+                .description(desc)
                 .icon(blueprint.getIcon() == null ? Material.PAPER : blueprint.getIcon())
                 .clickHandler((panel, u, clickType, slot) -> {
                     // Handle the world squares
-                    if (slot > 1 && slot < 5) {
-                        if (selected == null) {
+                    if (slot > MIN_WORLD_SLOT && slot < MAX_WORLD_SLOT) {
+                        if (clickType.equals(ClickType.RIGHT)) {
+                            u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
+                            PanelItem item = getBlueprintItem(addon, slot, bb, ENV_TO_BP.get(SLOT_TO_ENV.get(slot)));
+                            // Remove the item and replace with the blank
+                            bb.clearBlueprint(SLOT_TO_ENV.get(slot));
+                            panel.getItems().put(slot, item);
+                            panel.getInventory().setItem(slot, item.getItem());
+                            // Save
+                            plugin.getBlueprintsManager().saveBlueprintBundle(addon, bb);
+                        } else if (selected == null) {
                             u.sendRawMessage("Select Blueprint first");
                             u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_ANVIL_HIT, 1F, 1F);
-
-                        } else if (clickType.equals(ClickType.RIGHT)) {
-                            u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
-                            // Remove the item and replace with the blank
-                            if (slot == 2) {
-                                // Overworld
-                                bb.clearBlueprint(World.Environment.NORMAL);
-                                panel.getItems().put(2, getBlueprintItem(bb, overWorld));
-                            } else if (slot == 3) {
-                                // Nether
-                                bb.clearBlueprint(World.Environment.NETHER);
-                                panel.getItems().put(3, getBlueprintItem(bb, netherWorld));
-                            } else if (slot == 4) {
-                                // Overworld
-                                bb.clearBlueprint(World.Environment.THE_END);
-                                panel.getItems().put(4, getBlueprintItem(bb, endWorld));
-                            }
                         } else {
                             // Add
                             u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
+                            Blueprint bp = selected.getValue();
+                            PanelItem item = getBlueprintItem(addon, slot, bb, bp);
                             // make slot the chosen one
-                            if (slot == 2) {
-                                // Overworld
-                                bb.setBlueprint(World.Environment.NORMAL, selected.getValue());
-                                panel.getItems().put(2, getBlueprintItem(bb, blueprint));
-                                panel.getInventory().setItem(2, getBlueprintItem(bb, blueprint).getItem());
-                            } else if (slot == 3) {
-                                // Nether
-                                bb.setBlueprint(World.Environment.NETHER, selected.getValue());
-                                panel.getItems().put(3, getBlueprintItem(bb, blueprint));
-                                panel.getInventory().setItem(3, getBlueprintItem(bb, blueprint).getItem());
-                            } else if (slot == 4) {
-                                // Overworld
-                                bb.setBlueprint(World.Environment.THE_END, selected.getValue());
-                                panel.getItems().put(4, getBlueprintItem(bb, blueprint));
-                                panel.getInventory().setItem(4, getBlueprintItem(bb, blueprint).getItem());
-                            }
+                            bb.setBlueprint(SLOT_TO_ENV.get(slot), bp);
+                            panel.getItems().put(slot, item);
+                            panel.getInventory().setItem(slot, item.getItem());
+                            // Save
+                            plugin.getBlueprintsManager().saveBlueprintBundle(addon, bb);
                         }
                     } else {
                         // Select blueprint
@@ -170,9 +215,6 @@ public class BlueprintManagementPanel {
                                 panel.getInventory().getItem(slot).addUnsafeEnchantment(Enchantment.ARROW_DAMAGE, 1);
                             } else if (slot == selected.getKey()){
                                 // Clicked on same item
-                                u.getPlayer().playSound(u.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
-                                selected = null;
-                                panel.getInventory().getItem(slot).removeEnchantment(Enchantment.ARROW_DAMAGE);
                             } else {
                                 // Another item already selected
                                 panel.getInventory().getItem(selected.getKey()).removeEnchantment(Enchantment.ARROW_DAMAGE);
@@ -196,11 +238,7 @@ public class BlueprintManagementPanel {
                 .icon(Material.GREEN_BANNER)
                 .clickHandler((panel, u, clickType, slot) -> {
                     u.closeInventory();
-                    BlueprintBundle bb = new BlueprintBundle();
-                    bb.setIcon(Material.SNOW_BLOCK);
-                    bb.setUniqueId(UUID.randomUUID().toString());
-                    bb.setDisplayName("New Bundle");
-                    askForName(u.getPlayer(), addon, bb);
+                    askForName(u.getPlayer(), addon);
                     return true;
                 })
                 .build();
@@ -210,13 +248,13 @@ public class BlueprintManagementPanel {
         return true;
     }
 
-    public void askForName(Conversable whom, GameModeAddon addon, BlueprintBundle bb) {
+    public void askForName(Conversable whom, GameModeAddon addon) {
         new ConversationFactory(BentoBox.getInstance())
         .withModality(true)
         .withLocalEcho(false)
         .withPrefix(new NameConversationPrefix())
         .withTimeout(90)
-        .withFirstPrompt(new NamePrompt(addon, bb))
+        .withFirstPrompt(new NamePrompt(addon))
         .withEscapeSequence("exit")
         .withEscapeSequence("quit")
         .buildConversation(whom).begin();

--- a/src/main/java/world/bentobox/bentobox/panels/BundleManagementPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/BundleManagementPanel.java
@@ -1,0 +1,14 @@
+package world.bentobox.bentobox.panels;
+
+import org.bukkit.event.inventory.ClickType;
+
+import world.bentobox.bentobox.api.panels.Panel;
+import world.bentobox.bentobox.api.user.User;
+
+public class BundleManagementPanel {
+    private BundleManagementPanel() {}
+
+    public static boolean openPanel(Panel panel, User user, ClickType clickType, int slot ) {
+        return true;
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/panels/IslandCreationPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/IslandCreationPanel.java
@@ -43,7 +43,7 @@ public class IslandCreationPanel {
                     || user.hasPermission(perm)) {
                 // Add an item
                 pb.item(new PanelItemBuilder().name(bb.getDisplayName()).description(bb.getDescription())
-                        .icon(bb.getIcon()).name(bb.getUniqueId()).clickHandler((panel, user1, clickType, slot1) -> {
+                        .icon(bb.getIcon()).clickHandler((panel, user1, clickType, slot1) -> {
                             user1.closeInventory();
                             command.execute(user1, label, Collections.singletonList(bb.getUniqueId()));
                             return true;

--- a/src/main/java/world/bentobox/bentobox/panels/ManagementPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/ManagementPanel.java
@@ -72,7 +72,7 @@ public class ManagementPanel {
                         .name(user.getTranslation(LOCALE_REF + "views.gamemodes.blueprints.name"))
                         .description(user.getTranslation(LOCALE_REF + "views.gamemodes.blueprints.description"))
                         .clickHandler((panel, user1, clickType, slot) -> {
-                            BlueprintManagementPanel.openPanel(user, gameModeAddon);
+                            new BlueprintManagementPanel(plugin).openPanel(user, gameModeAddon);
                             return true;
                         })
                         .build();


### PR DESCRIPTION
This PR gives admins a simple management console for Blueprint Bundles. 

Admin command is: **blueprint** or **bp**, e.g. **/bsb bp**

### Features
- Create a new blueprint bundle
- Delete a blueprint bundle
- Assign, overwrite and remove blueprints to the Normal, Nether and End world blueprint slots
- Require players to have the permission to see/use bundle (not applicable to default bundle)
- Create/change bundle description

### To do
- Rename bundle
- Localization
- Set/change icon of blueprint

### Not supported in this version
- Blueprint meta data editing/changing

### How to use

Open up the GUI:
<img width="356" alt="Screen Shot 2019-05-19 at 7 24 23 PM" src="https://user-images.githubusercontent.com/4407265/57992980-c82d1d80-7a6b-11e9-8dc8-a39253523a2b.png">
Select a bundle to edit it (The default one should always be visible) or click the green banner to make a new bundle.

If you create a new bundle, the GUI will close and you should type in the name of the bundle. Color codes using & are translated. The maximum length is 32 characters.

### The Bundle Edit GUI
You can edit bundles in this screen:
<img width="358" alt="Screen Shot 2019-05-19 at 7 28 25 PM" src="https://user-images.githubusercontent.com/4407265/57993076-4db0cd80-7a6c-11e9-95eb-dceda03c4e4f.png">
Click on the icon in the top left to change the description.
To add a blueprint to the bundle, click on a blueprint (the pieces of paper) to highlight it and then click in the Green (Normal world), Red (Nether) or Yellow (End) slots to place it. You can mix and match how you like.
To remove a blueprint from the bundle, place another one on top of it, or right click on it.

If this is not the default bundle, you can deleted it (Right click on the TNT), or require players to have the permission (click on the picture).
To exit click on the arrow.

