### PR TITLE
Delete experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,10 @@ matrix:
     - jdk: openjdk11
         
 script:
-    - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install
-    - export JAVA_HOME=$HOME/openjdk11
-    - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk11 --target $JAVA_HOME
-    - mvn sonar:sonar -Dsonar.projectKey=BentoBoxWorld_BentoBox
-
+    #- sonar-scanner
+    - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.projectKey=BentoBoxWorld_BentoBox
+    #- mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package -P sonar sonar:sonar -B
+    #- echo "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 cache:
     directories:
         - '$HOME/.m2/repository'

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         <powermock.version>2.0.4</powermock.version>
         <mongodb.version>3.8.0</mongodb.version>
         <!-- More visible way to change dependency versions -->
-        <spigot.version>1.16.2-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.16.4-R0.1-SNAPSHOT</spigot.version>
         <!-- Might differ from the last Spigot release for short periods of time -->
-        <paper.version>1.16.2-R0.1-SNAPSHOT</paper.version>
+        <paper.version>1.16.4-R0.1-SNAPSHOT</paper.version>
         <bstats.version>1.7</bstats.version>
         <vault.version>1.7</vault.version>
         <placeholderapi.version>2.10.5</placeholderapi.version>
@@ -291,6 +291,12 @@
             <version>1.0.2</version>
             <scope>compile</scope>
         </dependency>
