### PR TITLE
Fixed protection range never going down

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -153,7 +153,7 @@ public class JoinLeaveListener implements Listener {
             Island island = plugin.getIslands().getIsland(world, user);
             if (island != null) {
                 // Check if new owner has a different range permission than the island size
-                int range = user.getPermissionValue(plugin.getIWM().getAddon(island.getWorld()).get().getPermissionPrefix() + "island.range", island.getProtectionRange());
+                int range = user.getPermissionValue(plugin.getIWM().getAddon(island.getWorld()).get().getPermissionPrefix() + "island.range", plugin.getIWM().getIslandProtectionRange(world));
 
                 // Range can go up or down
                 if (range != island.getProtectionRange()) {


### PR DESCRIPTION
From months ago I realised that users that had bskyblock.island.range.55, and then had their permission removed, their island protection ranged didn't go down to default (50). In addition some strange things used to happen.
Today I've discovered this typo.