### PR TITLE
Adds saveObjectAsync with a CompletableFuture return for databases

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/AbstractDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/AbstractDatabaseHandler.java
@@ -4,6 +4,7 @@ import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.bukkit.Bukkit;
@@ -143,7 +144,7 @@ public abstract class AbstractDatabaseHandler<T> {
      *
      * @param instance that should be inserted into the database
      */
-    public abstract void saveObject(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException ;
+    public abstract CompletableFuture<Boolean> saveObject(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException ;
 
     /**
      * Deletes the object with the unique id from the database. If the object does not exist, it will fail silently.

--- a/src/main/java/world/bentobox/bentobox/database/Database.java
+++ b/src/main/java/world/bentobox/bentobox/database/Database.java
@@ -4,6 +4,7 @@ import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -82,18 +83,32 @@ public class Database<T> {
     }
 
     /**
-     * Save config object. Saving may be done async.
+     * Save object async. Saving may be done sync, depending on the underlying database.
      * @param instance to save
      * @return true if no immediate errors. If async, errors may occur later.
      */
-    public boolean saveObject(T instance) {
+    public CompletableFuture<Boolean> saveObjectAsync(T instance) {
         try {
-            handler.saveObject(instance);
+            return handler.saveObject(instance);
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | SecurityException
                 | IntrospectionException e) {
             logger.severe(() -> "Could not save object to database! Error: " + e.getMessage());
-            return false;
+            return new CompletableFuture<>();
         }
+
+    }
+
+    /**
+     * Save object. Saving may be done async or sync, depending on the underlying database.
+     * @param instance to save
+     * @return true - always.
+     * @deprecated Use {@link #saveObjectAsync(Object)}
+     */
+    @Deprecated
+    public boolean saveObject(T instance) {
+        saveObjectAsync(instance).thenAccept(r -> {
+            if (!r) logger.severe(() -> "Could not save object to database!");
+        });
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/database/Database.java
+++ b/src/main/java/world/bentobox/bentobox/database/Database.java
@@ -86,6 +86,7 @@ public class Database<T> {
      * Save object async. Saving may be done sync, depending on the underlying database.
      * @param instance to save
      * @return true if no immediate errors. If async, errors may occur later.
+     * @since 1.13.0
      */
     public CompletableFuture<Boolean> saveObjectAsync(T instance) {
         try {
@@ -95,14 +96,13 @@ public class Database<T> {
             logger.severe(() -> "Could not save object to database! Error: " + e.getMessage());
             return new CompletableFuture<>();
         }
-
     }
 
     /**
      * Save object. Saving may be done async or sync, depending on the underlying database.
      * @param instance to save
      * @return true - always.
-     * @deprecated Use {@link #saveObjectAsync(Object)}
+     * @deprecated As of 1.13.0. Use {@link #saveObjectAsync(Object)}.
      */
     @Deprecated
     public boolean saveObject(T instance) {

--- a/src/main/java/world/bentobox/bentobox/database/sql/sqlite/SQLiteDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/sqlite/SQLiteDatabaseHandler.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.database.sql.sqlite;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNull;
 
@@ -39,15 +40,18 @@ public class SQLiteDatabaseHandler<T> extends SQLDatabaseHandler<T> {
     }
 
     @Override
-    public void saveObject(T instance) {
+    public CompletableFuture<Boolean> saveObject(T instance) {
+        CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
         // Null check
         if (instance == null) {
-            plugin.logError("MySQL database request to store a null. ");
-            return;
+            plugin.logError("SQLite database request to store a null. ");
+            completableFuture.complete(false);
+            return completableFuture;
         }
         if (!(instance instanceof DataObject)) {
             plugin.logError("This class is not a DataObject: " + instance.getClass().getName());
-            return;
+            completableFuture.complete(false);
+            return completableFuture;
         }
         Gson gson = getGson();
         String toStore = gson.toJson(instance);
@@ -56,11 +60,13 @@ public class SQLiteDatabaseHandler<T> extends SQLDatabaseHandler<T> {
                 preparedStatement.setString(1, toStore);
                 preparedStatement.setString(2, ((DataObject)instance).getUniqueId());
                 preparedStatement.setString(3, toStore);
-                preparedStatement.execute();
+                completableFuture.complete(preparedStatement.execute());
             } catch (SQLException e) {
                 plugin.logError("Could not save object " + instance.getClass().getName() + " " + e.getMessage());
+                completableFuture.complete(false);
             }
         });
+        return completableFuture;
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/database/transition/TransitionDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/TransitionDatabaseHandler.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.database.transition;
 import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -83,9 +84,9 @@ public class TransitionDatabaseHandler<T> extends AbstractDatabaseHandler<T> {
      * @see world.bentobox.bentobox.database.AbstractDatabaseHandler#saveObject(java.lang.Object)
      */
     @Override
-    public void saveObject(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+    public CompletableFuture<Boolean> saveObject(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         // Save only in the destination database
-        toHandler.saveObject(instance);
+        return toHandler.saveObject(instance);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseConnector.java
@@ -116,7 +116,7 @@ public class YamlDatabaseConnector implements DatabaseConnector {
         }
     }
 
-    public void saveYamlFile(String data, String tableName, String fileName, Map<String, String> commentMap) {
+    boolean saveYamlFile(String data, String tableName, String fileName, Map<String, String> commentMap) {
         String name = fileName.endsWith(YML) ? fileName : fileName + YML;
         File tableFolder = new File(plugin.getDataFolder(), tableName);
         File file = new File(tableFolder, name);
@@ -127,11 +127,12 @@ public class YamlDatabaseConnector implements DatabaseConnector {
             writer.write(data);
         } catch (IOException e) {
             plugin.logError("Could not save yml file: " + tableName + " " + fileName + " " + e.getMessage());
-            return;
+            return false;
         }
         if (commentMap != null && !commentMap.isEmpty()) {
             commentFile(new File(tableFolder, name), commentMap);
         }
+        return true;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandler.java
@@ -334,7 +334,7 @@ public class YamlDatabaseHandler<T> extends AbstractDatabaseHandler<T> {
         CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
         // Null check
         if (instance == null) {
-            plugin.logError("YAML database request to store a null. ");
+            plugin.logError("YAML database request to store a null.");
             completableFuture.complete(false);
             return completableFuture;
         }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandDeletionManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandDeletionManager.java
@@ -68,7 +68,7 @@ public class IslandDeletionManager implements Listener {
         // Store location
         inDeletion.add(e.getDeletedIslandInfo().getLocation());
         // Save to database
-        handler.saveObject(e.getDeletedIslandInfo());
+        handler.saveObjectAsync(e.getDeletedIslandInfo());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -72,7 +72,7 @@ public class PlayersManager {
      * Save all players
      */
     public void saveAll(){
-        Collections.unmodifiableCollection(playerCache.values()).forEach(handler::saveObject);
+        Collections.unmodifiableCollection(playerCache.values()).forEach(handler::saveObjectAsync);
     }
 
     /**
@@ -281,7 +281,7 @@ public class PlayersManager {
         playerCache.get(user.getUniqueId()).setPlayerName(user.getName());
         Names newName = new Names(user.getName(), user.getUniqueId());
         // Add to names database
-        names.saveObject(newName);
+        names.saveObjectAsync(newName);
     }
 
     /**
@@ -425,7 +425,7 @@ public class PlayersManager {
      */
     public void save(UUID playerUUID) {
         if (playerCache.containsKey(playerUUID)) {
-            handler.saveObject(playerCache.get(playerUUID));
+            handler.saveObjectAsync(playerCache.get(playerUUID));
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 
@@ -39,7 +40,8 @@ public class HeadGetter {
                     Entry<String, PanelItem> en = it.next();
                     ItemStack playerSkull = new ItemStack(Material.PLAYER_HEAD, en.getValue().getItem().getAmount());
                     SkullMeta meta = (SkullMeta) playerSkull.getItemMeta();
-                    meta.setOwner(en.getKey());
+                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(en.getKey());
+                    meta.setOwningPlayer(offlinePlayer);
                     playerSkull.setItemMeta(meta);
                     // Save in cache
                     cachedHeads.put(en.getKey(), playerSkull);
@@ -66,6 +68,9 @@ public class HeadGetter {
             panelItem.setHead(cachedHeads.get(panelItem.getPlayerHeadName()).clone());
             requester.setHead(panelItem);
         } else {
+            BentoBox.getInstance().logDebug("Not in cache");
+            // Show Steve's head for now
+            panelItem.setHead(new ItemStack(Material.CREEPER_HEAD));
             // Get the name
             headRequesters.putIfAbsent(panelItem.getPlayerHeadName(), new HashSet<>());
             Set<HeadRequester> requesters = headRequesters.get(panelItem.getPlayerHeadName());

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -40,8 +40,7 @@ public class HeadGetter {
                     Entry<String, PanelItem> en = it.next();
                     ItemStack playerSkull = new ItemStack(Material.PLAYER_HEAD, en.getValue().getItem().getAmount());
                     SkullMeta meta = (SkullMeta) playerSkull.getItemMeta();
-                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(en.getKey());
-                    meta.setOwningPlayer(offlinePlayer);
+                    meta.setOwner(en.getKey());
                     playerSkull.setItemMeta(meta);
                     // Save in cache
                     cachedHeads.put(en.getKey(), playerSkull);
@@ -68,9 +67,6 @@ public class HeadGetter {
             panelItem.setHead(cachedHeads.get(panelItem.getPlayerHeadName()).clone());
             requester.setHead(panelItem);
         } else {
-            BentoBox.getInstance().logDebug("Not in cache");
-            // Show Steve's head for now
-            panelItem.setHead(new ItemStack(Material.CREEPER_HEAD));
             // Get the name
             headRequesters.putIfAbsent(panelItem.getPlayerHeadName(), new HashSet<>());
             Set<HeadRequester> requesters = headRequesters.get(panelItem.getPlayerHeadName());

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 

--- a/src/test/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandlerTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandlerTest.java
@@ -1,12 +1,15 @@
-/**
- *
- */
 package world.bentobox.bentobox.database.yaml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.framework;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.beans.IntrospectionException;
@@ -35,7 +38,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -91,11 +93,11 @@ public class YamlDatabaseHandlerTest {
         PowerMockito.mockStatic(Bukkit.class);
         when(Bukkit.getScheduler()).thenReturn(scheduler);
 
-        when(scheduler.runTaskAsynchronously(Mockito.any(), Mockito.any(Runnable.class))).thenReturn(task);
+        when(scheduler.runTaskAsynchronously(any(), any(Runnable.class))).thenReturn(task);
         Server server = mock(Server.class);
         World world = mock(World.class);
         when(world.getName()).thenReturn("cleanroom");
-        when(server.getWorld(Mockito.anyString())).thenReturn(world);
+        when(server.getWorld(anyString())).thenReturn(world);
         when(Bukkit.getServer()).thenReturn(server);
 
         // A YAML file representing island
@@ -105,11 +107,11 @@ public class YamlDatabaseHandlerTest {
         config.loadFromString(getYaml(uuid));
         YamlConfiguration config2 = new YamlConfiguration();
         config2.loadFromString(getYaml2(uuid2));
-        when(dbConnector.loadYamlFile(Mockito.anyString(), Mockito.anyString())).thenReturn(config, config2);
+        when(dbConnector.loadYamlFile(anyString(), anyString())).thenReturn(config, config2);
 
         // Flags Manager
         FlagsManager fm = mock(FlagsManager.class);
-        when(fm.getFlag(Mockito.anyString())).thenReturn(Optional.empty());
+        when(fm.getFlag(anyString())).thenReturn(Optional.empty());
         when(plugin.getFlagsManager()).thenReturn(fm);
 
         // Island
@@ -138,7 +140,7 @@ public class YamlDatabaseHandlerTest {
         .sorted(Comparator.reverseOrder())
         .map(Path::toFile)
         .forEach(File::delete);
-        Mockito.framework().clearInlineMocks();
+        framework().clearInlineMocks();
     }
 
     /**
@@ -189,7 +191,7 @@ public class YamlDatabaseHandlerTest {
         Location center = mock(Location.class);
         is.setCenter(center);
         handler.saveObject(is);
-        Mockito.verify(dbConnector).saveYamlFile(Mockito.anyString(), Mockito.eq("database/Island"), Mockito.eq("unique"), Mockito.isA(Map.class));
+        verify(dbConnector).saveYamlFile(anyString(), eq("database/Island"), eq("unique"), isA(Map.class));
     }
 
     /**
@@ -201,7 +203,7 @@ public class YamlDatabaseHandlerTest {
     @Test
     public void testSaveObjectNull() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         handler.saveObject(null);
-        Mockito.verify(plugin).logError("YAML database request to store a null.");
+        verify(plugin).logError("YAML database request to store a null.");
     }
 
     /**
@@ -215,7 +217,7 @@ public class YamlDatabaseHandlerTest {
         YamlDatabaseHandler<String> h = new YamlDatabaseHandler<String>(plugin, String.class, dbConnector);
         String test = "";
         h.saveObject(test);
-        Mockito.verify(plugin).logError("This class is not a DataObject: java.lang.String");
+        verify(plugin).logError("This class is not a DataObject: java.lang.String");
     }
 
     /**
@@ -238,7 +240,7 @@ public class YamlDatabaseHandlerTest {
     @Test
     public void testDeleteObjectNull() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         handler.deleteObject(null);
-        Mockito.verify(plugin).logError("YAML database request to delete a null.");
+        verify(plugin).logError("YAML database request to delete a null.");
     }
 
     /**
@@ -252,7 +254,7 @@ public class YamlDatabaseHandlerTest {
         YamlDatabaseHandler<String> h = new YamlDatabaseHandler<String>(plugin, String.class, dbConnector);
         String test = "";
         h.deleteObject(test);
-        Mockito.verify(plugin).logError("This class is not a DataObject: java.lang.String");
+        verify(plugin).logError("This class is not a DataObject: java.lang.String");
 
     }
 
@@ -261,7 +263,7 @@ public class YamlDatabaseHandlerTest {
      */
     @Test
     public void testObjectExists() {
-        when(dbConnector.uniqueIdExists(Mockito.eq(Island.class.getSimpleName()), Mockito.eq(uuid.toString()))).thenReturn(true);
+        when(dbConnector.uniqueIdExists(eq(Island.class.getSimpleName()), eq(uuid.toString()))).thenReturn(true);
         assertTrue(handler.objectExists(uuid.toString()));
         assertFalse(handler.objectExists("nope"));
     }
@@ -301,12 +303,12 @@ public class YamlDatabaseHandlerTest {
      */
     @Test
     public void testYamlDatabaseHandler() {
-        Mockito.verify(scheduler).runTaskAsynchronously(Mockito.eq(plugin), registerLambdaCaptor.capture());
+        verify(scheduler).runTaskAsynchronously(eq(plugin), registerLambdaCaptor.capture());
         Runnable lamda = registerLambdaCaptor.getValue();
         // Cannot run with true otherwise it'll infinite loop
         when(plugin.isShutdown()).thenReturn(true);
         lamda.run();
-        Mockito.verify(task).cancel();
+        verify(task).cancel();
 
     }
 


### PR DESCRIPTION
Async saving to the database should return a completable future so that code can be written to run after the value has absolutely been saved to the database. This PR adds the method to the database classes to enable this. It retains but deprecates the original saveObject method. That method's return value was useless since we moved to async saving. It has to be kept though to support backwards runtime compatibility for addons that use saveObject. 

I recommend all addons move to use saveObjectAsync after this PR is merged.