### PR TITLE
Fixes potion splash pvp check

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/settings/PVPListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/settings/PVPListener.java
@@ -136,8 +136,12 @@ public class PVPListener extends FlagListener {
     public void onSplashPotionSplash(final PotionSplashEvent e) {
         if (e.getEntity().getShooter() instanceof Player && getPlugin().getIWM().inWorld(e.getEntity().getWorld())) {
             User user = User.getInstance((Player)e.getEntity().getShooter());
-            // Run through affected entities and cancel the splash if any are a protected player
-            e.setCancelled(e.getAffectedEntities().stream().anyMatch(le -> blockPVP(user, le, e, getFlag(e.getEntity().getWorld()))));
+            // Run through affected entities and cancel the splash for protected players
+            for (LivingEntity le : e.getAffectedEntities()) {
+                if (!le.getUniqueId().equals(user.getUniqueId()) && blockPVP(user, le, e, getFlag(e.getEntity().getWorld()))) {
+                    e.setIntensity(le, 0);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Before this change, the entire potion splash would be cancelled if a single protected player would have been affected. Now, it will only remove the protected players themselves from the affected list.

This also ignores the player itself (`!le.getUniqueId().equals(user.getUniqueId()`), since I wasn't sure whether that is included with the pvp check - if it's not desired, I will remove it again

(Another probably unintended sideeffect of the old code was that it would _uncancel_ events that had potentially been cancelled by another plugin earlier, so this is fixed as well)