### PR TITLE
Automatically provides key-value pairs for PremadeEvents

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/events/BentoBoxEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/BentoBoxEvent.java
@@ -14,7 +14,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Provides the default methods expected when extending {@link Event}.
  * @author tastybento
- *
+ * @since 1.5.3
  */
 public abstract class BentoBoxEvent extends Event {
 
@@ -67,6 +67,4 @@ public abstract class BentoBoxEvent extends Event {
             return Collections.emptyMap();
         }
     }
-
 }
-

--- a/src/main/java/world/bentobox/bentobox/api/events/BentoBoxEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/BentoBoxEvent.java
@@ -1,0 +1,72 @@
+package world.bentobox.bentobox.api.events;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Provides the default methods expected when extending {@link Event}.
+ * @author tastybento
+ *
+ */
+public abstract class BentoBoxEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    /**
+     * The default constructor is defined for cleaner code.
+     * This constructor assumes the BentoBoxEvent is synchronous.
+     */
+    public BentoBoxEvent() {
+        this(false);
+    }
+
+    public BentoBoxEvent(boolean async) {
+        super(async);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    /**
+     * Get a map of key value pairs derived from the fields of this class by reflection.
+     * @return map
+     * @since 1.5.3
+     */
+    public Map<String, Object> getKeyValues() {
+        try {
+            Map<String, Object> map = new HashMap<>();
+            Arrays.asList(Introspector.getBeanInfo(this.getClass(), PremadeEvent.class).getPropertyDescriptors())
+            .stream()
+            // only get getters
+            .filter(pd -> Objects.nonNull(pd.getReadMethod()))
+            .forEach(pd -> { // invoke method to get value
+                try {
+                    Object value = pd.getReadMethod().invoke(this);
+                    if (value != null) {
+                        map.put(pd.getName(), value);
+                    }
+                } catch (Exception ignore) {}
+            });
+            return map;
+        } catch (IntrospectionException e) {
+            // Oh well, nothing
+            return Collections.emptyMap();
+        }
+    }
+
+}
+

--- a/src/main/java/world/bentobox/bentobox/api/events/BentoBoxEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/BentoBoxEvent.java
@@ -28,6 +28,11 @@ public abstract class BentoBoxEvent extends Event {
         this(false);
     }
 
+    /**
+     * Explicitly declares a BentoBoxEvent as synchronous or asynchronous.
+     * @param async - true indicates the event will fire asynchronously, false
+     *    by default from default constructor
+     */
     public BentoBoxEvent(boolean async) {
         super(async);
     }

--- a/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
@@ -1,20 +1,13 @@
 package world.bentobox.bentobox.api.events;
 
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
 import org.bukkit.event.Event;
-import org.bukkit.event.HandlerList;
 
 /**
  * Provides the default methods expected when extending {@link Event}.
+ * @deprecated Use {@link BentoBoxEvent} instead
  */
