### PR TITLE
Secured the handling of InventoryClickEvent for panels

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
@@ -12,6 +12,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.inventory.InventoryView;
@@ -31,7 +32,8 @@ public class PanelListenerManager implements Listener {
         InventoryView view = event.getView();
 
         // Open the inventory panel that this player has open (they can only ever have one)
-        if (openPanels.containsKey(user.getUniqueId())) {
+        if (openPanels.containsKey(user.getUniqueId()) &&
+            openPanels.get(user.getUniqueId()).getInventory().equals(event.getClickedInventory())) {
             // Cancel the event. If they don't want it to be cancelled then the click handler(s) should
             // uncancel it. If gui was from our environment, then cancel event anyway.
             event.setCancelled(true);
@@ -76,6 +78,13 @@ public class PanelListenerManager implements Listener {
     public void onLogOut(PlayerQuitEvent event) {
         openPanels.remove(event.getPlayer().getUniqueId());
     }
+
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onKick(PlayerKickEvent event) {
+        openPanels.remove(event.getPlayer().getUniqueId());
+    }
+
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPluginDisable(PluginDisableEvent event) {

--- a/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
@@ -79,13 +79,6 @@ public class PanelListenerManager implements Listener {
         openPanels.remove(event.getPlayer().getUniqueId());
     }
 
-
-    @EventHandler(priority = EventPriority.NORMAL)
-    public void onKick(PlayerKickEvent event) {
-        openPanels.remove(event.getPlayer().getUniqueId());
-    }
-
-
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPluginDisable(PluginDisableEvent event) {
         if (event.getPlugin().getName().equals("BentoBox")) {


### PR DESCRIPTION
https://github.com/BentoBoxWorld/Challenges/issues/132
This issue happens because AnvilGUIClick event was processed after BentoBox registers new Panel. 
I add extra check in InventoryClickEvent that not only checks if user has opened panel, but also compares if event and panel has the same inventory, before processing it as BentoBox Panel.

Add extra onKickEvent... do not know why.