### PR TITLE
Add addon version in enabling statement

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -221,7 +221,7 @@ public class AddonsManager {
      * @param addon addon
      */
     private void enableAddon(Addon addon) {
-        plugin.log("Enabling " + addon.getDescription().getName() + "...");
+        plugin.log("Enabling " + addon.getDescription().getName() + " (" + addon.getDescription().getVersion() + ")...");
         try {
             // If this is a GameModeAddon create the worlds, register it and load the blueprints
             if (addon instanceof GameModeAddon) {


### PR DESCRIPTION
This is one of the missing information in log files. It would be useful to see the version on enabling status.