### PR TITLE
Fixes owner being allowed to demote himself

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommand.java
@@ -52,6 +52,11 @@ public class IslandTeamPromoteCommand extends CompositeCommand {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return true;
         }
+        // Check if the user is not trying to promote/ demote himself
+        if (target == user) {
+            user.sendMessage("demote.errors.cant-demote-yourself");
+            return true;
+        }
         if (!inTeam(getWorld(), target) || !getOwner(getWorld(), user).equals(getOwner(getWorld(), target))) {
             user.sendMessage("general.errors.not-in-team");
             return true;

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -479,6 +479,8 @@ commands:
       demote:
         description: "demote a player on your island down a rank"
         parameters: "<player>"
+        errors:
+          cant-demote-yourself: "&cYou can't demote yourself!"
         failure: "&cPlayer cannot be demoted any further!"
         success: "&aDemoted [name] to [rank]"      
       promote:


### PR DESCRIPTION
I'd say this fixes #833 as it won't reallow owner to use team promote, nor demote command on himself.
Not sure for locales, but feel free to change.

PS: Actually, he is able only to demote himself. Promote won't work because he is already the highest rank.