### PR TITLE
Added ability to explicitly define asynchronous PremadeEvent

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
@@ -16,7 +16,6 @@ public abstract class PremadeEvent extends Event {
         this(false);
     }
 
-
     /**
      * This constructor is used to explicitly declare an PremadeEvent as synchronous or asynchronous.
      * @param async - true indicates the event will fire asynchronously, false

--- a/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
@@ -8,6 +8,28 @@ import org.bukkit.event.HandlerList;
  */
 public abstract class PremadeEvent extends Event {
 
+    /**
+     * The default constructor is defined for cleaner code. This constructor
+     * assumes the PremadeEvent is synchronous.
+     */
+    public PremadeEvent()
+    {
+        this(false);
+    }
+
+
+    /**
+     * This constructor is used to explicitly declare an PremadeEvent as synchronous
+     * or asynchronous.
+     * @param async - true indicates the event will fire asynchronously, false
+     *    by default from default constructor
+     */
+    public PremadeEvent(boolean async)
+    {
+        super(async);
+    }
+
+
     private static final HandlerList handlers = new HandlerList();
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
@@ -9,26 +9,23 @@ import org.bukkit.event.HandlerList;
 public abstract class PremadeEvent extends Event {
 
     /**
-     * The default constructor is defined for cleaner code. This constructor
-     * assumes the PremadeEvent is synchronous.
+     * The default constructor is defined for cleaner code.
+     * This constructor assumes the PremadeEvent is synchronous.
      */
-    public PremadeEvent()
-    {
+    public PremadeEvent() {
         this(false);
     }
 
 
     /**
-     * This constructor is used to explicitly declare an PremadeEvent as synchronous
-     * or asynchronous.
+     * This constructor is used to explicitly declare an PremadeEvent as synchronous or asynchronous.
      * @param async - true indicates the event will fire asynchronously, false
      *    by default from default constructor
+     * @since 1.5.2
      */
-    public PremadeEvent(boolean async)
-    {
+    public PremadeEvent(boolean async) {
         super(async);
     }
-
 
     private static final HandlerList handlers = new HandlerList();
 


### PR DESCRIPTION
BentoBox PreMade event does not allow to define async events.
This will allow to define them.