### PR TITLE
Ensures a single database connection is used.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/Database.java
+++ b/src/main/java/world/bentobox/bentobox/database/Database.java
@@ -21,6 +21,7 @@ public class Database<T> {
 
     private AbstractDatabaseHandler<T> handler;
     private Logger logger;
+    private static DatabaseSetup database;
 
     /**
      * Construct a database
@@ -29,7 +30,7 @@ public class Database<T> {
      */
     public Database(BentoBox plugin, Class<T> type)  {
         this.logger = plugin.getLogger();
-        handler = DatabaseSetup.getDatabase().getHandler(type);
+        setup(type);
     }
 
     /**
@@ -39,7 +40,15 @@ public class Database<T> {
      */
     public Database(Addon addon, Class<T> type)  {
         this.logger = addon.getLogger();
-        handler = DatabaseSetup.getDatabase().getHandler(type);
+        setup(type);
+    }
+
+    private void setup(Class<T> type) {
+        // Only do this query once
+        if (database == null) {
+            database = DatabaseSetup.getDatabase();
+        }
+        handler = database.getHandler(type);
     }
 
     /**
@@ -129,6 +138,7 @@ public class Database<T> {
      * Close the database
      */
     public void close() {
+        database = null;
         handler.close();
     }
 

--- a/src/main/java/world/bentobox/bentobox/database/mariadb/MariaDBDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/mariadb/MariaDBDatabaseConnector.java
@@ -18,7 +18,7 @@ public class MariaDBDatabaseConnector implements DatabaseConnector {
 
     private String connectionUrl;
     private DatabaseConnectionSettingsImpl dbSettings;
-    private Connection connection = null;
+    private static Connection connection = null;
 
     /**
      * Class for MariaDB database connections using the settings provided
@@ -32,10 +32,13 @@ public class MariaDBDatabaseConnector implements DatabaseConnector {
 
     @Override
     public Connection createConnection() {
-        try {
-            connection = DriverManager.getConnection(connectionUrl, dbSettings.getUsername(), dbSettings.getPassword());
-        } catch (SQLException e) {
-            Bukkit.getLogger().severe("Could not connect to the database! " + e.getMessage());
+        // Only get one connection at a time
+        if (connection == null) {
+            try {
+                connection = DriverManager.getConnection(connectionUrl, dbSettings.getUsername(), dbSettings.getPassword());
+            } catch (SQLException e) {
+                Bukkit.getLogger().severe("Could not connect to the database! " + e.getMessage());
+            }
         }
         return connection;
     }

--- a/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabaseConnector.java
@@ -12,7 +12,7 @@ import world.bentobox.bentobox.database.DatabaseConnector;
 
 public class MongoDBDatabaseConnector implements DatabaseConnector {
 
-    private MongoClient client;
+    private static MongoClient client;
     private DatabaseConnectionSettingsImpl dbSettings;
 
     /**
@@ -21,15 +21,18 @@ public class MongoDBDatabaseConnector implements DatabaseConnector {
      */
     MongoDBDatabaseConnector(DatabaseConnectionSettingsImpl dbSettings) {
         this.dbSettings = dbSettings;
-        MongoCredential credential = MongoCredential.createCredential(dbSettings.getUsername(),
-                dbSettings.getDatabaseName(),
-                dbSettings.getPassword().toCharArray());
-        MongoClientOptions options = MongoClientOptions.builder().sslEnabled(false).build();
-        client = new MongoClient(new ServerAddress(dbSettings.getHost(), dbSettings.getPort()), credential,options);
     }
 
     @Override
     public MongoDatabase createConnection() {
+        // Only get one client
+        if (client == null) {
+            MongoCredential credential = MongoCredential.createCredential(dbSettings.getUsername(),
+                    dbSettings.getDatabaseName(),
+                    dbSettings.getPassword().toCharArray());
+            MongoClientOptions options = MongoClientOptions.builder().sslEnabled(false).build();
+            client = new MongoClient(new ServerAddress(dbSettings.getHost(), dbSettings.getPort()), credential,options);
+        }
         return client.getDatabase(dbSettings.getDatabaseName());
     }
 

--- a/src/main/java/world/bentobox/bentobox/database/mysql/MySQLDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/mysql/MySQLDatabaseConnector.java
@@ -5,8 +5,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 import org.bukkit.Bukkit;
-
 import org.eclipse.jdt.annotation.NonNull;
+
 import world.bentobox.bentobox.database.DatabaseConnectionSettingsImpl;
 import world.bentobox.bentobox.database.DatabaseConnector;
 
@@ -14,7 +14,7 @@ public class MySQLDatabaseConnector implements DatabaseConnector {
 
     private String connectionUrl;
     private DatabaseConnectionSettingsImpl dbSettings;
-    private Connection connection = null;
+    private static Connection connection = null;
 
     /**
      * Class for MySQL database connections using the settings provided
@@ -28,10 +28,13 @@ public class MySQLDatabaseConnector implements DatabaseConnector {
 
     @Override
     public Connection createConnection() {
-        try {
-            connection = DriverManager.getConnection(connectionUrl, dbSettings.getUsername(), dbSettings.getPassword());
-        } catch (SQLException e) {
-            Bukkit.getLogger().severe("Could not connect to the database! " + e.getMessage());
+        // Only make one connection to the database
+        if (connection == null) {
+            try {
+                connection = DriverManager.getConnection(connectionUrl, dbSettings.getUsername(), dbSettings.getPassword());
+            } catch (SQLException e) {
+                Bukkit.getLogger().severe("Could not connect to the database! " + e.getMessage());
+            }
         }
         return connection;
     }

--- a/src/main/java/world/bentobox/bentobox/database/sqlite/SQLiteDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/sqlite/SQLiteDatabaseConnector.java
@@ -17,7 +17,7 @@ import java.sql.SQLException;
 public class SQLiteDatabaseConnector implements DatabaseConnector {
 
     private String connectionUrl;
-    private Connection connection = null;
+    private static Connection connection = null;
     private static final String DATABASE_FOLDER_NAME = "database";
 
     SQLiteDatabaseConnector(@NonNull BentoBox plugin) {
@@ -27,10 +27,13 @@ public class SQLiteDatabaseConnector implements DatabaseConnector {
 
     @Override
     public Object createConnection() {
-        try {
-            connection = DriverManager.getConnection(connectionUrl);
-        } catch (SQLException e) {
-            Bukkit.getLogger().severe("Could not connect to the database! " + e.getMessage());
+        // Only make one connection at a time
+        if (connection == null) {
+            try {
+                connection = DriverManager.getConnection(connectionUrl);
+            } catch (SQLException e) {
+                Bukkit.getLogger().severe("Could not connect to the database! " + e.getMessage());
+            }
         }
         return connection;
     }

--- a/src/test/java/world/bentobox/bentobox/database/DatabaseTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/DatabaseTest.java
@@ -68,6 +68,9 @@ public class DatabaseTest {
 
         PowerMockito.mockStatic(DatabaseSetup.class);
 
+        // Set the internal state of the static database variable to null for each test
+        Whitebox.setInternalState(Database.class, "database", (DatabaseSetup)null);
+
         dbSetup = mock(DatabaseSetup.class);
         handler = mock(AbstractDatabaseHandler.class);
         when(dbSetup.getHandler(Mockito.any())).thenReturn(handler);
@@ -87,6 +90,7 @@ public class DatabaseTest {
      */
     @After
     public void tearDown() throws Exception {
+        dbSetup = null;
     }
 
     /**


### PR DESCRIPTION
https://github.com/BentoBoxWorld/BentoBox/issues/805

Database connectors were creating a new connection every time they were
called. Also the top-level database object was being recreated every
time getDatabase was requested.