### PR TITLE
Enables game modes addons first

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -173,8 +173,11 @@ public class AddonsManager {
      */
     public void enableAddons() {
         if (getLoadedAddons().isEmpty()) return;
-        plugin.log("Enabling addons...");
-        getLoadedAddons().forEach(this::enableAddon);
+        plugin.log("Enabling game mode addons...");
+        // Enable GameModes first, then other addons
+        getLoadedAddons().stream().filter(GameModeAddon.class::isInstance).forEach(this::enableAddon);
+        plugin.log("Enabling other addons...");
+        getLoadedAddons().stream().filter(g -> !(g instanceof GameModeAddon)).forEach(this::enableAddon);
         // Set perms for enabled addons
         this.getEnabledAddons().forEach(this::setPerms);
         plugin.log("Addons successfully enabled.");
@@ -217,6 +220,7 @@ public class AddonsManager {
      * @param addon addon
      */
     private void enableAddon(Addon addon) {
+        plugin.log("Enabling " + addon.getDescription().getName() + "...");
         try {
             // If this is a GameModeAddon create the worlds, register it and load the blueprints
             if (addon instanceof GameModeAddon) {
@@ -241,7 +245,6 @@ public class AddonsManager {
             }
             new AddonEvent().builder().addon(addon).reason(AddonEvent.Reason.ENABLE).build();
             addon.setState(Addon.State.ENABLED);
-            plugin.log("Enabling " + addon.getDescription().getName() + "...");
         } catch (NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
             // Looks like the addon is incompatible, because it tries to refer to missing classes...
             handleAddonIncompatibility(addon);


### PR DESCRIPTION
We added the ability for addons to declare permissions using `[gamemode]` in _addon.yml_. However, addons still have to declare a list of game modes as `softdepends` if they wish to hook in a command because currently addon **enabling** is random. This PR makes it so that game mode addons are **always** enabled first so that non-game mode addons can know for certain that all game modes will be loaded before them and will not have to declare them as `depends` or `softdepends`. This will make them future-proof to new game modes. 

The only edge case here is if there were an addon that a game mode had to have enabled before that game mode was enabled. Currently, there are none and I can't think of a reason why one would be required right now because the main point of enabling is so that commands can be hooked under other commands. If we wished to enable this in the future, we could, but right now it's not needed.