### PR TITLE
Added IslandExitEvent#getToIsland() and IslandEnterEvent#getFromIsland()

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/events/IslandBaseEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/IslandBaseEvent.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import org.bukkit.Location;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.database.objects.Island;
 
@@ -17,6 +19,7 @@ public class IslandBaseEvent extends BentoBoxEvent implements Cancellable {
     protected final UUID playerUUID;
     protected final boolean admin;
     protected final Location location;
+    protected final Event rawEvent;
 
     public IslandBaseEvent(Island island) {
         super();
@@ -24,6 +27,7 @@ public class IslandBaseEvent extends BentoBoxEvent implements Cancellable {
         playerUUID = island == null ? null : island.getOwner();
         admin = false;
         location = island == null ? null : island.getCenter();
+        rawEvent = null;
     }
 
     /**
@@ -38,6 +42,23 @@ public class IslandBaseEvent extends BentoBoxEvent implements Cancellable {
         this.playerUUID = playerUUID;
         this.admin = admin;
         this.location = location;
+        rawEvent = null;
+    }
+    
+   /**
+     * @param island - island
+     * @param playerUUID - the player's UUID
+     * @param admin - true if ths is due to an admin event
+     * @param location - the location
+     * @param rawEvent - the raw event
+     */
+    public IslandBaseEvent(Island island, UUID playerUUID, boolean admin, Location location, Event rawEvent) {
+        super();
+        this.island = island;
+        this.playerUUID = playerUUID;
+        this.admin = admin;
+        this.location = location;
+        this.rawEvent = rawEvent;
     }
 
     /**
@@ -73,6 +94,14 @@ public class IslandBaseEvent extends BentoBoxEvent implements Cancellable {
      */
     public Location getLocation() {
         return location;
+    }
+    
+    /**
+     * @return the raw event
+     */
+    @Nullable
+    public Event getRawEvent() {
+        return rawEvent;
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.events.IslandBaseEvent;
 import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
@@ -362,9 +363,18 @@ public class IslandEvent extends IslandBaseEvent {
      * Cancellation has no effect.
      */
     public static class IslandEnterEvent extends IslandBaseEvent {
-        private IslandEnterEvent(Island island, UUID player, boolean admin, Location location) {
+        
+        private final @Nullable Island fromIsland;
+        
+        private IslandEnterEvent(Island island, UUID player, boolean admin, Location location, Island fromIsland) {
             // Final variables have to be declared in the constructor
             super(island, player, admin, location);
+            this.fromIsland = fromIsland;
+        }
+        
+        @Nullable
+        public Island getFromIsland() {
+            return fromIsland;
         }
     }
     /**
@@ -372,10 +382,22 @@ public class IslandEvent extends IslandBaseEvent {
      * Cancellation has no effect.
      */
     public static class IslandExitEvent extends IslandBaseEvent {
-        private IslandExitEvent(Island island, UUID player, boolean admin, Location location) {
+        
+        private final @Nullable Island toIsland;
+
+        
+        private IslandExitEvent(Island island, UUID player, boolean admin, Location location, Island toIsland) {
             // Final variables have to be declared in the constructor
             super(island, player, admin, location);
+            this.toIsland = toIsland;
         }
+        
+        @Nullable
+        public Island getToIsland() {
+            return toIsland;
+        }
+     
+        
     }
     /**
      * Fired when an island is locked
@@ -724,11 +746,11 @@ public class IslandEvent extends IslandBaseEvent {
                 Bukkit.getPluginManager().callEvent(deleted);
                 return deleted;
             case ENTER:
-                IslandEnterEvent enter = new IslandEnterEvent(island, player, admin, location);
+                IslandEnterEvent enter = new IslandEnterEvent(island, player, admin, location, oldIsland);
                 Bukkit.getPluginManager().callEvent(enter);
                 return enter;
             case EXIT:
-                IslandExitEvent exit = new IslandExitEvent(island, player, admin, location);
+                IslandExitEvent exit = new IslandExitEvent(island, player, admin, location, oldIsland);
                 Bukkit.getPluginManager().callEvent(exit);
                 return exit;
             case LOCK:

--- a/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
+++ b/src/main/java/world/bentobox/bentobox/api/events/island/IslandEvent.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -366,9 +367,9 @@ public class IslandEvent extends IslandBaseEvent {
         
         private final @Nullable Island fromIsland;
         
-        private IslandEnterEvent(Island island, UUID player, boolean admin, Location location, Island fromIsland) {
+        private IslandEnterEvent(Island island, UUID player, boolean admin, Location location, Island fromIsland, Event rawEvent) {
             // Final variables have to be declared in the constructor
-            super(island, player, admin, location);
+            super(island, player, admin, location, rawEvent);
             this.fromIsland = fromIsland;
         }
         
@@ -386,9 +387,9 @@ public class IslandEvent extends IslandBaseEvent {
         private final @Nullable Island toIsland;
 
         
-        private IslandExitEvent(Island island, UUID player, boolean admin, Location location, Island toIsland) {
+        private IslandExitEvent(Island island, UUID player, boolean admin, Location location, Island toIsland, Event rawEvent) {
             // Final variables have to be declared in the constructor
-            super(island, player, admin, location);
+            super(island, player, admin, location, rawEvent);
             this.toIsland = toIsland;
         }
         
@@ -595,6 +596,7 @@ public class IslandEvent extends IslandBaseEvent {
         private Location location;
         private IslandDeletion deletedIslandInfo;
         private BlueprintBundle blueprintBundle;
+        private Event rawEvent;
 
         /**
          * Stores new protection range for island.
@@ -667,6 +669,11 @@ public class IslandEvent extends IslandBaseEvent {
 
         public IslandEventBuilder location(Location center) {
             location = center;
+            return this;
+        }
+        
+        public IslandEventBuilder rawEvent(Event event) {
+            rawEvent = event;
             return this;
         }
 
@@ -746,11 +753,11 @@ public class IslandEvent extends IslandBaseEvent {
                 Bukkit.getPluginManager().callEvent(deleted);
                 return deleted;
             case ENTER:
-                IslandEnterEvent enter = new IslandEnterEvent(island, player, admin, location, oldIsland);
+                IslandEnterEvent enter = new IslandEnterEvent(island, player, admin, location, oldIsland, rawEvent);
                 Bukkit.getPluginManager().callEvent(enter);
                 return enter;
             case EXIT:
-                IslandExitEvent exit = new IslandExitEvent(island, player, admin, location, oldIsland);
+                IslandExitEvent exit = new IslandExitEvent(island, player, admin, location, oldIsland, rawEvent);
                 Bukkit.getPluginManager().callEvent(exit);
                 return exit;
             case LOCK:

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListener.java
@@ -28,15 +28,15 @@ public class EnterExitListener extends FlagListener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onMove(PlayerMoveEvent e) {
-        handleEnterExit(User.getInstance(e.getPlayer()), e.getFrom(), e.getTo());
+        handleEnterExit(User.getInstance(e.getPlayer()), e.getFrom(), e.getTo(), e);
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onTeleport(PlayerTeleportEvent e) {
-        handleEnterExit(User.getInstance(e.getPlayer()), e.getFrom(), e.getTo());
+        handleEnterExit(User.getInstance(e.getPlayer()), e.getFrom(), e.getTo(), e);
     }
 
-    private void handleEnterExit(@NonNull User user, @NonNull Location from, @NonNull Location to) {
+    private void handleEnterExit(@NonNull User user, @NonNull Location from, @NonNull Location to, @NonNull PlayerMoveEvent e) {
         // Only process if there is a change in X or Z coords
         if (from.getWorld() != null && from.getWorld().equals(to.getWorld())
                 && from.toVector().multiply(XZ).equals(to.toVector().multiply(XZ))) {
@@ -68,6 +68,7 @@ public class EnterExitListener extends FlagListener {
             .reason(IslandEvent.Reason.EXIT)
             .admin(false)
             .location(user.getLocation())
+            .rawEvent(e)
             .build();
 
             sendExitNotification(user, i);
@@ -82,6 +83,7 @@ public class EnterExitListener extends FlagListener {
             .reason(IslandEvent.Reason.ENTER)
             .admin(false)
             .location(user.getLocation())
+            .rawEvent(e)
             .build();
 
             sendEnterNotification(user, i);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListener.java
@@ -63,6 +63,7 @@ public class EnterExitListener extends FlagListener {
             // Fire the IslandExitEvent
             new IslandEvent.IslandEventBuilder()
             .island(i)
+            .oldIsland(islandTo.isPresent() ? islandTo.get() : null)
             .involvedPlayer(user.getUniqueId())
             .reason(IslandEvent.Reason.EXIT)
             .admin(false)
@@ -76,6 +77,7 @@ public class EnterExitListener extends FlagListener {
             // Fire the IslandEnterEvent
             new IslandEvent.IslandEventBuilder()
             .island(i)
+            .oldIsland(islandFrom.isPresent() ? islandFrom.get() : null)
             .involvedPlayer(user.getUniqueId())
             .reason(IslandEvent.Reason.ENTER)
             .admin(false)


### PR DESCRIPTION
I'm working on improving IslandFly addon but I couldn't get the island I was going to enter on IslandExitEvent (user.getLocation() returns the exited island, not the new one. And the same for event.getLocation()).

So I've added these two new methods.

EDIT: Added rawEvent(Event) to IslandEventBuilder and getRawEvent() to IslandBaseEvent in order to add more flexibility.
IslandEnterEvent#getRawEvent() and IslandExitEvent#getRawEvent() returns PlayerMoveEvent.

Already tested and working on my server.