### PR TITLE
Remove unnecessary checks in IslandsManager and IslandWorldManager.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -91,9 +91,8 @@ public class IslandWorldManager {
      * @return true if in a world or false if not
      */
     public boolean inWorld(@Nullable World world) {
-        return world != null && ((world.getEnvironment().equals(Environment.NETHER) && isIslandNether(world))
-                || (world.getEnvironment().equals(Environment.THE_END) && isIslandEnd(world))
-                || (world.getEnvironment().equals(Environment.NORMAL)) && gameModes.containsKey(world));
+        return world != null && gameModes.containsKey(world) &&
+            (world.getEnvironment().equals(Environment.NORMAL) || isIslandNether(world) || isIslandEnd(world));
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -342,19 +342,11 @@ public class IslandsManager {
      */
     public Optional<Island> getIslandAt(Location location) {
         // If this is not an Island World or a standard Nether or End, skip
-        if (!plugin.getIWM().inWorld(location)
-                || (plugin.getIWM().isNether(location.getWorld()) && !plugin.getIWM().isNetherIslands(location.getWorld()))
-                || (plugin.getIWM().isEnd(location.getWorld()) && !plugin.getIWM().isEndIslands(location.getWorld()))
-                ) {
+        if (!plugin.getIWM().inWorld(location))
+        {
             return Optional.empty();
         }
-        // Do not return an island if there is no nether or end or islands in them
-        if ((location.getWorld().getEnvironment().equals(World.Environment.NETHER) &&
-                (!plugin.getIWM().isNetherGenerate(location.getWorld()) || !plugin.getIWM().isNetherIslands(location.getWorld())))
-                || (location.getWorld().getEnvironment().equals(World.Environment.THE_END) &&
-                        (!plugin.getIWM().isEndGenerate(location.getWorld()) || !plugin.getIWM().isEndIslands(location.getWorld())))) {
-            return Optional.empty();
-        }
+
         return Optional.ofNullable(islandCache.getIslandAt(location));
     }
 


### PR DESCRIPTION
Removed checks overlaps a lot. It is not necessary to check multiple time if island is nether and end island, as they will not change their status in runtime.

THIS WILL BREAK SOME TESTS.
But not because changes are not correct, but because tests are incorrect. They set #inWorld(World) to always return true.

Found this by investigating #676.

getIslandAt(Location) optimization is correct, as inWorld(World) already checked all these options that is required for world to be an Island World.

inWorld(World) can be optimized even more, by creating local object that contains worldSettings, to avoid getting element from map in isIslandNether(World) and isIslandEnd(World).
