### PR TITLE
Better island meta data api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.15.5</build.version>
+        <build.version>1.15.6</build.version>
     </properties>
 
     <!-- Profiles will allow to automatically change build version. -->

--- a/src/main/java/world/bentobox/bentobox/api/metadata/MetaDataAble.java
+++ b/src/main/java/world/bentobox/bentobox/api/metadata/MetaDataAble.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 /**
  * This interface is for all BentoBox objects that have meta data
  * @author tastybento
- * @since 1.15.5
+ * @since 1.15.6
  */
 public interface MetaDataAble {
 
@@ -25,7 +25,7 @@ public interface MetaDataAble {
      * Get meta data by key
      * @param key - key
      * @return the value to which the specified key is mapped, or null if there is no mapping for the key
-     * @since 1.15.5
+     * @since 1.15.6
      */
     default Optional<MetaDataValue> getMetaData(String key) {
         return getMetaData().map(m -> m.get(key));
@@ -36,7 +36,7 @@ public interface MetaDataAble {
      * @param key - key
      * @param value - value
      * @return the previous value associated with key, or empty if there was no mapping for key.
-     * @since 1.15.5
+     * @since 1.15.6
      */
     default Optional<MetaDataValue> putMetaData(String key, MetaDataValue value) {
         return getMetaData().map(m -> m.put(key, value));
@@ -46,7 +46,7 @@ public interface MetaDataAble {
      * Remove meta data
      * @param key - key to remove
      * @return the previous value associated with key, or empty if there was no mapping for key.
-     * @since 1.15.5
+     * @since 1.15.6
      */
     default Optional<MetaDataValue> removeMetaData(String key) {
         return getMetaData().map(m -> m.remove(key));

--- a/src/main/java/world/bentobox/bentobox/api/metadata/MetaDataAble.java
+++ b/src/main/java/world/bentobox/bentobox/api/metadata/MetaDataAble.java
@@ -1,30 +1,19 @@
 package world.bentobox.bentobox.api.metadata;
 
 import java.util.Map;
-
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * This interface is for all BentoBox objects that have meta data
  * @author tastybento
- * @since 1.15.4
+ * @since 1.15.5
  */
 public interface MetaDataAble {
-    /**
-     * @return the metaData, may be null
-     */
-    @Nullable
-    public Map<String, MetaDataValue> getMetaData();
 
     /**
-     * Get meta data by key
-     * @param key - key
-     * @return the value to which the specified key is mapped, or null if there is no mapping for the key
-     * @since 1.15.4
+     * @return the metaData
      */
-    @Nullable
-    public MetaDataValue getMetaData(@NonNull String key);
+    public Optional<Map<String, MetaDataValue>> getMetaData();
 
     /**
      * @param metaData the metaData to set
@@ -33,21 +22,34 @@ public interface MetaDataAble {
     public void setMetaData(Map<String, MetaDataValue> metaData);
 
     /**
-     * Put a key, value string pair into the object's meta data
+     * Get meta data by key
+     * @param key - key
+     * @return the value to which the specified key is mapped, or null if there is no mapping for the key
+     * @since 1.15.5
+     */
+    default Optional<MetaDataValue> getMetaData(String key) {
+        return getMetaData().map(m -> m.get(key));
+    }
+
+    /**
+     * Put a key, value string pair into the meta data
      * @param key - key
      * @param value - value
-     * @return the previous value associated with key, or null if there was no mapping for key.
-     * @since 1.15.4
+     * @return the previous value associated with key, or empty if there was no mapping for key.
+     * @since 1.15.5
      */
-    @Nullable
-    public MetaDataValue putMetaData(@NonNull String key, @NonNull MetaDataValue value);
+    default Optional<MetaDataValue> putMetaData(String key, MetaDataValue value) {
+        return getMetaData().map(m -> m.put(key, value));
+    }
 
     /**
      * Remove meta data
      * @param key - key to remove
-     * @return the previous value associated with key, or null if there was no mapping for key.
-     * @since 1.15.4
+     * @return the previous value associated with key, or empty if there was no mapping for key.
+     * @since 1.15.5
      */
-    @Nullable
-    public MetaDataValue removeMetaData(@NonNull String key);
+    default Optional<MetaDataValue> removeMetaData(String key) {
+        return getMetaData().map(m -> m.remove(key));
+    }
+
 }

--- a/src/main/java/world/bentobox/bentobox/api/metadata/MetaDataAble.java
+++ b/src/main/java/world/bentobox/bentobox/api/metadata/MetaDataAble.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.api.metadata;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * This interface is for all BentoBox objects that have meta data
@@ -11,8 +12,9 @@ import org.eclipse.jdt.annotation.NonNull;
  */
 public interface MetaDataAble {
     /**
-     * @return the metaData
+     * @return the metaData, may be null
      */
+    @Nullable
     public Map<String, MetaDataValue> getMetaData();
 
     /**
@@ -21,6 +23,7 @@ public interface MetaDataAble {
      * @return the value to which the specified key is mapped, or null if there is no mapping for the key
      * @since 1.15.4
      */
+    @Nullable
     public MetaDataValue getMetaData(@NonNull String key);
 
     /**
@@ -36,6 +39,7 @@ public interface MetaDataAble {
      * @return the previous value associated with key, or null if there was no mapping for key.
      * @since 1.15.4
      */
+    @Nullable
     public MetaDataValue putMetaData(@NonNull String key, @NonNull MetaDataValue value);
 
     /**
@@ -44,5 +48,6 @@ public interface MetaDataAble {
      * @return the previous value associated with key, or null if there was no mapping for key.
      * @since 1.15.4
      */
+    @Nullable
     public MetaDataValue removeMetaData(@NonNull String key);
 }

--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.events.OfflineMessageEvent;
+import world.bentobox.bentobox.api.metadata.MetaDataAble;
 import world.bentobox.bentobox.api.metadata.MetaDataValue;
 import world.bentobox.bentobox.util.Util;
 
@@ -44,7 +45,7 @@ import world.bentobox.bentobox.util.Util;
  *
  * @author tastybento
  */
-public class User {
+public class User implements MetaDataAble {
 
     private static Map<UUID, User> users = new HashMap<>();
 
@@ -639,47 +640,18 @@ public class User {
      * @return the metaData
      * @since 1.15.4
      */
-    @NonNull
-    public Map<String, MetaDataValue> getMetaData() {
+    @Override
+    public Optional<Map<String, MetaDataValue>> getMetaData() {
         return plugin.getPlayers().getPlayer(playerUUID).getMetaData();
-    }
-
-    /**
-     * Get meta data by key
-     * @param key - key
-     * @return optional value to which the specified key is mapped, or empty if there is no mapping for the key
-     * @since 1.15.4
-     */
-    public Optional<MetaDataValue> getMetaData(String key) {
-        return Optional.ofNullable(plugin.getPlayers().getPlayer(playerUUID).getMetaData().get(key));
     }
 
     /**
      * @param metaData the metaData to set
      * @since 1.15.4
      */
+    @Override
     public void setMetaData(Map<String, MetaDataValue> metaData) {
         plugin.getPlayers().getPlayer(playerUUID).setMetaData(metaData);
     }
 
-    /**
-     * Put a key, value string pair into the user's meta data
-     * @param key - key
-     * @param value - value
-     * @return the previous value associated with key, or empty if there was no mapping for key.
-     * @since 1.15.4
-     */
-    public Optional<MetaDataValue> putMetaData(String key, MetaDataValue value) {
-        return Optional.ofNullable(plugin.getPlayers().getPlayer(playerUUID).getMetaData().put(key, value));
-    }
-
-    /**
-     * Remove meta data
-     * @param key - key to remove
-     * @return the previous value associated with key, or empty if there was no mapping for key.
-     * @since 1.15.4
-     */
-    public Optional<MetaDataValue> removeMetaData(String key) {
-        return Optional.ofNullable(plugin.getPlayers().getPlayer(playerUUID).getMetaData().remove(key));
-    }
 }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -1247,25 +1247,15 @@ public class Island implements DataObject, MetaDataAble {
         this.reserved = reserved;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "Island [deleted=" + deleted + ", uniqueId=" + uniqueId + ", center=" + center + ", range=" + range
-                + ", protectionRange=" + protectionRange + ", maxEverProtectionRange=" + maxEverProtectionRange
-                + ", world=" + world + ", gameMode=" + gameMode + ", name=" + name + ", createdDate=" + createdDate
-                + ", updatedDate=" + updatedDate + ", owner=" + owner + ", members=" + members + ", spawn=" + spawn
-                + ", purgeProtected=" + purgeProtected + ", flags=" + flags + ", history=" + history
-                + ", levelHandicap=" + levelHandicap + ", spawnPoint=" + spawnPoint + ", doNotLoad=" + doNotLoad + "]";
-    }
-
     /**
      * @return the metaData
      * @since 1.15.4
      */
     @Override
     public Map<String, MetaDataValue> getMetaData() {
+        if (metaData == null) {
+            metaData = new HashMap<>();
+        }
         return metaData;
     }
 
@@ -1276,8 +1266,9 @@ public class Island implements DataObject, MetaDataAble {
      * @since 1.15.4
      */
     @Override
+    @Nullable
     public MetaDataValue getMetaData(String key) {
-        return this.metaData.get(key);
+        return getMetaData().get(key);
     }
 
     /**
@@ -1297,8 +1288,9 @@ public class Island implements DataObject, MetaDataAble {
      * @since 1.15.4
      */
     @Override
+    @Nullable
     public MetaDataValue putMetaData(String key, MetaDataValue value) {
-        return this.metaData.put(key, value);
+        return getMetaData().put(key, value);
     }
 
     /**
@@ -1308,7 +1300,29 @@ public class Island implements DataObject, MetaDataAble {
      * @since 1.15.4
      */
     @Override
+    @Nullable
     public MetaDataValue removeMetaData(String key) {
-        return this.metaData.remove(key);
+        return getMetaData().remove(key);
     }
+
+    @Override
+    public String toString() {
+        return "Island [deleted=" + deleted + ", " + (uniqueId != null ? "uniqueId=" + uniqueId + ", " : "")
+                + (center != null ? "center=" + center + ", " : "") + "range=" + range + ", protectionRange="
+                + protectionRange + ", maxEverProtectionRange=" + maxEverProtectionRange + ", "
+                + (world != null ? "world=" + world + ", " : "")
+                + (gameMode != null ? "gameMode=" + gameMode + ", " : "") + (name != null ? "name=" + name + ", " : "")
+                + "createdDate=" + createdDate + ", updatedDate=" + updatedDate + ", "
+                + (owner != null ? "owner=" + owner + ", " : "") + (members != null ? "members=" + members + ", " : "")
+                + "spawn=" + spawn + ", purgeProtected=" + purgeProtected + ", "
+                + (flags != null ? "flags=" + flags + ", " : "") + (history != null ? "history=" + history + ", " : "")
+                + "levelHandicap=" + levelHandicap + ", "
+                + (spawnPoint != null ? "spawnPoint=" + spawnPoint + ", " : "") + "doNotLoad=" + doNotLoad + ", "
+                + (cooldowns != null ? "cooldowns=" + cooldowns + ", " : "")
+                + (commandRanks != null ? "commandRanks=" + commandRanks + ", " : "")
+                + (reserved != null ? "reserved=" + reserved + ", " : "")
+                + (metaData != null ? "metaData=" + metaData : "") + "]";
+    }
+
+
 }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -1249,26 +1250,14 @@ public class Island implements DataObject, MetaDataAble {
 
     /**
      * @return the metaData
-     * @since 1.15.4
+     * @since 1.15.5
      */
     @Override
-    public Map<String, MetaDataValue> getMetaData() {
+    public Optional<Map<String, MetaDataValue>> getMetaData() {
         if (metaData == null) {
             metaData = new HashMap<>();
         }
-        return metaData;
-    }
-
-    /**
-     * Get meta data by key
-     * @param key - key
-     * @return the value to which the specified key is mapped, or null if there is no mapping for the key
-     * @since 1.15.4
-     */
-    @Override
-    @Nullable
-    public MetaDataValue getMetaData(String key) {
-        return getMetaData().get(key);
+        return Optional.of(metaData);
     }
 
     /**
@@ -1278,31 +1267,6 @@ public class Island implements DataObject, MetaDataAble {
     @Override
     public void setMetaData(Map<String, MetaDataValue> metaData) {
         this.metaData = metaData;
-    }
-
-    /**
-     * Put a key, value string pair into the island's meta data
-     * @param key - key
-     * @param value - value
-     * @return the previous value associated with key, or null if there was no mapping for key.
-     * @since 1.15.4
-     */
-    @Override
-    @Nullable
-    public MetaDataValue putMetaData(String key, MetaDataValue value) {
-        return getMetaData().put(key, value);
-    }
-
-    /**
-     * Remove meta data
-     * @param key - key to remove
-     * @return the previous value associated with key, or null if there was no mapping for key.
-     * @since 1.15.4
-     */
-    @Override
-    @Nullable
-    public MetaDataValue removeMetaData(String key) {
-        return getMetaData().remove(key);
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/database/objects/Players.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Players.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.database.objects;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -11,7 +12,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.gson.annotations.Expose;
@@ -352,64 +352,26 @@ public class Players implements DataObject, MetaDataAble {
 
     /**
      * @return the metaData
-     * @since 1.15.4
+     * @since 1.15.5
+     * @see User#getMetaData()
      */
     @Override
-    public Map<String, MetaDataValue> getMetaData() {
+    public Optional<Map<String, MetaDataValue>> getMetaData() {
         if (metaData == null) {
             metaData = new HashMap<>();
         }
-        return metaData;
-    }
-
-    /**
-     * Get meta data by key
-     * @param key - key
-     * @return the value to which the specified key is mapped, or null if there is no mapping for the key
-     * @since 1.15.4
-     */
-    @Override
-    @Nullable
-    public MetaDataValue getMetaData(@NonNull String key) {
-        return getMetaData().get(key);
+        return Optional.of(metaData);
     }
 
     /**
      * @param metaData the metaData to set
      * @since 1.15.4
+     * @see User#setMetaData(Map)
      */
     @Override
     public void setMetaData(Map<String, MetaDataValue> metaData) {
         this.metaData = metaData;
     }
 
-    /**
-     * Put a key, value string pair into the player's meta data. For API usage, it is best
-     * to use the methods in the User class.
-     * @param key - key
-     * @param value - value
-     * @return the previous value associated with key, or null if there was no mapping for key.
-     * @since 1.15.4
-     * @see User#putMetaData(String, MetaDataValue)
-     */
-    @Override
-    @Nullable
-    public MetaDataValue putMetaData(@NonNull String key, @NonNull MetaDataValue value) {
-        return getMetaData().put(key, value);
-    }
-
-    /**
-     * Remove meta data.For API usage, it is best
-     * to use the methods in the User class.
-     * @param key - key to remove
-     * @return the previous value associated with key, or null if there was no mapping for key.
-     * @since 1.15.4
-     * @see User#removeMetaData(String)
-     */
-    @Override
-    @Nullable
-    public MetaDataValue removeMetaData(@NonNull String key) {
-        return getMetaData().remove(key);
-    }
 
 }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Players.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Players.java
@@ -20,6 +20,7 @@ import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.api.metadata.MetaDataAble;
 import world.bentobox.bentobox.api.metadata.MetaDataValue;
+import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -351,6 +352,7 @@ public class Players implements DataObject, MetaDataAble {
 
     /**
      * @return the metaData
+     * @since 1.15.4
      */
     @Override
     public Map<String, MetaDataValue> getMetaData() {
@@ -367,6 +369,7 @@ public class Players implements DataObject, MetaDataAble {
      * @since 1.15.4
      */
     @Override
+    @Nullable
     public MetaDataValue getMetaData(@NonNull String key) {
         return getMetaData().get(key);
     }
@@ -381,24 +384,30 @@ public class Players implements DataObject, MetaDataAble {
     }
 
     /**
-     * Put a key, value string pair into the player's meta data
+     * Put a key, value string pair into the player's meta data. For API usage, it is best
+     * to use the methods in the User class.
      * @param key - key
      * @param value - value
      * @return the previous value associated with key, or null if there was no mapping for key.
      * @since 1.15.4
+     * @see User#putMetaData(String, MetaDataValue)
      */
     @Override
+    @Nullable
     public MetaDataValue putMetaData(@NonNull String key, @NonNull MetaDataValue value) {
         return getMetaData().put(key, value);
     }
 
     /**
-     * Remove meta data
+     * Remove meta data.For API usage, it is best
+     * to use the methods in the User class.
      * @param key - key to remove
      * @return the previous value associated with key, or null if there was no mapping for key.
      * @since 1.15.4
+     * @see User#removeMetaData(String)
      */
     @Override
+    @Nullable
     public MetaDataValue removeMetaData(@NonNull String key) {
         return getMetaData().remove(key);
     }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1650,4 +1650,5 @@ public class IslandsManager {
 
         return r;
     }
+
 }

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -603,7 +603,7 @@ public class UserTest {
     @Test
     public void testMetaData() {
         User u = User.getInstance(player);
-        assertTrue(u.getMetaData().isEmpty());
+        assertTrue(u.getMetaData().get().isEmpty());
         // Store a string in a new key
         assertFalse(u.putMetaData("string", new MetaDataValue("a string")).isPresent());
         // Store an int in a new key
@@ -620,9 +620,9 @@ public class UserTest {
         // Try to remove non-existent key
         assertFalse(u.removeMetaData("ggogg").isPresent());
         // Set the meta data as blank
-        assertFalse(u.getMetaData().isEmpty());
+        assertFalse(u.getMetaData().get().isEmpty());
         u.setMetaData(new HashMap<>());
-        assertTrue(u.getMetaData().isEmpty());
+        assertTrue(u.getMetaData().get().isEmpty());
     }
 
 }


### PR DESCRIPTION
This improves the previous MetaData API without breaking too much by using the MetaDataAble interface uniformly and making all the appropriate methods return optionals instead of nulls. Implementing classes need only implement the getter and setter for the metadata field. This approach removes a lot of code duplication and unifies the API between Island and User (and Player).