### PR TITLE
Fixes some errors with HeadGetter

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
@@ -2,17 +2,13 @@ package world.bentobox.bentobox.api.panels;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.OptionalInt;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.api.user.User;
@@ -190,18 +186,15 @@ public class Panel implements HeadRequester, InventoryHolder {
     @Override
     public void setHead(PanelItem item) {
         // Update the panel item
-        // Replace the item in the item list if the name is the same
-        items = items.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (item.getName().equals(e.getValue().getName()) ? item : e.getValue())));
-        // Replace the inventory slot item
-        for (int i = 0; i < inventory.getSize(); i++) {
-            ItemStack it = inventory.getItem(i);
-            if (it != null && it.getType().equals(Material.PLAYER_HEAD)) {
-                ItemMeta meta = it.getItemMeta();
-                if (meta != null && ChatColor.stripColor(item.getName()).equals(ChatColor.stripColor(meta.getLocalizedName()))) {
-                    inventory.setItem(i, item.getItem());
-                }
-            }
+        // Find panel item index in items and replace it once more in inventory to update it.
+
+        OptionalInt index = this.items.entrySet().stream().
+            filter(entry -> entry.getValue() == item).
+            mapToInt(Map.Entry::getKey).findFirst();
+
+        if (index.isPresent()) {
+            // Update item inside inventory to change icon only if item is inside panel.
+            this.inventory.setItem(index.getAsInt(), item.getItem());
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/util/Pair.java
+++ b/src/main/java/world/bentobox/bentobox/util/Pair.java
@@ -17,6 +17,25 @@ public class Pair<X, Z> {
         this.z = z;
     }
 
+
+    /**
+     * Returns X element as key.
+     * @return X element
+     */
+    public X getKey() {
+        return x;
+    }
+
+
+    /**
+     * Returns Z element as value.
+     * @return Z element
+     */
+    public Z getValue() {
+        return z;
+    }
+
+
     /* (non-Javadoc)
      * @see java.lang.Object#toString()
      */


### PR DESCRIPTION
There were multiple issues in HearGetter.

1. If someone 2 GUI's requested player heads at the same time, then one of them could easily throw ConcurrentModificationException, as it used Map structure, where it is not necessary. 
2. If the creator wanted 2 different icons with the same player head, it was not possible, as implementation allowed only one player head with the same name, due to using a hashmap.
3. There were unnecessary code that overwrites all PanelItems with the same name if they were requested by Head Getter. This also prevented to use the same name for PanelItem but with different player heads.

Also, I added Pair#getKey and Pair#getValue as I like to use getters more than variables directly.