+<dependency> <!-- Spigot (this includes Spigot API, Bukkit API, Craftbukkit and NMS) -->
+    <groupId>org.spigotmc</groupId>
+    <artifactId>spigot</artifactId>
+    <version>1.16.4-R0.1-SNAPSHOT</version>
+    <scope>provided</scope>
+</dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
@@ -61,11 +61,11 @@ public class IslandDeletion implements DataObject {
         uniqueId = UUID.randomUUID().toString();
         location = island.getCenter();
         minX = location.getBlockX() - range;
-        minXChunk =  (minX >> 4) - 1;
+        minXChunk =  minX >> 4;
         maxX = range + location.getBlockX();
         maxXChunk = maxX >> 4;
         minZ = location.getBlockZ() - range;
-        minZChunk = (minZ >> 4) - 1;
+        minZChunk = minZ >> 4;
         maxZ = range + location.getBlockZ();
         maxZChunk = maxZ >> 4;
         box = BoundingBox.of(new Vector(minX, 0, minZ), new Vector(maxX, 255, maxZ));

--- a/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
@@ -61,11 +61,11 @@ public class IslandDeletion implements DataObject {
         uniqueId = UUID.randomUUID().toString();
         location = island.getCenter();
         minX = location.getBlockX() - range;
-        minXChunk =  minX >> 4;
+        minXChunk =  (minX >> 4) - 1;
         maxX = range + location.getBlockX();
         maxXChunk = maxX >> 4;
         minZ = location.getBlockZ() - range;
-        minZChunk = minZ >> 4;
+        minZChunk = (minZ >> 4) - 1;
         maxZ = range + location.getBlockZ();
         maxZChunk = maxZ >> 4;
         box = BoundingBox.of(new Vector(minX, 0, minZ), new Vector(maxX, 255, maxZ));

--- a/src/main/java/world/bentobox/bentobox/nms/NMSAbstraction.java
+++ b/src/main/java/world/bentobox/bentobox/nms/NMSAbstraction.java
@@ -1,0 +1,27 @@
+package world.bentobox.bentobox.nms;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
+
+import net.minecraft.server.v1_16_R3.IBlockData;
+
+public interface NMSAbstraction {
+
+    static final IBlockData AIR = ((CraftBlockData) Bukkit.createBlockData(Material.AIR)).getState();
+
+    /**
+     * Update the low-level chunk information for the given block to the new block ID and data.  This
+     * change will not be propagated to clients until the chunk is refreshed to them.
+     * @param chunk - chunk to be changed
+     * @param x - x coordinate within chunk 0 - 15
+     * @param y - y coordinate within chunk 0 - world height, e.g. 255
+     * @param z - z coordinate within chunk 0 - 15
+     * @param blockData - block data to set the block
+     * @param applyPhysics - apply physics or not
+     */
+    public void setBlockInNativeChunk(Chunk chunk, int x, int y, int z, BlockData blockData, boolean applyPhysics);
+
+}

--- a/src/main/java/world/bentobox/bentobox/nms/fallback/NMSHandler.java
+++ b/src/main/java/world/bentobox/bentobox/nms/fallback/NMSHandler.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.nms.fallback;
+
+import org.bukkit.Chunk;
+import org.bukkit.block.data.BlockData;
+
+import world.bentobox.bentobox.nms.NMSAbstraction;
+
+/**
+ * @author tastybento
+ *
+ */
+public class NMSHandler implements NMSAbstraction {
+
+    @Override
+    public void setBlockInNativeChunk(Chunk chunk, int x, int y, int z, BlockData blockData, boolean applyPhysics) {
+        chunk.getBlock(x, y, z).setBlockData(blockData, applyPhysics);
+    }
+
+
+}

--- a/src/main/java/world/bentobox/bentobox/nms/v1_16_R3/NMSHandler.java
+++ b/src/main/java/world/bentobox/bentobox/nms/v1_16_R3/NMSHandler.java
@@ -16,7 +16,7 @@ public class NMSHandler implements NMSAbstraction {
         net.minecraft.server.v1_16_R3.World nmsWorld = ((CraftWorld) chunk.getWorld()).getHandle();
         net.minecraft.server.v1_16_R3.Chunk nmsChunk = nmsWorld.getChunkAt(chunk.getX(), chunk.getZ());
         BlockPosition bp = new BlockPosition((chunk.getX() << 4) + x, y, (chunk.getZ() << 4) + z);
-        //IBlockData ibd = net.minecraft.server.v1_16_R3.Block.getByCombinedId(blockId + (data << 12));
+        // Setting the block to air before setting to another state prevents some console errors
         nmsChunk.setType(bp, AIR, applyPhysics, true);
         nmsChunk.setType(bp, craft.getState(), applyPhysics, true);
     }

--- a/src/main/java/world/bentobox/bentobox/nms/v1_16_R3/NMSHandler.java
+++ b/src/main/java/world/bentobox/bentobox/nms/v1_16_R3/NMSHandler.java
@@ -1,0 +1,25 @@
+package world.bentobox.bentobox.nms.v1_16_R3;
+
+import org.bukkit.Chunk;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
+
+import net.minecraft.server.v1_16_R3.BlockPosition;
+import world.bentobox.bentobox.nms.NMSAbstraction;
+
+public class NMSHandler implements NMSAbstraction {
+
+    @Override
+    public void setBlockInNativeChunk(Chunk chunk, int x, int y, int z, BlockData blockData, boolean applyPhysics) {
+        CraftBlockData craft = (CraftBlockData) blockData;
+        net.minecraft.server.v1_16_R3.World nmsWorld = ((CraftWorld) chunk.getWorld()).getHandle();
+        net.minecraft.server.v1_16_R3.Chunk nmsChunk = nmsWorld.getChunkAt(chunk.getX(), chunk.getZ());
+        BlockPosition bp = new BlockPosition((chunk.getX() << 4) + x, y, (chunk.getZ() << 4) + z);
+        //IBlockData ibd = net.minecraft.server.v1_16_R3.Block.getByCombinedId(blockId + (data << 12));
+        nmsChunk.setType(bp, AIR, applyPhysics, true);
+        nmsChunk.setType(bp, craft.getState(), applyPhysics, true);
+    }
+
+
+}

--- a/src/main/java/world/bentobox/bentobox/util/DeleteIslandChunks.java
+++ b/src/main/java/world/bentobox/bentobox/util/DeleteIslandChunks.java
@@ -2,11 +2,13 @@ package world.bentobox.bentobox.util;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.World.Environment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.generator.ChunkGenerator;
@@ -33,8 +35,10 @@ public class DeleteIslandChunks {
     private BukkitTask task;
     private IslandDeletion di;
     private boolean inDelete;
+    private BentoBox plugin;
 
     public DeleteIslandChunks(BentoBox plugin, IslandDeletion di) {
+        this.plugin = plugin;
         // Fire event
         IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETE_CHUNKS).build();
 
@@ -48,36 +52,76 @@ public class DeleteIslandChunks {
             for (int i = 0; i < plugin.getSettings().getDeleteSpeed(); i++) {
                 plugin.getIWM().getAddon(di.getWorld()).ifPresent(gm -> {
                     // Overworld
-                    processChunk(gm, di.getWorld(), chunkX, chunkZ);
-                    // Nether
-                    if (plugin.getIWM().isNetherGenerate(di.getWorld()) && plugin.getIWM().isNetherIslands(di.getWorld())) {
-                        processChunk(gm, plugin.getIWM().getNetherWorld(di.getWorld()), chunkX, chunkZ);
-                    }
-                    // End
-                    if (plugin.getIWM().isEndGenerate(di.getWorld()) && plugin.getIWM().isEndIslands(di.getWorld())) {
-                        processChunk(gm, plugin.getIWM().getEndWorld(di.getWorld()), chunkX, chunkZ);
-                    }
-                    chunkZ++;
-                    if (chunkZ > di.getMaxZChunk()) {
-                        chunkZ = di.getMinZChunk();
-                        chunkX++;
-                        if (chunkX > di.getMaxXChunk()) {
-                            // We're done
-                            task.cancel();
-                            // Fire event
-                            IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETED).build();
-                        }
-                    }
+                    processChunk(gm, Environment.NORMAL, chunkX, chunkZ).thenAccept(b -> {
+                        // Nether
+                        processChunk(gm, Environment.NETHER, chunkX, chunkZ).thenAccept(n -> {
+                            // End
+                            processChunk(gm, Environment.NETHER, chunkX, chunkZ).thenAccept(e -> {
+                                chunkZ++;
+                                if (chunkZ > di.getMaxZChunk()) {
+                                    chunkZ = di.getMinZChunk();
+                                    chunkX++;
+                                    if (chunkX > di.getMaxXChunk()) {
+                                        // We're done
+                                        task.cancel();
+                                        // Fire event
+                                        IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETED).build();
+                                    }
+                                }
+                            });
+                        });
+                    });
                 });
             }
-            inDelete = false;
         }, 0L, 20L);
     }
 
