### PR TITLE
Decouple island location from island center.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -120,7 +120,7 @@ public class AdminDeleteCommand extends ConfirmableCommand {
         if (vector == null) {
             user.sendMessage("general.success");
         } else {
-            user.sendMessage("commands.admin.delete.deleted-island", "[xyz]", Util.xyz(vector));
+            user.sendMessage("commands.admin.delete.deleted-island", TextVariables.XYZ, Util.xyz(vector));
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
@@ -83,7 +83,7 @@ public class AdminRegisterCommand extends ConfirmableCommand {
             if (i.isSpawn()) {
                 getIslands().clearSpawn(i.getWorld());
             }
-            user.sendMessage("commands.admin.register.registered-island", "[xyz]", Util.xyz(i.getCenter().toVector()),
+            user.sendMessage("commands.admin.register.registered-island", TextVariables.XYZ, Util.xyz(i.getCenter().toVector()),
                     TextVariables.NAME, targetName);
             user.sendMessage("general.success");
             // Build and call event
@@ -114,7 +114,7 @@ public class AdminRegisterCommand extends ConfirmableCommand {
                 getIslands().setOwner(user, targetUUID, i);
                 i.setReserved(true);
                 i.getCenter().getBlock().setType(Material.BEDROCK);
-                user.sendMessage("commands.admin.register.reserved-island", "[xyz]", Util.xyz(i.getCenter().toVector()),
+                user.sendMessage("commands.admin.register.reserved-island", TextVariables.XYZ, Util.xyz(i.getCenter().toVector()),
                         TextVariables.NAME, targetName);
                 // Build and fire event
                 IslandEvent.builder()

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetLocationCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetLocationCommand.java
@@ -1,0 +1,107 @@
+package world.bentobox.bentobox.api.commands.admin;
+
+
+import java.util.List;
+import java.util.Optional;
+
+import org.bukkit.Location;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.ConfirmableCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
+
+
+/**
+ * This command sets the island location. This defines the center of the protected area.
+ * The island location can be anywhere inside the island range area. Therefore the protected
+ * range can be up to 2x the island range.
+ * The island location will change for all environments.
+ * @author tastybento
+ * @since 1.16.0
+ */
+public class AdminSetLocationCommand extends ConfirmableCommand
+{
+    private Location targetLoc;
+    private Island island;
+
+
+    /**
+     * Sub-command constructor
+     *
+     * @param parent - the parent composite command
+     */
+    public AdminSetLocationCommand(CompositeCommand parent) {
+        super(parent, "setlocation");
+    }
+
+
+    @Override
+    public void setup()
+    {
+        this.setPermission("admin.setlocation");
+        this.setParametersHelp("commands.admin.setlocation.parameters");
+        this.setDescription("commands.admin.setlocation.description");
+    }
+
+    @Override
+    public boolean canExecute(User user, String label, List<String> args) {
+        if (args.size() == 3) {
+            // Get location
+            targetLoc = getLocation(user, args);
+        } else {
+            targetLoc = new Location(getWorld(), user.getLocation().getBlockX(), user.getLocation().getBlockY(), user.getLocation().getBlockZ());
+        }
+        if (targetLoc == null) {
+            user.sendMessage("commands.admin.setlocation.xyz-error");
+            return false;
+        }
+        Optional<Island> optionalIsland = getIslands().getIslandAt(targetLoc);
+        if (!optionalIsland.isPresent()) {
+            user.sendMessage("commands.admin.setspawnpoint.no-island-here");
+            return false;
+        }
+        island = optionalIsland.get();
+        return true;
+    }
+
+    private Location getLocation(User user, List<String> args) {
+        try {
+            int x = Integer.parseInt(args.get(0));
+            int y = Integer.parseInt(args.get(1));
+            int z = Integer.parseInt(args.get(2));
+            return new Location(getWorld(), x, y, z);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        String name = getPlayers().getName(island.getOwner());
+        user.sendMessage("commands.admin.setlocation.island", TextVariables.XYZ, Util.xyz(island.getCenter().toVector()), TextVariables.NAME, name);
+        // Confirm
+        this.askConfirmation(user, user.getTranslation("commands.admin.setlocation.confirmation", TextVariables.XYZ, Util.xyz(targetLoc.toVector())),
+                () -> this.setLocation(user));
+        return true;
+    }
+
+
+    /**
+     * Set the island location to the user's location.
+     * @param user User who initiate change.
+     */
+    private void setLocation(User user) {
+        try {
+            // Set
+            island.setLocation(targetLoc);
+            user.sendMessage("commands.admin.setlocation.success", TextVariables.XYZ, Util.xyz(targetLoc.toVector()));
+        } catch (Exception e) {
+            user.sendMessage("commands.admin.setlocation.failure", TextVariables.XYZ, Util.xyz(targetLoc.toVector()));
+            getAddon().logError("Island location could not be changed because the island does not exist");
+        }
+
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetProtectionCenterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetProtectionCenterCommand.java
@@ -15,14 +15,14 @@ import world.bentobox.bentobox.util.Util;
 
 
 /**
- * This command sets the island location. This defines the center of the protected area.
- * The island location can be anywhere inside the island range area. Therefore the protected
+ * This command sets the center of the protected area.
+ * The location can be anywhere inside the island range area. Therefore the protected
  * range can be up to 2x the island range.
- * The island location will change for all environments.
+ * The location will change for all environments.
  * @author tastybento
  * @since 1.16.0
  */
-public class AdminSetLocationCommand extends ConfirmableCommand
+public class AdminSetProtectionCenterCommand extends ConfirmableCommand
 {
     private Location targetLoc;
     private Island island;
@@ -33,17 +33,17 @@ public class AdminSetLocationCommand extends ConfirmableCommand
      *
      * @param parent - the parent composite command
      */
-    public AdminSetLocationCommand(CompositeCommand parent) {
-        super(parent, "setlocation");
+    public AdminSetProtectionCenterCommand(CompositeCommand parent) {
+        super(parent, "setprotectionlocation");
     }
 
 
     @Override
     public void setup()
     {
-        this.setPermission("admin.setlocation");
-        this.setParametersHelp("commands.admin.setlocation.parameters");
-        this.setDescription("commands.admin.setlocation.description");
+        this.setPermission("admin.setprotectionlocation");
+        this.setParametersHelp("commands.admin.setprotectionlocation.parameters");
+        this.setDescription("commands.admin.setprotectionlocation.description");
     }
 
     @Override
@@ -55,7 +55,7 @@ public class AdminSetLocationCommand extends ConfirmableCommand
             targetLoc = new Location(getWorld(), user.getLocation().getBlockX(), user.getLocation().getBlockY(), user.getLocation().getBlockZ());
         }
         if (targetLoc == null) {
-            user.sendMessage("commands.admin.setlocation.xyz-error");
+            user.sendMessage("commands.admin.setprotectionlocation.xyz-error");
             return false;
         }
         Optional<Island> optionalIsland = getIslands().getIslandAt(targetLoc);
@@ -81,9 +81,9 @@ public class AdminSetLocationCommand extends ConfirmableCommand
     @Override
     public boolean execute(User user, String label, List<String> args) {
         String name = getPlayers().getName(island.getOwner());
-        user.sendMessage("commands.admin.setlocation.island", TextVariables.XYZ, Util.xyz(island.getCenter().toVector()), TextVariables.NAME, name);
+        user.sendMessage("commands.admin.setprotectionlocation.island", TextVariables.XYZ, Util.xyz(island.getCenter().toVector()), TextVariables.NAME, name);
         // Confirm
-        this.askConfirmation(user, user.getTranslation("commands.admin.setlocation.confirmation", TextVariables.XYZ, Util.xyz(targetLoc.toVector())),
+        this.askConfirmation(user, user.getTranslation("commands.admin.setprotectionlocation.confirmation", TextVariables.XYZ, Util.xyz(targetLoc.toVector())),
                 () -> this.setLocation(user));
         return true;
     }
@@ -96,11 +96,11 @@ public class AdminSetLocationCommand extends ConfirmableCommand
     private void setLocation(User user) {
         try {
             // Set
-            island.setLocation(targetLoc);
-            user.sendMessage("commands.admin.setlocation.success", TextVariables.XYZ, Util.xyz(targetLoc.toVector()));
+            island.setProtectionCenter(targetLoc);
+            user.sendMessage("commands.admin.setprotectionlocation.success", TextVariables.XYZ, Util.xyz(targetLoc.toVector()));
         } catch (Exception e) {
-            user.sendMessage("commands.admin.setlocation.failure", TextVariables.XYZ, Util.xyz(targetLoc.toVector()));
-            getAddon().logError("Island location could not be changed because the island does not exist");
+            user.sendMessage("commands.admin.setprotectionlocation.failure", TextVariables.XYZ, Util.xyz(targetLoc.toVector()));
+            getAddon().logError("Protection location could not be changed because the island does not exist");
         }
 
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetspawnCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetspawnCommand.java
@@ -73,7 +73,7 @@ public class AdminSetspawnCommand extends ConfirmableCommand {
         getIslands().setSpawn(i);
         i.setSpawnPoint(World.Environment.NORMAL, user.getLocation());
         // Set the island's range to the full island space because it is spawn
-        i.setProtectionRange(i.getRange());
+        i.setProtectionRange(i.getRange() * 2);
         user.sendMessage("commands.admin.setspawn.success");
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
@@ -82,7 +82,7 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
         // Remove all island players that reference this island
         oldIsland.getMembers().clear();
         getIslands().save(oldIsland);
-        user.sendMessage("commands.admin.unregister.unregistered-island", "[xyz]", Util.xyz(oldIsland.getCenter().toVector()),
+        user.sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, Util.xyz(oldIsland.getCenter().toVector()),
                 TextVariables.NAME, targetName);
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
@@ -91,7 +91,7 @@ public abstract class DefaultAdminCommand extends CompositeCommand {
         // Settings
         new AdminSettingsCommand(this);
         // Location
-        new AdminSetLocationCommand(this);
+        new AdminSetProtectionCenterCommand(this);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
@@ -90,6 +90,8 @@ public abstract class DefaultAdminCommand extends CompositeCommand {
         new AdminPurgeCommand(this);
         // Settings
         new AdminSettingsCommand(this);
+        // Location
+        new AdminSetLocationCommand(this);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
@@ -55,7 +55,7 @@ public class AdminRangeAddCommand extends CompositeCommand {
         Island island = getIslands().getIsland(getWorld(), targetUUID);
         int newRange = island.getProtectionRange() + Integer.parseInt(args.get(1));
 
-        if (newRange > island.getRange()) {
+        if (newRange > island.getRange() * 2) {
             user.sendMessage("commands.admin.range.invalid-value.too-high", TextVariables.NUMBER, String.valueOf(island.getRange()));
             return false;
         } else if (newRange == island.getProtectionRange()) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommand.java
@@ -105,7 +105,7 @@ public class AdminRangeDisplayCommand extends CompositeCommand {
     }
 
     private void drawZone(User user, Particle particle, Particle.DustOptions dustOptions, Island island, int range) {
-        Location center = island.getLocation();
+        Location center = island.getProtectionCenter();
         // Get player Y coordinate
         int playerY = user.getPlayer().getLocation().getBlockY() + 1;
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommand.java
@@ -11,6 +11,7 @@ import org.bukkit.Particle;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 
 /**
  * @author Poslovitch
@@ -84,15 +85,15 @@ public class AdminRangeDisplayCommand extends CompositeCommand {
 
             getIslands().getIslandAt(user.getLocation()).ifPresent(island -> {
                 // Draw the island protected area
-                drawZone(user, Particle.BARRIER, null, island.getCenter(), island.getProtectionRange());
+                drawZone(user, Particle.BARRIER, null, island, island.getProtectionRange());
 
                 // Draw the default protected area if island protected zone is different
                 if (island.getProtectionRange() != getPlugin().getIWM().getIslandProtectionRange(getWorld())) {
-                    drawZone(user, Particle.VILLAGER_HAPPY, null, island.getCenter(), getPlugin().getIWM().getIslandProtectionRange(getWorld()));
+                    drawZone(user, Particle.VILLAGER_HAPPY, null, island, getPlugin().getIWM().getIslandProtectionRange(getWorld()));
                 }
 
                 // Draw the island area
-                drawZone(user, Particle.REDSTONE, new Particle.DustOptions(Color.GRAY, 1.0F), island.getCenter(), island.getRange());
+                drawZone(user, Particle.REDSTONE, new Particle.DustOptions(Color.GRAY, 1.0F), island, island.getRange());
             });
         }, 20, 30));
     }
@@ -103,7 +104,8 @@ public class AdminRangeDisplayCommand extends CompositeCommand {
         displayRanges.remove(user);
     }
 
-    private void drawZone(User user, Particle particle, Particle.DustOptions dustOptions, Location center, int range) {
+    private void drawZone(User user, Particle particle, Particle.DustOptions dustOptions, Island island, int range) {
+        Location center = island.getLocation();
         // Get player Y coordinate
         int playerY = user.getPlayer().getLocation().getBlockY() + 1;
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
@@ -60,7 +60,7 @@ public class AdminRangeSetCommand extends CompositeCommand {
             return false;
         }
         if (range > island.getRange() * 2) {
-            user.sendMessage("commands.admin.range.invalid-value.too-high", TextVariables.NUMBER, String.valueOf(island.getRange()));
+            user.sendMessage("commands.admin.range.invalid-value.too-high", TextVariables.NUMBER, String.valueOf(2 * island.getRange()));
             return false;
         }
         if (range == island.getProtectionRange()) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
@@ -55,7 +55,7 @@ public class AdminRangeSetCommand extends CompositeCommand {
         Island island = getIslands().getIsland(getWorld(), targetUUID);
 
         // Do some sanity checks to make sure the new protection range won't cause problems
-        if (range <= 1) {
+        if (range < 0) {
             user.sendMessage("commands.admin.range.invalid-value.too-low", TextVariables.NUMBER, args.get(1));
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
@@ -55,7 +55,7 @@ public class AdminRangeSetCommand extends CompositeCommand {
         Island island = getIslands().getIsland(getWorld(), targetUUID);
 
         // Do some sanity checks to make sure the new protection range won't cause problems
-        if (range < 0) {
+        if (range < 1) {
             user.sendMessage("commands.admin.range.invalid-value.too-low", TextVariables.NUMBER, args.get(1));
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommand.java
@@ -59,7 +59,7 @@ public class AdminRangeSetCommand extends CompositeCommand {
             user.sendMessage("commands.admin.range.invalid-value.too-low", TextVariables.NUMBER, args.get(1));
             return false;
         }
-        if (range > island.getRange()) {
+        if (range > island.getRange() * 2) {
             user.sendMessage("commands.admin.range.invalid-value.too-high", TextVariables.NUMBER, String.valueOf(island.getRange()));
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/localization/TextVariables.java
+++ b/src/main/java/world/bentobox/bentobox/api/localization/TextVariables.java
@@ -29,4 +29,9 @@ public class TextVariables {
      * @since 1.15.0
      */
     public static final String GAMEMODE = "[gamemode]";
+    /**
+     * Used for coordinates
+     * @since 1.16.0
+     */
+    public static final String XYZ = "[xyz]";
 }

--- a/src/main/java/world/bentobox/bentobox/blueprints/BlueprintPaster.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/BlueprintPaster.java
@@ -132,7 +132,7 @@ public class BlueprintPaster {
         // Offset due to bedrock
         Vector off = bp.getBedrock() != null ? bp.getBedrock() : new Vector(0,0,0);
         // Calculate location for pasting
-        this.location = island.getLocation().toVector().subtract(off).toLocation(world);
+        this.location = island.getProtectionCenter().toVector().subtract(off).toLocation(world);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/blueprints/BlueprintPaster.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/BlueprintPaster.java
@@ -132,7 +132,7 @@ public class BlueprintPaster {
         // Offset due to bedrock
         Vector off = bp.getBedrock() != null ? bp.getBedrock() : new Vector(0,0,0);
         // Calculate location for pasting
-        this.location = island.getCenter().toVector().subtract(off).toLocation(world);
+        this.location = island.getLocation().toVector().subtract(off).toLocation(world);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
@@ -53,16 +53,17 @@ public class IslandDeletion implements DataObject {
     public IslandDeletion() {}
 
     public IslandDeletion(Island island) {
-        // Get the world's island distance
+        // Calculate the minimum required range to delete the island
+        int range = Math.min(island.getMaxEverProtectionRange(), island.getRange());
         uniqueId = UUID.randomUUID().toString();
         location = island.getCenter();
-        minX = island.getMinX();
+        minX = location.getBlockX() - range;
         minXChunk =  minX >> 4;
-        maxX = island.getMaxX();
+        maxX = range + location.getBlockX();
         maxXChunk = maxX >> 4;
-        minZ = island.getMinZ();
+        minZ = location.getBlockZ() - range;
         minZChunk = minZ >> 4;
-        maxZ = island.getMaxZ();
+        maxZ = range + location.getBlockZ();
         maxZChunk = maxZ >> 4;
         box = island.getBoundingBox();
     }

--- a/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
@@ -9,8 +9,6 @@ import org.bukkit.util.Vector;
 
 import com.google.gson.annotations.Expose;
 
-import world.bentobox.bentobox.BentoBox;
-
 /**
  * Data object to store islands in deletion
  * @author tastybento
@@ -56,18 +54,17 @@ public class IslandDeletion implements DataObject {
 
     public IslandDeletion(Island island) {
         // Get the world's island distance
-        int range = BentoBox.getInstance().getIWM().getIslandDistance(island.getWorld());
         uniqueId = UUID.randomUUID().toString();
         location = island.getCenter();
-        minX = location.getBlockX() - range;
+        minX = island.getMinX();
         minXChunk =  minX >> 4;
-        maxX = range + location.getBlockX();
+        maxX = island.getMaxX();
         maxXChunk = maxX >> 4;
-        minZ = location.getBlockZ() - range;
+        minZ = island.getMinZ();
         minZChunk = minZ >> 4;
-        maxZ = range + location.getBlockZ();
+        maxZ = island.getMaxZ();
         maxZChunk = maxZ >> 4;
-        box = BoundingBox.of(new Vector(minX, 0, minZ), new Vector(maxX, 255, maxZ));
+        box = island.getBoundingBox();
     }
 
     /* (non-Javadoc)

--- a/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
@@ -56,8 +56,7 @@ public class IslandDeletion implements DataObject {
 
     public IslandDeletion(Island island) {
         // Get the world's island distance
-        int islandDistance = BentoBox.getInstance().getIWM().getIslandDistance(island.getWorld());
-        int range = Math.min(island.getMaxEverProtectionRange(), islandDistance);
+        int range = BentoBox.getInstance().getIWM().getIslandDistance(island.getWorld());
         uniqueId = UUID.randomUUID().toString();
         location = island.getCenter();
         minX = location.getBlockX() - range;

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -221,7 +221,7 @@ public class JoinLeaveListener implements Listener {
                     // Call Protection Range Change event. Does not support canceling.
                     IslandEvent.builder()
                     .island(island)
-                    .location(island.getLocation())
+                    .location(island.getProtectionCenter())
                     .reason(IslandEvent.Reason.RANGE_CHANGE)
                     .involvedPlayer(user.getUniqueId())
                     .admin(true)

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -205,8 +205,8 @@ public class JoinLeaveListener implements Listener {
             if (island != null) {
                 // Check if new owner has a different range permission than the island size
                 int range = user.getPermissionValue(plugin.getIWM().getAddon(island.getWorld()).map(GameModeAddon::getPermissionPrefix).orElse("") + "island.range", island.getProtectionRange());
-                // Range cannot be greater than the island distance
-                range = Math.min(range, plugin.getIWM().getIslandDistance(island.getWorld()));
+                // Range cannot be greater than the island distance * 2
+                range = Math.min(range, 2 * plugin.getIWM().getIslandDistance(island.getWorld()));
                 // Range can go up or down
                 if (range != island.getProtectionRange()) {
                     user.sendMessage("commands.admin.setrange.range-updated", TextVariables.NUMBER, String.valueOf(range));

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -218,10 +218,10 @@ public class JoinLeaveListener implements Listener {
 
                     island.setProtectionRange(range);
 
-                    // Call Protection Range Change event. Does not support cancelling.
+                    // Call Protection Range Change event. Does not support canceling.
                     IslandEvent.builder()
                     .island(island)
-                    .location(island.getCenter())
+                    .location(island.getLocation())
                     .reason(IslandEvent.Reason.RANGE_CHANGE)
                     .involvedPlayer(user.getUniqueId())
                     .admin(true)

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
@@ -118,7 +118,7 @@ public class InvincibleVisitorsListener extends FlagListener implements ClickHan
                 // Teleport
                 new SafeSpotTeleport.Builder(getPlugin())
                 .entity(p)
-                .location(island.getLocation().toVector().toLocation(p.getWorld()))
+                .location(island.getProtectionCenter().toVector().toLocation(p.getWorld()))
                 .build());
             } else if (getIslands().hasIsland(p.getWorld(), p.getUniqueId())) {
                 // No island in this location - if the player has an island try to teleport them back

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
@@ -118,7 +118,7 @@ public class InvincibleVisitorsListener extends FlagListener implements ClickHan
                 // Teleport
                 new SafeSpotTeleport.Builder(getPlugin())
                 .entity(p)
-                .location(island.getCenter().toVector().toLocation(p.getWorld()))
+                .location(island.getLocation().toVector().toLocation(p.getWorld()))
                 .build());
             } else if (getIslands().hasIsland(p.getWorld(), p.getUniqueId())) {
                 // No island in this location - if the player has an island try to teleport them back

--- a/src/main/java/world/bentobox/bentobox/lists/GameModePlaceholder.java
+++ b/src/main/java/world/bentobox/bentobox/lists/GameModePlaceholder.java
@@ -87,6 +87,26 @@ public enum GameModePlaceholder {
      */
     ISLAND_CENTER_Z("island_center_z", (addon, user, island) -> island == null ? "" : String.valueOf(island.getCenter().getBlockZ())),
     /**
+     * Returns the coordinates of the island's location, which may be different to the center.
+     * @since 1.16.0
+     */
+    ISLAND_LOCATION("island_location", (addon, user, island) -> island == null ? "" : Util.xyz(island.getLocation().toVector())),
+    /**
+     * Returns the X coordinate of the island's location.
+     * @since 1.16.0
+     */
+    ISLAND_LOCATION_X("island_location_x", (addon, user, island) -> island == null ? "" : String.valueOf(island.getLocation().getBlockX())),
+    /**
+     * Returns the Y coordinate of the island's location.
+     * @since 1.16.0
+     */
+    ISLAND_LOCATION_Y("island_location_y", (addon, user, island) -> island == null ? "" : String.valueOf(island.getLocation().getBlockY())),
+    /**
+     * Returns the Z coordinate of the island's location.
+     * @since 1.16.0
+     */
+    ISLAND_LOCATION_Z("island_location_z", (addon, user, island) -> island == null ? "" : String.valueOf(island.getLocation().getBlockZ())),
+    /**
      * Returns the maximum number of members the island can have
      * @since 1.5.0
      */
@@ -185,6 +205,30 @@ public enum GameModePlaceholder {
      */
     VISITED_ISLAND_CENTER_Z("visited_island_center_z", (addon, user, island) ->
     getVisitedIsland(addon, user).map(value -> String.valueOf(value.getCenter().getBlockZ())).orElse("")),
+    /**
+     * Returns the coordinates of the location of the island the player is standing on.
+     * @since 1.16.0
+     */
+    VISITED_ISLAND_LOCATION("visited_island_location", (addon, user, island) ->
+    getVisitedIsland(addon, user).map(value -> Util.xyz(value.getLocation().toVector())).orElse("")),
+    /**
+     * Returns the X coordinate of the location of the island the player is standing on.
+     * @since 1.16.0
+     */
+    VISITED_ISLAND_LOCATION_X("visited_island_location_x", (addon, user, island) ->
+    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getLocation().getBlockX())).orElse("")),
+    /**
+     * Returns the Y coordinate of the location of the island the player is standing on.
+     * @since 1.16.0
+     */
+    VISITED_ISLAND_LOCATION_Y("visited_island_location_y", (addon, user, island) ->
+    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getLocation().getBlockY())).orElse("")),
+    /**
+     * Returns the Z coordinate of the location of the island the player is standing on.
+     * @since 1.16.0
+     */
+    VISITED_ISLAND_LOCATION_Z("visited_island_location_z", (addon, user, island) ->
+    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getLocation().getBlockZ())).orElse("")),
     /**
      * Returns the maximum number of members the island the player is standing on can have.
      * @since 1.5.2

--- a/src/main/java/world/bentobox/bentobox/lists/GameModePlaceholder.java
+++ b/src/main/java/world/bentobox/bentobox/lists/GameModePlaceholder.java
@@ -90,22 +90,22 @@ public enum GameModePlaceholder {
      * Returns the coordinates of the island's location, which may be different to the center.
      * @since 1.16.0
      */
-    ISLAND_LOCATION("island_location", (addon, user, island) -> island == null ? "" : Util.xyz(island.getLocation().toVector())),
+    ISLAND_LOCATION("island_location", (addon, user, island) -> island == null ? "" : Util.xyz(island.getProtectionCenter().toVector())),
     /**
      * Returns the X coordinate of the island's location.
      * @since 1.16.0
      */
-    ISLAND_LOCATION_X("island_location_x", (addon, user, island) -> island == null ? "" : String.valueOf(island.getLocation().getBlockX())),
+    ISLAND_LOCATION_X("island_location_x", (addon, user, island) -> island == null ? "" : String.valueOf(island.getProtectionCenter().getBlockX())),
     /**
      * Returns the Y coordinate of the island's location.
      * @since 1.16.0
      */
-    ISLAND_LOCATION_Y("island_location_y", (addon, user, island) -> island == null ? "" : String.valueOf(island.getLocation().getBlockY())),
+    ISLAND_LOCATION_Y("island_location_y", (addon, user, island) -> island == null ? "" : String.valueOf(island.getProtectionCenter().getBlockY())),
     /**
      * Returns the Z coordinate of the island's location.
      * @since 1.16.0
      */
-    ISLAND_LOCATION_Z("island_location_z", (addon, user, island) -> island == null ? "" : String.valueOf(island.getLocation().getBlockZ())),
+    ISLAND_LOCATION_Z("island_location_z", (addon, user, island) -> island == null ? "" : String.valueOf(island.getProtectionCenter().getBlockZ())),
     /**
      * Returns the maximum number of members the island can have
      * @since 1.5.0
@@ -210,25 +210,25 @@ public enum GameModePlaceholder {
      * @since 1.16.0
      */
     VISITED_ISLAND_LOCATION("visited_island_location", (addon, user, island) ->
-    getVisitedIsland(addon, user).map(value -> Util.xyz(value.getLocation().toVector())).orElse("")),
+    getVisitedIsland(addon, user).map(value -> Util.xyz(value.getProtectionCenter().toVector())).orElse("")),
     /**
      * Returns the X coordinate of the location of the island the player is standing on.
      * @since 1.16.0
      */
     VISITED_ISLAND_LOCATION_X("visited_island_location_x", (addon, user, island) ->
-    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getLocation().getBlockX())).orElse("")),
+    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getProtectionCenter().getBlockX())).orElse("")),
     /**
      * Returns the Y coordinate of the location of the island the player is standing on.
      * @since 1.16.0
      */
     VISITED_ISLAND_LOCATION_Y("visited_island_location_y", (addon, user, island) ->
-    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getLocation().getBlockY())).orElse("")),
+    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getProtectionCenter().getBlockY())).orElse("")),
     /**
      * Returns the Z coordinate of the location of the island the player is standing on.
      * @since 1.16.0
      */
     VISITED_ISLAND_LOCATION_Z("visited_island_location_z", (addon, user, island) ->
-    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getLocation().getBlockZ())).orElse("")),
+    getVisitedIsland(addon, user).map(value -> String.valueOf(value.getProtectionCenter().getBlockZ())).orElse("")),
     /**
      * Returns the maximum number of members the island the player is standing on can have.
      * @since 1.5.2

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1370,7 +1370,7 @@ public class IslandsManager {
                     int oldRange = island.getProtectionRange();
                     island.setProtectionRange(range);
 
-                    // Call Protection Range Change event. Does not support cancelling.
+                    // Call Protection Range Change event. Does not support canceling.
                     IslandEvent.builder()
                     .island(island)
                     .location(island.getCenter())
@@ -1625,7 +1625,7 @@ public class IslandsManager {
                         highestIsland = i;
                     }
                     String xyz = Util.xyz(i.getCenter().toVector());
-                    user.sendMessage("commands.admin.team.fix.rank-on-island", TextVariables.RANK, user.getTranslation(rank), "[xyz]", xyz);
+                    user.sendMessage("commands.admin.team.fix.rank-on-island", TextVariables.RANK, user.getTranslation(rank), TextVariables.XYZ, xyz);
                     user.sendRawMessage(i.getUniqueId());
                 }
                 // Fix island ownership in cache

--- a/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
+++ b/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
@@ -319,7 +319,7 @@ public class SafeSpotTeleport {
          * @return Builder
          */
         public Builder island(Island island) {
-            this.location = island.getLocation();
+            this.location = island.getProtectionCenter();
             return this;
         }
 

--- a/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
+++ b/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
@@ -319,7 +319,7 @@ public class SafeSpotTeleport {
          * @return Builder
          */
         public Builder island(Island island) {
-            this.location = island.getCenter();
+            this.location = island.getLocation();
             return this;
         }
 

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -193,7 +193,7 @@ commands:
       team-members-title: "Team members:"
       team-owner-format: "&a [name] [rank]"
       team-member-format: "&b [name] [rank]"
-      island-location: "Island location: [xyz]"
+      island-protection-center: "Protection area center: [xyz]"
       island-center: "Island center: [xyz]"
       island-coords: "Island coordinates: [xz1] to [xz2]"
       islands-in-trash: "&d Player has islands in trash."
@@ -251,14 +251,14 @@ commands:
       unknown-rank: "&c Unknown rank!"
       not-possible: "&c Rank must be higher than visitor."
       rank-set: "&a Rank set from &b [from] &a to &b [to] &a on &b [name]&a 's island."
-    setlocation:
+    setprotectionlocation:
       parameters: "[x y z coords]"
       description: "set current location or [x y z] as center of island's protection area"
       island: "&c This will affect the island at [xyz] owned by '[name]'."
-      confirmation: "&c Are you sure you want to set [xyz] as the island's location?"
-      success: "&a Successfully set [xyz] as the island location."
-      fail: "&a Successfully set [xyz] as the island location."
-      island-location-changed: "&a [user] changed island's location to [xyz]."
+      confirmation: "&c Are you sure you want to set [xyz] as the protection center?"
+      success: "&a Successfully set [xyz] as the protection center."
+      fail: "&a Successfully set [xyz] as the protection center."
+      island-location-changed: "&a [user] changed island's protection center to [xyz]."
       xyz-error: "&c Specify three integer coordinates: e.g, 100 120 100"
     setspawn:
       description: "set an island as spawn for this gamemode"

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -194,6 +194,7 @@ commands:
       team-owner-format: "&a [name] [rank]"
       team-member-format: "&b [name] [rank]"
       island-location: "Island location: [xyz]"
+      island-center: "Island center: [xyz]"
       island-coords: "Island coordinates: [xz1] to [xz2]"
       islands-in-trash: "&d Player has islands in trash."
       protection-range: "Protection range: [range]"
@@ -250,6 +251,15 @@ commands:
       unknown-rank: "&c Unknown rank!"
       not-possible: "&c Rank must be higher than visitor."
       rank-set: "&a Rank set from &b [from] &a to &b [to] &a on &b [name]&a 's island."
+    setlocation:
+      parameters: "[x y z coords]"
+      description: "set current location or [x y z] as center of island's protection area"
+      island: "&c This will affect the island at [xyz] owned by '[name]'."
+      confirmation: "&c Are you sure you want to set [xyz] as the island's location?"
+      success: "&a Successfully set [xyz] as the island location."
+      fail: "&a Successfully set [xyz] as the island location."
+      island-location-changed: "&a [user] changed island's location to [xyz]."
+      xyz-error: "&c Specify three integer coordinates: e.g, 100 120 100"
     setspawn:
       description: "set an island as spawn for this gamemode"
       already-spawn: "&c This island is already a spawn!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,7 +12,7 @@ load: STARTUP
 
 loadbefore: [Multiverse-Core, Residence]
 
-softdepend: [Vault, PlaceholderAPI, dynmap, WorldEdit, WorldBorderAPI, BsbMongo]
+softdepend: [Vault, PlaceholderAPI, dynmap, WorldEdit, WorldBorderAPI, BsbMongo, WorldGeneratorApi]
 
 permissions:
   bentobox.admin:

--- a/src/test/java/world/bentobox/bentobox/TestBentoBox.java
+++ b/src/test/java/world/bentobox/bentobox/TestBentoBox.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,7 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -83,14 +83,15 @@ public class TestBentoBox extends AbstractCommonSetup {
         when(Bukkit.getOfflinePlayer(any(UUID.class))).thenReturn(offlinePlayer);
         when(offlinePlayer.getName()).thenReturn("tastybento");
 
-        Mockito.when(player.hasPermission(Mockito.anyString())).thenReturn(true);
+        when(player.hasPermission(anyString())).thenReturn(true);
 
-        Mockito.when(ownerOfIsland.getLocation()).thenReturn(location);
-        Mockito.when(visitorToIsland.getLocation()).thenReturn(location);
+        when(ownerOfIsland.getLocation()).thenReturn(location);
+        when(visitorToIsland.getLocation()).thenReturn(location);
+        when(location.clone()).thenReturn(location);
 
-        Mockito.when(player.getUniqueId()).thenReturn(MEMBER_UUID);
-        Mockito.when(ownerOfIsland.getUniqueId()).thenReturn(uuid);
-        Mockito.when(visitorToIsland.getUniqueId()).thenReturn(VISITOR_UUID);
+        when(player.getUniqueId()).thenReturn(MEMBER_UUID);
+        when(ownerOfIsland.getUniqueId()).thenReturn(uuid);
+        when(visitorToIsland.getUniqueId()).thenReturn(VISITOR_UUID);
 
         island.setOwner(uuid);
         island.setProtectionRange(100);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -33,6 +33,7 @@ import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.CommandsManager;
@@ -252,7 +253,7 @@ public class AdminRegisterCommandTest {
         AdminRegisterCommand itl = new AdminRegisterCommand(ac);
         assertTrue(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         // Add other verifications
-        verify(user).sendMessage(eq("commands.admin.register.registered-island"), eq("[xyz]"), eq("123,123,432"), eq("[name]"), eq("tastybento"));
+        verify(user).sendMessage(eq("commands.admin.register.registered-island"), eq(TextVariables.XYZ), eq("123,123,432"), eq("[name]"), eq("tastybento"));
         verify(user).sendMessage(eq("general.success"));
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
@@ -226,7 +226,7 @@ public class AdminUnregisterCommandTest {
         AdminUnregisterCommand itl = new AdminUnregisterCommand(ac);
         UUID targetUUID = UUID.randomUUID();
         itl.unregisterPlayer(user, "name", targetUUID);
-        verify(user).sendMessage("commands.admin.unregister.unregistered-island", "[xyz]", "1,2,3", TextVariables.NAME, "name");
+        verify(user).sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, "1,2,3", TextVariables.NAME, "name");
         assertTrue(map.isEmpty());
         verify(im).removePlayer(any(), eq(uuid1));
         verify(im).removePlayer(any(), eq(uuid2));

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
@@ -214,9 +214,9 @@ public class AdminRangeSetCommandTest {
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();
         args.add("tastybento");
-        args.add("100");
+        args.add("1000");
         arc.execute(user, "", args);
-        Mockito.verify(user).sendMessage("commands.admin.range.invalid-value.too-high", TextVariables.NUMBER, "50");
+        Mockito.verify(user).sendMessage("commands.admin.range.invalid-value.too-high", TextVariables.NUMBER, "100");
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/database/objects/IslandDeletionTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/objects/IslandDeletionTest.java
@@ -66,7 +66,6 @@ public class IslandDeletionTest {
         when(iwm.getWorldSettings(any())).thenReturn(ws);
 
         // Island
-        when(island.getMaxEverProtectionRange()).thenReturn(1000);
         when(island.getWorld()).thenReturn(world);
         when(island.getCenter()).thenReturn(location);
 

--- a/src/test/java/world/bentobox/bentobox/database/objects/IslandDeletionTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/objects/IslandDeletionTest.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.database.objects;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -111,7 +112,7 @@ public class IslandDeletionTest {
      */
     @Test
     public void testGetMaxXChunk() {
-        assertEquals(84, id.getMaxXChunk());
+        assertEquals(77, id.getMaxXChunk());
     }
 
     /**
@@ -119,7 +120,7 @@ public class IslandDeletionTest {
      */
     @Test
     public void testGetMaxZChunk() {
-        assertEquals(-322, id.getMaxZChunk());
+        assertEquals(-328, id.getMaxZChunk());
     }
 
     /**
@@ -127,7 +128,7 @@ public class IslandDeletionTest {
      */
     @Test
     public void testGetMinXChunk() {
-        assertEquals(71, id.getMinXChunk());
+        assertEquals(77, id.getMinXChunk());
     }
 
     /**
@@ -135,7 +136,7 @@ public class IslandDeletionTest {
      */
     @Test
     public void testGetMinZChunk() {
-        assertEquals(-335, id.getMinZChunk());
+        assertEquals(-328, id.getMinZChunk());
     }
 
     /**
@@ -156,15 +157,21 @@ public class IslandDeletionTest {
     }
 
     /**
+     * Test method for {@link world.bentobox.bentobox.database.objects.IslandDeletion#getBox()}.
+     */
+    @Test
+    public void testBox() {
+        assertNull(id.getBox());
+    }
+
+    /**
      * Test method for {@link world.bentobox.bentobox.database.objects.IslandDeletion#toString()}.
      */
     @Test
     public void testToString() {
         assertTrue(id.toString().endsWith(
-                ", minXChunk=71,"
-                        + " maxXChunk=84, minZChunk=-335, maxZChunk=-322, minX=1145, minZ=-5345,"
-                        + " maxX=1345, maxZ=-5145, box=BoundingBox [minX=1145.0, minY=0.0, minZ=-5345.0,"
-                        + " maxX=1345.0, maxY=255.0, maxZ=-5145.0]]"));
+                "minXChunk=77, maxXChunk=77, minZChunk=-328,"
+                        + " maxZChunk=-328, minX=1245, minZ=-5245, maxX=1245, maxZ=-5245, box=null]"));
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandlerTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandlerTest.java
@@ -32,6 +32,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -140,6 +141,7 @@ public class YamlDatabaseHandlerTest {
     /**
      * Test method for {@link world.bentobox.bentobox.database.yaml.YamlDatabaseHandler#loadObjects()}.
      */
+    @Ignore("YAML database is no longer supported")
     @Test
     public void testLoadObjects() throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, NoSuchMethodException, IntrospectionException {
         List<Island> list = handler.loadObjects();
@@ -160,6 +162,7 @@ public class YamlDatabaseHandlerTest {
      * @throws IllegalAccessException
      * @throws InstantiationException
      */
+    @Ignore("YAML database is no longer supported")
     @Test
     public void testLoadObject() throws InstantiationException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, NoSuchMethodException, IntrospectionException {
         String name = UUID.randomUUID().toString();
@@ -176,6 +179,7 @@ public class YamlDatabaseHandlerTest {
      * @throws InvocationTargetException
      * @throws IllegalAccessException
      */
+    @Ignore("YAML database is no longer supported")
     @SuppressWarnings("unchecked")
     @Test
     public void testSaveObject() throws IllegalAccessException, InvocationTargetException, IntrospectionException {

--- a/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
@@ -245,9 +245,9 @@ public class JoinLeaveListenerTest {
         // Verify
         verify(player).sendMessage(eq("commands.admin.setrange.range-updated"));
         // Verify island setting
-        verify(island).setProtectionRange(eq(100));
+        verify(island).setProtectionRange(eq(200));
         // Verify log
-        verify(plugin).log("Island protection range changed from 50 to 100 for tastybento due to permission.");
+        verify(plugin).log("Island protection range changed from 50 to 200 for tastybento due to permission.");
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/PortalTeleportationListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PortalTeleportationListenerTest.java
@@ -403,7 +403,7 @@ public class PortalTeleportationListenerTest {
         when(iwm.isPasteMissingIslands(any())).thenReturn(true);
         Island isle = mock(Island.class);
         when(isle.getWorld()).thenReturn(world);
-        when(isle.getLocation()).thenReturn(from);
+        when(isle.getProtectionCenter()).thenReturn(from);
         when(isle.hasEndIsland()).thenReturn(false);
         Optional<Island> island = Optional.of(isle );
         when(im.getIslandAt(any())).thenReturn(island);

--- a/src/test/java/world/bentobox/bentobox/listeners/PortalTeleportationListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PortalTeleportationListenerTest.java
@@ -403,7 +403,7 @@ public class PortalTeleportationListenerTest {
         when(iwm.isPasteMissingIslands(any())).thenReturn(true);
         Island isle = mock(Island.class);
         when(isle.getWorld()).thenReturn(world);
-        when(isle.getCenter()).thenReturn(from);
+        when(isle.getLocation()).thenReturn(from);
         when(isle.hasEndIsland()).thenReturn(false);
         Optional<Island> island = Optional.of(isle );
         when(im.getIslandAt(any())).thenReturn(island);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
@@ -128,7 +128,7 @@ public class InvincibleVisitorsListenerTest {
         Location location = mock(Location.class);
         Vector vector = mock(Vector.class);
         when(location.toVector()).thenReturn(vector);
-        when(island.getLocation()).thenReturn(location);
+        when(island.getProtectionCenter()).thenReturn(location);
         when(im.getIsland(any(World.class), any(User.class))).thenReturn(island);
         optionalIsland = Optional.of(island);
         // Visitor

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
@@ -128,7 +128,7 @@ public class InvincibleVisitorsListenerTest {
         Location location = mock(Location.class);
         Vector vector = mock(Vector.class);
         when(location.toVector()).thenReturn(vector);
-        when(island.getCenter()).thenReturn(location);
+        when(island.getLocation()).thenReturn(location);
         when(im.getIsland(any(World.class), any(User.class))).thenReturn(island);
         optionalIsland = Optional.of(island);
         // Visitor
@@ -255,7 +255,7 @@ public class InvincibleVisitorsListenerTest {
         assertTrue(e.isCancelled());
         verify(player, never()).setGameMode(eq(GameMode.SPECTATOR));
     }
-    
+
     @Test
     public void testOnVisitorGetDamageNPC() {
         when(player.hasMetadata(eq("NPC"))).thenReturn(true);

--- a/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportBuilderTest.java
@@ -94,7 +94,7 @@ public class SafeSpotTeleportBuilderTest {
         sstb.entity(player);
         // Add island
         Island island = mock(Island.class);
-        when(island.getLocation()).thenReturn(loc);
+        when(island.getProtectionCenter()).thenReturn(loc);
         sstb.island(island);
         // Build - expect success
         SafeSpotTeleport result = sstb.build();

--- a/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleportBuilderTest.java
@@ -94,7 +94,7 @@ public class SafeSpotTeleportBuilderTest {
         sstb.entity(player);
         // Add island
         Island island = mock(Island.class);
-        when(island.getCenter()).thenReturn(loc);
+        when(island.getLocation()).thenReturn(loc);
         sstb.island(island);
         // Build - expect success
         SafeSpotTeleport result = sstb.build();


### PR DESCRIPTION
This PR enables the protection area to move anywhere within the island boundaries. This is required to enable a new game mode I'm working on where the island protection zone starts small and increases based on achievements/challenges. I need a way to move the protection zone anywhere within the island boundaries and not be locked to the center.

I added an admin command to enable manual setting of the island location. I also expanded the info command to show the island location.

In summary, the island location is the center of the protection area. It is usually the center of the island but can be moved. The protection area will not go outside the island range. However, as it is possible for the island location to be right on the edge of the island range, the protection range value can now be up to the diameter of the island, i.e., 2 * island range.