### PR TITLE
Makes command ranks a protection setting

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -1,8 +1,6 @@
 package world.bentobox.bentobox;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import world.bentobox.bentobox.api.configuration.ConfigComment;
@@ -10,7 +8,6 @@ import world.bentobox.bentobox.api.configuration.ConfigEntry;
 import world.bentobox.bentobox.api.configuration.ConfigObject;
 import world.bentobox.bentobox.api.configuration.StoreAt;
 import world.bentobox.bentobox.database.DatabaseSetup.DatabaseType;
-import world.bentobox.bentobox.managers.RanksManager;
 
 /**
  * All the plugin settings are here
@@ -78,10 +75,6 @@ public class Settings implements ConfigObject {
     @ConfigComment("Add other fake player names here if required")
     @ConfigEntry(path = "general.fakeplayers", experimental = true)
     private Set<String> fakePlayers = new HashSet<>();
-
-    @ConfigComment("Rank required to use a command. e.g., use the invite command. Default is owner rank is required.")
-    @ConfigEntry(path = "general.rank-command")
-    private Map<String, Integer> rankCommand = new HashMap<>();
 
     @ConfigEntry(path = "panel.close-on-click-outside")
     private boolean closePanelOnClickOutside = true;
@@ -291,22 +284,6 @@ public class Settings implements ConfigObject {
 
     public void setFakePlayers(Set<String> fakePlayers) {
         this.fakePlayers = fakePlayers;
-    }
-
-    public Map<String, Integer> getRankCommand() {
-        return rankCommand;
-    }
-
-    public int getRankCommand(String command) {
-        return rankCommand.getOrDefault(command, RanksManager.OWNER_RANK);
-    }
-
-    public void setRankCommand(String command, int rank) {
-        rankCommand.put(command, rank);
-    }
-
-    public void setRankCommand(Map<String, Integer> rankCommand) {
-        this.rankCommand = rankCommand;
     }
 
     public boolean isClosePanelOnClickOutside() {

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandBanCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandBanCommand.java
@@ -48,7 +48,7 @@ public class IslandBanCommand extends CompositeCommand {
         }
         // Check rank to use command
         Island island = getIslands().getIsland(getWorld(), user);
-        if (island.getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
@@ -51,7 +51,8 @@ public class IslandExpelCommand extends CompositeCommand {
             return false;
         }
         // Check rank to use command
-        if (getIslands().getIsland(getWorld(), user).getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommand.java
@@ -42,7 +42,8 @@ public class IslandUnbanCommand extends CompositeCommand {
             return false;
         }
         // Check rank to use command
-        if (getIslands().getIsland(getWorld(), user).getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommand.java
@@ -49,7 +49,7 @@ public class IslandTeamCoopCommand extends CompositeCommand {
         }
         // Check rank to use command
         Island island = getIslands().getIsland(getWorld(), user);
-        if (island.getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
@@ -17,6 +17,7 @@ import world.bentobox.bentobox.api.events.IslandBaseEvent;
 import world.bentobox.bentobox.api.events.team.TeamEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 
 public class IslandTeamInviteCommand extends CompositeCommand {
@@ -45,7 +46,8 @@ public class IslandTeamInviteCommand extends CompositeCommand {
             return false;
         }
         // Check rank to use command
-        if (getIslands().getIsland(getWorld(), user).getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -39,6 +39,12 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.not-owner");
             return false;
         }
+        // Check rank to use command
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
+            user.sendMessage("general.errors.no-permission");
+            return false;
+        }
         // If args are not right, show help
         if (args.size() != 1) {
             showHelp(this, user);

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommand.java
@@ -5,6 +5,7 @@ import java.util.List;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
 
 public class IslandTeamPromoteCommand extends CompositeCommand {
@@ -24,6 +25,7 @@ public class IslandTeamPromoteCommand extends CompositeCommand {
             setParametersHelp("commands.island.team.demote.parameters");
             setDescription("commands.island.team.demote.description");
         }
+        this.setConfigurableRankCommand();
     }
 
     @Override
@@ -33,7 +35,8 @@ public class IslandTeamPromoteCommand extends CompositeCommand {
             return true;
         }
         // Check rank to use command
-        if (getIslands().getIsland(getWorld(), user).getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommand.java
@@ -45,7 +45,7 @@ public class IslandTeamTrustCommand extends CompositeCommand {
         }
         // Check rank to use command
         Island island = getIslands().getIsland(getWorld(), user);
-        if (island.getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommand.java
@@ -48,7 +48,8 @@ public class IslandTeamUncoopCommand extends CompositeCommand {
             return false;
         }
         // Check rank to use command
-        if (getIslands().getIsland(getWorld(), user).getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommand.java
@@ -48,7 +48,8 @@ public class IslandTeamUntrustCommand extends CompositeCommand {
             return false;
         }
         // Check rank to use command
-        if (getIslands().getIsland(getWorld(), user).getRank(user) < getPlugin().getSettings().getRankCommand(getUsage())) {
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island.getRank(user) < island.getRankCommand(getUsage())) {
             user.sendMessage("general.errors.no-permission");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet.Builder;
 import com.google.gson.annotations.Expose;
 
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -154,6 +155,16 @@ public class Island implements DataObject {
     @Expose
     private Map<Flag, Long> cooldowns = new HashMap<>();
 
+    /**
+     * Commands and the rank required to use them for this island
+     */
+    @Expose
+    private Map<String, Integer> commandRanks;
+
+    /*
+     * *************************** Constructors ******************************
+     */
+
     public Island() {}
 
     public Island(@NonNull Location location, UUID owner, int protectionRange) {
@@ -194,6 +205,10 @@ public class Island implements DataObject {
         this.updatedDate = island.updatedDate;
         this.world = island.world;
     }
+
+    /*
+     * *************************** Methods ******************************
+     */
 
     /**
      * Adds a team member. If player is on banned list, they will be removed from it.
@@ -1092,6 +1107,40 @@ public class Island implements DataObject {
      */
     public void setCooldowns(Map<Flag, Long> cooldowns) {
         this.cooldowns = cooldowns;
+    }
+
+    /**
+     * @return the commandRanks
+     */
+    public Map<String, Integer> getCommandRanks() {
+        return commandRanks;
+    }
+
+    /**
+     * @param commandRanks the commandRanks to set
+     */
+    public void setCommandRanks(Map<String, Integer> commandRanks) {
+        this.commandRanks = commandRanks;
+    }
+
+    /**
+     * Get the rank required to run command on this island.
+     * The command must have been registered with a rank.
+     * @param command - the string given by {@link CompositeCommand#getUsage()}
+     * @return Rank value required, or if command is not set {@link RanksManager#OWNER_RANK}
+     */
+    public int getRankCommand(String command) {
+        return commandRanks == null ? RanksManager.OWNER_RANK : commandRanks.getOrDefault(command, RanksManager.OWNER_RANK);
+    }
+
+    /**
+     *
+     * @param command - the string given by {@link CompositeCommand#getUsage()}
+     * @param rank value as used by {@link RanksManager}
+     */
+    public void setRankCommand(String command, int rank) {
+        if (this.commandRanks == null) this.commandRanks = new HashMap<>();
+        this.commandRanks.put(command, rank);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClick.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClick.java
@@ -36,26 +36,26 @@ public class CommandCycleClick implements ClickHandler {
         Island island = plugin.getIslands().getIsland(user.getWorld(), user.getUniqueId());
         if (island != null && island.getOwner().equals(user.getUniqueId())) {
             RanksManager rm = plugin.getRanksManager();
-            int currentRank = plugin.getSettings().getRankCommand(command);
+            int currentRank = island.getRankCommand(command);
             if (click.equals(ClickType.LEFT)) {
                 if (currentRank == RanksManager.OWNER_RANK) {
-                    plugin.getSettings().setRankCommand(command, RanksManager.MEMBER_RANK);
+                    island.setRankCommand(command, RanksManager.MEMBER_RANK);
                 } else {
-                    plugin.getSettings().setRankCommand(command, rm.getRankUpValue(currentRank));
+                    island.setRankCommand(command, rm.getRankUpValue(currentRank));
                 }
                 user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1F, 1F);
             } else if (click.equals(ClickType.RIGHT)) {
                 if (currentRank == RanksManager.MEMBER_RANK) {
-                    plugin.getSettings().setRankCommand(command, RanksManager.OWNER_RANK);
+                    island.setRankCommand(command, RanksManager.OWNER_RANK);
                 } else {
-                    plugin.getSettings().setRankCommand(command, rm.getRankDownValue(currentRank));
+                    island.setRankCommand(command, rm.getRankDownValue(currentRank));
                 }
                 user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1F, 1F);
             }
             // Apply change to panel
             panel.getInventory().setItem(slot, commandRankClickListener.getPanelItem(command, user).getItem());
-            // Save config
-            plugin.saveConfig();
+            // Save island
+            plugin.getIslands().save(island);
 
         } else {
             user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandRankClickListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandRankClickListener.java
@@ -18,6 +18,7 @@ import world.bentobox.bentobox.api.panels.PanelItem.ClickHandler;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
@@ -44,6 +45,14 @@ public class CommandRankClickListener implements ClickHandler {
         String reqPerm = iwm.getPermissionPrefix(Util.getWorld(user.getWorld())) + ".admin.settings.COMMAND_RANKS";
         if (!user.hasPermission(reqPerm)) {
             user.sendMessage("general.errors.no-permission", "[permission]", reqPerm);
+            user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
+            return true;
+        }
+
+        // Get the user's island
+        Island island = plugin.getIslands().getIsland(user.getWorld(), user.getUniqueId());
+        if (island == null || !island.getOwner().equals(user.getUniqueId())) {
+            user.sendMessage("general.errors.not-owner");
             user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
             return true;
         }
@@ -78,9 +87,11 @@ public class CommandRankClickListener implements ClickHandler {
      * Gets the rank command panel item
      * @param c - rank string
      * @param user - user
+     * @param island - user's island
      * @return panel item for this command
      */
     public PanelItem getPanelItem(String c, User user) {
+        Island island = plugin.getIslands().getIsland(user.getWorld(), user);
         PanelItemBuilder pib = new PanelItemBuilder();
         pib.name(c);
         pib.clickHandler(new CommandCycleClick(this, c));
@@ -89,11 +100,11 @@ public class CommandRankClickListener implements ClickHandler {
         String d = user.getTranslation("protection.panel.flag-item.description-layout", TextVariables.DESCRIPTION, "");
         pib.description(d);
         plugin.getRanksManager().getRanks().forEach((reference, score) -> {
-            if (score >= RanksManager.MEMBER_RANK && score < plugin.getSettings().getRankCommand(c)) {
+            if (score >= RanksManager.MEMBER_RANK && score < island.getRankCommand(c)) {
                 pib.description(user.getTranslation("protection.panel.flag-item.blocked-rank") + user.getTranslation(reference));
-            } else if (score <= RanksManager.OWNER_RANK && score > plugin.getSettings().getRankCommand(c)) {
+            } else if (score <= RanksManager.OWNER_RANK && score > island.getRankCommand(c)) {
                 pib.description(user.getTranslation("protection.panel.flag-item.allowed-rank") + user.getTranslation(reference));
-            } else if (score == plugin.getSettings().getRankCommand(c)) {
+            } else if (score == island.getRankCommand(c)) {
                 pib.description(user.getTranslation("protection.panel.flag-item.minimal-rank") + user.getTranslation(reference));
             }
         });

--- a/src/main/java/world/bentobox/bentobox/lists/Flags.java
+++ b/src/main/java/world/bentobox/bentobox/lists/Flags.java
@@ -238,6 +238,11 @@ public final class Flags {
     // Experience
     public static final Flag EXPERIENCE_PICKUP = new Flag.Builder("EXPERIENCE_PICKUP", Material.EXPERIENCE_BOTTLE).listener(new ExperiencePickupListener()).build();
 
+    // Command ranks
+    public static final Flag COMMAND_RANKS = new Flag.Builder("COMMAND_RANKS", Material.PLAYER_HEAD)
+            .clickHandler(new CommandRankClickListener()).usePanel(true).build();
+
+
     // TNT
     /**
      * @deprecated As of 1.5.0, for removal.
@@ -364,9 +369,6 @@ public final class Flags {
      * @see CreeperListener
      */
     public static final Flag CREEPER_GRIEFING = new Flag.Builder("CREEPER_GRIEFING", Material.CREEPER_HEAD).type(Type.WORLD_SETTING).build();
-
-    public static final Flag COMMAND_RANKS = new Flag.Builder("COMMAND_RANKS", Material.PLAYER_HEAD).type(Type.WORLD_SETTING)
-            .clickHandler(new CommandRankClickListener()).usePanel(true).build();
 
     public static final Flag COARSE_DIRT_TILLING = new Flag.Builder("COARSE_DIRT_TILLING", Material.COARSE_DIRT).type(Type.WORLD_SETTING).defaultSetting(true).listener(new CoarseDirtTillingListener()).build();
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -39,8 +39,6 @@ general:
   # /!\ This feature is experimental and might not work as expected or might not work at all.
   fakeplayers:
     - '[CoFH]'
-  # Rank required to use a command. e.g., use the invite command. Default is owner rank is required.
-  rank-command: {}
 panel:
   close-on-click-outside: true
 logs:

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.api.commands.island;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,7 +75,6 @@ public class IslandBanCommandTest {
 
         // Settings
         Settings s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
@@ -164,6 +164,7 @@ public class IslandBanCommandTest {
         IslandBanCommand ibc = new IslandBanCommand(ic);
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         when(island.getRank(Mockito.any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(ibc.execute(user, ibc.getLabel(), Collections.singletonList("bill")));
         Mockito.verify(user).sendMessage("general.errors.no-permission");
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
@@ -6,6 +6,7 @@ package world.bentobox.bentobox.api.commands.island;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -91,7 +92,6 @@ public class IslandExpelCommandTest {
 
         // Settings
         Settings s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
@@ -237,6 +237,7 @@ public class IslandExpelCommandTest {
     public void testCanExecuteLowRank() {
         when(im.hasIsland(Mockito.any(), Mockito.any(User.class))).thenReturn(true);
         when(island.getRank(Mockito.any())).thenReturn(RanksManager.VISITOR_RANK);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(iec.canExecute(user, "", Collections.singletonList("tasty")));
         Mockito.verify(user).sendMessage("general.errors.no-permission");
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommandTest.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.api.commands.island;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,8 +74,6 @@ public class IslandUnbanCommandTest {
 
         // Settings
         Settings s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
-
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
@@ -162,6 +161,7 @@ public class IslandUnbanCommandTest {
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         when(im.hasIsland(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
         when(island.getRank(Mockito.any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(iubc.execute(user, iubc.getLabel(), Collections.singletonList("bill")));
         Mockito.verify(user).sendMessage("general.errors.no-permission");
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
@@ -6,6 +6,7 @@ package world.bentobox.bentobox.api.commands.island.team;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -51,13 +53,19 @@ import world.bentobox.bentobox.managers.RanksManager;
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
 public class IslandTeamCoopCommandTest {
 
+    @Mock
     private CompositeCommand ic;
     private UUID uuid;
+    @Mock
     private User user;
+    @Mock
     private IslandsManager im;
+    @Mock
     private PlayersManager pm;
     private UUID notUUID;
+    @Mock
     private Settings s;
+    @Mock
     private Island island;
 
     /**
@@ -73,16 +81,11 @@ public class IslandTeamCoopCommandTest {
         CommandsManager cm = mock(CommandsManager.class);
         when(plugin.getCommandsManager()).thenReturn(cm);
 
-        // Settings
-        s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
-
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
         Player p = mock(Player.class);
         // Sometimes use Mockito.withSettings().verboseLogging()
-        user = mock(User.class);
         when(user.isOp()).thenReturn(false);
         uuid = UUID.randomUUID();
         notUUID = UUID.randomUUID();
@@ -95,16 +98,14 @@ public class IslandTeamCoopCommandTest {
         User.setPlugin(plugin);
 
         // Parent command has no aliases
-        ic = mock(CompositeCommand.class);
         when(ic.getSubCommandAliases()).thenReturn(new HashMap<>());
 
         // Player has island to begin with
-        im = mock(IslandsManager.class);
         when(im.hasIsland(any(), Mockito.any(UUID.class))).thenReturn(true);
         when(im.inTeam(any(), Mockito.any(UUID.class))).thenReturn(true);
         when(im.isOwner(any(), any())).thenReturn(true);
         when(im.getOwner(any(), any())).thenReturn(uuid);
-        island = mock(Island.class);
+        // Island
         when(island.getRank(any())).thenReturn(RanksManager.OWNER_RANK);
         when(im.getIsland(any(), Mockito.any(User.class))).thenReturn(island);
         when(im.getIsland(any(), Mockito.any(UUID.class))).thenReturn(island);
@@ -114,8 +115,6 @@ public class IslandTeamCoopCommandTest {
         when(im.inTeam(any(), eq(uuid))).thenReturn(true);
 
         // Player Manager
-        pm = mock(PlayersManager.class);
-
         when(plugin.getPlayers()).thenReturn(pm);
 
         // Server & Scheduler
@@ -162,6 +161,7 @@ public class IslandTeamCoopCommandTest {
     @Test
     public void testCanExecuteLowRank() {
         when(island.getRank(any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("bill")));
         verify(user).sendMessage(eq("general.errors.no-permission"));

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -55,6 +56,7 @@ public class IslandTeamInviteAcceptCommandTest {
     private IslandsManager im;
     private PlayersManager pm;
     private UUID notUUID;
+    @Mock
     private Settings s;
     private Island island;
     private IslandTeamInviteAcceptCommand c;
@@ -76,8 +78,6 @@ public class IslandTeamInviteAcceptCommandTest {
         when(plugin.getCommandsManager()).thenReturn(cm);
 
         // Settings
-        s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
         when(plugin.getSettings()).thenReturn(s);
 
         // Player

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
@@ -4,6 +4,7 @@
 package world.bentobox.bentobox.api.commands.island.team;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +19,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -50,6 +52,7 @@ public class IslandTeamInviteCommandTest {
     private IslandsManager im;
     private PlayersManager pm;
     private UUID notUUID;
+    @Mock
     private Settings s;
     private Island island;
 
@@ -67,8 +70,6 @@ public class IslandTeamInviteCommandTest {
         when(plugin.getCommandsManager()).thenReturn(cm);
 
         // Settings
-        s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
@@ -143,6 +144,7 @@ public class IslandTeamInviteCommandTest {
     @Test
     public void testExecuteLowRank() {
         when(island.getRank(Mockito.any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamInviteCommand itl = new IslandTeamInviteCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), new ArrayList<>()));
         Mockito.verify(user).sendMessage(Mockito.eq("general.errors.no-permission"));

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyString;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.managers.RanksManager;
 
 /**
  * @author tastybento
@@ -73,6 +75,8 @@ public class IslandTeamKickCommandTest {
     private Player target;
     @Mock
     private CompositeCommand subCommand;
+    @Mock
+    private Island island;
 
     /**
      * @throws java.lang.Exception
@@ -159,9 +163,10 @@ public class IslandTeamKickCommandTest {
         when(Bukkit.getServer()).thenReturn(server);
 
         // Island
-        Island island = mock(Island.class);
         when(island.getUniqueId()).thenReturn("uniqueid");
         when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
+        when(im.getIsland(any(), any(User.class))).thenReturn(island);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.VISITOR_RANK);
 
     }
 
@@ -226,9 +231,22 @@ public class IslandTeamKickCommandTest {
     public void testExecuteDifferentPlayerNotInTeam() {
         IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
         when(pm.getUUID(any())).thenReturn(notUUID);
-        when(im.getMembers(any(), any())).thenReturn(new HashSet<>());
+        when(im.getMembers(any(), any())).thenReturn(Collections.emptySet());
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("poslovitch")));
         verify(user).sendMessage(eq("general.errors.not-in-team"));
+    }
+
+    /**
+     * Test method for {@link IslandTeamKickCommand#execute(User, String, java.util.List)}
+     */
+    @Test
+    public void testExecuteDifferentPlayerNoRank() {
+        IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
+        when(pm.getUUID(any())).thenReturn(notUUID);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
+        when(island.getRank(any())).thenReturn(RanksManager.VISITOR_RANK);
+        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("poslovitch")));
+        verify(user).sendMessage(eq("general.errors.no-permission"));
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
@@ -4,6 +4,7 @@
 package world.bentobox.bentobox.api.commands.island.team;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +20,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -51,6 +53,7 @@ public class IslandTeamTrustCommandTest {
     private IslandsManager im;
     private PlayersManager pm;
     private UUID notUUID;
+    @Mock
     private Settings s;
     private Island island;
 
@@ -68,9 +71,6 @@ public class IslandTeamTrustCommandTest {
         when(plugin.getCommandsManager()).thenReturn(cm);
 
         // Settings
-        s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
-
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
@@ -146,6 +146,7 @@ public class IslandTeamTrustCommandTest {
     @Test
     public void testExecuteLowRank() {
         when(island.getRank(Mockito.any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("bill")));
         Mockito.verify(user).sendMessage(Mockito.eq("general.errors.no-permission"));

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommandTest.java
@@ -5,6 +5,7 @@ package world.bentobox.bentobox.api.commands.island.team;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,6 +26,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -60,6 +62,7 @@ public class IslandTeamUncoopCommandTest {
     private IslandsManager im;
     private PlayersManager pm;
     private UUID notUUID;
+    @Mock
     private Settings s;
     private Island island;
 
@@ -77,9 +80,6 @@ public class IslandTeamUncoopCommandTest {
         when(plugin.getCommandsManager()).thenReturn(cm);
 
         // Settings
-        s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
-
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
@@ -155,6 +155,7 @@ public class IslandTeamUncoopCommandTest {
     @Test
     public void testExecuteLowRank() {
         when(island.getRank(Mockito.any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamUncoopCommand itl = new IslandTeamUncoopCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("bill")));
         Mockito.verify(user).sendMessage(Mockito.eq("general.errors.no-permission"));

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommandTest.java
@@ -5,6 +5,7 @@ package world.bentobox.bentobox.api.commands.island.team;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,6 +26,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -60,6 +62,7 @@ public class IslandTeamUntrustCommandTest {
     private IslandsManager im;
     private PlayersManager pm;
     private UUID notUUID;
+    @Mock
     private Settings s;
     private Island island;
 
@@ -77,9 +80,6 @@ public class IslandTeamUntrustCommandTest {
         when(plugin.getCommandsManager()).thenReturn(cm);
 
         // Settings
-        s = mock(Settings.class);
-        when(s.getRankCommand(Mockito.anyString())).thenReturn(RanksManager.OWNER_RANK);
-
         when(plugin.getSettings()).thenReturn(s);
 
         // Player
@@ -103,18 +103,18 @@ public class IslandTeamUntrustCommandTest {
 
         // Player has island to begin with
         im = mock(IslandsManager.class);
-        when(im.hasIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(true);
-        when(im.inTeam(Mockito.any(), Mockito.any(UUID.class))).thenReturn(true);
-        when(im.isOwner(Mockito.any(), Mockito.any())).thenReturn(true);
-        when(im.getOwner(Mockito.any(), Mockito.any())).thenReturn(uuid);
+        when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
+        when(im.inTeam(any(), any(UUID.class))).thenReturn(true);
+        when(im.isOwner(any(), any())).thenReturn(true);
+        when(im.getOwner(any(), any())).thenReturn(uuid);
         island = mock(Island.class);
-        when(island.getRank(Mockito.any())).thenReturn(RanksManager.OWNER_RANK);
-        when(im.getIsland(Mockito.any(), Mockito.any(User.class))).thenReturn(island);
-        when(im.getIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(island);
+        when(island.getRank(any())).thenReturn(RanksManager.OWNER_RANK);
+        when(im.getIsland(any(), any(User.class))).thenReturn(island);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
         when(plugin.getIslands()).thenReturn(im);
 
         // Has team
-        when(im.inTeam(Mockito.any(), Mockito.eq(uuid))).thenReturn(true);
+        when(im.inTeam(any(), Mockito.eq(uuid))).thenReturn(true);
 
         // Player Manager
         pm = mock(PlayersManager.class);
@@ -128,12 +128,12 @@ public class IslandTeamUntrustCommandTest {
 
         // Locales
         LocalesManager lm = mock(LocalesManager.class);
-        when(lm.get(Mockito.any(), Mockito.any())).thenReturn("mock translation");
+        when(lm.get(any(), any())).thenReturn("mock translation");
         when(plugin.getLocalesManager()).thenReturn(lm);
 
         // IWM friendly name
         IslandWorldManager iwm = mock(IslandWorldManager.class);
-        when(iwm.getFriendlyName(Mockito.any())).thenReturn("BSkyBlock");
+        when(iwm.getFriendlyName(any())).thenReturn("BSkyBlock");
         when(plugin.getIWM()).thenReturn(iwm);
     }
 
@@ -142,8 +142,8 @@ public class IslandTeamUntrustCommandTest {
      */
     @Test
     public void testExecuteNoisland() {
-        when(im.hasIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(false);
-        when(im.inTeam(Mockito.any(), Mockito.any(UUID.class))).thenReturn(false);
+        when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
+        when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("bill")));
         Mockito.verify(user).sendMessage(Mockito.eq("general.errors.no-island"));
@@ -154,7 +154,8 @@ public class IslandTeamUntrustCommandTest {
      */
     @Test
     public void testExecuteLowRank() {
-        when(island.getRank(Mockito.any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRank(any())).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRankCommand(any())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("bill")));
         Mockito.verify(user).sendMessage(Mockito.eq("general.errors.no-permission"));
@@ -176,7 +177,7 @@ public class IslandTeamUntrustCommandTest {
     @Test
     public void testExecuteUnknownPlayer() {
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
-        when(pm.getUUID(Mockito.any())).thenReturn(null);
+        when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         Mockito.verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
     }
@@ -187,10 +188,10 @@ public class IslandTeamUntrustCommandTest {
     @Test
     public void testExecuteSamePlayer() {
         PowerMockito.mockStatic(User.class);
-        when(User.getInstance(Mockito.any(UUID.class))).thenReturn(user);
+        when(User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
-        when(pm.getUUID(Mockito.any())).thenReturn(uuid);
+        when(pm.getUUID(any())).thenReturn(uuid);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         Mockito.verify(user).sendMessage(Mockito.eq("commands.island.team.untrust.cannot-untrust-yourself"));
     }
@@ -202,12 +203,12 @@ public class IslandTeamUntrustCommandTest {
     @Test
     public void testExecutePlayerHasRank() {
         PowerMockito.mockStatic(User.class);
-        when(User.getInstance(Mockito.any(UUID.class))).thenReturn(user);
+        when(User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
-        when(pm.getUUID(Mockito.any())).thenReturn(notUUID);
-        when(im.inTeam(Mockito.any(), Mockito.any())).thenReturn(true);
-        when(im.getMembers(Mockito.any(), Mockito.any())).thenReturn(Collections.singleton(notUUID));
+        when(pm.getUUID(any())).thenReturn(notUUID);
+        when(im.inTeam(any(), any())).thenReturn(true);
+        when(im.getMembers(any(), any())).thenReturn(Collections.singleton(notUUID));
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("bento")));
         Mockito.verify(user).sendMessage(Mockito.eq("commands.island.team.untrust.cannot-untrust-member"));
     }
@@ -227,7 +228,7 @@ public class IslandTeamUntrustCommandTest {
     @Test
     public void testTabCompleteNoIsland() {
         // No island
-        when(im.getIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(null);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         IslandTeamUntrustCommand ibc = new IslandTeamUntrustCommand(ic);
         // Set up the user
         User user = mock(User.class);
@@ -263,9 +264,9 @@ public class IslandTeamUntrustCommandTest {
         // Return a set of players
         PowerMockito.mockStatic(Bukkit.class);
         OfflinePlayer offlinePlayer = mock(OfflinePlayer.class);
-        when(Bukkit.getOfflinePlayer(Mockito.any(UUID.class))).thenReturn(offlinePlayer);
+        when(Bukkit.getOfflinePlayer(any(UUID.class))).thenReturn(offlinePlayer);
         when(offlinePlayer.getName()).thenReturn("adam", "ben", "cara", "dave", "ed", "frank", "freddy", "george", "harry", "ian", "joe");
-        when(island.getRank(Mockito.any())).thenReturn(
+        when(island.getRank(any())).thenReturn(
                 RanksManager.TRUSTED_RANK,
                 RanksManager.TRUSTED_RANK,
                 RanksManager.TRUSTED_RANK,


### PR DESCRIPTION
See #557 

This puts the command rank settings into the Island object so that individual island owners can decide who can use what command.

It also fixes some bugs around this feature where the rank setting was not being checked.