### PR TITLE
Improve the messages in en-US

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeCommand.java
@@ -45,7 +45,7 @@ public class AdminPurgeCommand extends CompositeCommand implements Listener {
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
         if (inPurge) {
-            user.sendMessage("commands.admin.purge.purge-in-progress");
+            user.sendMessage("commands.admin.purge.purge-in-progress", TextVariables.LABEL, getTopLabel());
             return false;
         }
         if (args.isEmpty()) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeUnownedCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeUnownedCommand.java
@@ -32,7 +32,7 @@ public class AdminPurgeUnownedCommand extends ConfirmableCommand {
         }
         AdminPurgeCommand parentCommand = ((AdminPurgeCommand)getParent());
         if (parentCommand.isInPurge()) {
-            user.sendMessage("commands.admin.purge.purge-in-progress");
+            user.sendMessage("commands.admin.purge.purge-in-progress", TextVariables.LABEL, getTopLabel());
             return false;
         }
         Set<String> unowned = getUnownedIslands();

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -16,33 +16,35 @@ general:
   invalid: "Invalid"
   errors:
     command-cancelled: "&cCommand cancelled."
-    no-permission: "&cYou don't have the permission to execute this command (&7[permission]&c)."
+    no-permission: "&cYou do not have the permission to execute this command (&7[permission]&c)."
     use-in-game: "&cThis command is only available in game."
     no-team: "&cYou do not have a team!"
     no-island: "&cYou do not have an island!"
-    player-has-island: "&cPlayer already has an island!"
-    player-has-no-island: "&cThat player has no island!"
+    player-has-island: "&cThis player already has an island!"
+    player-has-no-island: "&cThis player does not have an island!"
     already-have-island: "&cYou already have an island!"
-    no-safe-location-found: "&cCould not find a safe spot to teleport you to on the island."
+    no-safe-location-found: "&cWe could not find a safe spot to teleport you to."
     not-owner: "&cYou are not the owner of the island!"
-    not-in-team: "&cThat player is not in your team!"
-    offline-player: "&cThat player is offline or doesn't exist."
+    not-in-team: "&cThis player is not in your team!"
+    offline-player: "&cThis player is offline or unknown."
     unknown-player: "&c[name] is an unknown player!"
-    general: "&cThat command is not ready yet - contact admin"
+    general: "&cThis command is not ready yet, please contact an administrator."
     unknown-command: "&cUnknown command. Do &b/[label] help &cfor help."
     wrong-world: "&cYou are not in the right world to do that!"
-    you-must-wait: "&cYou must wait [number]s before you can do that command again."
-    must-be-positive-number: "&c[number] is not a valid positive number."
+    you-must-wait: "&cYou must wait &b[number]&c seconds before you can use this command again."
+    must-be-positive-number: "&b[number]&c is not a valid positive number."
   tips:
-    changing-obsidian-to-lava: "Changing obsidian back into lava. Be careful!"
+    changing-obsidian-to-lava: |
+      &aChanging obsidian back into lava...
+      &cBe careful next time!
 
 commands:
   # Parameters in <> are required, parameters in [] are optional
   help:
-    header: "&7=========== &c[label] help &7==========="
+    header: "&7----------- &c[label] help &7-----------"
     syntax: "&b[usage] &a[parameters]&7: &e[description]"
     syntax-no-parameters: "&b[usage]&7: &e[description]"
-    end: "&7================================="
+    end: "&7---------------------------------"
     parameters: "[command]"
     description: "help command"
     console: "Console"
@@ -63,40 +65,44 @@ commands:
       add:
         description: "adds resets to the player"
         parameters: "<player> <resets>"
-        success: "&aSuccessfully added &b[number] &aresets to &b[name], increasing the total to &b[total]&a resets."
+        success: "&aSuccessfully added &b[number]&a resets to &b[name]&a, increasing the total to &b[total]&a resets."
       remove:
-        description: "removes resets to the player"
+        description: "removes resets from the player"
         parameters: "<player> <resets>"
-        success: "&aSuccessfully removed &b[number] &aresets to &b[name], decreasing the total to &b[total]&a resets."
+        success: "&aSuccessfully removed &b[number]&a resets from &b[name]&a, decreasing the total to &b[total]&a resets."
     purge:
       parameters: "[days]" 
       description: "purge islands abandoned for more than [days]"
-      days-or-more: "Must be at least 1 day or more"     
-      purgable-islands: "Found [number] purgable islands."
-      purge-in-progress: "&cPurging in progress. Use purge stop to cancel"
-      number-error: "&cArgument must be a number of days"
-      confirm: "&dType [label] purge confirm to start purging"  
-      completed: "&aPurging stopped"
-      see-console-for-status: "Purge started. See console for status" 
+      days-or-more: "&cMust be at least &b1&c day or more."
+      purgable-islands: "&aFound &b[number]&a purgable islands."
+      purge-in-progress: |
+        &aPurging in progress.
+        &aUse &b/[label] purge stop &ato cancel.
+      number-error: "&cPlease provide a valid number of days."
+      confirm: "&cType &b/[label] purge confirm &cto start purging."
+      completed: "&aPurge stopped."
+      see-console-for-status: |
+        &aPurge started.
+        &aSee the console for status.
       protect:
-        description: "Toggle island purge protection"
+        description: "toggle island purge protection"
         move-to-island: "&cMove to an island first!"
-        protecting: "&aPurge-protecting island"
-        unprotecting: "&aRemoving purge protection"
+        protecting: "&aProtecting this island from the purge."
+        unprotecting: "&aThis island is no longer protected from the purge."
       stop:
-        description: "Stop a purge in progress"
-        stopping: "Stopping the purge"
-        no-purge-in-progress: "&cNo purge in progress!"
+        description: "stop a purge in progress"
+        stopping: "&aStopping the purge."
+        no-purge-in-progress: "&cThere is no purge in progress!"
       unowned:
-        description: "Purge unowned islands - requires confirmation"
-        unowned-islands: "&dFound [number] islands"
+        description: "purge unowned islands - requires confirmation"
+        unowned-islands: "&aFound &b[number]&a islands."
         
     team:
       add:
         parameters: "<owner> <player>"
         description: "add player to owner's team"
-        name-not-owner: "&c[name] is not the owner."
-        name-has-island: "&c[name] has an island. Unregister or delete them first!"
+        name-not-owner: "&b[name]&c is not the owner of an island."
+        name-has-island: "&b[name]&c already has an island. Unregister or delete them first!"
         success: "&b[name]&a has been added to &b[owner]&a's island."
       disband:
         parameters: "<owner>"


### PR DESCRIPTION
The goal of this PR is to ensure that:

- [ ] All relevant sentences end with **dots**!
- [ ] All the messages can be easily understood by non-native speakers, i.e. through the use of a simpler grammar with a more common vocabulary.
- [ ] Color codes are standardized:
    * [ ] `&a` for "friendly" messages: the action succeeded, etc...
    * [ ] `&c` for "errors", critical messages or warnings: confirmations, etc...
    * [ ] `&b` should precede any "variables" or things we want the user to focus on: command suggestions, numbers, player names...
    * [ ] `&e` for descriptions.
    * [ ] Darker colors variants in case the brighter ones are not providing enough reading comfort (especially the brighter colors in GUIs' titles).
    * [ ] `&7` for punctuation, mostly brackets (they help to pinpoint side information).
- [ ]  Messages targeting players should not mention any technical back-end details.
- [ ]  Messages targeting admins should provide precise explanations of the consequences of an action or solutions to a problem.
- [ ] Multi-sentences messages are spread over multiple lines if it is appropriate.

-------

I decided to do such a thing while I was translating some stuff on GitLocalize. If we want our translations to be of good quality, then we need to provide a high-quality baseline. We will also need to write down translation guidelines so that all addons live in the same boat 🙂.

-------

@tastybento: Since I'm not a native speaker, I'd really like you to check some of the changes I do, in order to make sure I'm not doing any silly mistakes.

I'm creating this PR as a draft for now since there's still plenty of room to improve.