-    private void processChunk(GameModeAddon gm, World world, int x, int z) {
-        if (PaperLib.isChunkGenerated(world, x, z)) {
-            PaperLib.getChunkAtAsync(world, x, z).thenAccept(chunk -> regenerateChunk(gm, chunk));
+    private CompletableFuture<Boolean> processChunk(GameModeAddon gm, Environment env, int x, int z) {
+        World world = di.getWorld();
+        switch (env) {
+        case NETHER:
+            // Nether
+            if (plugin.getIWM().isNetherGenerate(di.getWorld()) && plugin.getIWM().isNetherIslands(di.getWorld())) {
+                world = plugin.getIWM().getNetherWorld(di.getWorld());
+            } else {
+                return CompletableFuture.completedFuture(false);
+            }
+            break;
+        case THE_END:
+            // End
+            if (plugin.getIWM().isEndGenerate(di.getWorld()) && plugin.getIWM().isEndIslands(di.getWorld())) {
+                world = plugin.getIWM().getEndWorld(di.getWorld());
+            } else {
+                return CompletableFuture.completedFuture(false);
+            }
+            break;
+        default:
+            break;
         }
+        if (PaperLib.isChunkGenerated(world, x, z)) {
+            // Load adjacent chunks
+            loadSurrounding(gm, world, x - 1, z - 1, x, z);
+            return CompletableFuture.completedFuture(true);
+        }
+        return CompletableFuture.completedFuture(false);
+    }
+
+    private void loadSurrounding(GameModeAddon gm, World world, int x, int z, int centerX, int centerZ) {
+        PaperLib.getChunkAtAsync(world, x, z).thenAccept(chunk -> {
+            if (x < centerX + 1) {
+                int xx = x + 1;
+                if (x == centerX && z == centerZ) xx++;
+                loadSurrounding(gm, world, xx, z, centerX, centerZ);
+                return;
+            }
+            if (z < centerZ + 1) {
+                int xx = centerX - 1 ;
+                int zz = z + 1;
+                loadSurrounding(gm, world, xx, zz, centerX, centerZ);
+                return;
+            }
+            regenerateChunk(gm, chunk);
+        });
     }
 
     private void regenerateChunk(GameModeAddon gm, Chunk chunk) {
@@ -91,30 +135,36 @@ public class DeleteIslandChunks {
         ChunkGenerator cg = gm.getDefaultWorldGenerator(chunk.getWorld().getName(), "");
         // Will be null if use-own-generator is set to true
         if (cg != null) {
-            ChunkData cd = cg.generateChunkData(chunk.getWorld(), new Random(), chunk.getX(), chunk.getZ(), grid);
-            int baseX = chunk.getX() << 4;
-            int baseZ = chunk.getZ() << 4;
-            for (int x = 0; x < 16; x++) {
-                for (int z = 0; z < 16; z++) {
-                    if (di.inBounds(baseX + x, baseZ + z)) {                        
-                        for (int y = 0; y < chunk.getWorld().getMaxHeight(); y++) {
-                            // Note: setting block to air before setting it to something else stops a bug in the server
-                            // where it reports a "
-                            chunk.getBlock(x, y, z).setType(Material.AIR, false);
-                            chunk.getBlock(x, y, z).setBlockData(cd.getBlockData(x, y, z), false);
-                            // 3D biomes, 4 blocks separated
-                            if (x%4 == 0 && y%4 == 0 && z%4 == 0) {
-                                chunk.getBlock(x, y, z).setBiome(grid.getBiome(x, y, z));
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                ChunkData cd = cg.generateChunkData(chunk.getWorld(), new Random(), chunk.getX(), chunk.getZ(), grid);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    int baseX = chunk.getX() << 4;
+                    int baseZ = chunk.getZ() << 4;
+                    for (int x = 0; x < 16; x++) {
+                        for (int z = 0; z < 16; z++) {
+                            if (di.inBounds(baseX + x, baseZ + z)) {
+                                for (int y = 0; y < chunk.getWorld().getMaxHeight(); y++) {
+                                    // Note: setting block to air before setting it to something else stops a bug in the server
+                                    // where it reports a "
+                                    chunk.getBlock(x, y, z).setType(Material.AIR, false);
+                                    chunk.getBlock(x, y, z).setBlockData(cd.getBlockData(x, y, z), false);
+                                    // 3D biomes, 4 blocks separated
+                                    if (x%4 == 0 && y%4 == 0 && z%4 == 0) {
+                                        chunk.getBlock(x, y, z).setBiome(grid.getBiome(x, y, z));
+                                    }
+                                }
                             }
                         }
                     }
-                }
-            }
+                    // Remove all entities in chunk, including any dropped items as a result of clearing the blocks above
+                    Arrays.stream(chunk.getEntities()).filter(e -> !(e instanceof Player) && di.inBounds(e.getLocation().getBlockX(), e.getLocation().getBlockZ())).forEach(Entity::remove);
+                    if (!isLoaded) {
+                        chunk.unload(true);
+                    }
+                    inDelete = false;
+                });
+            });
         }
-        // Remove all entities in chunk, including any dropped items as a result of clearing the blocks above
-        Arrays.stream(chunk.getEntities()).filter(e -> !(e instanceof Player) && di.inBounds(e.getLocation().getBlockX(), e.getLocation().getBlockZ())).forEach(Entity::remove);
-        if (!isLoaded) {
-            chunk.unload(true);
-        }
+
     }
 }

--- a/src/main/java/world/bentobox/bentobox/util/DeleteIslandChunks.java
+++ b/src/main/java/world/bentobox/bentobox/util/DeleteIslandChunks.java
@@ -61,31 +61,30 @@ public class DeleteIslandChunks {
             if (inDelete) return;
             inDelete = true;
             for (int i = 0; i < plugin.getSettings().getDeleteSpeed(); i++) {
-                plugin.getIWM().getAddon(di.getWorld()).ifPresent(gm -> {
-                    // Overworld
-                    processChunk(gm, Environment.NORMAL, chunkX, chunkZ).thenAccept(b -> {
-                        // Nether
-                        processChunk(gm, Environment.NETHER, chunkX, chunkZ).thenAccept(n -> {
-                            // End
-                            processChunk(gm, Environment.NETHER, chunkX, chunkZ).thenAccept(e -> {
-                                chunkZ++;
-                                if (chunkZ > di.getMaxZChunk()) {
-                                    chunkZ = di.getMinZChunk();
-                                    chunkX++;
-                                    if (chunkX > di.getMaxXChunk()) {
-                                        // We're done
-                                        task.cancel();
-                                        // Fire event
-                                        IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETED).build();
-                                    }
-                                }
-                            });
-                        });
-                    });
-                });
+                plugin.getIWM().getAddon(di.getWorld()).ifPresent(gm ->
+                // Overworld
+                processChunk(gm, Environment.NORMAL, chunkX, chunkZ).thenRun(() ->
+                // Nether
+                processChunk(gm, Environment.NETHER, chunkX, chunkZ).thenRun(() ->
+                // End
+                processChunk(gm, Environment.NETHER, chunkX, chunkZ).thenRun(() -> finish()))));
             }
         }, 0L, 20L);
 
