### PR TITLE
Added more transition databases

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -40,8 +40,9 @@ public class Settings implements ConfigObject {
     // Database
     @ConfigComment("JSON, MYSQL, MARIADB (10.2.3+), MONGODB, SQLITE and YAML(deprecated).")
     @ConfigComment("Transition database options are:")
-    @ConfigComment("  YAML2JSON, YAML2MARIADB, YAML2MYSQL")
-    @ConfigComment("  JSON2MARIADB, JSON2MYSQL, MYSQL2JSON")
+    @ConfigComment("  YAML2JSON, YAML2MARIADB, YAML2MYSQL, YAML2MONGODB, YAML2SQLITE")
+    @ConfigComment("  JSON2MARIADB, JSON2MYSQL, JSON2MONGODB, JSON2SQLITE")
+    @ConfigComment("  MYSQL2JSON, MARIADB2JSON, MONGODB2JSON, SQLITE2JSON")
     @ConfigComment("If you need others, please make a feature request.")
     @ConfigComment("Transition options enable migration from one database type to another. Use /bbox migrate.")
     @ConfigComment("YAML and JSON are file-based databases.")

--- a/src/main/java/world/bentobox/bentobox/database/DatabaseSetup.java
+++ b/src/main/java/world/bentobox/bentobox/database/DatabaseSetup.java
@@ -6,12 +6,7 @@ import world.bentobox.bentobox.database.mariadb.MariaDBDatabase;
 import world.bentobox.bentobox.database.mongodb.MongoDBDatabase;
 import world.bentobox.bentobox.database.mysql.MySQLDatabase;
 import world.bentobox.bentobox.database.sqlite.SQLiteDatabase;
-import world.bentobox.bentobox.database.transition.Json2MariaDBDatabase;
-import world.bentobox.bentobox.database.transition.Json2MySQLDatabase;
-import world.bentobox.bentobox.database.transition.MySQL2JsonDatabase;
-import world.bentobox.bentobox.database.transition.Yaml2JsonDatabase;
-import world.bentobox.bentobox.database.transition.Yaml2MariaDBDatabase;
-import world.bentobox.bentobox.database.transition.Yaml2MySQLDatabase;
+import world.bentobox.bentobox.database.transition.*;
 import world.bentobox.bentobox.database.yaml.YamlDatabase;
 
 import java.util.Arrays;
@@ -58,6 +53,18 @@ public interface DatabaseSetup {
          */
         YAML2MARIADB(new Yaml2MariaDBDatabase()),
 
+        /**
+         * Transition database, from YAML to MongoDB
+         * @since 1.6.0
+         */
+        YAML2MONGODB(new Yaml2MongoDBDatabase()),
+
+        /**
+         * Transition database, from YAML to SQLite
+         * @since 1.6.0
+         */
+        YAML2SQLITE(new Yaml2SQLiteDatabase()),
+
         JSON(new JSONDatabase()),
         /**
          * Transition database, from JSON to MySQL
@@ -70,7 +77,20 @@ public interface DatabaseSetup {
          */
         JSON2MARIADB(new Json2MariaDBDatabase()),
 
+        /**
+         * Transition database, from JSON to MongoDB
+         * @since 1.6.0
+         */
+        JSON2MONGODB(new Json2MongoDBDatabase()),
+
+        /**
+         * Transition database, from JSON to SQLite
+         * @since 1.6.0
+         */
+        JSON2SQLITE(new Json2SQLiteDatabase()),
+
         MYSQL(new MySQLDatabase()),
+
         /**
          * Transition database, from MySQL to JSON
          * @since 1.5.0
@@ -81,12 +101,30 @@ public interface DatabaseSetup {
          */
         MARIADB(new MariaDBDatabase()),
 
+        /**
+         * Transition database, from MariaDB to JSON
+         * @since 1.6.0
+         */
+        MARIADB2JSON(new MariaDB2JsonDatabase()),
+
         MONGODB(new MongoDBDatabase()),
+
+        /**
+         * Transition database, from MongoDB to JSON
+         * @since 1.6.0
+         */
+        MONGODB2JSON(new MongoDB2JsonDatabase()),
 
         /**
          * @since 1.6.0
          */
-        SQLITE(new SQLiteDatabase());
+        SQLITE(new SQLiteDatabase()),
+
+        /**
+         * Transition database, from SQLite to JSON
+         * @since 1.6.0
+         */
+        SQLITE2JSON(new SQLite2JsonDatabase());
 
         DatabaseSetup database;
 

--- a/src/main/java/world/bentobox/bentobox/database/transition/Json2MongoDBDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/Json2MongoDBDatabase.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.database.transition;
+
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+import world.bentobox.bentobox.database.json.JSONDatabase;
+import world.bentobox.bentobox.database.mongodb.MongoDBDatabase;
+
+
+/**
+ * @author BONNe
+ * @since 1.6.0
+ */
+public class Json2MongoDBDatabase implements DatabaseSetup {
+
+    @Override
+    public <T> AbstractDatabaseHandler<T> getHandler(Class<T> type) {
+        return new TransitionDatabaseHandler<>(type, new JSONDatabase().getHandler(type), new MongoDBDatabase().getHandler(type));
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/database/transition/Json2SQLiteDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/Json2SQLiteDatabase.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.database.transition;
+
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+import world.bentobox.bentobox.database.json.JSONDatabase;
+import world.bentobox.bentobox.database.sqlite.SQLiteDatabase;
+
+
+/**
+ * @author BONNe
+ * @since 1.6.0
+ */
+public class Json2SQLiteDatabase implements DatabaseSetup {
+
+    @Override
+    public <T> AbstractDatabaseHandler<T> getHandler(Class<T> type) {
+        return new TransitionDatabaseHandler<>(type, new JSONDatabase().getHandler(type), new SQLiteDatabase().getHandler(type));
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/database/transition/MariaDB2JsonDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/MariaDB2JsonDatabase.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.database.transition;
+
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+import world.bentobox.bentobox.database.json.JSONDatabase;
+import world.bentobox.bentobox.database.mariadb.MariaDBDatabase;
+
+
+/**
+ * @author BONNe
+ * @since 1.6.0
+ */
+public class MariaDB2JsonDatabase implements DatabaseSetup {
+
+    @Override
+    public <T> AbstractDatabaseHandler<T> getHandler(Class<T> type) {
+        return new TransitionDatabaseHandler<>(type, new MariaDBDatabase().getHandler(type), new JSONDatabase().getHandler(type));
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/database/transition/MongoDB2JsonDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/MongoDB2JsonDatabase.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.database.transition;
+
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+import world.bentobox.bentobox.database.json.JSONDatabase;
+import world.bentobox.bentobox.database.mongodb.MongoDBDatabase;
+
+
+/**
+ * @author BONNe
+ * @since 1.6.0
+ */
+public class MongoDB2JsonDatabase implements DatabaseSetup {
+
+    @Override
+    public <T> AbstractDatabaseHandler<T> getHandler(Class<T> type) {
+        return new TransitionDatabaseHandler<>(type, new MongoDBDatabase().getHandler(type), new JSONDatabase().getHandler(type));
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/database/transition/SQLite2JsonDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/SQLite2JsonDatabase.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.database.transition;
+
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+import world.bentobox.bentobox.database.json.JSONDatabase;
+import world.bentobox.bentobox.database.sqlite.SQLiteDatabase;
+
+
+/**
+ * @author BONNe
+ * @since 1.6.0
+ */
+public class SQLite2JsonDatabase implements DatabaseSetup {
+
+    @Override
+    public <T> AbstractDatabaseHandler<T> getHandler(Class<T> type) {
+        return new TransitionDatabaseHandler<>(type, new SQLiteDatabase().getHandler(type), new JSONDatabase().getHandler(type));
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/database/transition/Yaml2MongoDBDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/Yaml2MongoDBDatabase.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.database.transition;
+
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+import world.bentobox.bentobox.database.mongodb.MongoDBDatabase;
+import world.bentobox.bentobox.database.yaml.YamlDatabase;
+
+
+/**
+ * @author BONNe
+ * @since 1.6.0
+ */
+public class Yaml2MongoDBDatabase implements DatabaseSetup {
+
+    @Override
+    public <T> AbstractDatabaseHandler<T> getHandler(Class<T> type) {
+        return new TransitionDatabaseHandler<>(type, new YamlDatabase().getHandler(type), new MongoDBDatabase().getHandler(type));
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/database/transition/Yaml2SQLiteDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/Yaml2SQLiteDatabase.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.database.transition;
+
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+import world.bentobox.bentobox.database.sqlite.SQLiteDatabase;
+import world.bentobox.bentobox.database.yaml.YamlDatabase;
+
+
+/**
+ * @author BONNe
+ * @since 1.6.0
+ */
+public class Yaml2SQLiteDatabase implements DatabaseSetup {
+
+    @Override
+    public <T> AbstractDatabaseHandler<T> getHandler(Class<T> type) {
+        return new TransitionDatabaseHandler<>(type, new YamlDatabase().getHandler(type), new SQLiteDatabase().getHandler(type));
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,8 +13,9 @@ general:
   database:
     # JSON, MYSQL, MARIADB (10.2.3+), MONGODB, SQLITE and YAML(deprecated).
     # Transition database options are:
-    #   YAML2JSON, YAML2MARIADB, YAML2MYSQL
-    #   JSON2MARIADB, JSON2MYSQL, MYSQL2JSON
+    #   YAML2JSON, YAML2MARIADB, YAML2MYSQL, YAML2MONGODB, YAML2SQLITE
+    #   JSON2MARIADB, JSON2MYSQL, JSON2MONGODB, JSON2SQLITE
+    #   MYSQL2JSON, MARIADB2JSON, MONGODB2JSON, SQLITE2JSON
     # If you need others, please make a feature request.
     # Transition options enable migration from one database type to another. Use /bbox migrate.
     # YAML and JSON are file-based databases.


### PR DESCRIPTION
Comes from (#793)

Add missing database transitions from YAML to MongoDB and SQLite.
Add missing database transitions from JSON to MongoDB and SQLite.
Add database transitions from SQLite to JSON.
Add database transitions from MongoDB to JSON.
Add database transitions from MariaDB to JSON.