### PR TITLE
Fixed BentoBox not properly disabling if errors at startup

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -238,8 +238,8 @@ public class BentoBox extends JavaPlugin {
         Bukkit.getScheduler().runTaskLater(this, () -> {
             if (!isLoaded) {
                 logError("BentoBox could not load correctly. Disabling plugin! Check console for errors.");
-                instance.setEnabled(false);
                 this.onDisable();
+                instance.setEnabled(false);
             }
         }, 2L);
     }

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -193,8 +193,8 @@ public class BentoBox extends JavaPlugin {
             flagsManager.registerListeners();
 
             // Load metrics
-             metrics = new BStats(this);
-             metrics.registerMetrics();
+            metrics = new BStats(this);
+            metrics.registerMetrics();
 
             // Register Multiverse hook - MV loads AFTER BentoBox
             // Make sure all worlds are already registered to Multiverse.
@@ -204,7 +204,7 @@ public class BentoBox extends JavaPlugin {
             // Register additional hooks
             hooksManager.registerHook(new DynmapHook());
             hooksManager.registerHook(new WorldEditHook());
-
+            Integer.valueOf("xxx");
             webManager = new WebManager(this);
 
             final long enableTime = System.currentTimeMillis() - enableStart;
@@ -215,7 +215,7 @@ public class BentoBox extends JavaPlugin {
                     "[time]", String.valueOf(loadTime + enableTime));
 
             // Poll for blueprints loading to be finished - async so could be a completely variable time
-            blueprintLoadingTask = Bukkit.getScheduler().runTaskTimer(instance, () -> {
+            blueprintLoadingTask = Bukkit.getScheduler().runTaskLater(instance, () -> {
                 if (getBlueprintsManager().isBlueprintsLoaded()) {
                     blueprintLoadingTask.cancel();
                     // Tell all addons that everything is loaded
@@ -225,7 +225,7 @@ public class BentoBox extends JavaPlugin {
                     Bukkit.getPluginManager().callEvent(new BentoBoxReadyEvent());
                     instance.log("All blueprints loaded.");
                 }
-            }, 0L, 1L);
+            }, 1L);
 
             if (getSettings().getDatabaseType().equals(DatabaseSetup.DatabaseType.YAML)) {
                 logWarning("*** You're still using YAML database ! ***");
@@ -235,6 +235,13 @@ public class BentoBox extends JavaPlugin {
                 logWarning("*** *** *** *** *** *** *** *** *** *** ***");
             }
         });
+        Bukkit.getScheduler().runTaskLater(this, () -> {
+            if (!isLoaded) {
+                logError("BentoBox could not load correctly. Disabling plugin! Check console for errors.");
+                instance.setEnabled(false);
+                this.onDisable();
+            }
+        }, 2L);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -204,7 +204,7 @@ public class BentoBox extends JavaPlugin {
             // Register additional hooks
             hooksManager.registerHook(new DynmapHook());
             hooksManager.registerHook(new WorldEditHook());
-            Integer.valueOf("xxx");
+
             webManager = new WebManager(this);
 
             final long enableTime = System.currentTimeMillis() - enableStart;


### PR DESCRIPTION
https://github.com/BentoBoxWorld/BentoBox/issues/1281

There's no way to check if the task completes except to check for a flag that is set at the very end. This approach runs another scheduler to check that the loaded flag is set. Another approach is to put a big try/catch around all the code in the task. If you know of a better way to do this, let me know.