### PR TITLE
Fix a minor problem in language translation

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/localization/BentoBoxLocale.java
+++ b/src/main/java/world/bentobox/bentobox/api/localization/BentoBoxLocale.java
@@ -53,8 +53,9 @@ public class BentoBoxLocale {
      * @return Text for this locale reference or the reference if nothing has been found
      */
     public String get(String reference) {
-        if (config.contains(reference)) {
-            return config.getString(reference);
+        Object obj = config.get(reference);
+        if (obj instanceof String) {
+            return obj.toString();
         }
         return reference; // return reference in case nothing has been found
     }


### PR DESCRIPTION
If you use `config.getString()`, when you encounter such a Yaml section:

```
root:
  materials:
    cobblestone: 'Cobblestone'
    stone:
      name: 'Stone'
      description: 'Just a stone'
```

Like this: `config.getString("root.materials.cobblestone")`
Will return: `"Cobblestone"`

This way: `config.getString("root.materials.stone")`
Will return: `"MemorySection[path='root.materials.stone', root='YamlConfiguration']"`

Therefore, you should use `config.get()`, and then check the returned object type.