### PR TITLE
Force UTF-8 encoding in MariaDB database

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseConnector.java
@@ -15,7 +15,7 @@ public class MariaDBDatabaseConnector extends SQLDatabaseConnector {
      */
     MariaDBDatabaseConnector(DatabaseConnectionSettingsImpl dbSettings) {
         super(dbSettings, "jdbc:mysql://" + dbSettings.getHost() + ":" + dbSettings.getPort() + "/" + dbSettings.getDatabaseName()
-        + "?autoReconnect=true&useSSL=false&allowMultiQueries=true");
+        + "?autoReconnect=true&useSSL=false&allowMultiQueries=true&useUnicode=true&characterEncoding=UTF-8");
     }
 
 }


### PR DESCRIPTION
I've added utf-8 support for MariaDB which when getting data from mariadb, the table replacing some (ğüşç) UTF-8 letters to "?"