### PR TITLE
Add DefaultPlayerCommand and DefaultAdminCommand

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
@@ -26,93 +26,93 @@ import world.bentobox.bentobox.api.user.User;
  */
 public abstract class DefaultAdminCommand extends CompositeCommand
 {
-	/**
-	 * This is the top-level command constructor for commands that have no parent.
-	 *
-	 * @param addon   - GameMode addon
-	 */
-	public DefaultAdminCommand(GameModeAddon addon)
-	{
-		// Register command with alias from config.
-		super(addon,
-			addon.getWorldSettings().getAdminCommandAlias().split(" ")[0],
-			addon.getWorldSettings().getAdminCommandAlias().split(" "));
-	}
+    /**
+     * This is the top-level command constructor for commands that have no parent.
+     *
+     * @param addon   - GameMode addon
+     */
+    public DefaultAdminCommand(GameModeAddon addon)
+    {
+        // Register command with alias from config.
+        super(addon,
+            addon.getWorldSettings().getAdminCommandAliases().split(" ")[0],
+            addon.getWorldSettings().getAdminCommandAliases().split(" "));
+    }
 
 
-	/**
-	 * Setups anything that is necessary for default main admin command.
-	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#setup()
-	 */
-	@Override
-	public void setup()
-	{
-		this.setPermission("admin.*");
-		this.setOnlyPlayer(false);
+    /**
+     * Setups anything that is necessary for default main admin command.
+     * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#setup()
+     */
+    @Override
+    public void setup()
+    {
+        this.setPermission("admin.*");
+        this.setOnlyPlayer(false);
 
-		this.setParametersHelp("commands.admin.help.parameters");
-		this.setDescription("commands.admin.help.description");
+        this.setParametersHelp("commands.admin.help.parameters");
+        this.setDescription("commands.admin.help.description");
 
-		new AdminVersionCommand(this);
-		new AdminTeleportCommand(this, "tp");
-		new AdminTeleportCommand(this, "tpnether");
-		new AdminTeleportCommand(this, "tpend");
-		new AdminGetrankCommand(this);
-		new AdminSetrankCommand(this);
-		new AdminInfoCommand(this);
-		// Team commands
-		new AdminTeamAddCommand(this);
-		new AdminTeamKickCommand(this);
-		new AdminTeamDisbandCommand(this);
-		new AdminTeamSetownerCommand(this);
-		// Schems
-		new AdminBlueprintCommand(this);
-		// Register/unregister islands
-		new AdminRegisterCommand(this);
-		new AdminUnregisterCommand(this);
-		// Range
-		new AdminRangeCommand(this);
-		// Resets
-		new AdminResetsCommand(this);
-		// Delete
-		new AdminDeleteCommand(this);
-		// Why
-		new AdminWhyCommand(this);
-		// Deaths
-		new AdminDeathsCommand(this);
-		// Reload
-		new AdminReloadCommand(this);
-		// Spawn
-		new AdminSetspawnCommand(this);
-		// Reset flags
-		new AdminResetFlagsCommand(this);
-		// Trash
-		//new AdminTrashCommand(this);
-		//new AdminEmptyTrashCommand(this);
-		//new AdminSwitchtoCommand(this);
-		// Switch
-		new AdminSwitchCommand(this);
-		// Purge
-		new AdminPurgeCommand(this);
-		// Settings
-		new AdminSettingsCommand(this);
-	}
+        new AdminVersionCommand(this);
+        new AdminTeleportCommand(this, "tp");
+        new AdminTeleportCommand(this, "tpnether");
+        new AdminTeleportCommand(this, "tpend");
+        new AdminGetrankCommand(this);
+        new AdminSetrankCommand(this);
+        new AdminInfoCommand(this);
+        // Team commands
+        new AdminTeamAddCommand(this);
+        new AdminTeamKickCommand(this);
+        new AdminTeamDisbandCommand(this);
+        new AdminTeamSetownerCommand(this);
+        // Schems
+        new AdminBlueprintCommand(this);
+        // Register/unregister islands
+        new AdminRegisterCommand(this);
+        new AdminUnregisterCommand(this);
+        // Range
+        new AdminRangeCommand(this);
+        // Resets
+        new AdminResetsCommand(this);
+        // Delete
+        new AdminDeleteCommand(this);
+        // Why
+        new AdminWhyCommand(this);
+        // Deaths
+        new AdminDeathsCommand(this);
+        // Reload
+        new AdminReloadCommand(this);
+        // Spawn
+        new AdminSetspawnCommand(this);
+        // Reset flags
+        new AdminResetFlagsCommand(this);
+        // Trash
+        //new AdminTrashCommand(this);
+        //new AdminEmptyTrashCommand(this);
+        //new AdminSwitchtoCommand(this);
+        // Switch
+        new AdminSwitchCommand(this);
+        // Purge
+        new AdminPurgeCommand(this);
+        // Settings
+        new AdminSettingsCommand(this);
+    }
 
 
-	/**
-	 * Defines what will be executed when this command is run.
-	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#execute(User, String, List<String>)
-	 */
-	@Override
-	public boolean execute(User user, String label, List<String> args)
-	{
-		if (user != null && !args.isEmpty())
-		{
-			user.sendMessage("general.errors.unknown-command", TextVariables.LABEL, getTopLabel());
-			return false;
-		}
+    /**
+     * Defines what will be executed when this command is run.
+     * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#execute(User, String, List<String>)
+     */
+    @Override
+    public boolean execute(User user, String label, List<String> args)
+    {
+        if (user != null && !args.isEmpty())
+        {
+            user.sendMessage("general.errors.unknown-command", TextVariables.LABEL, getTopLabel());
+            return false;
+        }
 
-		// By default run the attached help command, if it exists (it should)
-		return this.showHelp(this, user);
-	}
+        // By default run the attached help command, if it exists (it should)
+        return this.showHelp(this, user);
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
@@ -1,0 +1,116 @@
+package world.bentobox.bentobox.api.commands.admin;
+
+
+import java.util.List;
+
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCommand;
+import world.bentobox.bentobox.api.commands.admin.deaths.AdminDeathsCommand;
+import world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand;
+import world.bentobox.bentobox.api.commands.admin.range.AdminRangeCommand;
+import world.bentobox.bentobox.api.commands.admin.resets.AdminResetsCommand;
+import world.bentobox.bentobox.api.commands.admin.team.AdminTeamAddCommand;
+import world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand;
+import world.bentobox.bentobox.api.commands.admin.team.AdminTeamKickCommand;
+import world.bentobox.bentobox.api.commands.admin.team.AdminTeamSetownerCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+
+
+/**
+ * This is default Admin command for console and op. It contains all necessary parts that
+ * for main command.
+ */
+public abstract class DefaultAdminCommand extends CompositeCommand
+{
+	/**
+	 * This is the top-level command constructor for commands that have no parent.
+	 *
+	 * @param addon   - GameMode addon
+	 */
+	public DefaultAdminCommand(GameModeAddon addon)
+	{
+		// Register command with alias from config.
+		super(addon,
+			addon.getWorldSettings().getAdminCommandAlias().split(" ")[0],
+			addon.getWorldSettings().getAdminCommandAlias().split(" "));
+	}
+
+
+	/**
+	 * Setups anything that is necessary for default main admin command.
+	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#setup()
+	 */
+	@Override
+	public void setup()
+	{
+		this.setPermission("admin.*");
+		this.setOnlyPlayer(false);
+
+		this.setParametersHelp("commands.admin.help.parameters");
+		this.setDescription("commands.admin.help.description");
+
+		new AdminVersionCommand(this);
+		new AdminTeleportCommand(this, "tp");
+		new AdminTeleportCommand(this, "tpnether");
+		new AdminTeleportCommand(this, "tpend");
+		new AdminGetrankCommand(this);
+		new AdminSetrankCommand(this);
+		new AdminInfoCommand(this);
+		// Team commands
+		new AdminTeamAddCommand(this);
+		new AdminTeamKickCommand(this);
+		new AdminTeamDisbandCommand(this);
+		new AdminTeamSetownerCommand(this);
+		// Schems
+		new AdminBlueprintCommand(this);
+		// Register/unregister islands
+		new AdminRegisterCommand(this);
+		new AdminUnregisterCommand(this);
+		// Range
+		new AdminRangeCommand(this);
+		// Resets
+		new AdminResetsCommand(this);
+		// Delete
+		new AdminDeleteCommand(this);
+		// Why
+		new AdminWhyCommand(this);
+		// Deaths
+		new AdminDeathsCommand(this);
+		// Reload
+		new AdminReloadCommand(this);
+		// Spawn
+		new AdminSetspawnCommand(this);
+		// Reset flags
+		new AdminResetFlagsCommand(this);
+		// Trash
+		//new AdminTrashCommand(this);
+		//new AdminEmptyTrashCommand(this);
+		//new AdminSwitchtoCommand(this);
+		// Switch
+		new AdminSwitchCommand(this);
+		// Purge
+		new AdminPurgeCommand(this);
+		// Settings
+		new AdminSettingsCommand(this);
+	}
+
+
+	/**
+	 * Defines what will be executed when this command is run.
+	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#execute(User, String, List<String>)
+	 */
+	@Override
+	public boolean execute(User user, String label, List<String> args)
+	{
+		if (user != null && !args.isEmpty())
+		{
+			user.sendMessage("general.errors.unknown-command", TextVariables.LABEL, getTopLabel());
+			return false;
+		}
+
+		// By default run the attached help command, if it exists (it should)
+		return this.showHelp(this, user);
+	}
+}

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
@@ -21,6 +21,8 @@ import world.bentobox.bentobox.api.user.User;
 /**
  * This is default Admin command for console and op. It contains all necessary parts that
  * for main command.
+ * @since 1.13.0
+ * @author BONNe
  */
 public abstract class DefaultAdminCommand extends CompositeCommand
 {

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultIslandCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultIslandCommand.java
@@ -14,6 +14,8 @@ import world.bentobox.bentobox.api.user.User;
 /**
  * This is default Island command for users. It contains all necessary parts for main
  * command.
+ * @since 1.13.0
+ * @author BONNe
  */
 public abstract class DefaultIslandCommand extends CompositeCommand
 {

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultIslandCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultIslandCommand.java
@@ -1,0 +1,140 @@
+package world.bentobox.bentobox.api.commands.island;
+
+
+import java.util.Collections;
+import java.util.List;
+
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+
+
+/**
+ * This is default Island command for users. It contains all necessary parts for main
+ * command.
+ */
+public abstract class DefaultIslandCommand extends CompositeCommand
+{
+	/**
+	 * This is the top-level command constructor for commands that have no parent.
+	 *
+	 * @param addon   - GameMode addon
+	 */
+	public DefaultIslandCommand(GameModeAddon addon)
+	{
+		// Register command with alias from config.
+		super(addon,
+			addon.getWorldSettings().getUserCommandAlias().split(" ")[0],
+			addon.getWorldSettings().getUserCommandAlias().split(" "));
+	}
+
+
+	/**
+	 * Setups anything that is necessary for default main user command.
+	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#setup()
+	 */
+	@Override
+	public void setup()
+	{
+		// Description
+		this.setDescription("commands.island.help.description");
+		// Limit to player
+		this.setOnlyPlayer(true);
+		// Permission
+		this.setPermission("island");
+
+		// Set up default subcommands
+
+		// Teleport commands
+		new IslandGoCommand(this);
+		new IslandSpawnCommand(this);
+
+		// Allows to create/reset island.
+		new IslandCreateCommand(this);
+		new IslandResetCommand(this);
+
+		// Displays info about the island.
+		new IslandInfoCommand(this);
+
+		// Settings related commands
+		new IslandSettingsCommand(this);
+		new IslandSethomeCommand(this);
+		new IslandSetnameCommand(this);
+		new IslandResetnameCommand(this);
+		new IslandLanguageCommand(this);
+
+		// Ban related commands
+		new IslandBanCommand(this);
+		new IslandUnbanCommand(this);
+		new IslandBanlistCommand(this);
+
+		// Kicks visitors or coops/trusted from island
+		new IslandExpelCommand(this);
+
+		// Tells owner of adjacent islands
+		new IslandNearCommand(this);
+
+		// Team commands
+		new IslandTeamCommand(this);
+	}
+
+
+	/**
+	 * Defines what will be executed when this command is run.
+	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#execute(User, String, List<String>)
+	 */
+	@Override
+	public boolean execute(User user, String label, List<String> args)
+	{
+		if (user == null)
+		{
+			return false;
+		}
+
+		if (!args.isEmpty())
+		{
+			user.sendMessage("general.errors.unknown-command", TextVariables.LABEL, this.getTopLabel());
+			return false;
+		}
+
+		// Check if user has an island.
+		if (this.getIslands().getIsland(this.getWorld(), user.getUniqueId()) != null)
+		{
+			// Default command if user has an island.
+			String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultHasIslandSubCommand();
+
+			// If command exists, the call it.
+			// Otherwise, just use "go" command.
+			if (command != null && this.getSubCommand(command).isPresent())
+			{
+				return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
+			}
+			else
+			{
+				return this.getSubCommand("go").
+					map(goCmd -> goCmd.call(user, goCmd.getLabel(), Collections.emptyList())).
+					orElse(false);
+			}
+		}
+		else
+		{
+			// Default command if user does not have an island.
+			String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultUserSubCommand();
+
+			// If command exists, the call it.
+			// Otherwise, just use "go" command.
+			if (command != null && this.getSubCommand(command).isPresent())
+			{
+				return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
+			}
+			else
+			{
+				return this.getSubCommand("create").
+					map(createCmd -> createCmd.call(user, createCmd.getLabel(), Collections.emptyList())).
+					orElse(false);
+			}
+		}
+	}
+}

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultIslandCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultIslandCommand.java
@@ -19,124 +19,124 @@ import world.bentobox.bentobox.api.user.User;
  */
 public abstract class DefaultIslandCommand extends CompositeCommand
 {
-	/**
-	 * This is the top-level command constructor for commands that have no parent.
-	 *
-	 * @param addon   - GameMode addon
-	 */
-	public DefaultIslandCommand(GameModeAddon addon)
-	{
-		// Register command with alias from config.
-		super(addon,
-			addon.getWorldSettings().getUserCommandAlias().split(" ")[0],
-			addon.getWorldSettings().getUserCommandAlias().split(" "));
-	}
+    /**
+     * This is the top-level command constructor for commands that have no parent.
+     *
+     * @param addon   - GameMode addon
+     */
+    public DefaultIslandCommand(GameModeAddon addon)
+    {
+        // Register command with alias from config.
+        super(addon,
+            addon.getWorldSettings().getIslandCommandAliases().split(" ")[0],
+            addon.getWorldSettings().getIslandCommandAliases().split(" "));
+    }
 
 
-	/**
-	 * Setups anything that is necessary for default main user command.
-	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#setup()
-	 */
-	@Override
-	public void setup()
-	{
-		// Description
-		this.setDescription("commands.island.help.description");
-		// Limit to player
-		this.setOnlyPlayer(true);
-		// Permission
-		this.setPermission("island");
+    /**
+     * Setups anything that is necessary for default main user command.
+     * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#setup()
+     */
+    @Override
+    public void setup()
+    {
+        // Description
+        this.setDescription("commands.island.help.description");
+        // Limit to player
+        this.setOnlyPlayer(true);
+        // Permission
+        this.setPermission("island");
 
-		// Set up default subcommands
+        // Set up default subcommands
 
-		// Teleport commands
-		new IslandGoCommand(this);
-		new IslandSpawnCommand(this);
+        // Teleport commands
+        new IslandGoCommand(this);
+        new IslandSpawnCommand(this);
 
-		// Allows to create/reset island.
-		new IslandCreateCommand(this);
-		new IslandResetCommand(this);
+        // Allows to create/reset island.
+        new IslandCreateCommand(this);
+        new IslandResetCommand(this);
 
-		// Displays info about the island.
-		new IslandInfoCommand(this);
+        // Displays info about the island.
+        new IslandInfoCommand(this);
 
-		// Settings related commands
-		new IslandSettingsCommand(this);
-		new IslandSethomeCommand(this);
-		new IslandSetnameCommand(this);
-		new IslandResetnameCommand(this);
-		new IslandLanguageCommand(this);
+        // Settings related commands
+        new IslandSettingsCommand(this);
+        new IslandSethomeCommand(this);
+        new IslandSetnameCommand(this);
+        new IslandResetnameCommand(this);
+        new IslandLanguageCommand(this);
 
-		// Ban related commands
-		new IslandBanCommand(this);
-		new IslandUnbanCommand(this);
-		new IslandBanlistCommand(this);
+        // Ban related commands
+        new IslandBanCommand(this);
+        new IslandUnbanCommand(this);
+        new IslandBanlistCommand(this);
 
-		// Kicks visitors or coops/trusted from island
-		new IslandExpelCommand(this);
+        // Kicks visitors or coops/trusted from island
+        new IslandExpelCommand(this);
 
-		// Tells owner of adjacent islands
-		new IslandNearCommand(this);
+        // Tells owner of adjacent islands
+        new IslandNearCommand(this);
 
-		// Team commands
-		new IslandTeamCommand(this);
-	}
+        // Team commands
+        new IslandTeamCommand(this);
+    }
 
 
-	/**
-	 * Defines what will be executed when this command is run.
-	 * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#execute(User, String, List<String>)
-	 */
-	@Override
-	public boolean execute(User user, String label, List<String> args)
-	{
-		if (user == null)
-		{
-			return false;
-		}
+    /**
+     * Defines what will be executed when this command is run.
+     * @see world.bentobox.bentobox.api.commands.BentoBoxCommand#execute(User, String, List<String>)
+     */
+    @Override
+    public boolean execute(User user, String label, List<String> args)
+    {
+        if (user == null)
+        {
+            return false;
+        }
 
-		if (!args.isEmpty())
-		{
-			user.sendMessage("general.errors.unknown-command", TextVariables.LABEL, this.getTopLabel());
-			return false;
-		}
+        if (!args.isEmpty())
+        {
+            user.sendMessage("general.errors.unknown-command", TextVariables.LABEL, this.getTopLabel());
+            return false;
+        }
 
-		// Check if user has an island.
-		if (this.getIslands().getIsland(this.getWorld(), user.getUniqueId()) != null)
-		{
-			// Default command if user has an island.
-			String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultHasIslandSubCommand();
+        // Check if user has an island.
+        if (this.getIslands().getIsland(this.getWorld(), user.getUniqueId()) != null)
+        {
+            // Default command if user has an island.
+            String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultHasIslandSubCommand();
 
-			// If command exists, the call it.
-			// Otherwise, just use "go" command.
-			if (command != null && this.getSubCommand(command).isPresent())
-			{
-				return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
-			}
-			else
-			{
-				return this.getSubCommand("go").
-					map(goCmd -> goCmd.call(user, goCmd.getLabel(), Collections.emptyList())).
-					orElse(false);
-			}
-		}
-		else
-		{
-			// Default command if user does not have an island.
-			String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultUserSubCommand();
+            // If command exists, the call it.
+            // Otherwise, just use "go" command.
+            if (command != null && this.getSubCommand(command).isPresent())
+            {
+                return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
+            }
+            else
+            {
+                return this.getSubCommand("go").
+                    map(goCmd -> goCmd.call(user, goCmd.getLabel(), Collections.emptyList())).
+                    orElse(false);
+            }
+        }
+        else
+        {
+            // Default command if user does not have an island.
+            String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultIslandSubCommand();
 
-			// If command exists, the call it.
-			// Otherwise, just use "go" command.
-			if (command != null && this.getSubCommand(command).isPresent())
-			{
-				return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
-			}
-			else
-			{
-				return this.getSubCommand("create").
-					map(createCmd -> createCmd.call(user, createCmd.getLabel(), Collections.emptyList())).
-					orElse(false);
-			}
-		}
-	}
+            // If command exists, the call it.
+            // Otherwise, just use "go" command.
+            if (command != null && this.getSubCommand(command).isPresent())
+            {
+                return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
+            }
+            else
+            {
+                return this.getSubCommand("create").
+                    map(createCmd -> createCmd.call(user, createCmd.getLabel(), Collections.emptyList())).
+                    orElse(false);
+            }
+        }
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
@@ -12,24 +12,23 @@ import world.bentobox.bentobox.api.user.User;
 
 
 /**
- * This is default Island command for users. It contains all necessary parts for main
- * command.
+ * This is default player command class. It contains all necessary parts for main /[gamemode] command.
  * @since 1.13.0
  * @author BONNe
  */
-public abstract class DefaultIslandCommand extends CompositeCommand
+public abstract class DefaultPlayerCommand extends CompositeCommand
 {
     /**
      * This is the top-level command constructor for commands that have no parent.
      *
      * @param addon   - GameMode addon
      */
-    public DefaultIslandCommand(GameModeAddon addon)
+    public DefaultPlayerCommand(GameModeAddon addon)
     {
         // Register command with alias from config.
         super(addon,
-            addon.getWorldSettings().getIslandCommandAliases().split(" ")[0],
-            addon.getWorldSettings().getIslandCommandAliases().split(" "));
+            addon.getWorldSettings().getPlayerCommandAliases().split(" ")[0],
+            addon.getWorldSettings().getPlayerCommandAliases().split(" "));
     }
 
 
@@ -105,7 +104,7 @@ public abstract class DefaultIslandCommand extends CompositeCommand
         if (this.getIslands().getIsland(this.getWorld(), user.getUniqueId()) != null)
         {
             // Default command if user has an island.
-            String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultHasIslandSubCommand();
+            String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultPlayerAction();
 
             // If command exists, the call it.
             // Otherwise, just use "go" command.
@@ -123,10 +122,10 @@ public abstract class DefaultIslandCommand extends CompositeCommand
         else
         {
             // Default command if user does not have an island.
-            String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultIslandSubCommand();
+            String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultNewPlayerAction();
 
             // If command exists, the call it.
-            // Otherwise, just use "go" command.
+            // Otherwise, just use "create" command.
             if (command != null && this.getSubCommand(command).isPresent())
             {
                 return this.getSubCommand(command).get().call(user, label, Collections.emptyList());

--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -483,14 +483,14 @@ public interface WorldSettings extends ConfigObject {
 
 
     /**
-     * Returns all aliases for main user command.
+     * Returns all aliases for main player command.
      * It is assumed that all aliases are split with whitespace between them.
      * String cannot be empty.
      * Default value: {@code getFriendlyName()} (to retain backward compatibility).
      * @return String value
      * @since 1.13.0
      */
-    default String getIslandCommandAliases()
+    default String getPlayerCommandAliases()
     {
         return this.getFriendlyName().toLowerCase();
     }
@@ -505,7 +505,7 @@ public interface WorldSettings extends ConfigObject {
      * @return name of default sub-command for main command if user does have an island.
      * @since 1.13.0
      */
-    default String getDefaultHasIslandSubCommand()
+    default String getDefaultPlayerAction()
     {
         return "go";
     }
@@ -513,14 +513,14 @@ public interface WorldSettings extends ConfigObject {
 
     /**
      * Returns default sub-command for users when they execute main user command and they
-     * does not have an island.
+     * do not have an island.
      * If defined sub-command does not exist in accessible user command list, then it will
      * still call "create" sub-command.
      * Default value: {@code "create"} (to retain backward compatibility)
      * @return name of default sub-command for main command if user does not have an island.
      * @since 1.13.0
      */
-    default String getDefaultIslandSubCommand()
+    default String getDefaultNewPlayerAction()
     {
         return "create";
     }

--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -467,4 +467,61 @@ public interface WorldSettings extends ConfigObject {
         return true;
     }
 
+
+    /**
+     * Returns all aliases for main admin command.
+     * It is assumed that all aliases are split with whitespace between them.
+     * String cannot be empty.
+     * Default value: {@code getFriendlyName() + "admin"} (to retain backward compatibility).
+     * @return String value
+     * @since 1.13.0
+     */
+    default String getAdminCommandAlias()
+    {
+        return this.getFriendlyName().toLowerCase() + "admin";
+    }
+
+
+    /**
+     * Returns all aliases for main user command.
+     * It is assumed that all aliases are split with whitespace between them.
+     * String cannot be empty.
+     * Default value: {@code getFriendlyName()} (to retain backward compatibility).
+     * @return String value
+     * @since 1.13.0
+     */
+    default String getUserCommandAlias()
+    {
+        return this.getFriendlyName().toLowerCase();
+    }
+
+
+    /**
+     * Returns sub-command for users when they execute main user command and they have an
+     * island.
+     * If defined sub-command does not exist in accessible user command list, then it will
+     * still call "go" sub-command.
+     * Default value: {@code "go"} (to retain backward compatibility)
+     * @return name of default sub-command for main command if user does have an island.
+     * @since 1.13.0
+     */
+    default String getDefaultHasIslandSubCommand()
+    {
+        return "go";
+    }
+
+
+    /**
+     * Returns default sub-command for users when they execute main user command and they
+     * does not have an island.
+     * If defined sub-command does not exist in accessible user command list, then it will
+     * still call "create" sub-command.
+     * Default value: {@code "create"} (to retain backward compatibility)
+     * @return name of default sub-command for main command if user does not have an island.
+     * @since 1.13.0
+     */
+    default String getDefaultUserSubCommand()
+    {
+        return "create";
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -476,7 +476,7 @@ public interface WorldSettings extends ConfigObject {
      * @return String value
      * @since 1.13.0
      */
-    default String getAdminCommandAlias()
+    default String getAdminCommandAliases()
     {
         return this.getFriendlyName().toLowerCase() + "admin";
     }
@@ -490,7 +490,7 @@ public interface WorldSettings extends ConfigObject {
      * @return String value
      * @since 1.13.0
      */
-    default String getUserCommandAlias()
+    default String getIslandCommandAliases()
     {
         return this.getFriendlyName().toLowerCase();
     }
@@ -520,7 +520,7 @@ public interface WorldSettings extends ConfigObject {
      * @return name of default sub-command for main command if user does not have an island.
      * @since 1.13.0
      */
-    default String getDefaultUserSubCommand()
+    default String getDefaultIslandSubCommand()
     {
         return "create";
     }


### PR DESCRIPTION
Implement 4 new WorldSettings getters:
- getAdminCommandAlias() - returns String with all main admin command aliases for gamemodes
- getUserCommandAlias() - returns String with all main user command aliases for gamemodes
- getDefaultHasIslandSubCommand() - returns String with default sub-command for users with islands which is called on user command.
- getDefaultUserSubCommand() - returns String with default sub-command for users without an island which is called on user command.

For backward compatibility reasons added some default values that would make some sense.

These new getters are used in 2 new abstract classes:
- DefaultAdminCommand - class that contains all admin sub-commands. (based on bskyblock)
- DefaultIslandCommand - class that contains all user sub-commands. (based on bskyblock)

DefaultIslandCommand also customize default command call, if defaultUserSubCommand or defaultHasIslandSubCommand is provided.

This fixes #498 and adds the ability to unify command creation for all game-modes.