### PR TITLE
Fixed ender dragon issue in 1.14+

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/BlockEndDragon.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/BlockEndDragon.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.listeners;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World.Environment;
 import org.bukkit.event.EventHandler;
@@ -7,7 +8,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.world.ChunkLoadEvent;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.BentoBox;
@@ -21,28 +23,50 @@ public class BlockEndDragon implements Listener {
         this.plugin = plugin;
     }
 
+
     /**
-     * This listener moves the end exit island high up in the sky
-     * @param e - event
+     * This listener add portal frame at the top of the world, when player joins certain world. This will
+     * prevent ender dragon to spawn, as if any portal frame exists, the it is considered that dragon is
+     * killed.
+     * @param event - event
      */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEnd(ChunkLoadEvent e) {
-        if (!e.getWorld().getEnvironment().equals(Environment.THE_END)
-                || e.getChunk().getX() != 0
-				|| e.getChunk().getZ() != 0
-				|| !Flags.REMOVE_END_EXIT_ISLAND.isSetForWorld(e.getWorld())
-				|| !plugin.getIWM().inWorld(e.getWorld())
-                || !plugin.getIWM().isEndGenerate(e.getWorld())
-                || !plugin.getIWM().isEndIslands(e.getWorld())
-                || e.getChunk().getBlock(0, 255, 0).getType().equals(Material.END_PORTAL))
+    public void onPlayerChangeWorld(PlayerChangedWorldEvent event) {
+        Location location = event.getPlayer().getLocation();
+
+        if (!plugin.getIWM().isIslandEnd(location.getWorld())
+            || !Flags.REMOVE_END_EXIT_ISLAND.isSetForWorld(location.getWorld())
+            || location.getWorld().getBlockAt(0, 255, 0).getType().equals(Material.END_PORTAL))
         {
-            // No need to process.
             return;
         }
 
         // Setting a End Portal at the top will trick dragon legacy check.
-        e.getChunk().getBlock(0, 255, 0).setType(Material.END_PORTAL, false);
+        location.getWorld().getBlockAt(0, 255, 0).setType(Material.END_PORTAL, false);
     }
+
+
+    /**
+     * This listener add portal frame at the top of the world, when player joins certain world. This will
+     * prevent ender dragon to spawn, as if any portal frame exists, the it is considered that dragon is
+     * killed.
+     * @param event - event
+     */
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onPlayerJoinWorld(PlayerJoinEvent event) {
+        Location location = event.getPlayer().getLocation();
+
+        if (!plugin.getIWM().isIslandEnd(location.getWorld())
+            || !Flags.REMOVE_END_EXIT_ISLAND.isSetForWorld(location.getWorld())
+            || location.getWorld().getBlockAt(0, 255, 0).getType().equals(Material.END_PORTAL))
+        {
+            return;
+        }
+
+        // Setting a End Portal at the top will trick dragon legacy check.
+        location.getWorld().getBlockAt(0, 255, 0).setType(Material.END_PORTAL, false);
+    }
+
 
     /**
      * Silently prevents block placing in the dead zone.

--- a/src/main/java/world/bentobox/bentobox/listeners/BlockEndDragon.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/BlockEndDragon.java
@@ -23,12 +23,10 @@ public class BlockEndDragon implements Listener {
         this.plugin = plugin;
     }
 
-
     /**
-     * This listener add portal frame at the top of the world, when player joins certain world. This will
-     * prevent ender dragon to spawn, as if any portal frame exists, the it is considered that dragon is
-     * killed.
-     * @param event - event
+     * Adds a portal frame at the top of the world, when a player joins an island End world.
+     * This prevents the Ender Dragon from spawning: if any portal frame exists, then the dragon is considered killed already.
+     * @param event PlayerChangedWorldEvent
      */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerChangeWorld(PlayerChangedWorldEvent event) {
@@ -36,8 +34,7 @@ public class BlockEndDragon implements Listener {
 
         if (!plugin.getIWM().isIslandEnd(location.getWorld())
             || !Flags.REMOVE_END_EXIT_ISLAND.isSetForWorld(location.getWorld())
-            || location.getWorld().getBlockAt(0, 255, 0).getType().equals(Material.END_PORTAL))
-        {
+            || location.getWorld().getBlockAt(0, 255, 0).getType().equals(Material.END_PORTAL)) {
             return;
         }
 
@@ -45,12 +42,10 @@ public class BlockEndDragon implements Listener {
         location.getWorld().getBlockAt(0, 255, 0).setType(Material.END_PORTAL, false);
     }
 
-
     /**
-     * This listener add portal frame at the top of the world, when player joins certain world. This will
-     * prevent ender dragon to spawn, as if any portal frame exists, the it is considered that dragon is
-     * killed.
-     * @param event - event
+     * Adds a portal frame at the top of the world, when a player joins an island End world.
+     * This prevents the Ender Dragon from spawning: if any portal frame exists, then the dragon is considered killed already.
+     * @param event PlayerJoinEvent
      */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerJoinWorld(PlayerJoinEvent event) {
@@ -58,15 +53,13 @@ public class BlockEndDragon implements Listener {
 
         if (!plugin.getIWM().isIslandEnd(location.getWorld())
             || !Flags.REMOVE_END_EXIT_ISLAND.isSetForWorld(location.getWorld())
-            || location.getWorld().getBlockAt(0, 255, 0).getType().equals(Material.END_PORTAL))
-        {
+            || location.getWorld().getBlockAt(0, 255, 0).getType().equals(Material.END_PORTAL)) {
             return;
         }
 
         // Setting a End Portal at the top will trick dragon legacy check.
         location.getWorld().getBlockAt(0, 255, 0).setType(Material.END_PORTAL, false);
     }
-
 
     /**
      * Silently prevents block placing in the dead zone.


### PR DESCRIPTION
Mojang changed spawn chunk loading again, so they are all time loaded again. That mean, previous hack, that puts a portal on chunk load will not work anymore, as chunks are loaded before the event even is registered.

I fixed it by moving from ChunkLoadEvent to PlayerChangeWorldEvent as it will kick always when player joins the end.