### PR TITLE
Uses async location loading for home teleporting

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandBanCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandBanCommand.java
@@ -112,7 +112,7 @@ public class IslandBanCommand extends CompositeCommand {
                 target.sendMessage("commands.island.ban.owner-banned-you", TextVariables.NAME, issuer.getName());
                 // If the player is online, has an island and on the banned island, move them home immediately
                 if (target.isOnline() && getIslands().hasIsland(getWorld(), target.getUniqueId()) && island.onIsland(target.getLocation())) {
-                    getIslands().homeTeleport(getWorld(), target.getPlayer());
+                    getIslands().homeTeleportAsync(getWorld(), target.getPlayer());
                     island.getWorld().playSound(target.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1F, 1F);
                 }
                 return true;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
@@ -85,8 +85,8 @@ public class IslandExpelCommand extends CompositeCommand {
         }
         // Cannot ban ops
         if (target.isOp() ||
-            target.hasPermission(this.getPermissionPrefix() + "admin.noexpel") ||
-            target.hasPermission(this.getPermissionPrefix() + "mod.bypassexpel")) {
+                target.hasPermission(this.getPermissionPrefix() + "admin.noexpel") ||
+                target.hasPermission(this.getPermissionPrefix() + "mod.bypassexpel")) {
             user.sendMessage(CANNOT_EXPEL);
             return false;
         }
@@ -116,7 +116,7 @@ public class IslandExpelCommand extends CompositeCommand {
             // Success
             user.sendMessage(SUCCESS, TextVariables.NAME, target.getName());
             // Teleport home
-            getIslands().homeTeleport(getWorld(), target.getPlayer());
+            getIslands().homeTeleportAsync(getWorld(), target.getPlayer());
             return true;
         } else if (getIslands().getSpawn(getWorld()).isPresent()){
             // Success

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
@@ -56,11 +56,11 @@ public class IslandGoCommand extends DelayedTeleportCommand {
             int homeValue = Integer.parseInt(args.get(0));
             int maxHomes = user.getPermissionValue(getPermissionPrefix() + "island.maxhomes", getIWM().getMaxHomes(getWorld()));
             if (homeValue > 1 && homeValue <= maxHomes) {
-                this.delayCommand(user, () -> getIslands().homeTeleport(getWorld(), user.getPlayer(), homeValue));
+                this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer(), homeValue));
                 return true;
             }
         }
-        this.delayCommand(user, () -> getIslands().homeTeleport(getWorld(), user.getPlayer()));
+        this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer()));
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -148,18 +148,19 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
         getIslands().setJoinTeam(teamIsland, playerUUID);
         //Move player to team's island
         getPlayers().clearHomeLocations(getWorld(), playerUUID);
-        getIslands().homeTeleport(getWorld(), user.getPlayer());
-        // Delete the old island
-        if (island != null) {
-            getIslands().deleteIsland(island, true, user.getUniqueId());
-        }
+        getIslands().homeTeleportAsync(getWorld(), user.getPlayer()).thenRun(() -> {
+            // Delete the old island
+            if (island != null) {
+                getIslands().deleteIsland(island, true, user.getUniqueId());
+            }
+            // Put player back into normal mode
+            user.setGameMode(getIWM().getDefaultGameMode(getWorld()));
+
+        });
         // Reset deaths
         if (getIWM().isTeamJoinDeathReset(getWorld())) {
             getPlayers().setDeaths(getWorld(), playerUUID, 0);
         }