-public abstract class PremadeEvent extends Event {
+@Deprecated
+public abstract class PremadeEvent extends BentoBoxEvent {
 
     /**
      * The default constructor is defined for cleaner code.
@@ -32,44 +25,6 @@ public abstract class PremadeEvent extends Event {
      */
     public PremadeEvent(boolean async) {
         super(async);
-    }
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @Override
-    public HandlerList getHandlers() {
-        return getHandlerList();
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
-    /**
-     * Get a map of key value pairs derived from the fields of this class by reflection.
-     * @return map
-     * @since 1.5.3
-     */
-    public Map<String, Object> getKeyValues() {
-        try {
-            Map<String, Object> map = new HashMap<>();
-            Arrays.asList(Introspector.getBeanInfo(this.getClass(), PremadeEvent.class).getPropertyDescriptors())
-            .stream()
-            // only get getters
-            .filter(pd -> Objects.nonNull(pd.getReadMethod()))
-            .forEach(pd -> { // invoke method to get value
-                try {
-                    Object value = pd.getReadMethod().invoke(this);
-                    if (value != null) {
-                        map.put(pd.getName(), value);
-                    }
-                } catch (Exception ignore) {}
-            });
-            return map;
-        } catch (IntrospectionException e) {
-            // Oh well, nothing
-            return Collections.emptyMap();
-        }
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.event.Event;
 
 /**
  * Provides the default methods expected when extending {@link Event}.
- * @deprecated Use {@link BentoBoxEvent} instead
+ * @deprecated As of 1.5.3, for removal. Use {@link BentoBoxEvent} instead.
  */
 @Deprecated
 public abstract class PremadeEvent extends BentoBoxEvent {

--- a/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/PremadeEvent.java
@@ -1,5 +1,13 @@
 package world.bentobox.bentobox.api.events;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -36,4 +44,32 @@ public abstract class PremadeEvent extends Event {
     public static HandlerList getHandlerList() {
         return handlers;
     }
+
+    /**
+     * Get a map of key value pairs derived from the fields of this class by reflection.
+     * @return map
+     * @since 1.5.3
+     */
+    public Map<String, Object> getKeyValues() {
+        try {
+            Map<String, Object> map = new HashMap<>();
+            Arrays.asList(Introspector.getBeanInfo(this.getClass(), PremadeEvent.class).getPropertyDescriptors())
+            .stream()
+            // only get getters
+            .filter(pd -> Objects.nonNull(pd.getReadMethod()))
+            .forEach(pd -> { // invoke method to get value
+                try {
+                    Object value = pd.getReadMethod().invoke(this);
+                    if (value != null) {
+                        map.put(pd.getName(), value);
+                    }
+                } catch (Exception ignore) {}
+            });
+            return map;
+        } catch (IntrospectionException e) {
+            // Oh well, nothing
+            return Collections.emptyMap();
+        }
+    }
+
 }

--- a/src/main/java/world/bentobox/bentobox/api/events/addon/AddonBaseEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/addon/AddonBaseEvent.java
@@ -26,6 +26,7 @@ public class AddonBaseEvent extends PremadeEvent {
     /**
      * @return the keyValues
      */
+    @Override
     public Map<String, Object> getKeyValues() {
         return keyValues;
     }


### PR DESCRIPTION
https://github.com/BentoBoxWorld/Challenges/pull/138

This PR is an approach that avoids addons having to create their own key-value pairs for events so long as they extend PremadeEvent.

Here's a test plugin that "listens" for the ChallengeCompletedEvent:

```
package world.bentobox.test;

import org.bukkit.Bukkit;
import org.bukkit.event.EventHandler;
import org.bukkit.event.Listener;
import org.bukkit.plugin.java.JavaPlugin;

import world.bentobox.bentobox.api.events.PremadeEvent;


public class Test extends JavaPlugin implements Listener {

    @Override
    public void onEnable(){
        Bukkit.getPluginManager().registerEvents(this, this);
    }

    @EventHandler
    public void onSomething(PremadeEvent e) {
        if (!e.getEventName().equals("ChallengeCompletedEvent")) return;
        Bukkit.getLogger().info("Event name = " + e.getEventName());
        e.getKeyValues().forEach((k,v) -> Bukkit.getLogger().info(k + " => " + v));
    }
}
```

Really simple, right?

Note that you have to listen for **PremadeEvent** and not **ChallengeCompletedEvent**. You cannot reference **ChallengeCompletedEvent** anywhere in your code otherwise you'll get NoClassDefFoundError. However, the name of the event is correctly listed as **ChallengeCompletedEvent**.

The output from this plugin would be after completing a few challenges:
```
[22:00:45 INFO]: Event name = ChallengeCompletedEvent
[22:00:45 INFO]: playerUUID => 5988eecd-1dcd-4080-a843-785b62419abb
[22:00:45 INFO]: challengeID => askyblock_treecollector
[22:00:45 INFO]: completionCount => 1
[22:00:45 INFO]: admin => false
[22:02:07 INFO]: Event name = ChallengeCompletedEvent
[22:02:07 INFO]: playerUUID => 5988eecd-1dcd-4080-a843-785b62419abb
[22:02:07 INFO]: challengeID => askyblock_stonesmelter
[22:02:07 INFO]: completionCount => 1
[22:02:07 INFO]: admin => false
[22:02:10 INFO]: Event name = ChallengeCompletedEvent
[22:02:10 INFO]: playerUUID => 5988eecd-1dcd-4080-a843-785b62419abb
[22:02:10 INFO]: challengeID => askyblock_stonesmelter
[22:02:10 INFO]: completionCount => 1
[22:02:10 INFO]: admin => false
```

(By the way @BONNe - I notice the completionCount never increases in the event, even though it increases in the GUI. Bug?)
