### PR TITLE
Add AdminSetSpawnPointCommand to change an island's spawn point

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetSpawnPointCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetSpawnPointCommand.java
@@ -1,9 +1,3 @@
-//
-// Created by BONNe
-// Copyright - 2020
-//
-
-
 package world.bentobox.bentobox.api.commands.admin;
 
 
@@ -26,85 +20,75 @@ import world.bentobox.bentobox.database.objects.Island;
  */
 public class AdminSetSpawnPointCommand extends ConfirmableCommand
 {
-	/**
-	 * Sub-command constructor
-	 *
-	 * @param parent - the parent composite command
-	 */
-	public AdminSetSpawnPointCommand(CompositeCommand parent)
-	{
-		super(parent, "setspawnpoint");
-	}
+    /**
+     * Sub-command constructor
+     *
+     * @param parent - the parent composite command
+     */
+    public AdminSetSpawnPointCommand(CompositeCommand parent)
+    {
+        super(parent, "setspawnpoint");
+    }
 
 
-	/**
-	 * Setups anything that is needed for this command. <br/><br/> It is recommended you do the following in this
-	 * method:
-	 * <ul>
-	 *     <li>Register any of the sub-commands of this command;</li>
-	 *     <li>Define the permission required to use this command using {@link CompositeCommand#setPermission(String)};</li>
-	 *     <li>Define whether this command can only be run by players or not using {@link CompositeCommand#setOnlyPlayer(boolean)};</li>
-	 * </ul>
-	 */
-	@Override
-	public void setup()
-	{
-		this.setPermission("admin.setspawnpoint");
-		this.setOnlyPlayer(true);
-		this.setDescription("commands.admin.setspawnpoint.description");
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setup()
+    {
+        this.setPermission("admin.setspawnpoint");
+        this.setOnlyPlayer(true);
+        this.setDescription("commands.admin.setspawnpoint.description");
+    }
 
 
-	/**
-	 * Defines what will be executed when this command is run.
-	 *
-	 * @param user the {@link User} who is executing this command.
-	 * @param label the label which has been used to execute this command. It can be {@link CompositeCommand#getLabel()}
-	 * or an alias.
-	 * @param args the command arguments.
-	 * @return {@code true} if the command executed successfully, {@code false} otherwise.
-	 */
-	@Override
-	public boolean execute(User user, String label, List<String> args)
-	{
-		Optional<Island> optionalIsland = this.getIslands().getIslandAt(user.getLocation());
+    /**
+	 * This method finds an island in user location and asks confirmation if spawn point
+	 * must be changed to that location.
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean execute(User user, String label, List<String> args)
+    {
+        Optional<Island> optionalIsland = this.getIslands().getIslandAt(user.getLocation());
 
-		if (optionalIsland.isPresent() &&
-			(optionalIsland.get().hasNetherIsland() ||
-			!World.Environment.NETHER.equals(user.getLocation().getWorld().getEnvironment())) &&
-			(optionalIsland.get().hasEndIsland() ||
-			!World.Environment.THE_END.equals(user.getLocation().getWorld().getEnvironment())))
-		{
-			// Everything's fine, we can set the location as spawn point for island :)
-			this.askConfirmation(user, user.getTranslation("commands.admin.setspawnpoint.confirmation"),
-				() -> this.setSpawnPoint(user, optionalIsland.get()));
+        if (optionalIsland.isPresent() &&
+            (optionalIsland.get().hasNetherIsland() ||
+            !World.Environment.NETHER.equals(user.getLocation().getWorld().getEnvironment())) &&
+            (optionalIsland.get().hasEndIsland() ||
+            !World.Environment.THE_END.equals(user.getLocation().getWorld().getEnvironment())))
+        {
+            // Everything's fine, we can set the location as spawn point for island :)
+            this.askConfirmation(user, user.getTranslation("commands.admin.setspawnpoint.confirmation"),
+                () -> this.setSpawnPoint(user, optionalIsland.get()));
 
-			return true;
-		}
-		else
-		{
-			user.sendMessage("commands.admin.setspawnpoint.no-island-here");
-			return false;
-		}
-	}
+            return true;
+        }
+        else
+        {
+            user.sendMessage("commands.admin.setspawnpoint.no-island-here");
+            return false;
+        }
+    }
 
 
-	/**
-	 * This method changes spawn point for island at given user location.
-	 * @param user User who initiate spawn point change.
-	 * @param island Island which is targeted by user.
-	 */
-	private void setSpawnPoint(User user, Island island)
-	{
-		island.setSpawnPoint(Objects.requireNonNull(user.getLocation().getWorld()).getEnvironment(),
-			user.getLocation());
-		user.sendMessage("commands.admin.setspawnpoint.success");
+    /**
+     * This method changes spawn point for island at given user location.
+     * @param user User who initiate spawn point change.
+     * @param island Island which is targeted by user.
+     */
+    private void setSpawnPoint(User user, Island island)
+    {
+        island.setSpawnPoint(Objects.requireNonNull(user.getLocation().getWorld()).getEnvironment(),
+            user.getLocation());
+        user.sendMessage("commands.admin.setspawnpoint.success");
 
-		if (!island.isSpawn())
-		{
-			island.getPlayersOnIsland().forEach(player ->
-				User.getInstance(player).sendMessage("commands.admin.setspawnpoint.island-spawnpoint-changed",
-					"[user]", user.getName()));
-		}
-	}
+        if (!island.isSpawn())
+        {
+            island.getPlayersOnIsland().forEach(player ->
+                User.getInstance(player).sendMessage("commands.admin.setspawnpoint.island-spawnpoint-changed",
+                    "[user]", user.getName()));
+        }
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetSpawnPointCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetSpawnPointCommand.java
@@ -1,0 +1,110 @@
+//
+// Created by BONNe
+// Copyright - 2020
+//
+
+
+package world.bentobox.bentobox.api.commands.admin;
+
+
+import org.bukkit.World;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.ConfirmableCommand;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+
+
+/**
+ * This command sets spawn point for island at admin location for island on which admin is located.
+ * This command is only for player entity.
+ * @author BONNe
+ * @since 1.13.0
+ */
+public class AdminSetSpawnPointCommand extends ConfirmableCommand
+{
+	/**
+	 * Sub-command constructor
+	 *
+	 * @param parent - the parent composite command
+	 */
+	public AdminSetSpawnPointCommand(CompositeCommand parent)
+	{
+		super(parent, "setspawnpoint");
+	}
+
+
+	/**
+	 * Setups anything that is needed for this command. <br/><br/> It is recommended you do the following in this
+	 * method:
+	 * <ul>
+	 *     <li>Register any of the sub-commands of this command;</li>
+	 *     <li>Define the permission required to use this command using {@link CompositeCommand#setPermission(String)};</li>
+	 *     <li>Define whether this command can only be run by players or not using {@link CompositeCommand#setOnlyPlayer(boolean)};</li>
+	 * </ul>
+	 */
+	@Override
+	public void setup()
+	{
+		this.setPermission("admin.setspawnpoint");
+		this.setOnlyPlayer(true);
+		this.setDescription("commands.admin.setspawnpoint.description");
+	}
+
+
+	/**
+	 * Defines what will be executed when this command is run.
+	 *
+	 * @param user the {@link User} who is executing this command.
+	 * @param label the label which has been used to execute this command. It can be {@link CompositeCommand#getLabel()}
+	 * or an alias.
+	 * @param args the command arguments.
+	 * @return {@code true} if the command executed successfully, {@code false} otherwise.
+	 */
+	@Override
+	public boolean execute(User user, String label, List<String> args)
+	{
+		Optional<Island> optionalIsland = this.getIslands().getIslandAt(user.getLocation());
+
+		if (optionalIsland.isPresent() &&
+			(optionalIsland.get().hasNetherIsland() ||
+			!World.Environment.NETHER.equals(user.getLocation().getWorld().getEnvironment())) &&
+			(optionalIsland.get().hasEndIsland() ||
+			!World.Environment.THE_END.equals(user.getLocation().getWorld().getEnvironment())))
+		{
+			// Everything's fine, we can set the location as spawn point for island :)
+			this.askConfirmation(user, user.getTranslation("commands.admin.setspawnpoint.confirmation"),
+				() -> this.setSpawnPoint(user, optionalIsland.get()));
+
+			return true;
+		}
+		else
+		{
+			user.sendMessage("commands.admin.setspawnpoint.no-island-here");
+			return false;
+		}
+	}
+
+
+	/**
+	 * This method changes spawn point for island at given user location.
+	 * @param user User who initiate spawn point change.
+	 * @param island Island which is targeted by user.
+	 */
+	private void setSpawnPoint(User user, Island island)
+	{
+		island.setSpawnPoint(Objects.requireNonNull(user.getLocation().getWorld()).getEnvironment(),
+			user.getLocation());
+		user.sendMessage("commands.admin.setspawnpoint.success");
+
+		if (!island.isSpawn())
+		{
+			island.getPlayersOnIsland().forEach(player ->
+				User.getInstance(player).sendMessage("commands.admin.setspawnpoint.island-spawnpoint-changed",
+					"[user]", user.getName()));
+		}
+	}
+}

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -246,6 +246,12 @@ commands:
       no-island-here: "&c There is no island here."
       confirmation: "&c Are you sure you want to set this island as the spawn for this world?"
       success: "&a Successfully set this island as the spawn for this world."
+    setspawnpoint:
+      description: "set current location as spawn point for this island"
+      no-island-here: "&c There is no island here."
+      confirmation: "&c Are you sure you want to set this location as the spawn point for this island?"
+      success: "&a Successfully set this location as the spawn point for this island."
+      island-spawnpoint-changed: "&a [user] changed this island spawn point."
     settings:
       parameters: "[player]"
       description: "open system settings or island settings for player"


### PR DESCRIPTION
Fixes #937

This command allows changing spawn point for any island in each environment separately.
This is only the admin command. 