### PR TITLE
Changed Webtool link old to new

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are also plenty of other official or community-made Addons you can try and
 ## Downloads
 
 ### Webtool
-A [webtool](https://bentobox-tool.herokuapp.com/) is currently being developed to allow you to easily setup BentoBox and Addons on your server.
+A [webtool](https://bentobox.cleverapps.io/) is currently being developed to allow you to easily setup BentoBox and Addons on your server.
 
 ### Direct links
 * [Download](https://github.com/BentoBoxWorld/BentoBox/releases)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are also plenty of other official or community-made Addons you can try and
 ## Downloads
 
 ### Webtool
-A [webtool](https://bentobox.cleverapps.io/) is currently being developed to allow you to easily setup BentoBox and Addons on your server.
+A [webtool](https://download.bentobox.world/) is currently being developed to allow you to easily setup BentoBox and Addons on your server.
 
 ### Direct links
 * [Download](https://github.com/BentoBoxWorld/BentoBox/releases)


### PR DESCRIPTION
Replaced the old site with the new Webtool that is found at: https://bentobox.cleverapps.io/