### PR TITLE
Enables panels to know the context of the world that initiated them.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommand.java
@@ -78,9 +78,9 @@ public class AdminSettingsCommand extends CompositeCommand {
         // Player settings
         new TabbedPanelBuilder()
         .user(user)
-        .world(getWorld())
-        .tab(1, new SettingsTab(getWorld(), user, island, Flag.Type.PROTECTION))
-        .tab(2, new SettingsTab(getWorld(), user, island, Flag.Type.SETTING))
+        .world(island.getWorld())
+        .tab(1, new SettingsTab(user, island, Flag.Type.PROTECTION))
+        .tab(2, new SettingsTab(user, island, Flag.Type.SETTING))
         .startingSlot(1)
         .size(54)
         .build().openPanel();

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
@@ -15,6 +15,8 @@ import world.bentobox.bentobox.util.Util;
  */
 public class IslandSettingsCommand extends CompositeCommand {
 
+    private Island island;
+
     public IslandSettingsCommand(CompositeCommand islandCommand) {
         super(islandCommand, "settings", "flags", "options");
     }
@@ -28,23 +30,26 @@ public class IslandSettingsCommand extends CompositeCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
-        // Settings are only shown if you are in the right world
         if (Util.getWorld(user.getWorld()).equals(getWorld())) {
-            return true;
+            // Player is in same world
+            island = getIslands().getIslandAt(user.getLocation()).orElseGet(() -> getIslands().getIsland(user.getWorld(), user.getUniqueId()));
         } else {
-            user.sendMessage("general.errors.wrong-world");
+            island = getIslands().getIsland(getWorld(), user);
+        }
+        if (island == null) {
+            user.sendMessage("general.errors.no-island");
             return false;
         }
+        return true;
     }
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        Island island = getIslands().getIslandAt(user.getLocation()).orElseGet(() -> getIslands().getIsland(user.getWorld(), user.getUniqueId()));
         new TabbedPanelBuilder()
         .user(user)
-        .world(getWorld())
-        .tab(1, new SettingsTab(getWorld(), user, island, Flag.Type.PROTECTION))
-        .tab(2, new SettingsTab(getWorld(), user, island, Flag.Type.SETTING))
+        .world(island.getWorld())
+        .tab(1, new SettingsTab(user, island, Flag.Type.PROTECTION))
+        .tab(2, new SettingsTab(user, island, Flag.Type.SETTING))
         .startingSlot(1)
         .size(54)
         .hideIfEmpty()

--- a/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
@@ -4,12 +4,14 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.eclipse.jdt.annotation.NonNull;
 
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.listeners.PanelListenerManager;
 import world.bentobox.bentobox.util.heads.HeadGetter;
@@ -27,6 +29,7 @@ public class Panel implements HeadRequester, InventoryHolder {
     private PanelListener listener;
     private User user;
     private String name;
+    private World world;
 
     /**
      * Various types of Panel that can be created.
@@ -49,6 +52,17 @@ public class Panel implements HeadRequester, InventoryHolder {
      */
     public Panel(String name, Map<Integer, PanelItem> items, int size, User user, PanelListener listener, Type type) {
         makePanel(name, items, size, user, listener, type);
+    }
+
+    /**
+     * @param pb - PanelBuilder
+     * @since 1.16.0
+     */
+    public Panel(PanelBuilder pb) {
+        this.world = pb.getWorld();
+        this.makePanel(pb.getName(), pb.getItems(),
+                Math.max(pb.getSize(), pb.getItems().isEmpty() ? pb.getSize() : pb.getItems().lastKey() + 1),
+                pb.getUser(), pb.getListener(), pb.getPanelType());
     }
 
     protected void makePanel(String name, Map<Integer, PanelItem> items, int size, User user,
@@ -200,4 +214,23 @@ public class Panel implements HeadRequester, InventoryHolder {
     public String getName() {
         return name;
     }
+
+    /**
+     * Get the world that applies to this panel
+     * @return the optional world
+     * @since 1.16.0
+     */
+    public Optional<World> getWorld() {
+        return Optional.ofNullable(world);
+    }
+
+    /**
+     * @param world the world to set
+     * @since 1.16.0
+     */
+    public void setWorld(World world) {
+        this.world = world;
+    }
+
+
 }

--- a/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
@@ -42,6 +42,7 @@ public class TabbedPanel extends Panel implements PanelListener {
      */
     public TabbedPanel(TabbedPanelBuilder tpb) {
         this.tpb = tpb;
+        this.setWorld(tpb.getWorld());
     }
 
     /* (non-Javadoc)

--- a/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelBuilder.java
@@ -4,6 +4,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.bukkit.ChatColor;
+import org.bukkit.World;
 
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem;
@@ -22,6 +23,7 @@ public class PanelBuilder {
     private User user;
     private PanelListener listener;
     private Panel.Type type = Panel.Type.INVENTORY;
+    private World world;
 
     public PanelBuilder name(String name) {
         this.name = ChatColor.translateAlternateColorCodes('&', name);
@@ -116,12 +118,21 @@ public class PanelBuilder {
     }
 
     /**
+     * Set the game world that applies this panel
+     * @param world
+     * @return PanelBuilder
+     */
+    public PanelBuilder world(World world) {
+        this.world = world;
+        return this;
+    }
+
+    /**
      * Build the panel
      * @return Panel
      */
     public Panel build() {
-        // items.lastKey() is a slot position, so the panel size is this value + 1
-        return new Panel(name, items, Math.max(size, items.isEmpty() ? size : items.lastKey() + 1), user, listener, type);
+        return new Panel(this);
     }
 
     /**
@@ -167,4 +178,14 @@ public class PanelBuilder {
     public Panel.Type getPanelType() {
         return type;
     }
+
+    /**
+     * @return the world
+     * @since 1.16.0
+     */
+    public World getWorld() {
+        return world;
+    }
+
+
 }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClick.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClick.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.listeners.flags.clicklisteners;
 
 import org.bukkit.Sound;
+import org.bukkit.World;
 import org.bukkit.event.inventory.ClickType;
 
 import world.bentobox.bentobox.BentoBox;
@@ -32,8 +33,9 @@ public class CommandCycleClick implements ClickHandler {
     public boolean onClick(Panel panel, User user, ClickType click, int slot) {
         // Left clicking increases the rank required
         // Right clicking decreases the rank required
-        // Get the user's island
-        Island island = plugin.getIslands().getIsland(user.getWorld(), user.getUniqueId());
+        // Get the user's island for the game world
+        World world = panel.getWorld().orElse(user.getWorld());
+        Island island = plugin.getIslands().getIsland(world, user.getUniqueId());
         if (island != null && island.getOwner().equals(user.getUniqueId())) {
             RanksManager rm = plugin.getRanksManager();
             int currentRank = island.getRankCommand(command);
@@ -53,7 +55,7 @@ public class CommandCycleClick implements ClickHandler {
                 user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1F, 1F);
             }
             // Apply change to panel
-            panel.getInventory().setItem(slot, commandRankClickListener.getPanelItem(command, user).getItem());
+            panel.getInventory().setItem(slot, commandRankClickListener.getPanelItem(command, user, world).getItem());
             // Save island
             plugin.getIslands().save(island);
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoLimitClickListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoLimitClickListener.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.listeners.flags.clicklisteners;
 
 import org.bukkit.Sound;
+import org.bukkit.World;
 import org.bukkit.event.inventory.ClickType;
 
 import world.bentobox.bentobox.BentoBox;
@@ -26,8 +27,9 @@ public class GeoLimitClickListener implements ClickHandler {
             user.sendMessage("general.errors.wrong-world");
             return true;
         }
+        World world = panel.getWorld().orElse(user.getWorld());
         IslandWorldManager iwm = BentoBox.getInstance().getIWM();
-        String reqPerm = iwm.getPermissionPrefix(Util.getWorld(user.getWorld())) + "admin.settings.GEO_LIMIT_MOBS";
+        String reqPerm = iwm.getPermissionPrefix(Util.getWorld(world)) + "admin.settings.GEO_LIMIT_MOBS";
         if (!user.hasPermission(reqPerm)) {
             user.sendMessage("general.errors.no-permission", "[permission]", reqPerm);
             user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
@@ -35,19 +37,19 @@ public class GeoLimitClickListener implements ClickHandler {
         }
 
         // Open the Sub Settings panel
-        openPanel(user);
+        openPanel(user, world);
 
         return true;
     }
 
-    private void openPanel(User user) {
+    private void openPanel(User user, World world) {
         // Close the current panel
         user.closeInventory();
         // Open a new panel
         new TabbedPanelBuilder()
         .user(user)
-        .world(user.getWorld())
-        .tab(1, new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT))
+        .world(world)
+        .tab(1, new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world))
         .startingSlot(1)
         .size(54)
         .build().openPanel();

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
@@ -7,10 +7,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.inventory.ClickType;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
+
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -47,43 +49,45 @@ public class GeoMobLimitTab implements Tab, ClickHandler {
     private final BentoBox plugin = BentoBox.getInstance();
     private final User user;
     private final EntityLimitTabType type;
+    private final World world;
 
     /**
      * @param user - user viewing the tab
      * @param type - type of tab to show - Geo limit or Mob limit
+     * @param world - world where this tab is being used
      */
-    public GeoMobLimitTab(@NonNull User user, @NonNull EntityLimitTabType type) {
+    public GeoMobLimitTab(@NonNull User user, @NonNull EntityLimitTabType type, World world) {
         super();
         this.user = user;
         this.type = type;
+        this.world = world;
     }
 
 
     @Override
     public boolean onClick(Panel panel, User user, ClickType clickType, int slot) {
-        // This is a click on the mob limit panel
         // Case panel to Tabbed Panel to get the active page
         TabbedPanel tp = (TabbedPanel)panel;
         // Convert the slot and active page to an index
         int index = tp.getActivePage() * 36 + slot - 9;
         EntityType c = LIVING_ENTITY_TYPES.get(index);
         if (type == EntityLimitTabType.MOB_LIMIT) {
-            if (plugin.getIWM().getMobLimitSettings(user.getWorld()).contains(c.name())) {
-                plugin.getIWM().getMobLimitSettings(user.getWorld()).remove(c.name());
+            if (plugin.getIWM().getMobLimitSettings(world).contains(c.name())) {
+                plugin.getIWM().getMobLimitSettings(world).remove(c.name());
             } else {
-                plugin.getIWM().getMobLimitSettings(user.getWorld()).add(c.name());
+                plugin.getIWM().getMobLimitSettings(world).add(c.name());
             }
         } else {
-            if (plugin.getIWM().getGeoLimitSettings(user.getWorld()).contains(c.name())) {
-                plugin.getIWM().getGeoLimitSettings(user.getWorld()).remove(c.name());
+            if (plugin.getIWM().getGeoLimitSettings(world).contains(c.name())) {
+                plugin.getIWM().getGeoLimitSettings(world).remove(c.name());
             } else {
-                plugin.getIWM().getGeoLimitSettings(user.getWorld()).add(c.name());
+                plugin.getIWM().getGeoLimitSettings(world).add(c.name());
             }
         }
         // Apply change to panel
         panel.getInventory().setItem(slot, getPanelItem(c, user).getItem());
         // Save settings
-        plugin.getIWM().getAddon(Util.getWorld(user.getWorld())).ifPresent(GameModeAddon::saveWorldSettings);
+        plugin.getIWM().getAddon(Util.getWorld(world)).ifPresent(GameModeAddon::saveWorldSettings);
         return true;
     }
 
@@ -119,7 +123,7 @@ public class GeoMobLimitTab implements Tab, ClickHandler {
         pib.name(Util.prettifyText(c.toString()));
         pib.clickHandler(this);
         if (type == EntityLimitTabType.MOB_LIMIT) {
-            if (!BentoBox.getInstance().getIWM().getMobLimitSettings(user.getWorld()).contains(c.name())) {
+            if (!BentoBox.getInstance().getIWM().getMobLimitSettings(world).contains(c.name())) {
                 pib.icon(Material.GREEN_SHULKER_BOX);
                 pib.description(user.getTranslation("protection.flags.LIMIT_MOBS.can"));
             } else {
@@ -127,7 +131,7 @@ public class GeoMobLimitTab implements Tab, ClickHandler {
                 pib.description(user.getTranslation("protection.flags.LIMIT_MOBS.cannot"));
             }
         } else {
-            if (BentoBox.getInstance().getIWM().getGeoLimitSettings(user.getWorld()).contains(c.name())) {
+            if (BentoBox.getInstance().getIWM().getGeoLimitSettings(world).contains(c.name())) {
                 pib.icon(Material.GREEN_SHULKER_BOX);
                 pib.description(user.getTranslation("protection.panel.flag-item.setting-active"));
             } else {

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/MobLimitClickListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/MobLimitClickListener.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.listeners.flags.clicklisteners;
 
 import org.bukkit.Sound;
+import org.bukkit.World;
 import org.bukkit.event.inventory.ClickType;
 
 import world.bentobox.bentobox.BentoBox;
@@ -26,8 +27,9 @@ public class MobLimitClickListener implements ClickHandler {
             user.sendMessage("general.errors.wrong-world");
             return true;
         }
+        World world = panel.getWorld().orElse(user.getWorld());
         IslandWorldManager iwm = BentoBox.getInstance().getIWM();
-        String reqPerm = iwm.getPermissionPrefix(Util.getWorld(user.getWorld())) + "admin.settings.LIMIT_MOBS";
+        String reqPerm = iwm.getPermissionPrefix(Util.getWorld(world)) + "admin.settings.LIMIT_MOBS";
         if (!user.hasPermission(reqPerm)) {
             user.sendMessage("general.errors.no-permission", "[permission]", reqPerm);
             user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_METAL_HIT, 1F, 1F);
@@ -35,19 +37,19 @@ public class MobLimitClickListener implements ClickHandler {
         }
 
         // Open the Sub Settings panel
-        openPanel(user);
+        openPanel(user, world);
 
         return true;
     }
 
-    private void openPanel(User user) {
+    private void openPanel(User user, World world) {
         // Close the current panel
         user.closeInventory();
         // Open a new panel
         new TabbedPanelBuilder()
         .user(user)
-        .world(user.getWorld())
-        .tab(1, new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT))
+        .world(world)
+        .tab(1, new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world))
         .startingSlot(1)
         .size(54)
         .build().openPanel();

--- a/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
+++ b/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
@@ -47,16 +47,15 @@ public class SettingsTab implements Tab, ClickHandler {
 
     /**
      * Show a tab of settings
-     * @param world - world
      * @param user - user who is viewing the tab
      * @param island - the island
      * @param type - flag type
      */
-    public SettingsTab(World world, User user, Island island, Type type) {
-        this.world = world;
+    public SettingsTab(User user, Island island, Type type) {
         this.user = user;
         this.island = island;
         this.type = type;
+        this.world = island.getWorld();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.Inventory;
 import org.eclipse.jdt.annotation.NonNull;
@@ -38,17 +39,20 @@ import world.bentobox.bentobox.api.panels.TabbedPanel;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab.EntityLimitTabType;
 import world.bentobox.bentobox.managers.IslandWorldManager;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * @author tastybento
  *
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Bukkit.class, BentoBox.class})
+@PrepareForTest({Bukkit.class, BentoBox.class, Util.class})
 public class GeoMobLimitTabTest {
 
     @Mock
     private User user;
+    @Mock
+    private World world;
     @Mock
     private TabbedPanel panel;
     @Mock
@@ -82,6 +86,9 @@ public class GeoMobLimitTabTest {
         when(panel.getInventory()).thenReturn(inv);
         // User
         when(user.getTranslation(anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+        // Util
+        PowerMockito.mockStatic(Util.class, Mockito.CALLS_REAL_METHODS);
+        when(Util.getWorld(any())).thenReturn(world);
     }
 
     @After
@@ -94,7 +101,7 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testOnClick() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         // BAT and COW in list
         assertEquals(2, list.size());
         assertEquals("COW", list.get(1));
@@ -116,7 +123,7 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testOnClickMobLimit() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world);
         // BAT and COW in list
         assertEquals(2, list.size());
         assertEquals("COW", list.get(1));
@@ -138,7 +145,7 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testGetIcon() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world);
         PanelItem icon = tab.getIcon();
         assertEquals("protection.flags.LIMIT_MOBS.name", icon.getName());
         assertEquals(Material.IRON_BOOTS, icon.getItem().getType());
@@ -149,7 +156,7 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testGetIconGeoLimit() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         PanelItem icon = tab.getIcon();
         assertEquals("protection.flags.GEO_LIMIT_MOBS.name", icon.getName());
         assertEquals(Material.CHAINMAIL_CHESTPLATE, icon.getItem().getType());
@@ -160,9 +167,9 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testGetName() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world);
         assertEquals("protection.flags.LIMIT_MOBS.name", tab.getName());
-        tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT);
+        tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         assertEquals("protection.flags.GEO_LIMIT_MOBS.name", tab.getName());
     }
 
@@ -171,14 +178,14 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testGetPanelItemsMobLimit() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world);
         List<@Nullable PanelItem> items = tab.getPanelItems();
         assertFalse(items.isEmpty());
         items.forEach(i -> {
             if (i.getName().equals("Cow") || i.getName().equals("Bat")) {
-                assertEquals(Material.RED_SHULKER_BOX, i.getItem().getType());
+                assertEquals("Name : " + i.getName(), Material.RED_SHULKER_BOX, i.getItem().getType());
             } else {
-                assertEquals(Material.GREEN_SHULKER_BOX, i.getItem().getType());
+                assertEquals("Name : " + i.getName(), Material.GREEN_SHULKER_BOX, i.getItem().getType());
             }
         });
     }
@@ -188,14 +195,14 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testGetPanelItemsGeoLimit() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         List<@Nullable PanelItem> items = tab.getPanelItems();
         assertFalse(items.isEmpty());
         items.forEach(i -> {
             if (i.getName().equals("Cow") || i.getName().equals("Bat")) {
-                assertEquals(Material.GREEN_SHULKER_BOX, i.getItem().getType());
+                assertEquals("Name : " + i.getName(), Material.GREEN_SHULKER_BOX, i.getItem().getType());
             } else {
-                assertEquals(Material.RED_SHULKER_BOX, i.getItem().getType());
+                assertEquals("Name : " + i.getName(), Material.RED_SHULKER_BOX, i.getItem().getType());
             }
         });
     }
@@ -205,7 +212,7 @@ public class GeoMobLimitTabTest {
      */
     @Test
     public void testGetPermission() {
-        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT);
+        GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         assertTrue(tab.getPermission().isEmpty());
     }
 


### PR DESCRIPTION
Panel API did not have this context so commands had to force players to
be in the world that the command used. These changes add the world
context to the PanelBuilder and changes the settings panels to use it.
Players and admins can now run settings commands in any world.

https://github.com/BentoBoxWorld/BentoBox/issues/1673