### PR TITLE
Implement option to enable SSL for database connections.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -93,6 +93,11 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "general.database.backup-period")
     private int databaseBackupPeriod = 5;
 
+    @ConfigComment("Allows to enable SSL protection to database connections for MongoDB,")
+    @ConfigComment("MariaDB, MySQL and PostgreSQL database servers.")
+    @ConfigEntry(path = "general.database.useSSL", since = "1.12.0")
+    private boolean useSSL = false;
+
     @ConfigComment("Allow FTB Autonomous Activator to work (will allow a pseudo player [CoFH] to place and break blocks and hang items)")
     @ConfigComment("Add other fake player names here if required")
     @ConfigEntry(path = "general.fakeplayers", experimental = true)
@@ -294,6 +299,24 @@ public class Settings implements ConfigObject {
 
     public int getDatabasePort() {
         return databasePort;
+    }
+
+    /**
+     * This method returns the useSSL value.
+     * @return the value of useSSL.
+     * @since 1.12.0
+     */
+    public boolean isUseSSL() {
+        return useSSL;
+    }
+
+    /**
+     * This method sets the useSSL value.
+     * @param useSSL the useSSL new value.
+     * @since 1.12.0
+     */
+    public void setUseSSL(boolean useSSL) {
+        this.useSSL = useSSL;
     }
 
     public void setDatabasePort(int databasePort) {

--- a/src/main/java/world/bentobox/bentobox/database/DatabaseConnectionSettingsImpl.java
+++ b/src/main/java/world/bentobox/bentobox/database/DatabaseConnectionSettingsImpl.java
@@ -8,6 +8,13 @@ public class DatabaseConnectionSettingsImpl {
     private String password;
 
     /**
+     * Allows to enable SSL protection to databases that supports it, like mariaDB, MySQL,
+     * PostgreSQL and MongoDB.
+     * @since 1.12.0
+     */
+    private boolean useSSL;
+
+    /**
      * Hosts database settings
      * @param host - database host
      * @param port - port
@@ -15,12 +22,13 @@ public class DatabaseConnectionSettingsImpl {
      * @param username - username 
      * @param password - password
      */
-    public DatabaseConnectionSettingsImpl(String host, int port, String databaseName, String username, String password) {
+    public DatabaseConnectionSettingsImpl(String host, int port, String databaseName, String username, String password, boolean useSSL) {
         this.host = host;
         this.port = port;
         this.databaseName = databaseName;
         this.username = username;
         this.password = password;
+        this.useSSL = useSSL;
     }
 
     /**
@@ -93,4 +101,20 @@ public class DatabaseConnectionSettingsImpl {
         this.password = password;
     }
 
+    /**
+     * This method returns the ssl value.
+     * @return the value of ssl.
+     */
+    public boolean isUseSSL() {
+        return useSSL;
+    }
+
+    /**
+     * This method sets the ssl value.
+     * @param useSSL the ssl new value.
+     *
+     */
+    public void setUseSSL(boolean useSSL) {
+        this.useSSL = useSSL;
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabase.java
@@ -30,7 +30,8 @@ public class MongoDBDatabase implements DatabaseSetup {
                     plugin.getSettings().getDatabasePort(),
                     plugin.getSettings().getDatabaseName(),
                     plugin.getSettings().getDatabaseUsername(),
-                    plugin.getSettings().getDatabasePassword()
+                    plugin.getSettings().getDatabasePassword(),
+                    plugin.getSettings().isUseSSL()
                     ));
         }
         return new MongoDBDatabaseHandler<>(plugin, type, connector);

--- a/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabaseConnector.java
@@ -37,7 +37,7 @@ public class MongoDBDatabaseConnector implements DatabaseConnector {
             MongoCredential credential = MongoCredential.createCredential(dbSettings.getUsername(),
                     dbSettings.getDatabaseName(),
                     dbSettings.getPassword().toCharArray());
-            MongoClientOptions options = MongoClientOptions.builder().sslEnabled(false).build();
+            MongoClientOptions options = MongoClientOptions.builder().sslEnabled(dbSettings.isUseSSL()).build();
             client = new MongoClient(new ServerAddress(dbSettings.getHost(), dbSettings.getPort()), credential,options);
         }
         return client.getDatabase(dbSettings.getDatabaseName());

--- a/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabase.java
@@ -24,7 +24,8 @@ public class MariaDBDatabase implements DatabaseSetup {
                     plugin.getSettings().getDatabasePort(),
                     plugin.getSettings().getDatabaseName(),
                     plugin.getSettings().getDatabaseUsername(),
-                    plugin.getSettings().getDatabasePassword()
+                    plugin.getSettings().getDatabasePassword(),
+                    plugin.getSettings().isUseSSL()
                     ));
         }
         return new MariaDBDatabaseHandler<>(plugin, type, connector);

--- a/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseConnector.java
@@ -15,7 +15,7 @@ public class MariaDBDatabaseConnector extends SQLDatabaseConnector {
      */
     MariaDBDatabaseConnector(DatabaseConnectionSettingsImpl dbSettings) {
         super(dbSettings, "jdbc:mysql://" + dbSettings.getHost() + ":" + dbSettings.getPort() + "/" + dbSettings.getDatabaseName()
-        + "?autoReconnect=true&useSSL=false&allowMultiQueries=true&useUnicode=true&characterEncoding=UTF-8");
+        + "?autoReconnect=true&useSSL=" + dbSettings.isUseSSL() + "&allowMultiQueries=true&useUnicode=true&characterEncoding=UTF-8");
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabase.java
@@ -21,7 +21,8 @@ public class MySQLDatabase implements DatabaseSetup {
                     plugin.getSettings().getDatabasePort(),
                     plugin.getSettings().getDatabaseName(),
                     plugin.getSettings().getDatabaseUsername(),
-                    plugin.getSettings().getDatabasePassword()
+                    plugin.getSettings().getDatabasePassword(),
+                    plugin.getSettings().isUseSSL()
                     ));
         }
         return new MySQLDatabaseHandler<>(plugin, type, connector);

