### PR TITLE
Target player must be online to be invited for coop

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommand.java
@@ -62,6 +62,11 @@ public class IslandTeamCoopCommand extends CompositeCommand {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
         }
+        User targetPlayer = User.getInstance(targetUUID);
+        if (!targetPlayer.isOnline()) {
+            user.sendMessage("general.errors.offline-player");
+            return false;
+        }
         // Check cooldown
         if (getSettings().getCoopCooldown() > 0 && checkCooldown(user, island.getUniqueId(), targetUUID.toString())) {
             return false;


### PR DESCRIPTION
1. Player A invited Player B to their island.
2. Player C invited Player B to coop while Player B was offline.
3. Player C told Player B to connect and accept the coop.
4. Player B did /is team accept (since it is the same command for island invite and coop), and he lost their island.