### PR TITLE
Revert "Persistent entities should never be removed."

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Animals;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
@@ -35,10 +34,6 @@ public class GeoLimitMobsListener extends FlagListener {
         // Kick off the task to remove entities that go outside island boundaries
         Bukkit.getScheduler().runTaskTimer(getPlugin(), () -> {
             mobSpawnTracker.entrySet().stream()
-            // Renamed entities should never be removed. Even if they moved 2k blocks away.
-            .filter(e -> e.getKey().getCustomName() == null)
-            // Persistent entities should never be removed, unless they are animals.
-            .filter(e -> !e.getKey().isPersistent() || e.getKey() instanceof Animals)
             .filter(e -> !e.getValue().onIsland(e.getKey().getLocation()))
             .map(Map.Entry::getKey)
             .forEach(Entity::remove);

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1386,8 +1386,7 @@ public class IslandsManager {
         loc.getWorld().getNearbyEntities(loc, plugin.getSettings().getClearRadius(),
                 plugin.getSettings().getClearRadius(),
                 plugin.getSettings().getClearRadius()).stream()
-        .filter(en -> !en.isPersistent()
-                && Util.isHostileEntity(en)
+        .filter(en -> Util.isHostileEntity(en)
                 && !plugin.getIWM().getRemoveMobsWhitelist(loc.getWorld()).contains(en.getType())
                 && !(en instanceof PufferFish))
         .filter(en -> en.getCustomName() == null)


### PR DESCRIPTION
Reverts BentoBoxWorld/BentoBox#1608

All entities are by default persistent so these changes mean no entities will be affected by it. I understand the idea, but there must be a different way to do this. I'm reverting because the current features no longer work.