### PR TITLE
Add new IslandEvent: IslandProtectionRangeChange

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -61,8 +62,22 @@ public class AdminRangeAddCommand extends CompositeCommand {
             return false;
         }
 
-        // Well, now it can be applied without taking any risks !
+        // Get old range for event
+        int oldRange = island.getProtectionRange();
+
+        // Well, now it can be applied without taking any risks!
         island.setProtectionRange(newRange);
+
+        // Call Protection Range Change event. Does not support cancelling.
+        IslandEvent.builder()
+            .island(island)
+            .location(island.getCenter())
+            .reason(IslandEvent.Reason.RANGE_CHANGE)
+            .involvedPlayer(target)
+            .admin(true)
+            .protectionRange(newRange, oldRange)
+            .build();
+
         user.sendMessage("commands.admin.range.add.success",
                 TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),
                 "[total]", String.valueOf(newRange));

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveCommand.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -61,8 +62,22 @@ public class AdminRangeRemoveCommand extends CompositeCommand {
             return false;
         }
 
-        // Well, now it can be applied without taking any risks !
+        // Get old range for event
+        int oldRange = island.getProtectionRange();
+
+        // Well, now it can be applied without taking any risks!
         island.setProtectionRange(newRange);
+
+        // Call Protection Range Change event. Does not support cancelling.
+        IslandEvent.builder()
+            .island(island)
+            .location(island.getCenter())
+            .reason(IslandEvent.Reason.RANGE_CHANGE)
+            .involvedPlayer(target)
+            .admin(true)
+            .protectionRange(newRange, oldRange)
+            .build();
+
         user.sendMessage("commands.admin.range.remove.success",
                 TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),
                 "[total]", String.valueOf(newRange));

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommand.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -46,9 +47,25 @@ public class AdminRangeResetCommand extends CompositeCommand {
         // Get island
         Island island = getIslands().getIsland(getWorld(), targetUUID);
 
+        // Get old range for event
+        int oldRange = island.getProtectionRange();
+
         // Reset the protection range
         int range = getIWM().getIslandProtectionRange(getWorld());
         island.setProtectionRange(range);
+
+        if (oldRange != range) {
+            // Call Protection Range Change event. Does not support cancelling.
+            IslandEvent.builder()
+                .island(island)
+                .location(island.getCenter())
+                .reason(IslandEvent.Reason.RANGE_CHANGE)
+                .involvedPlayer(targetUUID)
+                .admin(true)
+                .protectionRange(range, oldRange)
+                .build();
+        }
+
         user.sendMessage("commands.admin.range.reset.success", TextVariables.NUMBER, String.valueOf(range));
 
         return true;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -67,8 +68,22 @@ public class AdminRangeSetCommand extends CompositeCommand {
             return false;
         }
 
-        // Well, now it can be applied without taking any risks !
+        // Get old range for event
+        int oldRange = island.getProtectionRange();
+
+        // Well, now it can be applied without taking any risks!
         island.setProtectionRange(range);
+
+        // Call Protection Range Change event. Does not support cancelling.
+        IslandEvent.builder()
+            .island(island)
+            .location(island.getCenter())
+            .reason(IslandEvent.Reason.RANGE_CHANGE)
+            .involvedPlayer(targetUUID)
+            .admin(true)
+            .protectionRange(range, oldRange)
+            .build();
+
         user.sendMessage("commands.admin.range.set.success", TextVariables.NUMBER, String.valueOf(range));
 
         return true;

--- a/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
@@ -386,7 +386,7 @@ public class IslandEvent extends IslandBaseEvent {
      * Fired when island protection range is changed.
      * @since 1.11.0
      */
-    public static class IslandProtectionRangeChangeEvent extends IslandBanEvent {
+    public static class IslandProtectionRangeChangeEvent extends IslandBaseEvent {
         /**
          * New protection range value.
          */

--- a/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
@@ -129,7 +129,12 @@ public class IslandEvent extends IslandBaseEvent {
          * The island was reserved and now is being pasted.
          * @since 1.6.0
          */
-        RESERVED
+        RESERVED,
+        /**
+         * The island protection range was changed.
+         * @since 1.11.0
+         */
+        RANGE_CHANGE
     }
 
     public static IslandEventBuilder builder() {
@@ -376,6 +381,77 @@ public class IslandEvent extends IslandBaseEvent {
         }
     }
 
+
+    /**
+     * Fired when island protection range is changed.
+     * @since 1.11.0
+     */
+    public static class IslandProtectionRangeChangeEvent extends IslandBanEvent {
+        /**
+         * New protection range value.
+         */
+        private int newRange;
+
+        /**
+         * Old protection range value.
+         */
+        private int oldRange;
+
+        /**
+         * Constructor IslandProtectionRangeChange creates a new IslandProtectionRangeChange instance.
+         *
+         * @param island of type Island
+         * @param player of type UUID
+         * @param admin of type boolean
+         * @param location of type Location
+         * @param newRange of type int
+         * @param oldRange of type int
+         */
+        private IslandProtectionRangeChangeEvent(Island island, UUID player, boolean admin, Location location, int newRange, int oldRange) {
+            super(island, player, admin, location);
+            this.newRange = newRange;
+            this.oldRange = oldRange;
+        }
+
+
+        /**
+         * This method returns the newRange value.
+         * @return the value of newRange.
+         */
+        public int getNewRange() {
+            return newRange;
+        }
+
+
+        /**
+         * This method returns the oldRange value.
+         * @return the value of oldRange.
+         */
+        public int getOldRange() {
+            return oldRange;
+        }
+
+
+        /**
+         * This method sets the newRange value.
+         * @param newRange the newRange new value.
+         */
+        public void setNewRange(int newRange) {
+            this.newRange = newRange;
+        }
+
+
+        /**
+         * This method sets the oldRange value.
+         * @param oldRange the oldRange new value.
+         */
+        public void setOldRange(int oldRange) {
+            this.oldRange = oldRange;
+        }
+    }
+
+
+
     public static class IslandEventBuilder {
         // Here field are NOT final. They are just used for the building.
         private Island island;
@@ -385,6 +461,16 @@ public class IslandEvent extends IslandBaseEvent {
         private Location location;
         private IslandDeletion deletedIslandInfo;
         private BlueprintBundle blueprintBundle;
+
+        /**
+         * Stores new protection range for island.
+         */
+        private int newRange;
+
+        /**
+         * Stores old protection range for island.
+         */
+        private int oldRange;
 
         public IslandEventBuilder island(Island island) {
             this.island = island;
@@ -437,6 +523,21 @@ public class IslandEvent extends IslandBaseEvent {
             this.blueprintBundle = blueprintBundle;
             return this;
         }
+
+
+        /**
+         * Allows to set new and old protection range.
+         * @param newRange New value of protection range.
+         * @param oldRange Old value of protection range.
+         * @since 1.11.0
+         */
+        @NonNull
+        public IslandEventBuilder protectionRange(int newRange, int oldRange) {
+            this.newRange = newRange;
+            this.oldRange = oldRange;
+            return this;
+        }
+
 
         public IslandBaseEvent build() {
             // Call the generic event for developers who just want one event and use the Reason enum
@@ -507,6 +608,11 @@ public class IslandEvent extends IslandBaseEvent {
                 IslandUnregisteredEvent unreg = new IslandUnregisteredEvent(island, player, admin, location);
                 Bukkit.getPluginManager().callEvent(unreg);
                 return unreg;
+            case RANGE_CHANGE:
+                IslandProtectionRangeChangeEvent
+					change = new IslandProtectionRangeChangeEvent(island, player, admin, location, newRange, oldRange);
+                Bukkit.getPluginManager().callEvent(change);
+                return change;
             default:
                 IslandGeneralEvent general = new IslandGeneralEvent(island, player, admin, location);
                 Bukkit.getPluginManager().callEvent(general);

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -197,8 +198,22 @@ public class JoinLeaveListener implements Listener {
                     user.sendMessage("commands.admin.setrange.range-updated", TextVariables.NUMBER, String.valueOf(range));
                     plugin.log("Island protection range changed from " + island.getProtectionRange() + " to "
                             + range + " for " + user.getName() + " due to permission.");
+
+                    // Get old range for event
+                    int oldRange = island.getProtectionRange();
+
+                    island.setProtectionRange(range);
+
+                    // Call Protection Range Change event. Does not support cancelling.
+                    IslandEvent.builder()
+                        .island(island)
+                        .location(island.getCenter())
+                        .reason(IslandEvent.Reason.RANGE_CHANGE)
+                        .involvedPlayer(user.getUniqueId())
+                        .admin(true)
+                        .protectionRange(range, oldRange)
+                        .build();
                 }
-                island.setProtectionRange(range);
             }
         });
     }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1105,8 +1105,21 @@ public class IslandsManager {
                     target.sendMessage("commands.admin.setrange.range-updated", TextVariables.NUMBER, String.valueOf(range));
                     plugin.log("Setowner: Island protection range changed from " + island.getProtectionRange() + " to "
                             + range + " for " + user.getName() + " due to permission.");
+
+                    // Get old range for event
+                    int oldRange = island.getProtectionRange();
+                    island.setProtectionRange(range);
+
+                    // Call Protection Range Change event. Does not support cancelling.
+                    IslandEvent.builder()
+                        .island(island)
+                        .location(island.getCenter())
+                        .reason(IslandEvent.Reason.RANGE_CHANGE)
+                        .involvedPlayer(targetUUID)
+                        .admin(true)
+                        .protectionRange(range, oldRange)
+                        .build();
                 }
-                island.setProtectionRange(range);
             }
         });
     }


### PR DESCRIPTION
This event is fired when the island protection range is updated. It contains new and old protection range values.
Event implements cancellable as other IslandEvent, but cancelling (or changing event values) is not implemented.

This will allow some addons to detect when the protection range is changed without manually checking it.

Added `@since 1.11.0` as 1.10.1 looks like bugfix release... You can change it :) 