--- a/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseConnector.java
@@ -11,6 +11,6 @@ public class MySQLDatabaseConnector extends SQLDatabaseConnector {
      */
     MySQLDatabaseConnector(DatabaseConnectionSettingsImpl dbSettings) {
         super(dbSettings, "jdbc:mysql://" + dbSettings.getHost() + ":" + dbSettings.getPort() + "/" + dbSettings.getDatabaseName()
-        + "?autoReconnect=true&useSSL=false&allowMultiQueries=true&useUnicode=true&characterEncoding=UTF-8");
+        + "?autoReconnect=true&useSSL=" + dbSettings.isUseSSL() + "&allowMultiQueries=true&useUnicode=true&characterEncoding=UTF-8");
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabase.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabase.java
@@ -22,7 +22,8 @@ public class PostgreSQLDatabase implements DatabaseSetup {
                     plugin.getSettings().getDatabasePort(),
                     plugin.getSettings().getDatabaseName(),
                     plugin.getSettings().getDatabaseUsername(),
-                    plugin.getSettings().getDatabasePassword()
+                    plugin.getSettings().getDatabasePassword(),
+                    plugin.getSettings().isUseSSL()
                     ));
         }
         return new PostgreSQLDatabaseHandler<>(plugin, dataObjectClass, connector);

--- a/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseConnector.java
@@ -29,6 +29,6 @@ public class PostgreSQLDatabaseConnector extends SQLDatabaseConnector {
      */
     PostgreSQLDatabaseConnector(@NonNull DatabaseConnectionSettingsImpl dbSettings) {
         super(dbSettings, "jdbc:postgresql://" + dbSettings.getHost() + ":" + dbSettings.getPort() + "/" + dbSettings.getDatabaseName()
-        + "?autoReconnect=true&useSSL=false&allowMultiQueries=true&useUnicode=true&characterEncoding=UTF-8");
+        + "?autoReconnect=true&useSSL=" + dbSettings.isUseSSL() + "&allowMultiQueries=true&useUnicode=true&characterEncoding=UTF-8");
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,6 +58,10 @@ general:
     # This helps prevent issues if the server crashes.
     # Data is also saved at important points in the game.
     backup-period: 5
+    # Allows to enable SSL protection to database connections for MongoDB,
+    # MariaDB, MySQL and PostgreSQL database servers.
+    # Added since 1.2.0.
+    useSSL: false
   # Allow FTB Autonomous Activator to work (will allow a pseudo player [CoFH] to place and break blocks and hang items)
   # Add other fake player names here if required
   # /!\ This feature is experimental and might not work as expected or might not work at all.


### PR DESCRIPTION
This come up in Discord support channel, but and I notice that it is disabled by default.

This will allow toggling usage of SSL connection.