### PR TITLE
Adds explicit permissions to team commands

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -27,7 +27,7 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
 
     @Override
     public void setup() {
-        setPermission("island.team");
+        setPermission("island.team.accept");
         setOnlyPlayer(true);
         setDescription("commands.island.team.invite.accept.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
@@ -28,7 +28,7 @@ public class IslandTeamInviteCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("island.team");
+        setPermission("island.team.invite");
         setOnlyPlayer(true);
         setDescription("commands.island.team.invite.description");
         setConfigurableRankCommand();

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteRejectCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteRejectCommand.java
@@ -19,7 +19,7 @@ public class IslandTeamInviteRejectCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("island.team");
+        setPermission("island.team.reject");
         setOnlyPlayer(true);
         setDescription("commands.island.team.invite.reject.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -21,7 +21,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
 
     @Override
     public void setup() {
-        setPermission("island.team");
+        setPermission("island.team.kick");
         setOnlyPlayer(true);
         setParametersHelp("commands.island.team.kick.parameters");
         setDescription("commands.island.team.kick.description");

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommand.java
@@ -20,7 +20,7 @@ public class IslandTeamLeaveCommand extends ConfirmableCommand {
 
     @Override
     public void setup() {
-        setPermission("island.team");
+        setPermission("island.team.leave");
         setOnlyPlayer(true);
         setDescription("commands.island.team.leave.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
@@ -22,7 +22,7 @@ public class IslandTeamSetownerCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("island.team");
+        setPermission("island.team.setowner");
         setOnlyPlayer(true);
         setParametersHelp("commands.island.team.setowner.parameters");
         setDescription("commands.island.team.setowner.description");

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommand.java
@@ -28,7 +28,7 @@ public class IslandTeamUntrustCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("island.team.coop");
+        setPermission("island.team.trust");
         setOnlyPlayer(true);
         setParametersHelp("commands.island.team.untrust.parameters");
         setDescription("commands.island.team.untrust.description");


### PR DESCRIPTION
https://github.com/BentoBoxWorld/BentoBox/issues/1144

Also fixes a bug where the untrust was using the coop perm.

I'm making this a PR because by requiring explicit perms it'll suddenly remove commands from players unless admins upgrade to the latest addons. So, I don't think it should be merged until we have the game mode addons updated with the latest permissions in their addon.yml's.