### PR TITLE
Uses completablefutures to paste islands sequentially

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPasteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPasteCommand.java
@@ -25,7 +25,7 @@ public class AdminBlueprintPasteCommand extends CompositeCommand {
         AdminBlueprintCommand parent = (AdminBlueprintCommand) getParent();
         BlueprintClipboard clipboard = parent.getClipboards().computeIfAbsent(user.getUniqueId(), v -> new BlueprintClipboard());
         if (clipboard.isFull()) {
-            new BlueprintPaster(getPlugin(), clipboard, user.getLocation(), () -> {
+            new BlueprintPaster(getPlugin(), clipboard, user.getLocation()).paste().thenAccept(b -> {
                 user.sendMessage("general.success");
                 parent.showClipboard(user);
             });

--- a/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
@@ -240,11 +240,11 @@ public class PortalTeleportationListener implements Listener {
                 if (bp != null) {
                     new BlueprintPaster(plugin, bp,
                             to.getWorld(),
-                            island, () -> new SafeSpotTeleport.Builder(plugin)
-                            .entity(player)
-                            .location(island.getSpawnPoint(env) == null ? to : island.getSpawnPoint(env))
-                            // No need to use portal because there will be no portal on the other end
-                            .build());
+                            island).paste().thenAccept(b -> new SafeSpotTeleport.Builder(plugin)
+                                    .entity(player)
+                                    .location(island.getSpawnPoint(env) == null ? to : island.getSpawnPoint(env))
+                                    // No need to use portal because there will be no portal on the other end
+                                    .build());
                 } else {
                     plugin.logError("Could not paste default island in nether or end. Is there a nether-island or end-island blueprint?");
                 }

--- a/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
@@ -464,14 +464,8 @@ public class BlueprintsManager {
         // Paste
         if (bp != null) {
             new BlueprintPaster(plugin, bp, addon.getOverWorld(), island).paste().thenAccept(b -> {
-                plugin.logDebug("Pasted overworld island");
-                pasteNether(addon, bb, island).thenAccept(b2 -> {
-                    plugin.logDebug("Pasted nether island");
-                    pasteEnd(addon, bb, island).thenAccept(b3 -> {
-                        plugin.logDebug("Pasted end island");
-                        Bukkit.getScheduler().runTask(plugin, task);
-                    });
-                });
+                pasteNether(addon, bb, island).thenAccept(b2 ->
+                pasteEnd(addon, bb, island).thenAccept(b3 -> Bukkit.getScheduler().runTask(plugin, task)));
             });
         }
         return true;


### PR DESCRIPTION
This pastes the islands sequentially (overworld -> nether -> end -> task to run after pasting). This will help avoid concurrent pasting. Also, it ensures that the task to run after pasting doesn't run until *after* the last island is pasted. This also fixes a bug where the IslandResettedEvent and IslandCreatedEvent were firing after the overworld island was pasted but before the nether and end worlds were completely pasted. This caused the Level addon to incorrectly zero the island level if nether and end islands were included in the level calculation because they may have not been pasted when the calculations were run.