### PR TITLE
Add missing permission prefixes to expel command.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandBanCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandBanCommand.java
@@ -79,9 +79,7 @@ public class IslandBanCommand extends CompositeCommand {
         }
         target = User.getInstance(targetUUID);
         // Cannot ban ops
-        if (target.isOp() || (target.isOnline() && target.hasPermission(
-                getAddon()
-                .getPermissionPrefix() + "admin.noban"))) {
+        if (target.isOp() || (target.isOnline() && target.hasPermission(this.getPermissionPrefix() + "admin.noban"))) {
             user.sendMessage("commands.island.ban.cannot-ban");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
@@ -84,7 +84,9 @@ public class IslandExpelCommand extends CompositeCommand {
             return false;
         }
         // Cannot ban ops
-        if (target.isOp() || target.hasPermission("admin.noexpel") || target.hasPermission("mod.bypassexpel")) {
+        if (target.isOp() ||
+            target.hasPermission(this.getPermissionPrefix() + "admin.noexpel") ||
+            target.hasPermission(this.getPermissionPrefix() + "mod.bypassexpel")) {
             user.sendMessage(CANNOT_EXPEL);
             return false;
         }


### PR DESCRIPTION
admin.noexpel and mod.bypassexpel were without prefixes so they did not work properly.