### PR TITLE
Uncompressed blueprints

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/BlueprintClipboardManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/BlueprintClipboardManager.java
@@ -91,23 +91,39 @@ public class BlueprintClipboardManager {
      * @throws IOException exception if there's an issue loading or unzipping
      */
     public Blueprint loadBlueprint(String fileName) throws IOException {
+        File noZipFile = new File(blueprintFolder, BlueprintsManager.sanitizeFileName(fileName) + BlueprintsManager.UNCOMPRESSED_BLUEPRINT_SUFFIX);
+        if (noZipFile.exists()) {
+            return loadUncompressedBlueprint(BlueprintsManager.sanitizeFileName(fileName) + BlueprintsManager.UNCOMPRESSED_BLUEPRINT_SUFFIX, false);
+        }
         File zipFile = new File(blueprintFolder, BlueprintsManager.sanitizeFileName(fileName) + BlueprintsManager.BLUEPRINT_SUFFIX);
         if (!zipFile.exists()) {
             plugin.logError(LOAD_ERROR + zipFile.getName());
             throw new IOException(LOAD_ERROR + zipFile.getName());
         }
         unzip(zipFile.getAbsolutePath());
-        File file = new File(blueprintFolder, BlueprintsManager.sanitizeFileName(fileName));
+
+        return loadUncompressedBlueprint(BlueprintsManager.sanitizeFileName(fileName), true);
+    }
+
+    /**
+     * Load an uncompressed blueprint file (JSON)
+     * @param fileName - file name of the uncompressed file
+     * @param remove - true if the file is temporary and needs removing after use
+     * @return blueprint or null if nothing loaded
+     * @throws IOException - if there's an error loading
+     */
+    private Blueprint loadUncompressedBlueprint(String fileName, boolean remove) throws IOException {
+        File file = new File(blueprintFolder, fileName);
         if (!file.exists()) {
             plugin.logError(LOAD_ERROR + file.getName());
-            throw new IOException(LOAD_ERROR + file.getName() + " temp file");
+            throw new IOException(LOAD_ERROR + file.getName() + " uncompressed blueprint file");
         }
         Blueprint bp;
         try (FileReader fr = new FileReader(file)) {
             bp = gson.fromJson(fr, Blueprint.class);
         } catch (Exception e) {
-            plugin.logError("Blueprint has JSON error: " + zipFile.getName());
-            throw new IOException("Blueprint has JSON error: " + zipFile.getName());
+            plugin.logError("Blueprint has JSON error: " + fileName);
+            throw new IOException("Blueprint has JSON error: " + fileName);
         }
         Files.delete(file.toPath());
         // Bedrock check and set

--- a/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/BlueprintsManager.java
@@ -61,6 +61,7 @@ public class BlueprintsManager {
 
     public static final @NonNull String FOLDER_NAME = "blueprints";
     private static final String FOR = "' for ";
+    public static final String UNCOMPRESSED_BLUEPRINT_SUFFIX = ".blj";
 
     /**
      * Map of blueprint bundles to game mode addon.
@@ -296,7 +297,8 @@ public class BlueprintsManager {
             plugin.logError("There is no blueprint folder for addon " + addon.getDescription().getName());
             bpf.mkdirs();
         }
-        File[] bps = bpf.listFiles((dir, name) -> name.toLowerCase(Locale.ENGLISH).endsWith(BLUEPRINT_SUFFIX));
+        File[] bps = bpf.listFiles((dir, name) -> name.toLowerCase(Locale.ENGLISH).endsWith(BLUEPRINT_SUFFIX) 
+                || name.toLowerCase(Locale.ENGLISH).endsWith(UNCOMPRESSED_BLUEPRINT_SUFFIX));
         if (bps == null || bps.length == 0) {
             plugin.logError("No blueprints found for " + addon.getDescription().getName());
             return;

--- a/src/test/java/world/bentobox/bentobox/managers/BlueprintClipboardManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/BlueprintClipboardManagerTest.java
@@ -233,7 +233,7 @@ public class BlueprintClipboardManagerTest {
         } catch (Exception e) {
             assertTrue(e instanceof IOException);
         } finally {
-            verify(plugin).logError("Blueprint has JSON error: blueprint.blu");
+            verify(plugin).logError("Blueprint has JSON error: blueprint");
         }
     }
 
@@ -283,6 +283,27 @@ public class BlueprintClipboardManagerTest {
     }
 
     /**
+     * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#loadBlueprint(java.lang.String)}.
+     * @throws IOException
+     */
+    @Test
+    public void testLoadUncompressedBlueprint() throws IOException {
+        blueprintFolder.mkdirs();
+        // Make a blueprint file
+        File configFile = new File(blueprintFolder, BLUEPRINT + ".blj");
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        Files.write(configFile.toPath(), bytes, StandardOpenOption.CREATE);
+        BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder);
+        Blueprint bp = bcm.loadBlueprint(BLUEPRINT);
+        assertEquals(-2, bp.getBedrock().getBlockX());
+        assertEquals(-16, bp.getBedrock().getBlockY());
+        assertEquals(-1, bp.getBedrock().getBlockZ());
+        assertTrue(bp.getAttached().isEmpty());
+        assertTrue(bp.getEntities().isEmpty());
+        assertEquals(2, bp.getBlocks().size());
+    }
+
+    /**
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#load(java.lang.String)}.
      * @throws IOException
      */
@@ -319,6 +340,23 @@ public class BlueprintClipboardManagerTest {
         Files.write(configFile.toPath(), bytes, StandardOpenOption.CREATE);
         // Zip it
         zip(configFile);
+        BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder);
+        User user = mock(User.class);
+        assertTrue(bcm.load(user, BLUEPRINT));
+        verify(user).sendMessage("general.success");
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#load(world.bentobox.bentobox.api.user.User, java.lang.String)}.
+     * @throws IOException
+     */
+    @Test
+    public void testLoadUncompressedUserString() throws IOException {
+        blueprintFolder.mkdirs();
+        // Make a blueprint file
+        File configFile = new File(blueprintFolder, BLUEPRINT + ".blj");
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        Files.write(configFile.toPath(), bytes, StandardOpenOption.CREATE);
         BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder);
         User user = mock(User.class);
         assertTrue(bcm.load(user, BLUEPRINT));


### PR DESCRIPTION
This branch adds the ability to load uncompressed blueprints. This is a stepping stone to writing them and having the ability to be backwards compatible.

One of the reasons originally for using a zip file was because it could store multiple files and the thought was that blueprints could contain the whole bundle for a world and maybe other things too like icons. But it ended up just being a single file, so maybe it isn't required to compress them. However, we need to be backward compatible.