-        // Put player back into normal mode
-        user.setGameMode(getIWM().getDefaultGameMode(getWorld()));
-
         user.sendMessage("commands.island.team.invite.accept.you-joined-island", TextVariables.LABEL, getTopLabel());
         User inviter = User.getInstance(invite.getInviter());
         if (inviter != null) {

--- a/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
@@ -83,7 +83,7 @@ public class PortalTeleportationListener implements Listener {
             else if (plugin.getIslands().hasIsland(overWorld, e.getPlayer().getUniqueId())
                     || plugin.getIslands().inTeam(overWorld, e.getPlayer().getUniqueId())) {
                 e.setCancelled(true);
-                plugin.getIslands().homeTeleport(overWorld, e.getPlayer());
+                plugin.getIslands().homeTeleportAsync(overWorld, e.getPlayer());
             }
             // No island, so just do nothing
             return false;
@@ -175,7 +175,7 @@ public class PortalTeleportationListener implements Listener {
             // From standard nether
             else {
                 e.setCancelled(true);
-                plugin.getIslands().homeTeleport(overWorld, e.getPlayer());
+                plugin.getIslands().homeTeleportAsync(overWorld, e.getPlayer());
             }
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
@@ -149,7 +149,7 @@ public class LockAndBanListener extends FlagListener {
     private void eject(Player player) {
         // Teleport player to their home
         if (getIslands().hasIsland(player.getWorld(), player.getUniqueId()) || getIslands().inTeam(player.getWorld(), player.getUniqueId())) {
-            getIslands().homeTeleport(player.getWorld(), player);
+            getIslands().homeTeleportAsync(player.getWorld(), player);
         } else if (getIslands().getSpawn(player.getWorld()).isPresent()) {
             // Else, try to teleport him to the world spawn
             getIslands().spawnTeleport(player.getWorld(), player);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
@@ -121,7 +121,7 @@ public class InvincibleVisitorsListener extends FlagListener implements ClickHan
                 .build());
             } else if (getIslands().hasIsland(p.getWorld(), p.getUniqueId())) {
                 // No island in this location - if the player has an island try to teleport them back
-                getIslands().homeTeleport(p.getWorld(), p);
+                getIslands().homeTeleportAsync(p.getWorld(), p);
             } else {
                 // Else die, sorry.
                 e.setCancelled(false);

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -222,6 +222,7 @@ public class IslandsManager {
      *
      * @param l Location to be checked, not null.
      * @return a completable future that will be true if safe, otherwise false
+     * @since 1.14.0
      */
     public CompletableFuture<Boolean> isSafeLocationAsync(@NonNull Location l) {
         CompletableFuture<Boolean> result = new CompletableFuture<>();
@@ -503,7 +504,6 @@ public class IslandsManager {
      * @param location - the location
      * @return Optional Island object
      */
-
     public Optional<Island> getProtectedIslandAt(@NonNull Location location) {
         return getIslandAt(location).filter(i -> i.onIsland(location));
     }
@@ -514,6 +514,7 @@ public class IslandsManager {
      * @param user - user
      * @param number - number number
      * @return CompletableFuture with the location found, or null
+     * @since 1.14.0
      */
     public CompletableFuture<Location> getAsyncSafeHomeLocation(@NonNull World world, @NonNull User user, int number) {
         CompletableFuture<Location> result = new CompletableFuture<>();
@@ -734,7 +735,7 @@ public class IslandsManager {
      *
      * @param world - world to check
      * @param player - the player
-     * @deprecated Use homeTeleportAsync instead
+     * @deprecated as of 1.14.0. Use homeTeleportAsync instead.
      */
     @Deprecated
     public void homeTeleport(@NonNull World world, @NonNull Player player) {
@@ -748,7 +749,7 @@ public class IslandsManager {
      * @param world - world to check
      * @param player - the player
      * @param number - a number - home location to do to
-     * @deprecated Use homeTeleportAsync instead
+     * @deprecated as of 1.14.0. Use homeTeleportAsync instead.
      */
     @Deprecated
     public void homeTeleport(@NonNull World world, @NonNull Player player, int number) {
@@ -762,7 +763,7 @@ public class IslandsManager {
      * @param world - world to check
      * @param player - the player
      * @param newIsland - true if this is a new island teleport
-     * @deprecated Use homeTeleportAsync instead
+     * @deprecated as of 1.14.0. Use homeTeleportAsync instead.
      */
     @Deprecated
     public void homeTeleport(@NonNull World world, @NonNull Player player, boolean newIsland) {
@@ -776,6 +777,7 @@ public class IslandsManager {
      * @param world - world to check
      * @param player - the player
      * @return CompletableFuture true if successful, false if not
+     * @since 1.14.0
      */
     public CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player) {
         return homeTeleportAsync(world, player, 1, false);
@@ -789,6 +791,7 @@ public class IslandsManager {
      * @param player - the player
      * @param number - a number - home location to do to
      * @return CompletableFuture true if successful, false if not
+     * @since 1.14.0
      */
     public CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player, int number) {
         return homeTeleportAsync(world, player, number, false);
@@ -802,6 +805,7 @@ public class IslandsManager {
      * @param player - the player
      * @param newIsland - true if this is a new island teleport
      * @return CompletableFuture true if successful, false if not
+     * @since 1.14.0
      */
     public CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player, boolean newIsland) {
         return homeTeleportAsync(world, player, 1, newIsland);

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -214,6 +215,23 @@ public class IslandsManager {
         Block space1 = l.getBlock();
         Block space2 = l.getBlock().getRelative(BlockFace.UP);
         return checkIfSafe(l.getWorld(), ground.getType(), space1.getType(), space2.getType());
+    }
+
+    /**
+     * Checks if this location is safe for a player to teleport to and loads chunks async to check.
+     *
+     * @param l Location to be checked, not null.
+     * @return a completable future that will be true if safe, otherwise false
+     */
+    public CompletableFuture<Boolean> isSafeLocationAsync(@NonNull Location l) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        Util.getChunkAtAsync(l).thenRun(() -> {
+            Block ground = l.getBlock().getRelative(BlockFace.DOWN);
+            Block space1 = l.getBlock();
+            Block space2 = l.getBlock().getRelative(BlockFace.UP);
+            result.complete(checkIfSafe(l.getWorld(), ground.getType(), space1.getType(), space2.getType()));
+        });
+        return result;
     }
 
     /**
@@ -491,6 +509,88 @@ public class IslandsManager {
     }
 
     /**
+     * Get a safe home location using async chunk loading and set the home location
+     * @param world - world
+     * @param user - user
+     * @param number - number number
+     * @return CompletableFuture with the location found, or null
+     */
+    public CompletableFuture<Location> getAsyncSafeHomeLocation(@NonNull World world, @NonNull User user, int number) {
+        CompletableFuture<Location> result = new CompletableFuture<>();
+        // Check if the world is a gamemode world and the player has an island
+        Location islandLoc = getIslandLocation(world, user.getUniqueId());
+        if (!plugin.getIWM().inWorld(world) || islandLoc == null) {
+            result.complete(null);
+            return result;
+        }
+        // Try the numbered home location first
+        Location defaultHome = plugin.getPlayers().getHomeLocation(world, user, 1);
+        Location numberedHome = plugin.getPlayers().getHomeLocation(world, user, number);
+        Location l = numberedHome != null ? numberedHome : defaultHome;
+        if (l != null) {
+            Util.getChunkAtAsync(l).thenRun(() -> {
+                // Check if it is safe
+                if (isSafeLocation(l)) {
+                    result.complete(l);
+                    return;
+                }
+                // To cover slabs, stairs and other half blocks, try one block above
+                Location lPlusOne = l.clone().add(new Vector(0, 1, 0));
+                if (isSafeLocation(lPlusOne)) {
+                    // Adjust the home location accordingly
+                    plugin.getPlayers().setHomeLocation(user, lPlusOne, number);
+                    result.complete(lPlusOne);
+                    return;
+                }
+                // Try island
+                tryIsland(result, islandLoc, user, number);
+            });
+            return result;
+        }
+        // Try island
+        tryIsland(result, islandLoc, user, number);
+        return result;
+    }
+
+    private void tryIsland(CompletableFuture<Location> result, Location islandLoc, @NonNull User user, int number) {
+        Util.getChunkAtAsync(islandLoc).thenRun(() -> {
+            World w = islandLoc.getWorld();
+            if (isSafeLocation(islandLoc)) {
+                plugin.getPlayers().setHomeLocation(user, islandLoc, number);
+                result.complete(islandLoc.clone().add(new Vector(0.5D,0,0.5D)));
+                return;
+            } else {
+                // If these island locations are not safe, then we need to get creative
+                // Try the default location
+                Location dl = islandLoc.clone().add(new Vector(0.5D, 5D, 2.5D));
+                if (isSafeLocation(dl)) {
+                    plugin.getPlayers().setHomeLocation(user, dl, number);
+                    result.complete(dl);
+                    return;
+                }
+                // Try just above the bedrock
+                dl = islandLoc.clone().add(new Vector(0.5D, 5D, 0.5D));
+                if (isSafeLocation(dl)) {
+                    plugin.getPlayers().setHomeLocation(user, dl, number);
+                    result.complete(dl);
+                    return;
+                }
+                // Try all the way up to the sky
+                for (int y = islandLoc.getBlockY(); y < w.getMaxHeight(); y++) {
+                    dl = new Location(w, islandLoc.getX() + 0.5D, y, islandLoc.getZ() + 0.5D);
+                    if (isSafeLocation(dl)) {
+                        plugin.getPlayers().setHomeLocation(user, dl, number);
+                        result.complete(dl);
+                        return;
+                    }
+                }
+            }
+            result.complete(null);
+        });
+
+    }
+
+    /**
      * Determines a safe teleport spot on player's island or the team island
      * they belong to.
      *
@@ -634,7 +734,9 @@ public class IslandsManager {
      *
      * @param world - world to check
      * @param player - the player
+     * @deprecated Use homeTeleportAsync instead
      */
+    @Deprecated
     public void homeTeleport(@NonNull World world, @NonNull Player player) {
         homeTeleport(world, player, 1, false);
     }
@@ -646,7 +748,9 @@ public class IslandsManager {
      * @param world - world to check
      * @param player - the player
      * @param number - a number - home location to do to
+     * @deprecated Use homeTeleportAsync instead
      */
+    @Deprecated
     public void homeTeleport(@NonNull World world, @NonNull Player player, int number) {
         homeTeleport(world, player, number, false);
     }
@@ -658,10 +762,99 @@ public class IslandsManager {
      * @param world - world to check
      * @param player - the player
      * @param newIsland - true if this is a new island teleport
+     * @deprecated Use homeTeleportAsync instead
      */
+    @Deprecated
     public void homeTeleport(@NonNull World world, @NonNull Player player, boolean newIsland) {
         homeTeleport(world, player, 1, newIsland);
     }
+
+    /**
+     * This teleports player to their island. If not safe place can be found
+     * then the player is sent to spawn via /spawn command
+     *
+     * @param world - world to check
+     * @param player - the player
+     * @return CompletableFuture true if successful, false if not
+     */
+    public CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player) {
+        return homeTeleportAsync(world, player, 1, false);
+    }
+
+    /**
+     * Teleport player to a home location. If one cannot be found a search is done to
+     * find a safe place.
+     *
+     * @param world - world to check
+     * @param player - the player
+     * @param number - a number - home location to do to
+     * @return CompletableFuture true if successful, false if not
+     */
+    public CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player, int number) {
+        return homeTeleportAsync(world, player, number, false);
+    }
+
+    /**
+     * This teleports player to their island. If not safe place can be found
+     * then the player is sent to spawn via /spawn command
+     *
+     * @param world - world to check
+     * @param player - the player
+     * @param newIsland - true if this is a new island teleport
+     * @return CompletableFuture true if successful, false if not
+     */
+    public CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player, boolean newIsland) {
+        return homeTeleportAsync(world, player, 1, newIsland);
+    }
+
+
+    private CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player, int number, boolean newIsland) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        User user = User.getInstance(player);
+        user.sendMessage("commands.island.go.teleport");
+        // Stop any gliding
+        player.setGliding(false);
+        // Check if the player is a passenger in a boat
+        if (player.isInsideVehicle()) {
+            Entity boat = player.getVehicle();
+            if (boat instanceof Boat) {
+                player.leaveVehicle();
+                // Remove the boat so they don't lie around everywhere
+                boat.remove();
+                player.getInventory().addItem(new ItemStack(TREE_TO_BOAT.getOrDefault(((Boat) boat).getWoodType(), Material.OAK_BOAT)));
+                player.updateInventory();
+            }
+        }
+        this.getAsyncSafeHomeLocation(world, user, number).thenAccept(home -> {
+            if (home == null) {
+                // Try to fix this teleport location and teleport the player if possible
+                new SafeSpotTeleport.Builder(plugin)
+                .entity(player)
+                .island(plugin.getIslands().getIsland(world, user))
+                .homeNumber(number)
+                .thenRun(() -> teleported(world, user, number, newIsland))
+                .buildFuture()
+                .thenAccept(r -> result.complete(r));
+                return;
+            }
+            // Add home
+            if (plugin.getPlayers().getHomeLocations(world, player.getUniqueId()).isEmpty()) {
+                plugin.getPlayers().setHomeLocation(player.getUniqueId(), home);
+            }
+            PaperLib.teleportAsync(player, home).thenAccept(b -> {
+                // Only run the commands if the player is successfully teleported
+                if (b) {
+                    teleported(world, user, number, newIsland);
+                    result.complete(true);
+                } else {
+                    result.complete(false);
+                }
+
+            });
+        });
+        return result;
+    }
+
 
     /**
      * Teleport player to a home location. If one cannot be found a search is done to
@@ -672,7 +865,7 @@ public class IslandsManager {
      * @param number - a number - home location to do to
      * @param newIsland - true if this is a new island teleport
      */
-    public void homeTeleport(@NonNull World world, @NonNull Player player, int number, boolean newIsland) {
+    private void homeTeleport(@NonNull World world, @NonNull Player player, int number, boolean newIsland) {
         User user = User.getInstance(player);
         user.sendMessage("commands.island.go.teleport");
         Location home = getSafeHomeLocation(world, user, number);
@@ -1024,7 +1217,7 @@ public class IslandsManager {
         .filter(p -> island.onIsland(p.getLocation())).forEach(p -> {
             // Teleport island players to their island home
             if (!island.getMemberSet().contains(p.getUniqueId()) && (hasIsland(w, p.getUniqueId()) || inTeam(w, p.getUniqueId()))) {
-                homeTeleport(w, p);
+                homeTeleportAsync(w, p);
             } else {
                 // Move player to spawn
                 if (spawn.containsKey(w)) {

--- a/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
+++ b/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;

--- a/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
+++ b/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
@@ -372,12 +372,14 @@ public class SafeSpotTeleport {
         /**
          * Try to teleport the player
          * @return CompletableFuture that will become true if successfull and false if not
+         * @since 1.14.0
          */
         @Nullable
         public CompletableFuture<Boolean> buildFuture() {
             build();
             return result;
         }
+        
         /**
          * Try to teleport the player
          * @return SafeSpotTeleport
@@ -463,6 +465,7 @@ public class SafeSpotTeleport {
 
         /**
          * @return the result
+         * @since 1.14.0
          */
         public CompletableFuture<Boolean> getResult() {
             return result;

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
@@ -375,7 +375,7 @@ public class IslandExpelCommandTest {
         testCanExecute();
         assertTrue(iec.execute(user, "", Collections.singletonList("tasty")));
         verify(user).sendMessage("commands.island.expel.success", TextVariables.NAME, "target");
-        verify(im).homeTeleport(any(), any());
+        verify(im).homeTeleportAsync(any(), any());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/PortalTeleportationListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PortalTeleportationListenerTest.java
@@ -154,7 +154,7 @@ public class PortalTeleportationListenerTest {
         // Addon
         Optional<GameModeAddon> opAddon = Optional.of(gameModeAddon);
         when(iwm.getAddon(any())).thenReturn(opAddon);
-        
+
         // Blueprints
         when(plugin.getBlueprintsManager()).thenReturn(bpm);
         @Nullable
@@ -163,7 +163,7 @@ public class PortalTeleportationListenerTest {
         bp.setName("blueprintname");
         defaultBB.setBlueprint(World.Environment.NETHER, bp);
         defaultBB.setBlueprint(World.Environment.THE_END, bp);
-        when(bpm.getDefaultBlueprintBundle(any())).thenReturn(defaultBB);        
+        when(bpm.getDefaultBlueprintBundle(any())).thenReturn(defaultBB);
         when(bpm.getBlueprints(any())).thenReturn(Collections.singletonMap("blueprintname", bp));
         // Paster
 
@@ -266,7 +266,7 @@ public class PortalTeleportationListenerTest {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         np.onEndIslandPortal(e);
         assertTrue(e.isCancelled());
-        verify(im).homeTeleport(any(), eq(player));
+        verify(im).homeTeleportAsync(any(), eq(player));
     }
 
     /**
@@ -353,7 +353,7 @@ public class PortalTeleportationListenerTest {
         // Do not go to spawn
         verify(nether, never()).getSpawnLocation();
     }
-    
+
     /**
      * Test method for {@link PortalTeleportationListener#onNetherPortal(org.bukkit.event.player.PlayerPortalEvent)}.
      */
@@ -382,7 +382,7 @@ public class PortalTeleportationListenerTest {
         // Error
         verify(plugin).logError(eq("Could not paste default island in nether or end. Is there a nether-island or end-island blueprint?"));
     }
-    
+
     /**
      * Test method for {@link PortalTeleportationListener#onNetherPortal(org.bukkit.event.player.PlayerPortalEvent)}.
      */

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
@@ -241,7 +241,7 @@ public class LockAndBanListenerTest {
         // User should see a message
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
         // User should be teleported somewhere
-        Mockito.verify(im).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
         // Call teleport event
         PlayerTeleportEvent e = new PlayerTeleportEvent(player, inside, outside);
         // Pass to event listener
@@ -316,7 +316,7 @@ public class LockAndBanListenerTest {
         // Player should see a message
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
         // User should NOT be teleported somewhere
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
     }
 
     @Test
@@ -374,9 +374,9 @@ public class LockAndBanListenerTest {
         // Player should see a message and nothing should be sent to Player 2
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
         // User should be teleported somewhere
-        Mockito.verify(im).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
         // Player 2 should not be teleported
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player2));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player2));
         // Call teleport event
         PlayerTeleportEvent ev = new PlayerTeleportEvent(player, inside, outside);
         // Pass to event listener
@@ -440,7 +440,7 @@ public class LockAndBanListenerTest {
         // User should see a message
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
         // User should be teleported somewhere
-        Mockito.verify(im).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
         // Call teleport event
         PlayerTeleportEvent e = new PlayerTeleportEvent(player, inside, outside);
         // Pass to event listener
@@ -469,7 +469,7 @@ public class LockAndBanListenerTest {
         // User should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
         // User should not be teleported somewhere
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
     }
 
     @Test
@@ -493,7 +493,7 @@ public class LockAndBanListenerTest {
         // User should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
         // User should not be teleported somewhere
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
     }
 
     @Test
@@ -510,7 +510,7 @@ public class LockAndBanListenerTest {
         // User should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
         // User should not be teleported somewhere
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
     }
 
     @Test
@@ -533,7 +533,7 @@ public class LockAndBanListenerTest {
         // Player should see a message
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
         // User should NOT be teleported somewhere
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
     }
 
     @Test
@@ -597,7 +597,7 @@ public class LockAndBanListenerTest {
         // Player should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
         // User should NOT be teleported somewhere
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
     }
 
     @Test
@@ -687,7 +687,7 @@ public class LockAndBanListenerTest {
         // Player should not see a message
         Mockito.verify(notifier, Mockito.never()).notify(Mockito.any(), Mockito.anyString());
         // User should not be teleported somewhere
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
     }
 
     @Test
@@ -716,9 +716,9 @@ public class LockAndBanListenerTest {
         // Player should see a message and nothing should be sent to Player 2
         Mockito.verify(notifier).notify(Mockito.any(), Mockito.anyString());
         // User should be teleported somewhere
-        Mockito.verify(im).homeTeleport(Mockito.any(), Mockito.eq(player));
+        Mockito.verify(im).homeTeleportAsync(Mockito.any(), Mockito.eq(player));
         // Player 2 should not be teleported
-        Mockito.verify(im, Mockito.never()).homeTeleport(Mockito.any(), Mockito.eq(player2));
+        Mockito.verify(im, Mockito.never()).homeTeleportAsync(Mockito.any(), Mockito.eq(player2));
         // Call teleport event
         PlayerTeleportEvent ev = new PlayerTeleportEvent(player, inside, outside);
         // Pass to event listener

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
@@ -286,6 +286,6 @@ public class InvincibleVisitorsListenerTest {
         // Player should be teleported to their island
         listener.onVisitorGetDamage(e);
         assertTrue(e.isCancelled());
-        verify(im).homeTeleport(any(), eq(player));
+        verify(im).homeTeleportAsync(any(), eq(player));
     }
 }


### PR DESCRIPTION
https://github.com/BentoBoxWorld/BentoBox/issues/1241

This PR aims to make the teleport home function use async chunk/location loading. Further, the methods now return a `CompletableFuture` so that sequencing of activities can happen. E.g., island deletion will not happen until the player has actually teleported to their new island. Previously, we were seeing some glitches with servers where the island could start to delete before the async teleport had happened.

The overall aim is to prevent blocking actions on the main thread so that if a player does /is go, it will be able to find a safe spot for them async. Note that this may mean that the teleporting may take a while. This is already the case though as we use PaperLib's async teleport call.
