### PR TITLE
Added support to hide Vanished players from Teams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,24 +212,24 @@
             <version>${bstats.version}</version>
         </dependency>
 <!--         Mockito (Unit testing)-->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.mockito</groupId>-->
+<!--            <artifactId>mockito-core</artifactId>-->
+<!--            <version>3.1.0</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.powermock</groupId>-->
+<!--            <artifactId>powermock-module-junit4</artifactId>-->
+<!--            <version>${powermock.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.powermock</groupId>-->
+<!--            <artifactId>powermock-api-mockito2</artifactId>-->
+<!--            <version>${powermock.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
 <!--         Database-->
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>${bstats.version}</version>
         </dependency>
-<!--         Mockito (Unit testing)-->
+        <!-- Mockito (Unit testing) -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -230,7 +230,7 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
-<!--         Database-->
+        <!-- Database -->
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>
@@ -336,11 +336,11 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                <version>2.22.2</version>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -212,24 +212,24 @@
             <version>${bstats.version}</version>
         </dependency>
         <!-- Mockito (Unit testing) -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.mockito</groupId>-->
+<!--            <artifactId>mockito-core</artifactId>-->
+<!--            <version>3.1.0</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.powermock</groupId>-->
+<!--            <artifactId>powermock-module-junit4</artifactId>-->
+<!--            <version>${powermock.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.powermock</groupId>-->
+<!--            <artifactId>powermock-api-mockito2</artifactId>-->
+<!--            <version>${powermock.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
         <!-- Database -->
         <dependency>
             <groupId>org.mongodb</groupId>
@@ -438,33 +438,33 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
-                <configuration>
-                    <append>true</append>
-                    <excludes>
+<!--            <plugin>-->
+<!--                <groupId>org.jacoco</groupId>-->
+<!--                <artifactId>jacoco-maven-plugin</artifactId>-->
+<!--                <version>0.8.4</version>-->
+<!--                <configuration>-->
+<!--                    <append>true</append>-->
+<!--                    <excludes>-->
                         <!-- This is required to prevent Jacoco from adding 
                             synthetic fields to a JavaBean class (causes errors in testing) -->
-                        <exclude>**/*Names*</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>pre-unit-test</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>post-unit-test</id>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--                        <exclude>**/*Names*</exclude>-->
+<!--                    </excludes>-->
+<!--                </configuration>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>pre-unit-test</id>-->
+<!--                        <goals>-->
+<!--                            <goal>prepare-agent</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                    <execution>-->
+<!--                        <id>post-unit-test</id>-->
+<!--                        <goals>-->
+<!--                            <goal>report</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -212,24 +212,24 @@
             <version>${bstats.version}</version>
         </dependency>
 <!--         Mockito (Unit testing)-->
-<!--        <dependency>-->
-<!--            <groupId>org.mockito</groupId>-->
-<!--            <artifactId>mockito-core</artifactId>-->
-<!--            <version>3.1.0</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.powermock</groupId>-->
-<!--            <artifactId>powermock-module-junit4</artifactId>-->
-<!--            <version>${powermock.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.powermock</groupId>-->
-<!--            <artifactId>powermock-api-mockito2</artifactId>-->
-<!--            <version>${powermock.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
 <!--         Database-->
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -211,26 +211,26 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>${bstats.version}</version>
         </dependency>
-        <!-- Mockito (Unit testing) -->
-<!--        <dependency>-->
-<!--            <groupId>org.mockito</groupId>-->
-<!--            <artifactId>mockito-core</artifactId>-->
-<!--            <version>3.1.0</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.powermock</groupId>-->
-<!--            <artifactId>powermock-module-junit4</artifactId>-->
-<!--            <version>${powermock.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.powermock</groupId>-->
-<!--            <artifactId>powermock-api-mockito2</artifactId>-->
-<!--            <version>${powermock.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-        <!-- Database -->
+         Mockito (Unit testing)
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+         Database
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -336,11 +336,11 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-surefire-plugin</artifactId>-->
+<!--                <version>2.22.2</version>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>${bstats.version}</version>
         </dependency>
-         Mockito (Unit testing)
+<!--         Mockito (Unit testing)-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -230,7 +230,7 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
-         Database
+<!--         Database-->
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -438,33 +438,33 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.jacoco</groupId>-->
-<!--                <artifactId>jacoco-maven-plugin</artifactId>-->
-<!--                <version>0.8.4</version>-->
-<!--                <configuration>-->
-<!--                    <append>true</append>-->
-<!--                    <excludes>-->
-                        <!-- This is required to prevent Jacoco from adding 
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.4</version>
+                <configuration>
+                    <append>true</append>
+                    <excludes>
+                        <!-- This is required to prevent Jacoco from adding
                             synthetic fields to a JavaBean class (causes errors in testing) -->
-<!--                        <exclude>**/*Names*</exclude>-->
-<!--                    </excludes>-->
-<!--                </configuration>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <id>pre-unit-test</id>-->
-<!--                        <goals>-->
-<!--                            <goal>prepare-agent</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                    <execution>-->
-<!--                        <id>post-unit-test</id>-->
-<!--                        <goals>-->
-<!--                            <goal>report</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
+                        <exclude>**/*Names*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -104,8 +104,9 @@ public class IslandTeamCommand extends CompositeCommand {
                 "[online]", String.valueOf(onlineMembers.size()));
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
-        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
-                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline()).collect(Collectors.toList());
+        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream().filter(uuid -> user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer())).collect(Collectors.toList());Collectors.toList();
+//        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
+//                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline()).collect(Collectors.toList());
 
         for (int rank : ranks) {
             Set<UUID> players = island.getMemberSet(rank, false);

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -104,7 +104,7 @@ public class IslandTeamCommand extends CompositeCommand {
                 "[online]", String.valueOf(onlineMembers.size()));
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
-        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream().filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline() ? user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer()) : false).collect(Collectors.toList());Collectors.toList();
+        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream().filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline() ? user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer()) : false).collect(Collectors.toList());
 //        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
 //                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline()).collect(Collectors.toList());
 
@@ -148,9 +148,11 @@ public class IslandTeamCommand extends CompositeCommand {
                                     TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.days"));
                         }
 
-                        user.sendMessage("commands.island.team.info.member-layout.offline",
-                                TextVariables.NAME, offlineMember.getName(),
-                                "[last_seen]", lastSeen);
+                        if(!island.getMemberSet(RanksManager.TRUSTED_RANK, false).contains(member)) {
+                            user.sendMessage("commands.island.team.info.member-layout.offline",
+                                    TextVariables.NAME, offlineMember.getName(),
+                                    "[last_seen]", lastSeen);
+                        }
                     }
                 }
             }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -104,7 +104,7 @@ public class IslandTeamCommand extends CompositeCommand {
                 "[online]", String.valueOf(onlineMembers.size()));
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
-        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream().filter(uuid -> user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer())).collect(Collectors.toList());Collectors.toList();
+        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream().filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline() ? user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer()) : false).collect(Collectors.toList());Collectors.toList();
 //        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
 //                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline()).collect(Collectors.toList());
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -152,6 +152,10 @@ public class IslandTeamCommand extends CompositeCommand {
                             user.sendMessage("commands.island.team.info.member-layout.offline",
                                     TextVariables.NAME, offlineMember.getName(),
                                     "[last_seen]", lastSeen);
+                        }else if(!island.getMemberSet(RanksManager.COOP_RANK, false).contains(member)) {
+                            user.sendMessage("commands.island.team.info.coop-layout.offline",
+                                    TextVariables.NAME, offlineMember.getName(),
+                                    "[last_seen]", lastSeen);
                         }else{
                             user.sendMessage("commands.island.team.info.trusted-layout.offline",
                                     TextVariables.NAME, offlineMember.getName());

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -106,7 +106,7 @@ public class IslandTeamCommand extends CompositeCommand {
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
         onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
-                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid))).collect(Collectors.toList());
+                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).isOnline() ? Bukkit.getPlayer(uuid) : Bukkit.getOfflinePlayer(uuid))).collect(Collectors.toList());
 
         for (int rank : ranks) {
             Set<UUID> players = island.getMemberSet(rank, false);

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -148,16 +148,13 @@ public class IslandTeamCommand extends CompositeCommand {
                                     TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.days"));
                         }
 
-                        if(!island.getMemberSet(RanksManager.TRUSTED_RANK, false).contains(member)) {
+                        if(island.getMemberSet(RanksManager.MEMBER_RANK, true).contains(member)) {
                             user.sendMessage("commands.island.team.info.member-layout.offline",
                                     TextVariables.NAME, offlineMember.getName(),
                                     "[last_seen]", lastSeen);
-                        }else if(!island.getMemberSet(RanksManager.COOP_RANK, false).contains(member)) {
-                            user.sendMessage("commands.island.team.info.coop-layout.offline",
-                                    TextVariables.NAME, offlineMember.getName(),
-                                    "[last_seen]", lastSeen);
                         }else{
-                            user.sendMessage("commands.island.team.info.trusted-layout.offline",
+                            // This will prevent anyone that is trusted or below to not have a last-seen status
+                            user.sendMessage("commands.island.team.info.member-layout.offline-not-last-seen",
                                     TextVariables.NAME, offlineMember.getName());
                         }
                     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -104,7 +104,8 @@ public class IslandTeamCommand extends CompositeCommand {
                 "[online]", String.valueOf(onlineMembers.size()));
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
-        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream().filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline() ? user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer()) : false).collect(Collectors.toList());
+        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
+                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline() ? user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer()) : false).collect(Collectors.toList());
 //        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
 //                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline()).collect(Collectors.toList());
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -106,7 +106,7 @@ public class IslandTeamCommand extends CompositeCommand {
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
         onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
-                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).isOnline() ? Bukkit.getPlayer(uuid) : Bukkit.getOfflinePlayer(uuid))).collect(Collectors.toList());
+                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).isOnline() ? Bukkit.getOfflinePlayer(uuid).getPlayer() : Bukkit.getOfflinePlayer(uuid))).collect(Collectors.toList());
 
         for (int rank : ranks) {
             Set<UUID> players = island.getMemberSet(rank, false);

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -152,6 +152,9 @@ public class IslandTeamCommand extends CompositeCommand {
                             user.sendMessage("commands.island.team.info.member-layout.offline",
                                     TextVariables.NAME, offlineMember.getName(),
                                     "[last_seen]", lastSeen);
+                        }else{
+                            user.sendMessage("commands.island.team.info.member-layout.offline",
+                                    TextVariables.NAME, offlineMember.getName());
                         }
                     }
                 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -106,7 +106,7 @@ public class IslandTeamCommand extends CompositeCommand {
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
         onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
-                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).isOnline() ? Bukkit.getOfflinePlayer(uuid).getPlayer() : Bukkit.getOfflinePlayer(uuid))).collect(Collectors.toList());
+                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).getName())).collect(Collectors.toList());
 
         for (int rank : ranks) {
             Set<UUID> players = island.getMemberSet(rank, false);

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -20,6 +20,7 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
 
 public class IslandTeamCommand extends CompositeCommand {
 
@@ -105,9 +106,7 @@ public class IslandTeamCommand extends CompositeCommand {
 
         // We now need to get all online "members" of the island - incl. Trusted and coop
         onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
-                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline() ? user.getPlayer().canSee(Bukkit.getOfflinePlayer(uuid).getPlayer()) : false).collect(Collectors.toList());
-//        onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
-//                .filter(uuid -> Bukkit.getOfflinePlayer(uuid).isOnline()).collect(Collectors.toList());
+                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid))).collect(Collectors.toList());
 
         for (int rank : ranks) {
             Set<UUID> players = island.getMemberSet(rank, false);

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -153,7 +153,7 @@ public class IslandTeamCommand extends CompositeCommand {
                                     TextVariables.NAME, offlineMember.getName(),
                                     "[last_seen]", lastSeen);
                         }else{
-                            user.sendMessage("commands.island.team.info.member-layout.offline",
+                            user.sendMessage("commands.island.team.info.trusted-layout.offline",
                                     TextVariables.NAME, offlineMember.getName());
                         }
                     }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -520,12 +520,7 @@ commands:
         member-layout:
           online: "&a &l  o &r &f [name]"
           offline: "&c &l  o &r &f [name] &7 ([last_seen])"
