### PR TITLE
API addition - adds reset deaths on new island

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -255,7 +255,7 @@ public interface WorldSettings extends ConfigObject {
      * @return true if deaths in the world are reset when the player has a new island
      * @since 1.6.0
      */
-    boolean isDeathsResetOnNew();
+    boolean isDeathsResetOnNewIsland();
 
     /**
      * @return whether a player can set their home in the Nether or not.

--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -252,6 +252,12 @@ public interface WorldSettings extends ConfigObject {
     boolean isDeathsCounted();
 
     /**
+     * @return true if deaths in the world are reset when the player has a new island
+     * @since 1.6.0
+     */
+    boolean isDeathsResetOnNew();
+
+    /**
      * @return whether a player can set their home in the Nether or not.
      */
     boolean isAllowSetHomeInNether();

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -700,8 +700,24 @@ public class IslandWorldManager {
         gameModes.get(world).getWorldSettings().setResetEpoch(System.currentTimeMillis());
     }
 
+    /**
+     * Check if the death count should be reset when joining a team in this world
+     * @param world - world
+     * @return true or false
+     */
     public boolean isTeamJoinDeathReset(@NonNull World world) {
         return gameModes.get(world).getWorldSettings().isTeamJoinDeathReset();
+    }
+
+    /**
+     * Check if deaths in the world are reset when the player starts a new island.
+     * This includes a totally new island and also a new island from a reset.
+     * @param world - world
+     * @return true or false
+     * @since 1.6.0
+     */
+    public boolean isDeathsResetOnNew(@NonNull World world) {
+        return gameModes.get(world).getWorldSettings().isDeathsResetOnNew();
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -717,7 +717,7 @@ public class IslandWorldManager {
      * @since 1.6.0
      */
     public boolean isDeathsResetOnNew(@NonNull World world) {
-        return gameModes.get(world).getWorldSettings().isDeathsResetOnNew();
+        return gameModes.get(world).getWorldSettings().isDeathsResetOnNewIsland();
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -716,7 +716,7 @@ public class IslandWorldManager {
      * @return true or false
      * @since 1.6.0
      */
-    public boolean isDeathsResetOnNew(@NonNull World world) {
+    public boolean isDeathsResetOnNewIsland(@NonNull World world) {
         return gameModes.get(world).getWorldSettings().isDeathsResetOnNewIsland();
     }
 

--- a/src/main/java/world/bentobox/bentobox/managers/island/NewIsland.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/NewIsland.java
@@ -177,7 +177,7 @@ public class NewIsland {
         plugin.getPlayers().setHomeLocation(user, new Location(next.getWorld(), next.getX() + 0.5D, next.getY(), next.getZ() + 0.5D), 1);
 
         // Reset deaths
-        if (plugin.getIWM().isDeathsResetOnNew(world)) {
+        if (plugin.getIWM().isDeathsResetOnNewIsland(world)) {
             plugin.getPlayers().setDeaths(world, user.getUniqueId(), 0);
         }
 

--- a/src/main/java/world/bentobox/bentobox/managers/island/NewIsland.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/NewIsland.java
@@ -176,6 +176,11 @@ public class NewIsland {
         // Set home location
         plugin.getPlayers().setHomeLocation(user, new Location(next.getWorld(), next.getX() + 0.5D, next.getY(), next.getZ() + 0.5D), 1);
 
+        // Reset deaths
+        if (plugin.getIWM().isDeathsResetOnNew(world)) {
+            plugin.getPlayers().setDeaths(world, user.getUniqueId(), 0);
+        }
+
         // Save the player so that if the server crashes weird things won't happen
         plugin.getPlayers().save(user.getUniqueId());
 


### PR DESCRIPTION
BentoBox currently tracks deaths in the worlds but the current API only
allows them to be reset when a player joins a team. This setting enables
deaths to be reset when a player starts a new island or resets an
island.

This _should_ be the only additional WorldSetting we need for deaths. As it will require new versions of the GameModeAddons I've added @BONNe as a reviewer too for FYI. 

I actually need this setting for the Level Addon because levels can be affected by deaths. Right now, if a user restarts their island, prior deaths are not counted, but this is actually a bug (the island level is zeroed and deaths are included). This should be optional and part of the GameModeAddon settings.