### PR TITLE
Enables UUIDs to be used in admin commands as well as names

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -37,7 +37,7 @@ public class AdminDeleteCommand extends ConfirmableCommand {
             return false;
         }
         // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommand.java
@@ -46,7 +46,7 @@ public class AdminGetrankCommand extends CompositeCommand {
             return false;
         }
         // Get target player
-        targetUUID = getPlayers().getUUID(args.get(0));
+        targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommand.java
@@ -41,7 +41,7 @@ public class AdminInfoCommand extends CompositeCommand {
             return true;
         }
         // Get target player
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
@@ -39,7 +39,7 @@ public class AdminRegisterCommand extends ConfirmableCommand {
             return false;
         }
         // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -93,12 +93,12 @@ public class AdminRegisterCommand extends ConfirmableCommand {
             .admin(true)
             .build();
             IslandEvent.builder()
-                    .island(i)
-                    .involvedPlayer(targetUUID)
-                    .admin(true)
-                    .reason(IslandEvent.Reason.RANK_CHANGE)
-                    .rankChange(RanksManager.VISITOR_RANK, RanksManager.OWNER_RANK)
-                    .build();
+            .island(i)
+            .involvedPlayer(targetUUID)
+            .admin(true)
+            .reason(IslandEvent.Reason.RANK_CHANGE)
+            .rankChange(RanksManager.VISITOR_RANK, RanksManager.OWNER_RANK)
+            .build();
             return true;
         }).orElse(false)) {
             // Island does not exist - this is a reservation

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommand.java
@@ -48,7 +48,7 @@ public class AdminSetrankCommand extends CompositeCommand {
             return false;
         }
         // Get target player
-        targetUUID = getPlayers().getUUID(args.get(0));
+        targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -104,12 +104,12 @@ public class AdminSetrankCommand extends CompositeCommand {
         int currentRank = island.getRank(target);
         island.setRank(target, rankValue);
         IslandEvent.builder()
-                .island(island)
-                .involvedPlayer(targetUUID)
-                .admin(true)
-                .reason(IslandEvent.Reason.RANK_CHANGE)
-                .rankChange(currentRank, rankValue)
-                .build();
+        .island(island)
+        .involvedPlayer(targetUUID)
+        .admin(true)
+        .reason(IslandEvent.Reason.RANK_CHANGE)
+        .rankChange(currentRank, rankValue)
+        .build();
 
         String ownerName;
         if (ownerUUID != null) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommand.java
@@ -13,6 +13,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.panels.settings.SettingsTab;
 import world.bentobox.bentobox.panels.settings.WorldDefaultSettingsTab;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -46,7 +47,7 @@ public class AdminSettingsCommand extends CompositeCommand {
             return true;
         }
         // Get target player
-        @Nullable UUID targetUUID = getPlayers().getUUID(args.get(0));
+        @Nullable UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSwitchtoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSwitchtoCommand.java
@@ -12,6 +12,7 @@ import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
 
 public class AdminSwitchtoCommand extends ConfirmableCommand {
 
@@ -44,7 +45,7 @@ public class AdminSwitchtoCommand extends ConfirmableCommand {
             return false;
         }
         // Get target player
-        targetUUID = getPlayers().getUUID(args.get(0));
+        targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommand.java
@@ -48,7 +48,7 @@ public class AdminTeleportCommand extends CompositeCommand {
             return false;
         }
         // Convert name to a UUID
-        targetUUID = getPlayers().getUUID(args.get(0));
+        targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -61,7 +61,7 @@ public class AdminTeleportCommand extends CompositeCommand {
 
         if (args.size() == 2) {
             // We are trying to teleport another player
-            UUID playerToTeleportUUID = getPlayers().getUUID(args.get(1));
+            UUID playerToTeleportUUID = Util.getUUID(args.get(1));
             if (playerToTeleportUUID == null) {
                 user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(1));
                 return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
@@ -35,7 +35,7 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
             return false;
         }
         // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -68,12 +68,12 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
         .admin(true)
         .build();
         IslandEvent.builder()
-                .island(oldIsland)
-                .involvedPlayer(targetUUID)
-                .admin(true)
-                .reason(IslandEvent.Reason.RANK_CHANGE)
-                .rankChange(RanksManager.OWNER_RANK, RanksManager.VISITOR_RANK)
-                .build();
+        .island(oldIsland)
+        .involvedPlayer(targetUUID)
+        .admin(true)
+        .reason(IslandEvent.Reason.RANK_CHANGE)
+        .rankChange(RanksManager.OWNER_RANK, RanksManager.VISITOR_RANK)
+        .build();
         // Remove all island members
         oldIsland.getMemberSet().forEach(m -> {
             getIslands().removePlayer(getWorld(), m);

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminWhyCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminWhyCommand.java
@@ -35,7 +35,7 @@ public class AdminWhyCommand extends ConfirmableCommand {
             return false;
         }
         // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsAddCommand.java
@@ -34,16 +34,16 @@ public class AdminDeathsAddCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
         } else if (!Util.isInteger(args.get(1), true) || Integer.valueOf(args.get(1)) < 0) {
             user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.get(1));
         } else {
-            getPlayers().setDeaths(getWorld(), target, getPlayers().getDeaths(getWorld(), target) + Integer.valueOf(args.get(1)));
+            getPlayers().setDeaths(getWorld(), targetUUID, getPlayers().getDeaths(getWorld(), targetUUID) + Integer.valueOf(args.get(1)));
             user.sendMessage("commands.admin.deaths.add.success",
                     TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),
-                    "[total]", String.valueOf(getPlayers().getDeaths(getWorld(), target)));
+                    "[total]", String.valueOf(getPlayers().getDeaths(getWorld(), targetUUID)));
             return true;
         }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsRemoveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsRemoveCommand.java
@@ -34,15 +34,15 @@ public class AdminDeathsRemoveCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
         } else if (!Util.isInteger(args.get(1), true) || Integer.valueOf(args.get(1)) < 0) {
             user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.get(1));
         } else {
             // Make sure it cannot go under 0.
-            int newDeaths = Math.max(getPlayers().getDeaths(getWorld(), target) - Integer.valueOf(args.get(1)), 0);
-            getPlayers().setDeaths(getWorld(), target, newDeaths);
+            int newDeaths = Math.max(getPlayers().getDeaths(getWorld(), targetUUID) - Integer.valueOf(args.get(1)), 0);
+            getPlayers().setDeaths(getWorld(), targetUUID, newDeaths);
             user.sendMessage("commands.admin.deaths.remove.success",
                     TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),
                     "[total]", String.valueOf(newDeaths));

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsResetCommand.java
@@ -8,6 +8,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author Poslovitch
@@ -32,12 +33,12 @@ public class AdminDeathsResetCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
         } else {
-            getPlayers().setDeaths(getWorld(), target, 0);
+            getPlayers().setDeaths(getWorld(), targetUUID, 0);
             user.sendMessage("commands.admin.deaths.reset.success", TextVariables.NAME, args.get(0));
             return true;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsSetCommand.java
@@ -33,13 +33,13 @@ public class AdminDeathsSetCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
         } else if (!Util.isInteger(args.get(1), true) || Integer.valueOf(args.get(1)) < 0) {
             user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.get(1));
         } else {
-            getPlayers().setDeaths(getWorld(), target, Integer.valueOf(args.get(1)));
+            getPlayers().setDeaths(getWorld(), targetUUID, Integer.valueOf(args.get(1)));
             user.sendMessage("commands.admin.deaths.set.success", TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1));
             return true;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
