### PR TITLE
Improve bStats playersPerServer chart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <mongodb.version>3.8.0</mongodb.version>
         <!-- More visible way to change dependency versions -->
         <spigot.version>1.15.2-R0.1-SNAPSHOT</spigot.version>
-        <bstats.version>1.5</bstats.version>
+        <bstats.version>1.7</bstats.version>
         <vault.version>1.7</vault.version>
         <placeholderapi.version>2.10.4</placeholderapi.version>
         <mvdwplaceholderapi.version>master-SNAPSHOT</mvdwplaceholderapi.version>

--- a/src/main/java/world/bentobox/bentobox/BStats.java
+++ b/src/main/java/world/bentobox/bentobox/BStats.java
@@ -15,6 +15,7 @@ import world.bentobox.bentobox.api.flags.Flag;
 public class BStats {
 
     private final BentoBox plugin;
+    private final int bstatsId;
     private Metrics metrics;
 
     /**
@@ -24,13 +25,14 @@ public class BStats {
      */
     private int islandsCreatedCount = 0;
 
-    BStats(BentoBox plugin) {
+    BStats(BentoBox plugin, int bstatsId) {
         this.plugin = plugin;
+        this.bstatsId = bstatsId;
     }
 
     void registerMetrics() {
         if (metrics == null) {
-            metrics = new Metrics(plugin);
+            metrics = new Metrics(plugin, bstatsId);
             registerCustomMetrics();
         }
     }
@@ -133,7 +135,8 @@ public class BStats {
             else if (players <= 30) return "11-30";
             else if (players <= 50) return "31-50";
             else if (players <= 100) return "51-100";
-            else if (players <= 200) return "101-200";
+            else if (players <= 150) return "101-150";
+            else if (players <= 200) return "150-200";
             else return "201+";
         }));
     }

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -87,6 +87,7 @@ public class BentoBox extends JavaPlugin {
     // Metrics
     @Nullable
     private BStats metrics;
+    private static final int BSTATS_ID = 3555;
 
     private Config<Settings> configObject;
 
@@ -195,10 +196,8 @@ public class BentoBox extends JavaPlugin {
             flagsManager.registerListeners();
 
             // Load metrics
-            if (settings.isMetrics()) {
-                metrics = new BStats(this);
-                metrics.registerMetrics();
-            }
+             metrics = new BStats(this, BSTATS_ID);
+             metrics.registerMetrics();
 
             // Register Multiverse hook - MV loads AFTER BentoBox
             // Make sure all worlds are already registered to Multiverse.

--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -19,7 +19,7 @@ import world.bentobox.bentobox.database.DatabaseSetup.DatabaseType;
 @ConfigComment("This configuration file contains settings that mainly apply to or manage the following elements:")
 @ConfigComment(" * Data storage")
 @ConfigComment(" * Gamemodes (commands, ...)")
-@ConfigComment(" * Internet connectivity (metrics, web-based content-enriched features, ...)")
+@ConfigComment(" * Internet connectivity (web-based content-enriched features, ...)")
 @ConfigComment("")
 @ConfigComment("Note that this configuration file is dynamic:")
 @ConfigComment(" * It gets updated with the newest settings and comments after BentoBox loaded its settings from it.")
@@ -228,11 +228,6 @@ public class Settings implements ConfigObject {
     private boolean autoOwnershipTransferIgnoreRanks = false;
 
     /* WEB */
-    @ConfigComment("BentoBox uses bStats.org to get global data about the plugin to help improving it.")
-    @ConfigComment("bStats has nearly no effect on your server's performance and the sent data is completely")
-    @ConfigComment("anonymous so please consider twice if you really want to disable it.")
-    @ConfigEntry(path = "web.metrics")
-    private boolean metrics = true;
 
     @ConfigComment("Toggle whether BentoBox can connect to GitHub to get data about updates and addons.")
     @ConfigComment("Disabling this will result in the deactivation of the update checker and of some other")
@@ -256,14 +251,6 @@ public class Settings implements ConfigObject {
 
     // ---------------------------------------------
     // Getters and setters
-
-    public boolean isMetrics() {
-        return metrics;
-    }
-
-    public void setMetrics(boolean metrics) {
-        this.metrics = metrics;
-    }
 
     public String getDefaultLanguage() {
         return defaultLanguage;


### PR DESCRIPTION
This pr adds another player range filling the gap going by 50.
In the same run I updated bstats to their latest versions, given that I removed the config entries because they are now unnecessary. bstats sending info can be controlled by using the bstats config.yml.
1.7 requires the usage of a plugin id as well, which I included too.