+    }
+
+    private void finish() {
+        chunkZ++;
+        if (chunkZ > di.getMaxZChunk()) {
+            chunkZ = di.getMinZChunk();
+            chunkX++;
+            if (chunkX > di.getMaxXChunk()) {
+                // We're done
+                task.cancel();
+                // Fire event
+                IslandEvent.builder().deletedIslandInfo(di).reason(Reason.DELETED).build();
+            }
+        }
     }
 
     private CompletableFuture<Boolean> processChunk(GameModeAddon gm, Environment env, int x, int z) {

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.util;
 
+import java.lang.reflect.InvocationTargetException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -661,9 +662,15 @@ public class Util {
     /**
      * Checks what version the server is running and picks the appropriate NMS handler, or fallback
      * @return an NMS accelerated class for this server, or a fallback Bukkit API based one
-     * @throws Exception - thrown if the coding is wrong and there's no fallback
+     * @throws ClassNotFoundException - thrown if there is no fallback class - should never be thrown
+     * @throws SecurityException - thrown if security violation - should never be thrown
+     * @throws NoSuchMethodException - thrown if no constructor for NMS package
+     * @throws InvocationTargetException - should never be thrown
+     * @throws IllegalArgumentException - should never be thrown
+     * @throws IllegalAccessException - should never be thrown
+     * @throws InstantiationException - should never be thrown
      */
-    public static NMSAbstraction getNMS() throws Exception {
+    public static NMSAbstraction getNMS() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
         String serverPackageName = Bukkit.getServer().getClass().getPackage().getName();
         String pluginPackageName = plugin.getClass().getPackage().getName();
         String version = serverPackageName.substring(serverPackageName.lastIndexOf('.') + 1);


### PR DESCRIPTION
This uses 1.16.4 NMS to delete and regenerate blocks for islands. This is just an experiment because it does not try to abstract the NMS in DeleteIslandChunks.java.

In testing, this appears to be much faster than using Bukkit because it does not try to handle lighting, it does not update the player's client so it does not cause lag (I think). I have set the config.yml delete speed to 100 chunks per second.

Note that you have to logout and back in to see the deleted area. If you teleport back to your old island you will still see it there, but blocks may be weird because there will be a mismatch between the client's cache and the server. This is the same as what happened on ASkyBlock.

This is the jar file:
[BentoBox-1.15.3-SNAPSHOT-LOCAL.jar.zip](https://github.com/BentoBoxWorld/BentoBox/files/5609906/BentoBox-1.15.3-SNAPSHOT-LOCAL.jar.zip)

I'd like @BONNe to try it with CaveBlock and tell me what he thinks.

If this is acceptable, then we can possibly add it as an option.
