### PR TITLE
Add ability for DataObjects to specify custom db table name

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -97,9 +97,10 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "general.database.use-ssl", since = "1.12.0")
     private boolean useSSL = false;
 
-    @ConfigComment("Database table prefix character. Adds a prefix to the database tables. Not used by flatfile databases.")
+    @ConfigComment("Database table prefix. Adds a prefix to the database tables. Not used by flatfile databases.")
     @ConfigComment("Only the characters A-Z, a-z, 0-9 can be used. Invalid characters will become an underscore.")
     @ConfigComment("Set this to a unique value if you are running multiple BentoBox instances that share a database.")
+    @ConfigComment("Be careful about length - databases usually have a limit of 63 characters for table lengths")
     @ConfigEntry(path = "general.database.prefix-character", since = "1.13.0")
     private String databasePrefix = "";
 
@@ -238,16 +239,16 @@ public class Settings implements ConfigObject {
     private boolean autoOwnershipTransferIgnoreRanks = false;
 
     // Island deletion related settings
-	@ConfigComment("Toggles whether islands, when players are resetting them, should be kept in the world or deleted.")
-	@ConfigComment("* If set to 'true', whenever a player resets his island, his previous island will become unowned and won't be deleted from the world.")
-	@ConfigComment("  You can, however, still delete those unowned islands through purging.")
-	@ConfigComment("  On bigger servers, this can lead to an increasing world size.")
-	@ConfigComment("  Yet, this allows admins to retrieve a player's old island in case of an improper use of the reset command.")
-	@ConfigComment("  Admins can indeed re-add the player to his old island by registering him to it.")
-	@ConfigComment("* If set to 'false', whenever a player resets his island, his previous island will be deleted from the world.")
-	@ConfigComment("  This is the default behaviour.")
-	@ConfigEntry(path = "island.deletion.keep-previous-island-on-reset", since = "1.13.0")
-	private boolean keepPreviousIslandOnReset = false;
+    @ConfigComment("Toggles whether islands, when players are resetting them, should be kept in the world or deleted.")
+    @ConfigComment("* If set to 'true', whenever a player resets his island, his previous island will become unowned and won't be deleted from the world.")
+    @ConfigComment("  You can, however, still delete those unowned islands through purging.")
+    @ConfigComment("  On bigger servers, this can lead to an increasing world size.")
+    @ConfigComment("  Yet, this allows admins to retrieve a player's old island in case of an improper use of the reset command.")
+    @ConfigComment("  Admins can indeed re-add the player to his old island by registering him to it.")
+    @ConfigComment("* If set to 'false', whenever a player resets his island, his previous island will be deleted from the world.")
+    @ConfigComment("  This is the default behaviour.")
+    @ConfigEntry(path = "island.deletion.keep-previous-island-on-reset", since = "1.13.0")
+    private boolean keepPreviousIslandOnReset = false;
 
     /* WEB */
     @ConfigComment("Toggle whether BentoBox can connect to GitHub to get data about updates and addons.")
@@ -639,7 +640,7 @@ public class Settings implements ConfigObject {
      */
     public String getDatabasePrefix() {
         if (databasePrefix == null) databasePrefix = "";
-        return databasePrefix.isEmpty() ? "" : databasePrefix.replaceAll("[^a-zA-Z0-9]", "_").substring(0,1);
+        return databasePrefix.isEmpty() ? "" : databasePrefix.replaceAll("[^a-zA-Z0-9]", "_");
     }
 
     /**
@@ -649,23 +650,23 @@ public class Settings implements ConfigObject {
         this.databasePrefix = databasePrefix;
     }
 
-	/**
-	 * Returns whether islands, when reset, should be kept or deleted.
-	 * @return {@code true} if islands, when reset, should be kept; {@code false} otherwise.
-	 * @since 1.13.0
-	 */
-	public boolean isKeepPreviousIslandOnReset() {
-		return keepPreviousIslandOnReset;
-	}
+    /**
+     * Returns whether islands, when reset, should be kept or deleted.
+     * @return {@code true} if islands, when reset, should be kept; {@code false} otherwise.
+     * @since 1.13.0
+     */
+    public boolean isKeepPreviousIslandOnReset() {
+        return keepPreviousIslandOnReset;
+    }
 
-	/**
-	 * Sets whether islands, when reset, should be kept or deleted.
-	 * @param keepPreviousIslandOnReset {@code true} if islands, when reset, should be kept; {@code false} otherwise.
-	 * @since 1.13.0
-	 */
-	public void setKeepPreviousIslandOnReset(boolean keepPreviousIslandOnReset) {
-		this.keepPreviousIslandOnReset = keepPreviousIslandOnReset;
-	}
+    /**
+     * Sets whether islands, when reset, should be kept or deleted.
+     * @param keepPreviousIslandOnReset {@code true} if islands, when reset, should be kept; {@code false} otherwise.
+     * @since 1.13.0
+     */
+    public void setKeepPreviousIslandOnReset(boolean keepPreviousIslandOnReset) {
+        this.keepPreviousIslandOnReset = keepPreviousIslandOnReset;
+    }
 
     /**
      * Returns a MongoDB client connection URI to override default connection options.

--- a/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/mongodb/MongoDBDatabaseHandler.java
@@ -17,6 +17,7 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.util.JSON;
 
 import world.bentobox.bentobox.BentoBox;
@@ -66,7 +67,7 @@ public class MongoDBDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T> {
                 String newName = getName(plugin, dataObject);
                 if (!oldName.equals((newName)) && collectionExists(database, oldName) && !collectionExists(database, newName)){
                     collection = database.getCollection(oldName);
-                    collection.renameCollection(new MongoNamespace(newName));
+                    collection.renameCollection(new MongoNamespace(database.getName(), newName));
                 } else {
                     collection = database.getCollection(newName);
                 }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -53,6 +53,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  * @author Poslovitch
  */
+@Table(name = "Islands")
 public class Island implements DataObject {
 
     // True if this island is deleted and pending deletion from the database

--- a/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
@@ -16,6 +16,7 @@ import world.bentobox.bentobox.BentoBox;
  * @author tastybento
  * @since 1.1
  */
+@Table(name = "IslandDeletion")
 public class IslandDeletion implements DataObject {
 
     @Expose

--- a/src/main/java/world/bentobox/bentobox/database/objects/Names.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Names.java
@@ -9,20 +9,21 @@ import com.google.gson.annotations.Expose;
  * @author tastybento
  *
  */
+@Table(name = "Names")
 public class Names implements DataObject {
 
     @Expose
     private String uniqueId = ""; // name
     @Expose
     private UUID uuid;
-    
+
     public Names() {}
-    
+
     public Names(String name, UUID uuid) {
         this.uniqueId = name;
         this.uuid = uuid;
     }
-    
+
     @Override
     public String getUniqueId() {
         return uniqueId;
@@ -30,7 +31,7 @@ public class Names implements DataObject {
 
     @Override
     public void setUniqueId(String uniqueId) {
-        this.uniqueId = uniqueId;        
+        this.uniqueId = uniqueId;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/database/objects/Players.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Players.java
@@ -24,6 +24,7 @@ import world.bentobox.bentobox.util.Util;
  *
  * @author tastybento
  */
+@Table(name = "Players")
 public class Players implements DataObject {
     @Expose
     private Map<Location, Integer> homeLocations = new HashMap<>();

--- a/src/main/java/world/bentobox/bentobox/database/objects/Table.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Table.java
@@ -1,0 +1,22 @@
+package world.bentobox.bentobox.database.objects;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+/**
+ * Annotation to explicitly name tables
+ * @author tastybento
+ *
+ */
+public @interface Table {
+    /**
+     * @return name of the table to be used, if any
+     */
+    String name();
+
+}

--- a/src/main/java/world/bentobox/bentobox/database/objects/Table.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Table.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation to explicitly name tables
  * @author tastybento
- *
+ * @since 1.14.0
  */
 public @interface Table {
     /**

--- a/src/main/java/world/bentobox/bentobox/database/objects/Table.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Table.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  */
 public @interface Table {
     /**
-     * @return name of the table to be used, if any
+     * @return name of the table to be used in the database
      */
     String name();
 

--- a/src/main/java/world/bentobox/bentobox/database/sql/SQLDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/SQLDatabaseHandler.java
@@ -81,11 +81,19 @@ public class SQLDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T> {
      * Creates the table in the database if it doesn't exist already
      */
     protected void createSchema() {
+        if (sqlConfig.renameRequired()) {
+            // Transition from the old table name
+            try (PreparedStatement pstmt = connection.prepareStatement(sqlConfig.getRenameTableSQL())) {
+                pstmt.execute();
+            } catch (SQLException e) {
+                plugin.logError("Could not rename " + sqlConfig.getOldTableName() + " for data object " + dataObject.getCanonicalName() + " " + e.getMessage());
+            }
+        }
         // Prepare and execute the database statements
         try (PreparedStatement pstmt = connection.prepareStatement(sqlConfig.getSchemaSQL())) {
-            pstmt.executeUpdate();
+            pstmt.execute();
         } catch (SQLException e) {
-            plugin.logError("Problem trying to create schema for data object " + plugin.getSettings().getDatabasePrefix() + dataObject.getCanonicalName() + " " + e.getMessage());
+            plugin.logError("Problem trying to create schema for data object " + dataObject.getCanonicalName() + " " + e.getMessage());
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseHandler.java
@@ -25,7 +25,6 @@ public class MariaDBDatabaseHandler<T> extends SQLDatabaseHandler<T> {
     MariaDBDatabaseHandler(BentoBox plugin, Class<T> type, DatabaseConnector databaseConnector) {
         super(plugin, type, databaseConnector,
                 new SQLConfiguration(plugin, type)
-                .schema("CREATE TABLE IF NOT EXISTS `[tableName]` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (JSON_EXTRACT(json, \"$.uniqueId\")), UNIQUE INDEX i (uniqueId))")
-                .renameTable("RENAME TABLE IF EXISTS `[oldTableName]` TO `[tableName]`"));
+                .schema("CREATE TABLE IF NOT EXISTS `[tableName]` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (JSON_EXTRACT(json, \"$.uniqueId\")), UNIQUE INDEX i (uniqueId))"));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseHandler.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.database.sql.mariadb;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.DatabaseConnector;
+import world.bentobox.bentobox.database.objects.Table;
 import world.bentobox.bentobox.database.sql.SQLConfiguration;
 import world.bentobox.bentobox.database.sql.SQLDatabaseHandler;
 
@@ -23,8 +24,18 @@ public class MariaDBDatabaseHandler<T> extends SQLDatabaseHandler<T> {
      * @param databaseConnector - authentication details for the database
      */
     MariaDBDatabaseHandler(BentoBox plugin, Class<T> type, DatabaseConnector databaseConnector) {
-        super(plugin, type, databaseConnector, new SQLConfiguration(plugin.getSettings().getDatabasePrefix() + type.getCanonicalName())
-                .schema("CREATE TABLE IF NOT EXISTS `" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() +
+        super(plugin, type, databaseConnector,
+                new SQLConfiguration(plugin.getSettings().getDatabasePrefix() +
+                        (type.getAnnotation(Table.class) == null ?
+                                type.getCanonicalName()
+                                : type.getAnnotation(Table.class)
+                                .name()))
+                .schema("CREATE TABLE IF NOT EXISTS `" +
+                        plugin.getSettings().getDatabasePrefix() +
+                        (type.getAnnotation(Table.class) == null ?
+                                type.getCanonicalName()
+                                : type.getAnnotation(Table.class)
+                                .name()) +
                         "` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (JSON_EXTRACT(json, \"$.uniqueId\")), UNIQUE INDEX i (uniqueId))"));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mariadb/MariaDBDatabaseHandler.java
@@ -2,7 +2,6 @@ package world.bentobox.bentobox.database.sql.mariadb;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.DatabaseConnector;
-import world.bentobox.bentobox.database.objects.Table;
 import world.bentobox.bentobox.database.sql.SQLConfiguration;
 import world.bentobox.bentobox.database.sql.SQLDatabaseHandler;
 
@@ -25,17 +24,8 @@ public class MariaDBDatabaseHandler<T> extends SQLDatabaseHandler<T> {
      */
     MariaDBDatabaseHandler(BentoBox plugin, Class<T> type, DatabaseConnector databaseConnector) {
         super(plugin, type, databaseConnector,
-                new SQLConfiguration(plugin.getSettings().getDatabasePrefix() +
-                        (type.getAnnotation(Table.class) == null ?
-                                type.getCanonicalName()
-                                : type.getAnnotation(Table.class)
-                                .name()))
-                .schema("CREATE TABLE IF NOT EXISTS `" +
-                        plugin.getSettings().getDatabasePrefix() +
-                        (type.getAnnotation(Table.class) == null ?
-                                type.getCanonicalName()
-                                : type.getAnnotation(Table.class)
-                                .name()) +
-                        "` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (JSON_EXTRACT(json, \"$.uniqueId\")), UNIQUE INDEX i (uniqueId))"));
+                new SQLConfiguration(plugin, type)
+                .schema("CREATE TABLE IF NOT EXISTS `[tableName]` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (JSON_EXTRACT(json, \"$.uniqueId\")), UNIQUE INDEX i (uniqueId))")
+                .renameTable("RENAME TABLE IF EXISTS `[oldTableName]` TO `[tableName]`"));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseHandler.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.database.sql.mysql;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.DatabaseConnector;
+import world.bentobox.bentobox.database.objects.Table;
 import world.bentobox.bentobox.database.sql.SQLConfiguration;
 import world.bentobox.bentobox.database.sql.SQLDatabaseHandler;
 
@@ -23,8 +24,17 @@ public class MySQLDatabaseHandler<T> extends SQLDatabaseHandler<T> {
      * @param dbConnecter - authentication details for the database
      */
     MySQLDatabaseHandler(BentoBox plugin, Class<T> type, DatabaseConnector dbConnecter) {
-        super(plugin, type, dbConnecter, new SQLConfiguration(plugin.getSettings().getDatabasePrefix() + type.getCanonicalName())
-                .schema("CREATE TABLE IF NOT EXISTS `" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() +
+        super(plugin, type, dbConnecter, new SQLConfiguration(
+                plugin.getSettings().getDatabasePrefix() +
+                (type.getAnnotation(Table.class) == null ?
+                        type.getCanonicalName()
+                        : type.getAnnotation(Table.class)
+                        .name()))
+                .schema("CREATE TABLE IF NOT EXISTS `" + plugin.getSettings().getDatabasePrefix() +
+                        (type.getAnnotation(Table.class) == null ?
+                                type.getCanonicalName()
+                                : type.getAnnotation(Table.class)
+                                .name()) +
                         "` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB"));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseHandler.java
@@ -2,7 +2,6 @@ package world.bentobox.bentobox.database.sql.mysql;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.DatabaseConnector;
-import world.bentobox.bentobox.database.objects.Table;
 import world.bentobox.bentobox.database.sql.SQLConfiguration;
 import world.bentobox.bentobox.database.sql.SQLDatabaseHandler;
 
@@ -24,17 +23,7 @@ public class MySQLDatabaseHandler<T> extends SQLDatabaseHandler<T> {
      * @param dbConnecter - authentication details for the database
      */
     MySQLDatabaseHandler(BentoBox plugin, Class<T> type, DatabaseConnector dbConnecter) {
-        super(plugin, type, dbConnecter, new SQLConfiguration(
-                plugin.getSettings().getDatabasePrefix() +
-                (type.getAnnotation(Table.class) == null ?
-                        type.getCanonicalName()
-                        : type.getAnnotation(Table.class)
-                        .name()))
-                .schema("CREATE TABLE IF NOT EXISTS `" + plugin.getSettings().getDatabasePrefix() +
-                        (type.getAnnotation(Table.class) == null ?
-                                type.getCanonicalName()
-                                : type.getAnnotation(Table.class)
-                                .name()) +
-                        "` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB"));
+        super(plugin, type, dbConnecter, new SQLConfiguration(plugin, type)
+                .schema("CREATE TABLE IF NOT EXISTS `[tableName]` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB"));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseHandler.java
@@ -45,7 +45,7 @@ public class PostgreSQLDatabaseHandler<T> extends SQLDatabaseHandler<T> {
                 .loadObjects("SELECT json FROM \"[tableName]\"")
                 // Postgres exists function returns true or false natively
                 .objectExists("SELECT EXISTS(SELECT * FROM \"[tableName]\" WHERE uniqueid = ?)")
-                .renameTable("ALTER TABLE IF EXISTS \"[oldTableName]\"  RENAME TO \"[tableName]\"")
+                .renameTable("ALTER TABLE IF EXISTS \"[oldTableName]\" RENAME TO \"[tableName]\"")
                 );
     }
 

--- a/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseHandler.java
@@ -30,21 +30,22 @@ public class PostgreSQLDatabaseHandler<T> extends SQLDatabaseHandler<T> {
      * @param databaseConnector Contains the settings to create a connection to the database
      */
     PostgreSQLDatabaseHandler(BentoBox plugin, Class<T> type, DatabaseConnector databaseConnector) {
-        super(plugin, type, databaseConnector, new SQLConfiguration(plugin.getSettings().getDatabasePrefix() + type.getCanonicalName())
+        super(plugin, type, databaseConnector, new SQLConfiguration(plugin, type)
                 // Set uniqueid as the primary key (index). Postgresql convention is to use lower case field names
                 // Postgresql also uses double quotes (") instead of (`) around tables names with dots.
-                .schema("CREATE TABLE IF NOT EXISTS \"" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() + "\" (uniqueid VARCHAR PRIMARY KEY, json jsonb NOT NULL)")
-                .loadObject("SELECT * FROM \"" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() + "\" WHERE uniqueid = ? LIMIT 1")
-                .deleteObject("DELETE FROM \"" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() + "\" WHERE uniqueid = ?")
+                .schema("CREATE TABLE IF NOT EXISTS \"[tableName]\" (uniqueid VARCHAR PRIMARY KEY, json jsonb NOT NULL)")
+                .loadObject("SELECT * FROM \"[tableName]\" WHERE uniqueid = ? LIMIT 1")
+                .deleteObject("DELETE FROM \"[tableName]\" WHERE uniqueid = ?")
                 // uniqueId has to be added into the row explicitly so we need to override the saveObject method
                 // The json value is a string but has to be cast to json when done in Java
-                .saveObject("INSERT INTO \"" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() + "\" (uniqueid, json) VALUES (?, cast(? as json)) "
+                .saveObject("INSERT INTO \"[tableName]\" (uniqueid, json) VALUES (?, cast(? as json)) "
                         // This is the Postgresql version of UPSERT.
                         + "ON CONFLICT (uniqueid) "
                         + "DO UPDATE SET json = cast(? as json)")
-                .loadObjects("SELECT json FROM \"" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() + "\"")
+                .loadObjects("SELECT json FROM \"[tableName]\"")
                 // Postgres exists function returns true or false natively
-                .objectExists("SELECT EXISTS(SELECT * FROM \"" + plugin.getSettings().getDatabasePrefix() + type.getCanonicalName() + "\" WHERE uniqueid = ?)")
+                .objectExists("SELECT EXISTS(SELECT * FROM \"[tableName]\" WHERE uniqueid = ?)")
+                .renameTable("ALTER TABLE IF EXISTS \"[oldTableName]\"  RENAME TO \"[tableName]\"")
                 );
     }
 

--- a/src/test/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseHandlerTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/sql/mysql/MySQLDatabaseHandlerTest.java
@@ -147,7 +147,7 @@ public class MySQLDatabaseHandlerTest {
         when(resultSet.next()).thenReturn(true, true, true, false);
         when(ps.executeQuery(Mockito.anyString())).thenReturn(resultSet);
         List<Island> objects = handler.loadObjects();
-        verify(ps).executeQuery("SELECT `json` FROM `world.bentobox.bentobox.database.objects.Island`");
+        verify(ps).executeQuery("SELECT `json` FROM `Islands`");
         assertTrue(objects.size() == 3);
         assertEquals("xyz", objects.get(2).getUniqueId());
     }
@@ -166,7 +166,7 @@ public class MySQLDatabaseHandlerTest {
         when(resultSet.next()).thenReturn(true, true, true, false);
         when(ps.executeQuery(Mockito.anyString())).thenReturn(resultSet);
         List<Island> objects = handler.loadObjects();
-        verify(ps).executeQuery("SELECT `json` FROM `aworld.bentobox.bentobox.database.objects.Island`");
+        verify(ps).executeQuery("SELECT `json` FROM `aIslands`");
         assertTrue(objects.size() == 3);
         assertEquals("xyz", objects.get(2).getUniqueId());
     }
@@ -183,7 +183,7 @@ public class MySQLDatabaseHandlerTest {
         when(resultSet.next()).thenReturn(true, true, true, false);
         when(ps.executeQuery(Mockito.anyString())).thenReturn(resultSet);
         List<Island> objects = handler.loadObjects();
-        verify(ps).executeQuery("SELECT `json` FROM `world.bentobox.bentobox.database.objects.Island`");
+        verify(ps).executeQuery("SELECT `json` FROM `Islands`");
         assertTrue(objects.isEmpty());
         verify(plugin, Mockito.times(3)).logError("Could not load object java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $");
     }
@@ -200,7 +200,7 @@ public class MySQLDatabaseHandlerTest {
         when(resultSet.next()).thenReturn(true, true, true, false);
         when(ps.executeQuery(Mockito.anyString())).thenReturn(resultSet);
         List<Island> objects = handler.loadObjects();
-        verify(ps).executeQuery("SELECT `json` FROM `world.bentobox.bentobox.database.objects.Island`");
+        verify(ps).executeQuery("SELECT `json` FROM `Islands`");
         assertTrue(objects.isEmpty());
         verify(plugin).logError("Could not load objects SQL error");
 
@@ -327,7 +327,7 @@ public class MySQLDatabaseHandlerTest {
         when(plugin.isEnabled()).thenReturn(false);
         when(ps.execute()).thenThrow(new SQLException("fail!"));
         handler.saveObject(instance);
-        verify(plugin).logError(eq("Could not save object world.bentobox.bentobox.database.objects.Island fail!"));
+        verify(plugin).logError(eq("Could not save object Islands fail!"));
 
     }
 
@@ -375,7 +375,7 @@ public class MySQLDatabaseHandlerTest {
         when(ps.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(false);
         assertFalse(handler.objectExists("hello"));
-        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `world.bentobox.bentobox.database.objects.Island` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
+        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `Islands` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
         verify(ps).executeQuery();
         verify(ps).setString(1, "\"hello\"");
     }
@@ -391,7 +391,7 @@ public class MySQLDatabaseHandlerTest {
         when(resultSet.next()).thenReturn(true);
         when(resultSet.getBoolean(eq(1))).thenReturn(false);
         assertFalse(handler.objectExists("hello"));
-        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `world.bentobox.bentobox.database.objects.Island` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
+        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `Islands` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
         verify(ps).executeQuery();
         verify(ps).setString(1, "\"hello\"");
     }
@@ -407,7 +407,7 @@ public class MySQLDatabaseHandlerTest {
         when(resultSet.next()).thenReturn(true);
         when(resultSet.getBoolean(eq(1))).thenReturn(true);
         assertTrue(handler.objectExists("hello"));
-        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `world.bentobox.bentobox.database.objects.Island` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
+        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `Islands` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
         verify(ps).executeQuery();
         verify(ps).setString(1, "\"hello\"");
     }
@@ -425,7 +425,7 @@ public class MySQLDatabaseHandlerTest {
         when(resultSet.next()).thenReturn(true);
         when(resultSet.getBoolean(eq(1))).thenReturn(true);
         assertTrue(handler.objectExists("hello"));
-        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `aworld.bentobox.bentobox.database.objects.Island` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
+        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `aIslands` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
         verify(ps).executeQuery();
         verify(ps).setString(1, "\"hello\"");
     }
@@ -468,7 +468,7 @@ public class MySQLDatabaseHandlerTest {
         when(plugin.isEnabled()).thenReturn(false);
         when(ps.execute()).thenThrow(new SQLException("fail!"));
         handler.deleteID("abc123");
-        verify(plugin).logError(eq("Could not delete object world.bentobox.bentobox.database.objects.Island abc123 fail!"));
+        verify(plugin).logError(eq("Could not delete object Islands abc123 fail!"));
     }
 
     /**
@@ -489,7 +489,7 @@ public class MySQLDatabaseHandlerTest {
     @Test
     public void testMySQLDatabaseHandlerCreateSchema() throws SQLException {
         verify(dbConn).createConnection(any());
-        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `world.bentobox.bentobox.database.objects.Island` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
+        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `Islands` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
     }
 
     /**
@@ -501,7 +501,7 @@ public class MySQLDatabaseHandlerTest {
     public void testMySQLDatabaseHandlerCreateSchemaPrefix() throws SQLException {
         when(settings.getDatabasePrefix()).thenReturn("a");
         verify(dbConn).createConnection(any());
-        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `aworld.bentobox.bentobox.database.objects.Island` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
+        verify(connection).prepareStatement("CREATE TABLE IF NOT EXISTS `aIslands` (json JSON, uniqueId VARCHAR(255) GENERATED ALWAYS AS (json->\"$.uniqueId\"), UNIQUE INDEX i (uniqueId) ) ENGINE = INNODB");
     }
     /**
      * Test method for {@link world.bentobox.bentobox.database.sql.mysql.MySQLDatabaseHandler#MySQLDatabaseHandler(world.bentobox.bentobox.BentoBox, java.lang.Class, world.bentobox.bentobox.database.DatabaseConnector)}.
@@ -509,7 +509,7 @@ public class MySQLDatabaseHandlerTest {
      */
     @Test
     public void testMySQLDatabaseHandlerSchemaFail() throws SQLException {
-        when(ps.executeUpdate()).thenThrow(new SQLException("oh no!"));
+        when(ps.execute()).thenThrow(new SQLException("oh no!"));
         handler = new MySQLDatabaseHandler<>(plugin, Island.class, dbConn);
         verify(plugin).logError("Problem trying to create schema for data object world.bentobox.bentobox.database.objects.Island oh no!");
 


### PR DESCRIPTION
# Introduction
In BentoBox the implicit naming strategy for SQL table names and Mongo collections has been the canonical name of the class. This PR enables authors to change this default behavior by implementing a physical naming strategy via the @table type annotation on DataObject. This approach mirrors systems such as Hibernate.

## Example
The Island class is stored in a database table called "Islands".
```
@Table(name = "Islands")
public class Island implements DataObject {
...
```

# Features
* Backward compatibility - addons do not have to be rewritten
* @table annotation enables addon authors (and BentoBox authors) to specify the name of a table in the database.
* Automatic migration of tables from default to physical naming if used.
* Database prefix can now be longer than one letter.
* Database supported: (check mark means tested and verified)
 - [x] MySQL
 - [x] MariaDB
 - [x] SQLite
 - [x] PostgreSQL
 - [x] MongoDB 

## Automatic migration
If a DataObject uses the @table annotation and the database has
canonical class named tables, then the old table will renamed to the new
table automatically.

## Caveats
* Database table names must still be <64 chars - this is a hard coded limit for tables in MySQL, etc.
* Table names still need to be unique. Authors will need to make sure they don't pick a table name that is already taken.
* Migration goes one-way: downgrading to earlier versions of BentoBox will require manual renaming of the tables in the database.