### PR TITLE
Easier addon getter by their name

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -673,8 +673,9 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
     /**
      * @return the addon
      */
-    public Addon getAddon() {
-        return addon;
+    @SuppressWarnings("unchecked")
+    public <T extends Addon> T getAddon() {
+        return (T) addon;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -250,8 +250,9 @@ public class AddonsManager {
      * @return Optional addon object
      */
     @NonNull
-    public Optional<Addon> getAddonByName(@NonNull String name){
-        return addons.stream().filter(a -> a.getDescription().getName().equalsIgnoreCase(name)).findFirst();
+    @SuppressWarnings("unchecked")
+    public <T extends Addon> Optional<T> getAddonByName(@NonNull String name){
+        return addons.stream().filter(a -> a.getDescription().getName().equalsIgnoreCase(name)).map(a -> (T) a).findFirst();
     }
 
     @NonNull


### PR DESCRIPTION
A small improvement to get a certain addon from its name.
This allows getting addon main class without the necessity to cast if afterward (as the cast is done in `getAddonByName()` method).

This allows getting any addon main class much cleaner:

```java
// Returns Optional with correct Warp addon instance or Empty Optional
Optional<Warp> warps = this.getPlugin().getAddonsManager().getAddonByName("Warps");
```

This does not protect from incorrect class assignments.