-        trusted-layout:
-          online: "&a &l  o &r &f [name]"
-          offline: "&c &l  o &r &f [name]"
-        coop-layout:
-          online: "&a &l  o &r &f [name]"
-          offline: "&c &l  o &r &f [name]"
+          offline-not-last-seen: "&c &l  o &r &f [name]"
         last-seen:
           layout: "&b [number] &7 [unit] ago"
           days: "days"

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -523,6 +523,9 @@ commands:
         trusted-layout:
           online: "&a &l  o &r &f [name]"
           offline: "&c &l  o &r &f [name]"
+        coop-layout:
+          online: "&a &l  o &r &f [name]"
+          offline: "&c &l  o &r &f [name]"
         last-seen:
           layout: "&b [number] &7 [unit] ago"
           days: "days"

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -520,6 +520,9 @@ commands:
         member-layout:
           online: "&a &l  o &r &f [name]"
           offline: "&c &l  o &r &f [name] &7 ([last_seen])"
+        trusted-layout:
+          online: "&a &l  o &r &f [name]"
+          offline: "&c &l  o &r &f [name]"
         last-seen:
           layout: "&b [number] &7 [unit] ago"
           days: "days"


### PR DESCRIPTION
Added player.CanSee(Player) to check if player is hidden by vanish plugin,
Added custom layout to support hiding offline times for Coop & trusted roles as these roles do not have to be accepted by the recipient.