@@ -36,13 +36,13 @@ public class AdminRangeAddCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
         }
 
-        if (!(getIslands().hasIsland(getWorld(), target) || getIslands().inTeam(getWorld(), target))) {
+        if (!(getIslands().hasIsland(getWorld(), targetUUID) || getIslands().inTeam(getWorld(), targetUUID))) {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         }
@@ -52,7 +52,7 @@ public class AdminRangeAddCommand extends CompositeCommand {
             return false;
         }
 
-        Island island = getIslands().getIsland(getWorld(), target);
+        Island island = getIslands().getIsland(getWorld(), targetUUID);
         int newRange = island.getProtectionRange() + Integer.valueOf(args.get(1));
 
         if (newRange > island.getRange()) {
@@ -71,13 +71,13 @@ public class AdminRangeAddCommand extends CompositeCommand {
 
         // Call Protection Range Change event. Does not support cancelling.
         IslandEvent.builder()
-            .island(island)
-            .location(island.getCenter())
-            .reason(IslandEvent.Reason.RANGE_CHANGE)
-            .involvedPlayer(target)
-            .admin(true)
-            .protectionRange(newRange, oldRange)
-            .build();
+        .island(island)
+        .location(island.getCenter())
+        .reason(IslandEvent.Reason.RANGE_CHANGE)
+        .involvedPlayer(targetUUID)
+        .admin(true)
+        .protectionRange(newRange, oldRange)
+        .build();
 
         user.sendMessage("commands.admin.range.add.success",
                 TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveCommand.java
@@ -36,13 +36,13 @@ public class AdminRangeRemoveCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
         }
 
-        if (!(getIslands().hasIsland(getWorld(), target) || getIslands().inTeam(getWorld(), target))) {
+        if (!(getIslands().hasIsland(getWorld(), targetUUID) || getIslands().inTeam(getWorld(), targetUUID))) {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         }
@@ -52,7 +52,7 @@ public class AdminRangeRemoveCommand extends CompositeCommand {
             return false;
         }
 
-        Island island = getIslands().getIsland(getWorld(), target);
+        Island island = getIslands().getIsland(getWorld(), targetUUID);
         int newRange = island.getProtectionRange() + Integer.valueOf(args.get(1));
 
         if (newRange <= 1) {
@@ -71,13 +71,13 @@ public class AdminRangeRemoveCommand extends CompositeCommand {
 
         // Call Protection Range Change event. Does not support cancelling.
         IslandEvent.builder()
-            .island(island)
-            .location(island.getCenter())
-            .reason(IslandEvent.Reason.RANGE_CHANGE)
-            .involvedPlayer(target)
-            .admin(true)
-            .protectionRange(newRange, oldRange)
-            .build();
+        .island(island)
+        .location(island.getCenter())
+        .reason(IslandEvent.Reason.RANGE_CHANGE)
+        .involvedPlayer(targetUUID)
+        .admin(true)
+        .protectionRange(newRange, oldRange)
+        .build();
 
         user.sendMessage("commands.admin.range.remove.success",
                 TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommand.java
@@ -34,7 +34,7 @@ public class AdminRangeResetCommand extends CompositeCommand {
         }
 
         // Get target player
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -57,13 +57,13 @@ public class AdminRangeResetCommand extends CompositeCommand {
         if (oldRange != range) {
             // Call Protection Range Change event. Does not support cancelling.
             IslandEvent.builder()
-                .island(island)
-                .location(island.getCenter())
-                .reason(IslandEvent.Reason.RANGE_CHANGE)
-                .involvedPlayer(targetUUID)
-                .admin(true)
-                .protectionRange(range, oldRange)
-                .build();
+            .island(island)
+            .location(island.getCenter())
+            .reason(IslandEvent.Reason.RANGE_CHANGE)
+            .involvedPlayer(targetUUID)
+            .admin(true)
+            .protectionRange(range, oldRange)
+            .build();
         }
 
         user.sendMessage("commands.admin.range.reset.success", TextVariables.NUMBER, String.valueOf(range));

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
@@ -34,7 +34,7 @@ public class AdminRangeSetCommand extends CompositeCommand {
         }
 
         // Get target player
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsAddCommand.java
@@ -34,16 +34,16 @@ public class AdminResetsAddCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
         } else if (!Util.isInteger(args.get(1), true) || Integer.valueOf(args.get(1)) < 0) {
             user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.get(1));
         } else {
-            getPlayers().setResets(getWorld(), target, getPlayers().getResets(getWorld(), target) + Integer.valueOf(args.get(1)));
+            getPlayers().setResets(getWorld(), targetUUID, getPlayers().getResets(getWorld(), targetUUID) + Integer.valueOf(args.get(1)));
             user.sendMessage("commands.admin.resets.add.success",
                     TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),
-                    "[total]", String.valueOf(getPlayers().getResets(getWorld(), target)));
+                    "[total]", String.valueOf(getPlayers().getResets(getWorld(), targetUUID)));
             return true;
         }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsRemoveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsRemoveCommand.java
@@ -34,15 +34,15 @@ public class AdminResetsRemoveCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
         } else if (!Util.isInteger(args.get(1), true) || Integer.valueOf(args.get(1)) < 0) {
             user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.get(1));
         } else {
             // Make sure it cannot go under 0.
-            int newResets = Math.max(getPlayers().getResets(getWorld(), target) - Integer.valueOf(args.get(1)), 0);
-            getPlayers().setResets(getWorld(), target, newResets);
+            int newResets = Math.max(getPlayers().getResets(getWorld(), targetUUID) - Integer.valueOf(args.get(1)), 0);
+            getPlayers().setResets(getWorld(), targetUUID, newResets);
             user.sendMessage("commands.admin.resets.remove.success",
                     TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1),
                     "[total]", String.valueOf(newResets));

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsResetCommand.java
@@ -12,6 +12,7 @@ import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
 
 public class AdminResetsResetCommand extends ConfirmableCommand {
 
@@ -45,12 +46,12 @@ public class AdminResetsResetCommand extends ConfirmableCommand {
             return true;
         } else {
             // Then, it may be a player
-            UUID target = getPlayers().getUUID(args.get(0));
-            if (target == null) {
+            UUID targetUUID = Util.getUUID(args.get(0));
+            if (targetUUID == null) {
                 user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
                 return false;
             } else {
-                getPlayers().setResets(getWorld(), target, 0);
+                getPlayers().setResets(getWorld(), targetUUID, 0);
                 user.sendMessage("commands.admin.resets.reset.success", TextVariables.NAME, args.get(0));
                 return true;
             }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsSetCommand.java
@@ -28,13 +28,13 @@ public class AdminResetsSetCommand extends CompositeCommand {
             return false;
         }
 
-        UUID target = getPlayers().getUUID(args.get(0));
-        if (target == null) {
+        UUID targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
         } else if (!Util.isInteger(args.get(1), true) || Integer.valueOf(args.get(1)) <= 0) {
             user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.get(1));
         } else {
-            getPlayers().setResets(getWorld(), target, Integer.valueOf(args.get(1)));
+            getPlayers().setResets(getWorld(), targetUUID, Integer.valueOf(args.get(1)));
             user.sendMessage("commands.admin.resets.set.success",
                     TextVariables.NAME, args.get(0), TextVariables.NUMBER, args.get(1));
             return true;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommand.java
@@ -10,6 +10,7 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
 
 public class AdminTeamAddCommand extends CompositeCommand {
 
@@ -32,12 +33,12 @@ public class AdminTeamAddCommand extends CompositeCommand {
             return false;
         }
         // Get owner and target
-        UUID ownerUUID = getPlayers().getUUID(args.get(0));
+        UUID ownerUUID = Util.getUUID(args.get(0));
         if (ownerUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
         }
-        UUID targetUUID = getPlayers().getUUID(args.get(1));
+        UUID targetUUID = Util.getUUID(args.get(1));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(1));
             return false;
@@ -69,18 +70,18 @@ public class AdminTeamAddCommand extends CompositeCommand {
             getIslands().setJoinTeam(teamIsland, targetUUID);
             user.sendMessage("commands.admin.team.add.success", TextVariables.NAME, target.getName(), "[owner]", owner.getName());
             TeamEvent.builder()
-                    .island(teamIsland)
-                    .reason(TeamEvent.Reason.JOINED)
-                    .involvedPlayer(targetUUID)
-                    .admin(true)
-                    .build();
+            .island(teamIsland)
+            .reason(TeamEvent.Reason.JOINED)
+            .involvedPlayer(targetUUID)
+            .admin(true)
+            .build();
             IslandEvent.builder()
-                    .island(teamIsland)
-                    .involvedPlayer(targetUUID)
-                    .admin(true)
-                    .reason(IslandEvent.Reason.RANK_CHANGE)
-                    .rankChange(teamIsland.getRank(target), RanksManager.MEMBER_RANK)
-                    .build();
+            .island(teamIsland)
+            .involvedPlayer(targetUUID)
+            .admin(true)
+            .reason(IslandEvent.Reason.RANK_CHANGE)
+            .rankChange(teamIsland.getRank(target), RanksManager.MEMBER_RANK)
+            .build();
             return true;
         } else {
             user.sendMessage("general.errors.player-has-no-island");

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommand.java
@@ -10,6 +10,7 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
 
 public class AdminTeamDisbandCommand extends CompositeCommand {
 
@@ -32,7 +33,7 @@ public class AdminTeamDisbandCommand extends CompositeCommand {
             return false;
         }
         // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -64,12 +65,12 @@ public class AdminTeamDisbandCommand extends CompositeCommand {
                 .admin(true)
                 .build();
                 IslandEvent.builder()
-                        .island(island)
-                        .involvedPlayer(targetUUID)
-                        .admin(true)
-                        .reason(IslandEvent.Reason.RANK_CHANGE)
-                        .rankChange(island.getRank(mUser), RanksManager.VISITOR_RANK)
-                        .build();
+                .island(island)
+                .involvedPlayer(targetUUID)
+                .admin(true)
+                .reason(IslandEvent.Reason.RANK_CHANGE)
+                .rankChange(island.getRank(mUser), RanksManager.VISITOR_RANK)
+                .build();
             }
         });
         user.sendMessage("commands.admin.team.disband.success", TextVariables.NAME, args.get(0));

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommand.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
@@ -12,12 +13,15 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * Kicks the specified player from the island team.
  * @author tastybento
  */
 public class AdminTeamKickCommand extends CompositeCommand {
+
+    private @Nullable UUID targetUUID;
 
     public AdminTeamKickCommand(CompositeCommand parent) {
         super(parent, "kick");
@@ -39,7 +43,7 @@ public class AdminTeamKickCommand extends CompositeCommand {
         }
 
         // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -54,8 +58,6 @@ public class AdminTeamKickCommand extends CompositeCommand {
 
     @Override
     public boolean execute(User user, String label, @NonNull List<String> args) {
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
-
         Island island = getIslands().getIsland(getWorld(), targetUUID);
 
         if (targetUUID.equals(island.getOwner())) {
@@ -78,12 +80,12 @@ public class AdminTeamKickCommand extends CompositeCommand {
         .admin(true)
         .build();
         IslandEvent.builder()
-                .island(island)
-                .involvedPlayer(targetUUID)
-                .admin(true)
-                .reason(IslandEvent.Reason.RANK_CHANGE)
-                .rankChange(island.getRank(target), RanksManager.VISITOR_RANK)
-                .build();
+        .island(island)
+        .involvedPlayer(targetUUID)
+        .admin(true)
+        .reason(IslandEvent.Reason.RANK_CHANGE)
+        .rankChange(island.getRank(target), RanksManager.VISITOR_RANK)
+        .build();
         return true;
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
@@ -10,6 +10,7 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * Sets the owner of an island.
@@ -36,7 +37,7 @@ public class AdminTeamSetownerCommand extends CompositeCommand {
             return false;
         }
         // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        UUID targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -62,12 +63,12 @@ public class AdminTeamSetownerCommand extends CompositeCommand {
         .admin(true)
         .build();
         IslandEvent.builder()
-                .island(island)
-                .involvedPlayer(targetUUID)
-                .admin(true)
-                .reason(IslandEvent.Reason.RANK_CHANGE)
-                .rankChange(island.getRank(target), RanksManager.OWNER_RANK)
-                .build();
+        .island(island)
+        .involvedPlayer(targetUUID)
+        .admin(true)
+        .reason(IslandEvent.Reason.RANK_CHANGE)
+        .rankChange(island.getRank(target), RanksManager.OWNER_RANK)
+        .build();
         return true;
     }
 }

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -611,6 +611,7 @@ public class Util {
      * Get a UUID from a string. The string can be a known player's name or a UUID
      * @param nameOrUUID - name or UUID
      * @return UUID or null if unknown
+     * @since 1.13.0
      */
     @Nullable
     public static UUID getUUID(@NonNull String nameOrUUID) {

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -521,7 +522,7 @@ public class Util {
     public static boolean isPaper() {
         return isJUnitTest() ? false : PaperLib.isPaper();
     }
-    
+
     /**
      * I don't like doing this, but otherwise we need to set a flag in every test
      */
@@ -531,7 +532,7 @@ public class Util {
         for (StackTraceElement element : list) {
             if (element.getClassName().startsWith("org.junit.")) {
                 return true;
-            }           
+            }
         }
         return false;
     }
@@ -604,5 +605,23 @@ public class Util {
 
         // Everything's green!
         return true;
+    }
+
+    /**
+     * Get a UUID from a string. The string can be a known player's name or a UUID
+     * @param nameOrUUID - name or UUID
+     * @return UUID or null if unknown
+     */
+    @Nullable
+    public static UUID getUUID(@NonNull String nameOrUUID) {
+        UUID targetUUID = plugin.getPlayers().getUUID(nameOrUUID);
+        if (targetUUID != null) return targetUUID;
+        // Check if UUID is being used
+        try {
+            return UUID.fromString(nameOrUUID);
+        } catch (Exception e) {
+            // Do nothing
+        }
+        return null;
     }
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -36,6 +36,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -60,6 +61,9 @@ public class AdminDeleteCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+
+        // Util
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -129,17 +133,17 @@ public class AdminDeleteCommandTest {
     }
 
     /**
-     * Test method for {@link AdminDeleteCommand#execute(User, String, java.util.List)
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
     public void testExecuteNoTarget() {
         AdminDeleteCommand itl = new AdminDeleteCommand(ac);
-        assertFalse(itl.execute(user, itl.getLabel(), new ArrayList<>()));
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
         // Show help
     }
 
     /**
-     * Test method for {@link AdminDeleteCommand#execute(User, String, java.util.List)
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
     public void testExecuteUnknownPlayer() {
@@ -151,7 +155,7 @@ public class AdminDeleteCommandTest {
     }
 
     /**
-     * Test method for {@link AdminDeleteCommand#execute(User, String, java.util.List)
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
     public void testExecutePlayerNoIsland() {
@@ -164,7 +168,7 @@ public class AdminDeleteCommandTest {
     }
 
     /**
-     * Test method for {@link AdminDeleteCommand#execute(User, String, java.util.List)
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
     public void testExecuteOwner() {
@@ -178,10 +182,49 @@ public class AdminDeleteCommandTest {
     }
 
     /**
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
+     */
+    @Test
+    public void testcanExecuteSuccessUUID() {
+        when(im.inTeam(Mockito.any(), Mockito.any())).thenReturn(false);
+        when(im.getOwner(Mockito.any(), Mockito.any())).thenReturn(uuid);
+        Island is = mock(Island.class);
+        Location loc = mock(Location.class);
+        when(loc.toVector()).thenReturn(new Vector(123,123,432));
+        when(is.getCenter()).thenReturn(loc);
+        when(im.getIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(is);
+        // No such name
+        when(pm.getUUID(Mockito.any())).thenReturn(null);
+
+        AdminDeleteCommand itl = new AdminDeleteCommand(ac);
+        // Success because it's a valid UUID
+        assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList(uuid.toString())));
+    }
+    /**
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
+     */
+    @Test
+    public void testExecuteFailUUID() {
+        when(im.inTeam(Mockito.any(), Mockito.any())).thenReturn(false);
+        when(im.getOwner(Mockito.any(), Mockito.any())).thenReturn(uuid);
+        Island is = mock(Island.class);
+        Location loc = mock(Location.class);
+        when(loc.toVector()).thenReturn(new Vector(123,123,432));
+        when(is.getCenter()).thenReturn(loc);
+        when(im.getIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(is);
+        // No such name
+        when(pm.getUUID(Mockito.any())).thenReturn(null);
+
+        AdminDeleteCommand itl = new AdminDeleteCommand(ac);
+        // Fail because it's not a UUID
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("not-A-UUID")));
+    }
+
+    /**
      * Test method for {@link AdminDeleteCommand#execute(User, String, java.util.List)
      */
     @Test
-    public void testExecuteSuccess() {
+    public void testCanExecuteSuccess() {
         when(im.inTeam(Mockito.any(), Mockito.any())).thenReturn(false);
         when(im.getOwner(Mockito.any(), Mockito.any())).thenReturn(uuid);
         Island is = mock(Island.class);
@@ -193,11 +236,14 @@ public class AdminDeleteCommandTest {
         when(pm.getUUID(Mockito.any())).thenReturn(notUUID);
 
         AdminDeleteCommand itl = new AdminDeleteCommand(ac);
-        // First requires confirmation
-        assertTrue(itl.execute(user, itl.getLabel(), Arrays.asList(name)));
-        Mockito.verify(user).sendMessage("commands.confirmation.confirm", "[seconds]", "0");
+        assertTrue(itl.canExecute(user, itl.getLabel(), Arrays.asList(name)));
         // Confirm
         itl.execute(user, itl.getLabel(), Arrays.asList(name));
+        Mockito.verify(user).sendMessage("commands.confirmation.confirm", "[seconds]", "0");
     }
+
+
+
+
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommandTest.java
@@ -40,6 +40,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -77,6 +78,7 @@ public class AdminGetrankCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Ranks Manager
         when(plugin.getRanksManager()).thenReturn(rm);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
@@ -36,6 +36,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -61,6 +62,8 @@ public class AdminInfoCommandTest {
         // Set up plugin
         plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -41,6 +41,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 
 /**
@@ -73,6 +74,7 @@ public class AdminRegisterCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
@@ -70,6 +70,7 @@ public class AdminSetrankCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Ranks Manager
         rm = new RanksManager();
@@ -86,14 +87,15 @@ public class AdminSetrankCommandTest {
         Player p = mock(Player.class);
         when(p.getUniqueId()).thenReturn(targetUUID);
         User.getInstance(p);
-        
+
         // Online players
         PowerMockito.mockStatic(Util.class);
         when(Util.getOnlinePlayerList(any())).thenReturn(Collections.singletonList("tastybento"));
-        
+        when(Util.getUUID(anyString())).thenCallRealMethod();
+
         // Translations
         when(user.getTranslation(anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
-        
+
         // Command
         c = new AdminSetrankCommand(ac);
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommandTest.java
@@ -42,6 +42,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class})
@@ -64,6 +65,7 @@ public class AdminTeleportCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
@@ -46,6 +46,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
 
 
 /**
@@ -71,6 +72,7 @@ public class AdminUnregisterCommandTest {
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
 
+        Util.setPlugin(plugin);
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
         when(plugin.getCommandsManager()).thenReturn(cm);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommandTest.java
@@ -32,6 +32,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
@@ -49,6 +50,7 @@ public class AdminRangeCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommandTest.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package world.bentobox.bentobox.api.commands.admin.range;
 
 import static org.mockito.Mockito.mock;
@@ -32,6 +29,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -53,6 +51,7 @@ public class AdminRangeDisplayCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
@@ -39,6 +39,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -65,6 +66,7 @@ public class AdminRangeResetCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
@@ -39,6 +39,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -65,6 +66,7 @@ public class AdminRangeSetCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
@@ -36,6 +36,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -61,6 +62,7 @@ public class AdminTeamAddCommandTest {
         // Set up plugin
         plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
@@ -46,6 +46,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -80,6 +81,7 @@ public class AdminTeamDisbandCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,6 +45,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -78,6 +78,7 @@ public class AdminTeamKickCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -156,10 +157,9 @@ public class AdminTeamKickCommandTest {
     @Test
     public void testCanExecuteUnknownPlayer() {
         AdminTeamKickCommand itl = new AdminTeamKickCommand(ac);
-        String[] name = {"tastybento"};
         when(pm.getUUID(any())).thenReturn(null);
-        assertFalse(itl.canExecute(user, itl.getLabel(), Arrays.asList(name)));
-        verify(user).sendMessage("general.errors.unknown-player", "[name]", name[0]);
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
+        verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
     }
 
     /**
@@ -168,10 +168,9 @@ public class AdminTeamKickCommandTest {
     @Test
     public void testCanExecutePlayerNotInTeam() {
         AdminTeamKickCommand itl = new AdminTeamKickCommand(ac);
-        String[] name = {"tastybento"};
         when(pm.getUUID(any())).thenReturn(notUUID);
         when(im.getMembers(any(), any())).thenReturn(new HashSet<>());
-        assertFalse(itl.canExecute(user, itl.getLabel(), Arrays.asList(name)));
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         verify(user).sendMessage(eq("commands.admin.team.kick.not-in-team"));
     }
 
@@ -183,13 +182,13 @@ public class AdminTeamKickCommandTest {
         when(im.inTeam(any(), any())).thenReturn(true);
         Island is = mock(Island.class);
         when(im.getIsland(any(), any(UUID.class))).thenReturn(is);
-        String[] name = {"tastybento"};
         when(pm.getUUID(any())).thenReturn(notUUID);
 
         when(is.getOwner()).thenReturn(notUUID);
 
         AdminTeamKickCommand itl = new AdminTeamKickCommand(ac);
-        assertFalse(itl.execute(user, itl.getLabel(), Arrays.asList(name)));
+        assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
+        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         verify(user).sendMessage(eq("commands.admin.team.kick.cannot-kick-owner"));
         verify(is).showMembers(any());
         verify(im, never()).removePlayer(eq(world), eq(notUUID));
@@ -213,6 +212,7 @@ public class AdminTeamKickCommandTest {
         when(is.getOwner()).thenReturn(uuid);
 
         AdminTeamKickCommand itl = new AdminTeamKickCommand(ac);
+        assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList(name)));
         assertTrue(itl.execute(user, itl.getLabel(), Collections.singletonList(name)));
         verify(im).removePlayer(eq(world), eq(notUUID));
         verify(pm).clearHomeLocations(eq(world), eq(notUUID));

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
@@ -41,6 +41,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
@@ -69,6 +70,7 @@ public class AdminTeamSetownerCommandTest {
         // Set up plugin
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        Util.setPlugin(plugin);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);


### PR DESCRIPTION
Driven by https://github.com/BentoBoxWorld/BentoBox/issues/1297

Making a pull request because it affects a lot of code. It's a simple change though and just allows UUIDs to be used instead of names for Admin commands that require names. 

