### PR TITLE
Handles placeholder reloading.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxReloadCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxReloadCommand.java
@@ -39,6 +39,10 @@ public class BentoBoxReloadCommand extends ConfirmableCommand {
     public boolean execute(User user, String label, List<String> args) {
         if (args.isEmpty()) {
             this.askConfirmation(user, user.getTranslation("commands.bentobox.reload.warning"), () -> {
+                
+                // Unregister all placeholders
+                getPlugin().getPlaceholdersManager().unregisterAll();
+
                 // Close all open panels
                 PanelListenerManager.closeAllPanels();
 
@@ -53,6 +57,9 @@ public class BentoBoxReloadCommand extends ConfirmableCommand {
                 // Reload locales
                 getPlugin().getLocalesManager().reloadLanguages();
                 user.sendMessage("commands.bentobox.reload.locales-reloaded");
+                
+                // Register new default gamemode placeholders
+                getPlugin().getAddonsManager().getGameModeAddons().forEach(getPlugin().getPlaceholdersManager()::registerDefaultPlaceholders);
 
                 // Fire ready event
                 Bukkit.getPluginManager().callEvent(new BentoBoxReadyEvent());

--- a/src/main/java/world/bentobox/bentobox/hooks/placeholders/PlaceholderHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/placeholders/PlaceholderHook.java
@@ -68,4 +68,10 @@ public abstract class PlaceholderHook extends Hook {
      */
     @NonNull
     public abstract String replacePlaceholders(@NonNull Player player, @NonNull String string);
+    
+    /**
+     * Unregister all previously registered placeholders
+     * @since 1.15.0
+     */
+    public abstract void unregisterAll();
 }

--- a/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
@@ -122,10 +122,15 @@ public class PlaceholdersManager {
      * @since 1.5.0
      */
     public String replacePlaceholders(@NonNull Player player, @NonNull String string) {
-        Optional<PlaceholderAPIHook> papi = getPlaceholderAPIHook();
-        if (papi.isPresent()) {
-            string = papi.get().replacePlaceholders(player, string);
-        }
-        return string;
+        return getPlaceholderAPIHook().map(papi -> papi.replacePlaceholders(player, string)).orElse(string);
+    }
+
+    /**
+     * Unregisters all the placeholders.
+     * @since 1.15.0
+     */
+    public void unregisterAll() {
+        getPlaceholderAPIHook().ifPresent(hook -> hook.unregisterAll());
+        
     }
 }


### PR DESCRIPTION
Unregisters all PAPI placeholders and then re-registers them once the addons have been reloaded.

I am not sure where BentoBox placeholders are loaded, or if there are any.

This has not been tested yet.

Would fix https://github.com/BentoBoxWorld/BentoBox/issues/1502