### PR TITLE
Changed CreatureSpawnEvent to be EntitySpawnEvent and attempted to ed…

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
@@ -31,11 +31,10 @@ import world.bentobox.bentobox.util.Util;
 public class GeoMobLimitTab implements Tab, ClickHandler {
 
     /**
-     * A list of all living entity types, minus some
+     * A list of all entity types, minus some
      */
     private static final List<EntityType> LIVING_ENTITY_TYPES = Collections.unmodifiableList(Arrays.stream(EntityType.values())
-            .filter(EntityType::isAlive)
-            .filter(t -> !(t.equals(EntityType.PLAYER) || t.equals(EntityType.GIANT) || t.equals(EntityType.ARMOR_STAND)))
+            .filter(t -> !(t.equals(EntityType.PLAYER) || t.equals(EntityType.GIANT) || t.equals(EntityType.AREA_EFFECT_CLOUD)))
             .sorted(Comparator.comparing(EntityType::name))
             .collect(Collectors.toList()));
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
@@ -10,7 +10,9 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
+import org.bukkit.event.vehicle.VehicleCreateEvent;
 import org.bukkit.projectiles.ProjectileSource;
 
 import world.bentobox.bentobox.api.events.BentoBoxReadyEvent;
@@ -50,6 +52,19 @@ public class GeoLimitMobsListener extends FlagListener {
         if (getIWM().inWorld(e.getLocation())
                 && getIWM().getGeoLimitSettings(e.getLocation().getWorld()).contains(e.getEntityType().name())) {
             getIslands().getIslandAt(e.getLocation()).ifPresent(i -> mobSpawnTracker.put(e.getEntity(), i));
+        }
+    }
+
+    /**
+     * Track where a vehicle was created. This will determine its allowable movement zone.
+     * @param e - event
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onVehicleSpawn(VehicleCreateEvent e) {
+        Entity entity = e.getVehicle();
+        if (getIWM().inWorld(entity.getLocation())
+                && getIWM().getGeoLimitSettings(entity.getLocation().getWorld()).contains(entity.getType().name())) {
+            getIslands().getIslandAt(entity.getLocation()).ifPresent(i -> mobSpawnTracker.put(entity, i));
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
@@ -8,8 +8,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.projectiles.ProjectileSource;
 
@@ -46,7 +46,7 @@ public class GeoLimitMobsListener extends FlagListener {
      * @param e - event
      */
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-    public void onMobSpawn(CreatureSpawnEvent e) {
+    public void onMobSpawn(EntitySpawnEvent e) {
         if (getIWM().inWorld(e.getLocation())
                 && getIWM().getGeoLimitSettings(e.getLocation().getWorld()).contains(e.getEntityType().name())) {
             getIslands().getIslandAt(e.getLocation()).ifPresent(i -> mobSpawnTracker.put(e.getEntity(), i));

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
@@ -100,11 +100,11 @@ public class GeoMobLimitTabTest {
         assertEquals("COW", list.get(1));
         assertEquals("BAT", list.get(0));
         // Click on BAT
-        tab.onClick(panel, user, ClickType.LEFT, 9);
+        tab.onClick(panel, user, ClickType.LEFT, 11);
         assertEquals(1, list.size());
         assertEquals("COW", list.get(0));
         // Click on BAT again to have it added
-        tab.onClick(panel, user, ClickType.LEFT, 9);
+        tab.onClick(panel, user, ClickType.LEFT, 11);
         assertEquals(2, list.size());
         assertEquals("COW", list.get(0));
         assertEquals("BAT", list.get(1));


### PR DESCRIPTION
Simple change in an attempt to make TNT be geo limitable.  

(Based on chat with tastybento in discord it sounds like this isn't the change you are looking for as many of the entities added do not have getRemoveWhenFarAway(), and I do not currently know a clean way to implement a toggle for this that would be safe from the configs).

Also has the added bonus of being able to geo limit armour stands, falling blocks, fire charges  #973   and I assume a number of other entities that weren't caught by CreatureSpawnEvent. 


In addition I attempted to change the GUI to match this new ability of geo limit, however this seems to have caused errors in the automated tests and I'm unsure why that is. 
In addition I tested every entity that is now available in the geo limit tab and got these results (A number of entities may
need removing from this GUI marked as Needs removing in testing, but I could not come up with a clean way to do this) 

(In addition a small addon hack that I made when I was originally testing which makes the same changes can be found here: 
https://github.com/Zorua162/GeoLimitEntitesTest)
```
  geo-limit-settings:
  - ARMOR_STAND works
  - PLAYER doesn't work (probably for the best)
  - WITHER works
  - WITHER_SKELETON works
  - WITHER_SKULL (couldn't test in a short time frame)
  - AREA_EFFECT_CLOUD (Needs removing from GUI)
  - ARROW works
  - BAT works as before
  - BEE works
  - BLAZE works
  - BOAT Works with #7473507b
  - CAT works
  - CAVE_SPIDER works
  - CHICKEN works
  - COW works
  - COD works
  - CREEPER works
  - DONKEY works
  - DOLPHIN works
  - DRAGON_FIREBALL (Can't figure out how to test either sorry)
  - DROPPED_ITEM works
  - DROWNED works
  - EGG works
  - ELDER_GUARDIAN works
  - ENDERMAN works
  - ENDERMITE works
  - ENDER_CRYSTAL works
  - ENDER_DRAGON doesn't seem to work, but needs more testing
  - ENDER_PEARL works
  - ENDER_SIGNAL not entirely sure what this is 
  - EVOKER works
  - EVOKER_FANGS works
  - EXPERIENCE_ORB works
  - FALLING_BLOCK works including anvils and sand: extremely useful for grief prevention
  - FIREBALL works
  - FIREWORK works
  - FISHING_HOOK works
  - FOX works
  - GHAST works 
  - GUARDIAN works
  - HOGLIN works
  - HORSE works 
  - HUSK works
  - ILLUSIONER Not sure what this is NEEDS REMOVING?
  - IRON_GOLEM works
  - ITEM_FRAME NEEDS REMOVING
  - LEASH_HITCH NEEDS REMOVING
  - LIGHTNING NEEDS REMOVING
  - LLAMA works
  - LLAMA_SPIT NEEDS REMOVING?
  - MAGMA_CUBE works
  - MINECART works with #7473507b
  - MINECART_CHEST works with #7473507b
  - MINECART_COMMAND works with #7473507b
  - MINECART_FURNACE works with #7473507b
  - MINECART_HOPPER works with #7473507b
  - MINECART_TNT works with #7473507b
  - MINECART_MOB_SPAWNER works with #7473507b
  - MULE works
  - PIGLIN_BRUTE works
  - PIGLIN works
  - PIG works
  - PHANTOM works
  - PARROT works
  - PANDA works
  - PAINTING not sure how to test (NEEDS REMOVING)
  - OCELOT works
  - MUSHROOM_COW works
  - PILLAGER works
  - POLAR_BEAR works
  - PRIMED_TNT works!!
  - PUFFERFISH works
  - RABBIT works
  - RAVAGER works
  - SALMON works
  - SHEEP works
  - SHULKER works
  - SHULKER_BULLET works
  - SILVERFISH works
  - SKELETON works
  - SKELETON_HORSE works
  - SLIME works
  - SMALL_FIREBALL works
  - SNOWBALL works
  - SNOWMAN works
  - SPECTRAL_ARROW works
  - SPIDER works
  - SPLASH_POTION works
  - SQUID works
  - STRAY works
  - STRIDER works
  - THROWN_EXP_BOTTLE works
  - TRADER_LLAMA works
  - TRIDENT works
  - TROPICAL_FISH works
  - TURTLE works
  - UNKNOWN works
  - VEX works
  - VILLAGER works
  - VINDICATOR works
  - WANDERING_TRADER works
  - WITCH works
  - WOLF works
  - ZOGLIN works
  - ZOMBIE works
  - ZOMBIE_HORSE works
  - ZOMBIE_VILLAGER works
  - ZOMBIFIED_PIGLIN works
```