### PR TITLE
Uses perform command instead of direct call.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
@@ -107,7 +107,7 @@ public abstract class DefaultPlayerCommand extends CompositeCommand
             String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultPlayerAction();
 
             // Perform command or use "go" command.
-            if (command != null && user.performCommand(label + " " + command))
+            if (command != null && user.performCommand("/" + label + " " + command))
             {
                 return true;
             }
@@ -124,7 +124,7 @@ public abstract class DefaultPlayerCommand extends CompositeCommand
             String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultNewPlayerAction();
 
             // Perform command or use "create" command.
-            if (command != null && user.performCommand(label + " " + command))
+            if (command != null && user.performCommand("/" + label + " " + command))
             {
                 return true;
             }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
@@ -27,8 +27,8 @@ public abstract class DefaultPlayerCommand extends CompositeCommand
     {
         // Register command with alias from config.
         super(addon,
-            addon.getWorldSettings().getPlayerCommandAliases().split(" ")[0],
-            addon.getWorldSettings().getPlayerCommandAliases().split(" "));
+                addon.getWorldSettings().getPlayerCommandAliases().split(" ")[0],
+                addon.getWorldSettings().getPlayerCommandAliases().split(" "));
     }
 
 
@@ -106,17 +106,16 @@ public abstract class DefaultPlayerCommand extends CompositeCommand
             // Default command if user has an island.
             String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultPlayerAction();
 
-            // If command exists, the call it.
-            // Otherwise, just use "go" command.
-            if (command != null && this.getSubCommand(command).isPresent())
+            // Perform command or use "go" command.
+            if (command != null && user.performCommand(label + " " + command))
             {
-                return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
+                return true;
             }
             else
             {
                 return this.getSubCommand("go").
-                    map(goCmd -> goCmd.call(user, goCmd.getLabel(), Collections.emptyList())).
-                    orElse(false);
+                        map(goCmd -> goCmd.call(user, goCmd.getLabel(), Collections.emptyList())).
+                        orElse(false);
             }
         }
         else
@@ -124,17 +123,16 @@ public abstract class DefaultPlayerCommand extends CompositeCommand
             // Default command if user does not have an island.
             String command = this.<GameModeAddon>getAddon().getWorldSettings().getDefaultNewPlayerAction();
 
-            // If command exists, the call it.
-            // Otherwise, just use "create" command.
-            if (command != null && this.getSubCommand(command).isPresent())
+            // Perform command or use "create" command.
+            if (command != null && user.performCommand(label + " " + command))
             {
-                return this.getSubCommand(command).get().call(user, label, Collections.emptyList());
+                return true;
             }
             else
             {
                 return this.getSubCommand("create").
-                    map(createCmd -> createCmd.call(user, createCmd.getLabel(), Collections.emptyList())).
-                    orElse(false);
+                        map(createCmd -> createCmd.call(user, createCmd.getLabel(), Collections.emptyList())).
+                        orElse(false);
             }
         }
     }

--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -18,6 +18,7 @@ import org.bukkit.Particle;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
@@ -532,7 +533,15 @@ public class User {
      * @return true if the command was successful, otherwise false
      */
     public boolean performCommand(String command) {
-        return player.performCommand(command);
+        PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(getPlayer(), command);
+        Bukkit.getPluginManager().callEvent(event);
+         
+        // only perform the command, if the event wasn't cancelled by an other plugin:
+        if (!event.isCancelled()) {
+            return getPlayer().performCommand(event.getMessage());
+        }
+        // Cancelled, but it was recognized, so return true
+        return true;
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -25,6 +25,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -75,6 +76,8 @@ public class UserTest {
     private PluginManager pim;
     @Mock
     private CommandSender sender;
+    @Mock
+    private Server server;
 
     @Before
     public void setUp() throws Exception {
@@ -91,6 +94,10 @@ public class UserTest {
         when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         when(Bukkit.getPluginManager()).thenReturn(pim);
         when(Bukkit.getItemFactory()).thenReturn(itemFactory);
+
+        // Player
+        when(player.getServer()).thenReturn(server);
+        when(server.getOnlinePlayers()).thenReturn(Collections.emptySet());
 
         // IWM
         when(plugin.getIWM()).thenReturn(iwm);
@@ -487,7 +494,7 @@ public class UserTest {
         User u = User.getInstance(player);
         assertEquals(33, u.getPermissionValue("bskyblock.max", 2));
     }
-    
+
     /**
      * Test for {@link User#getPermissionValue(String, int)}
      */


### PR DESCRIPTION
Goal is to enable 3rd party alias plugins to catch the command.

iLemon had set up an island for `/is cp` to redirect to a 3rd party control panel plugin. With this change, it should be possible for that to intercept the call because performCommand is used instead of calling the subCommand. 

This PR is a draft right now, because I want iLemon to confirm it works for him.
[BentoBox-1.14.0-SNAPSHOT-LOCAL.jar.zip](https://github.com/BentoBoxWorld/BentoBox/files/4641294/BentoBox-1.14.0-SNAPSHOT-LOCAL.jar.zip)
