### PR TITLE
Implements ability to use faster player head gatherer

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -138,11 +138,27 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "panel.filler-material", since = "1.14.0")
     private Material panelFillerMaterial = Material.LIGHT_BLUE_STAINED_GLASS_PANE;
 
+    @ConfigComment("Toggle whether player head texture should be gathered from Mojang API or mc-heads.net cache server.")
+    @ConfigComment("Mojang API sometime may be slow and may limit requests to the player data, so this will allow to")
+    @ConfigComment("get player heads a bit faster then Mojang API.")
+    @ConfigEntry(path = "panel.use-cache-server", since = "1.16.0")
+    private boolean useCacheServer = false;
+
     @ConfigComment("Defines how long player skin texture link is stored into local cache before it is requested again.")
     @ConfigComment("Defined value is in the minutes.")
     @ConfigComment("Value 0 will not clear cache until server restart.")
     @ConfigEntry(path = "panel.head-cache-time", since = "1.14.1")
     private long playerHeadCacheTime = 60;
+
+    @ConfigComment("Defines a number of player heads requested per tasks.")
+    @ConfigComment("Setting it too large may lead to temporarily being blocked from head gatherer API.")
+    @ConfigEntry(path = "panel.heads-per-call", since = "1.16.0")
+    private int headsPerCall = 9;
+
+    @ConfigComment("Defines a number of ticks between each player head request task.")
+    @ConfigComment("Setting it too large may lead to temporarily being blocked from head gatherer API.")
+    @ConfigEntry(path = "panel.ticks-between-calls", since = "1.16.0", needsRestart = true)
+    private long ticksBetweenCalls = 10;
 
     /*
      * Logs
@@ -783,4 +799,76 @@ public class Settings implements ConfigObject {
 	{
 		this.playerHeadCacheTime = playerHeadCacheTime;
 	}
+
+
+    /**
+     * Is use cache server boolean.
+     *
+     * @return the boolean
+     * @since 1.16.0
+     */
+    public boolean isUseCacheServer()
+    {
+        return useCacheServer;
+    }
+
+
+    /**
+     * Sets use cache server.
+     *
+     * @param useCacheServer the use cache server
+     * @since 1.16.0
+     */
+    public void setUseCacheServer(boolean useCacheServer)
+    {
+        this.useCacheServer = useCacheServer;
+    }
+
+
+    /**
+     * Gets heads per call.
+     *
+     * @return the heads per call
+     * @since 1.16.0
+     */
+    public int getHeadsPerCall()
+    {
+        return headsPerCall;
+    }
+
+
+    /**
+     * Sets heads per call.
+     *
+     * @param headsPerCall the heads per call
+     * @since 1.16.0
+     */
+    public void setHeadsPerCall(int headsPerCall)
+    {
+        this.headsPerCall = headsPerCall;
+    }
+
+
+    /**
+     * Gets ticks between calls.
+     *
+     * @return the ticks between calls
+     * @since 1.16.0
+     */
+    public long getTicksBetweenCalls()
+    {
+        return ticksBetweenCalls;
+    }
+
+
+    /**
+     * Sets ticks between calls.
+     *
+     * @param ticksBetweenCalls the ticks between calls
+     * @since 1.16.0
+     */
+    public void setTicksBetweenCalls(long ticksBetweenCalls)
+    {
+        this.ticksBetweenCalls = ticksBetweenCalls;
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -82,11 +82,25 @@ panel:
   # Defines the Material of the item that fills the gaps (in the header, etc.) of most panels.
   # Added since 1.14.0.
   filler-material: LIGHT_BLUE_STAINED_GLASS_PANE
+  # Toggle whether player head texture should be gathered from Mojang API or mc-heads.net cache server.
+  # Mojang API sometime may be slow and may limit requests to the player data, so this will allow to
+  # get player heads a bit faster then Mojang API.
+  # Added since 1.16.0.
+  use-cache-server: true
   # Defines how long player skin texture link is stored into local cache before it is requested again.
   # Defined value is in the minutes.
   # Value 0 will not clear cache until server restart.
   # Added since 1.14.1.
   head-cache-time: 60
+  # Defines a number of player heads requested per tasks.
+  # Setting it too large may lead to temporarily being blocked from head gatherer API.
+  # Added since 1.16.0.
+  heads-per-call: 9
+  # Defines a number of ticks between each player head request task.
+  # Setting it too large may lead to temporarily being blocked from head gatherer API.
+  # Added since 1.16.0.
+  # /!\ In order to apply the changes made to this option, you must restart your server. Reloading BentoBox or the server won't work.
+  ticks-between-calls: 10
 logs:
   # Toggle whether superflat chunks regeneration should be logged in the server logs or not.
   # It can be spammy if there are a lot of superflat chunks to regenerate.


### PR DESCRIPTION
 Relates to #1646.

Adds 3 new BentoBox options:
- use-cache-server: option which allows using mc-heads.net API for gathering player heads. It is a bit faster than Mojang API.
- heads-per-call: option which allows specifying how many heads will be requested at once per each API call.
- ticks-between-calls: option which allows specifying how many ticks should wait until the next API call.

All these options will allow a much faster player head gatherer.

Changes include optimization for Mojang API too. For servers in online mode, HeadGetter will use Player UUID, instead of asking for UUID from API.