### PR TITLE
Improved/Fixed experience pickup flag on Paper servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,8 @@
         <mongodb.version>3.8.0</mongodb.version>
         <!-- More visible way to change dependency versions -->
         <spigot.version>1.15.2-R0.1-SNAPSHOT</spigot.version>
+        <!-- Might differ from the last Spigot release for short periods of time -->
+        <paper.version>1.15.2-R0.1-SNAPSHOT</paper.version>
         <bstats.version>1.7</bstats.version>
         <vault.version>1.7</vault.version>
         <placeholderapi.version>2.10.5</placeholderapi.version>
@@ -188,6 +190,13 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>${spigot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Paper API -->
+        <dependency>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Metrics -->

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PaperExperiencePickupListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PaperExperiencePickupListener.java
@@ -1,0 +1,19 @@
+package world.bentobox.bentobox.listeners.flags.protection;
+
+import com.destroystokyo.paper.event.player.PlayerPickupExperienceEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import world.bentobox.bentobox.lists.Flags;
+
+/**
+ * Handles the {@link Flags#EXPERIENCE_PICKUP} flag with a Paper specific pickup event.
+ */
+public class PaperExperiencePickupListener extends ExperiencePickupListener {
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onExperiencePickup(PlayerPickupExperienceEvent e) {
+        if (!checkIsland(e, e.getPlayer(), e.getExperienceOrb().getLocation(), Flags.EXPERIENCE_PICKUP)) {
+            e.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PaperExperiencePickupListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PaperExperiencePickupListener.java
@@ -7,6 +7,8 @@ import world.bentobox.bentobox.lists.Flags;
 
 /**
  * Handles the {@link Flags#EXPERIENCE_PICKUP} flag with a Paper specific pickup event.
+ * @since 1.13.0
+ * @author KennyTV
  */
 public class PaperExperiencePickupListener extends ExperiencePickupListener {
 

--- a/src/main/java/world/bentobox/bentobox/lists/Flags.java
+++ b/src/main/java/world/bentobox/bentobox/lists/Flags.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
@@ -29,6 +30,7 @@ import world.bentobox.bentobox.listeners.flags.protection.ItemDropPickUpListener
 import world.bentobox.bentobox.listeners.flags.protection.LeashListener;
 import world.bentobox.bentobox.listeners.flags.protection.LecternListener;
 import world.bentobox.bentobox.listeners.flags.protection.LockAndBanListener;
+import world.bentobox.bentobox.listeners.flags.protection.PaperExperiencePickupListener;
 import world.bentobox.bentobox.listeners.flags.protection.PhysicalInteractionListener;
 import world.bentobox.bentobox.listeners.flags.protection.PlaceBlocksListener;
 import world.bentobox.bentobox.listeners.flags.protection.PortalListener;
@@ -248,7 +250,8 @@ public final class Flags {
     public static final Flag ITEM_PICKUP = new Flag.Builder("ITEM_PICKUP", Material.SUGAR_CANE).mode(Flag.Mode.BASIC).build();
 
     // Experience
-    public static final Flag EXPERIENCE_PICKUP = new Flag.Builder("EXPERIENCE_PICKUP", Material.EXPERIENCE_BOTTLE).listener(new ExperiencePickupListener()).mode(Flag.Mode.ADVANCED).build();
+    public static final Flag EXPERIENCE_PICKUP = new Flag.Builder("EXPERIENCE_PICKUP", Material.EXPERIENCE_BOTTLE)
+            .listener(PaperLib.isPaper() ? new PaperExperiencePickupListener() : new ExperiencePickupListener()).mode(Flag.Mode.ADVANCED).build();
 
     // Command ranks
     public static final Flag COMMAND_RANKS = new Flag.Builder("COMMAND_RANKS", Material.PLAYER_HEAD)
@@ -355,7 +358,7 @@ public final class Flags {
 
     public static final Flag GEO_LIMIT_MOBS = new Flag.Builder("GEO_LIMIT_MOBS", Material.CHAINMAIL_CHESTPLATE).type(Type.WORLD_SETTING)
             .listener(new GeoLimitMobsListener()).clickHandler(new GeoLimitClickListener()).usePanel(true).build();
-    
+
     /**
      * @since 1.12.0
      */


### PR DESCRIPTION
Using Paper's PlayerPickupExperienceEvent, not only orb player targetting, but the actual pickup is cancelled as well (if Paper is used, that is).
This obviously has the need of adding Paper as a dependency for this single event usage, but given that the flag simply doesn't properly work otherwise, I figured it to be important enough