### PR TITLE
Adds maxMembers to the Island object for persistent storage

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -31,8 +31,6 @@ public class IslandTeamCommand extends CompositeCommand {
      */
     private Map<UUID, Invite> inviteMap;
 
-    private IslandTeamInviteCommand inviteCommand;
-
     public IslandTeamCommand(CompositeCommand parent) {
         super(parent, "team");
         inviteMap = new HashMap<>();
@@ -44,7 +42,7 @@ public class IslandTeamCommand extends CompositeCommand {
         setOnlyPlayer(true);
         setDescription("commands.island.team.description");
         // Register commands
-        inviteCommand = new IslandTeamInviteCommand(this);
+        new IslandTeamInviteCommand(this);
         new IslandTeamLeaveCommand(this);
         new IslandTeamSetownerCommand(this);
         new IslandTeamKickCommand(this);
@@ -73,9 +71,13 @@ public class IslandTeamCommand extends CompositeCommand {
             // Cancelled
             return false;
         }
+        Island island = getIslands().getIsland(getWorld(), playerUUID);
+        if (island == null) {
+            return false;
+        }
         Set<UUID> teamMembers = getMembers(getWorld(), user);
         if (ownerUUID.equals(playerUUID)) {
-            int maxSize = inviteCommand.getMaxTeamSize(user);
+            int maxSize = getIslands().getMaxMembers(island, RanksManager.MEMBER_RANK);
             if (teamMembers.size() < maxSize) {
                 user.sendMessage("commands.island.team.invite.you-can-invite", TextVariables.NUMBER, String.valueOf(maxSize - teamMembers.size()));
             } else {
@@ -83,7 +85,7 @@ public class IslandTeamCommand extends CompositeCommand {
             }
         }
         // Show members of island
-        showMembers(getIslands().getIsland(getWorld(), playerUUID), user);
+        showMembers(island, user);
         return true;
     }
 
@@ -101,7 +103,7 @@ public class IslandTeamCommand extends CompositeCommand {
 
         // Show header:
         user.sendMessage("commands.island.team.info.header",
-                "[max]", String.valueOf(inviteCommand.getMaxTeamSize(user)),
+                "[max]", String.valueOf(getIslands().getMaxMembers(island, RanksManager.MEMBER_RANK)),
                 "[total]", String.valueOf(island.getMemberSet().size()),
                 "[online]", String.valueOf(onlineMembers.size()));
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommand.java
@@ -99,7 +99,7 @@ public class IslandTeamCoopCommand extends CompositeCommand {
                 target.sendMessage("commands.island.team.coop.name-has-invited-you", TextVariables.NAME, user.getName());
                 target.sendMessage("commands.island.team.invite.to-accept-or-reject", TextVariables.LABEL, getTopLabel());
             } else {
-                if (island.getMemberSet(RanksManager.COOP_RANK, false).size() > getMaxCoopSize(user)) {
+                if (island.getMemberSet(RanksManager.COOP_RANK, false).size() >= getIslands().getMaxMembers(island, RanksManager.COOP_RANK)) {
                     user.sendMessage("commands.island.team.coop.is-full");
                     return false;
                 }
@@ -126,13 +126,4 @@ public class IslandTeamCoopCommand extends CompositeCommand {
         return Optional.of(Util.tabLimit(Util.getOnlinePlayerList(user), lastArg));
     }
 
-    /**
-     * Gets the maximum coop size for this player in this game based on the permission or the world's setting
-     * @param user user
-     * @return max coop size of user
-     * @since 1.13.0
-     */
-    public int getMaxCoopSize(User user) {
-        return user.getPermissionValue(getPermissionPrefix() + "coop.maxsize", getIWM().getMaxCoopSize(getWorld()));
-    }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -101,6 +101,10 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
         if (inviter != null) {
             Island island = getIslands().getIsland(getWorld(), inviter);
             if (island != null) {
+                if (island.getMemberSet(RanksManager.TRUSTED_RANK, false).size() > getIslands().getMaxMembers(island, RanksManager.TRUSTED_RANK)) {
+                    user.sendMessage("commands.island.team.trust.is-full");
+                    return;
+                }
                 island.setRank(user, RanksManager.TRUSTED_RANK);
                 IslandEvent.builder()
                 .island(island)
@@ -122,6 +126,10 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
         if (inviter != null) {
             Island island = getIslands().getIsland(getWorld(), inviter);
             if (island != null) {
+                if (island.getMemberSet(RanksManager.COOP_RANK, false).size() > getIslands().getMaxMembers(island, RanksManager.COOP_RANK)) {
+                    user.sendMessage("commands.island.team.coop.is-full");
+                    return;
+                }
                 island.setRank(user, RanksManager.COOP_RANK);
                 IslandEvent.builder()
                 .island(island)
@@ -143,6 +151,10 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
         Island island = getIslands().getIsland(getWorld(), playerUUID);
         // Get the team's island
         Island teamIsland = getIslands().getIsland(getWorld(), prospectiveOwnerUUID);
+        if (teamIsland.getMemberSet(RanksManager.MEMBER_RANK, true).size() > getIslands().getMaxMembers(teamIsland, RanksManager.MEMBER_RANK)) {
+            user.sendMessage("commands.island.team.invite.errors.island-is-full");
+            return;
+        }
         // Remove player as owner of the old island
         getIslands().removePlayer(getWorld(), playerUUID);
         // Remove money inventory etc. for leaving

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommand.java
@@ -101,7 +101,7 @@ public class IslandTeamTrustCommand extends CompositeCommand {
                 target.sendMessage("commands.island.team.trust.name-has-invited-you", TextVariables.NAME, user.getName());
                 target.sendMessage("commands.island.team.invite.to-accept-or-reject", TextVariables.LABEL, getTopLabel());
             } else {
-                if (island.getMemberSet(RanksManager.TRUSTED_RANK, false).size() > getMaxTrustSize(user)) {
+                if (island.getMemberSet(RanksManager.TRUSTED_RANK, false).size() >= getIslands().getMaxMembers(island, RanksManager.TRUSTED_RANK)) {
                     user.sendMessage("commands.island.team.trust.is-full");
                     return false;
                 }
@@ -128,13 +128,4 @@ public class IslandTeamTrustCommand extends CompositeCommand {
         return Optional.of(Util.tabLimit(Util.getOnlinePlayerList(user), lastArg));
     }
 
-    /**
-     * Gets the maximum trust size for this player in this game based on the permission or the world's setting
-     * @param user user
-     * @return max trust size of user
-     * @since 1.13.0
-     */
-    public int getMaxTrustSize(User user) {
-        return user.getPermissionValue(getPermissionPrefix() + "trust.maxsize", getIWM().getMaxTrustSize(getWorld()));
-    }
 }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -142,10 +142,11 @@ public class Island implements DataObject, MetaDataAble {
 
     /**
      * Maximum number of members allowed in this island.
+     * Key is rank, value is number
      * @since 1.16.0
      */
     @Expose
-    private Integer maxMembers;
+    private Map<Integer, Integer> maxMembers;
 
     //// State ////
     @Expose
@@ -1419,22 +1420,41 @@ public class Island implements DataObject, MetaDataAble {
     }
 
     /**
-     * Get the maximum number of island members
-     * @return the maxMembers - if null then the world default should be used. Negative values = unlimited.
+     * @return the maxMembers
      * @since 1.16.0
      */
-    @Nullable
-    public Integer getMaxMembers() {
-        return maxMembers;
+    public Map<Integer, Integer> getMaxMembers() {
+        return maxMembers == null ? new HashMap<>() : maxMembers;
     }
 
     /**
+     * @param maxMembers the maxMembers to set
+     * @since 1.16.0
+     */
+    public void setMaxMembers(Map<Integer, Integer> maxMembers) {
+        this.maxMembers = maxMembers;
+    }
+
+    /**
+     * Get the maximum number of island members
+     * @param rank island rank value from {@link RanksManager}
+     * @return the maxMembers for the rank given - if null then the world default should be used. Negative values = unlimited.
+     * @since 1.16.0
+     */
+    @Nullable
+    public Integer getMaxMembers(int rank) {
+        return getMaxMembers().get(rank);
+    }
+
+
+    /**
      * Set the maximum number of island members
+     * @param rank island rank value from {@link RanksManager}
      * @param maxMembers the maxMembers to set. If null then the world default applies. Negative values = unlimited.
      * @since 1.16.0
      */
-    public void setMaxMembers(@Nullable Integer maxMembers) {
-        this.maxMembers = maxMembers;
+    public void setMaxMembers(int rank, Integer maxMembers) {
+        getMaxMembers().put(rank, maxMembers);
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -140,6 +140,13 @@ public class Island implements DataObject, MetaDataAble {
     @Expose
     private Map<UUID, Integer> members = new HashMap<>();
 
+    /**
+     * Maximum number of members allowed in this island.
+     * @since 1.16.0
+     */
+    @Expose
+    private Integer maxMembers;
+
     //// State ////
     @Expose
     private boolean spawn = false;
@@ -1411,6 +1418,25 @@ public class Island implements DataObject, MetaDataAble {
         setChanged();
     }
 
+    /**
+     * Get the maximum number of island members
+     * @return the maxMembers - if null then the world default should be used. Negative values = unlimited.
+     * @since 1.16.0
+     */
+    @Nullable
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
+
+    /**
+     * Set the maximum number of island members
+     * @param maxMembers the maxMembers to set. If null then the world default applies. Negative values = unlimited.
+     * @since 1.16.0
+     */
+    public void setMaxMembers(@Nullable Integer maxMembers) {
+        this.maxMembers = maxMembers;
+    }
+
     @Override
     public String toString() {
         return "Island [changed=" + changed + ", deleted=" + deleted + ", "
@@ -1422,9 +1448,9 @@ public class Island implements DataObject, MetaDataAble {
                 + (gameMode != null ? "gameMode=" + gameMode + ", " : "") + (name != null ? "name=" + name + ", " : "")
                 + "createdDate=" + createdDate + ", updatedDate=" + updatedDate + ", "
                 + (owner != null ? "owner=" + owner + ", " : "") + (members != null ? "members=" + members + ", " : "")
-                + "spawn=" + spawn + ", purgeProtected=" + purgeProtected + ", "
-                + (flags != null ? "flags=" + flags + ", " : "") + (history != null ? "history=" + history + ", " : "")
-                + "levelHandicap=" + levelHandicap + ", "
+                + (maxMembers != null ? "maxMembers=" + maxMembers + ", " : "") + "spawn=" + spawn + ", purgeProtected="
+                + purgeProtected + ", " + (flags != null ? "flags=" + flags + ", " : "")
+                + (history != null ? "history=" + history + ", " : "") + "levelHandicap=" + levelHandicap + ", "
                 + (spawnPoint != null ? "spawnPoint=" + spawnPoint + ", " : "") + "doNotLoad=" + doNotLoad + ", "
                 + (cooldowns != null ? "cooldowns=" + cooldowns + ", " : "")
                 + (commandRanks != null ? "commandRanks=" + commandRanks + ", " : "")

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -51,7 +51,7 @@ public class JoinLeaveListener implements Listener {
         if (user == null || user.getUniqueId() == null) {
             return;
         }
-        UUID playerUUID = user.getUniqueId();
+        UUID playerUUID = event.getPlayer().getUniqueId();
 
         // Check if player hasn't joined before
         if (!players.isKnown(playerUUID)) {
@@ -89,6 +89,16 @@ public class JoinLeaveListener implements Listener {
 
         // Clear inventory if required
         clearPlayersInventory(Util.getWorld(event.getPlayer().getWorld()), user);
+
+        // Set island max members based on permissions if this player is the owner of an island
+        plugin.getIWM().getOverWorlds().stream()
+        .map(w -> plugin.getIslands().getIsland(w, playerUUID))
+        .filter(i -> playerUUID.equals(i.getOwner()))
+        .forEach(i -> {
+            plugin.getIslands().getMaxMembers(i, RanksManager.MEMBER_RANK);
+            plugin.getIslands().getMaxMembers(i, RanksManager.COOP_RANK);
+            plugin.getIslands().getMaxMembers(i, RanksManager.TRUSTED_RANK);
+        });
     }
 
 

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -496,24 +496,32 @@ public class IslandsManager {
      * Will update the value based on world settings or island owner permissions (if online).
      * If the island is unowned, then this value will be 0.
      * @param island - island
+     * @param rank {@link RanksManager.MEMBER_RANK}, {@link RanksManager.COOP_RANK}, or {@link RanksManager.TRUSTED_RANK}
      * @return max number of members. If negative, then this means unlimited.
      */
-    public int getMaxMembers(@NonNull Island island) {
+    public int getMaxMembers(@NonNull Island island, int rank) {
         if (island.getOwner() == null) {
+            // No owner, no rank settings
             island.setMaxMembers(null);
             this.save(island);
             return 0;
         }
         // Island max is either the world default or specified amount for this island
         int worldDefault = plugin.getIWM().getMaxTeamSize(island.getWorld());
-        int islandMax = island.getMaxMembers() == null ? worldDefault : island.getMaxMembers();
+        if (rank == RanksManager.COOP_RANK) {
+            worldDefault = plugin.getIWM().getMaxCoopSize(island.getWorld());
+        } else if (rank == RanksManager.TRUSTED_RANK) {
+            worldDefault = plugin.getIWM().getMaxTrustSize(island.getWorld());
+        }
+
+        int islandMax = island.getMaxMembers() == null ? worldDefault : island.getMaxMembers(rank);
         // Update based on owner permissions if online
         if (Bukkit.getPlayer(island.getOwner()) != null) {
             User owner = User.getInstance(island.getOwner());
             islandMax = owner.getPermissionValue(plugin.getIWM().getPermissionPrefix(island.getWorld())
                     + "team.maxsize", islandMax);
         }
-        island.setMaxMembers(islandMax == worldDefault ? null : islandMax);
+        island.setMaxMembers(rank, islandMax == worldDefault ? null : islandMax);
         this.save(island);
         return islandMax;
     }
@@ -521,11 +529,12 @@ public class IslandsManager {
     /**
      * Sets the island max member size.
      * @param island - island
+     * @param rank {@link RanksManager.MEMBER_RANK}, {@link RanksManager.COOP_RANK}, or {@link RanksManager.TRUSTED_RANK}
      * @param maxMembers - max number of members. If negative, then this means unlimited. Null means the world
      * default will be used.
      */
-    public void setMaxMembers(@NonNull Island island, Integer maxMembers) {
-        island.setMaxMembers(maxMembers);
+    public void setMaxMembers(@NonNull Island island, int rank, Integer maxMembers) {
+        island.setMaxMembers(rank, maxMembers);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -492,6 +492,43 @@ public class IslandsManager {
     }
 
     /**
+     * Gets the maximum number of island members allowed on this island.
+     * Will update the value based on world settings or island owner permissions (if online).
+     * If the island is unowned, then this value will be 0.
+     * @param island - island
+     * @return max number of members. If negative, then this means unlimited.
+     */
+    public int getMaxMembers(@NonNull Island island) {
+        if (island.getOwner() == null) {
+            island.setMaxMembers(null);
+            this.save(island);
+            return 0;
+        }
+        // Island max is either the world default or specified amount for this island
+        int worldDefault = plugin.getIWM().getMaxTeamSize(island.getWorld());
+        int islandMax = island.getMaxMembers() == null ? worldDefault : island.getMaxMembers();
+        // Update based on owner permissions if online
+        if (Bukkit.getPlayer(island.getOwner()) != null) {
+            User owner = User.getInstance(island.getOwner());
+            islandMax = owner.getPermissionValue(plugin.getIWM().getPermissionPrefix(island.getWorld())
+                    + "team.maxsize", islandMax);
+        }
+        island.setMaxMembers(islandMax == worldDefault ? null : islandMax);
+        this.save(island);
+        return islandMax;
+    }
+
+    /**
+     * Sets the island max member size.
+     * @param island - island
+     * @param maxMembers - max number of members. If negative, then this means unlimited. Null means the world
+     * default will be used.
+     */
+    public void setMaxMembers(@NonNull Island island, Integer maxMembers) {
+        island.setMaxMembers(maxMembers);
+    }
+
+    /**
      * Returns the island at the location or Optional empty if there is none.
      * This includes only the protected area. Use {@link #getIslandAt(Location)}
      * for the full island space.

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -498,6 +498,7 @@ public class IslandsManager {
      * @param island - island
      * @param rank {@link RanksManager.MEMBER_RANK}, {@link RanksManager.COOP_RANK}, or {@link RanksManager.TRUSTED_RANK}
      * @return max number of members. If negative, then this means unlimited.
+     * @since 1.16.0
      */
     public int getMaxMembers(@NonNull Island island, int rank) {
         if (island.getOwner() == null) {
@@ -508,10 +509,13 @@ public class IslandsManager {
         }
         // Island max is either the world default or specified amount for this island
         int worldDefault = plugin.getIWM().getMaxTeamSize(island.getWorld());
+        String perm = "team.maxsize";
         if (rank == RanksManager.COOP_RANK) {
             worldDefault = plugin.getIWM().getMaxCoopSize(island.getWorld());
+            perm = "coop.maxsize";
         } else if (rank == RanksManager.TRUSTED_RANK) {
             worldDefault = plugin.getIWM().getMaxTrustSize(island.getWorld());
+            perm = "trust.maxsize";
         }
 
         int islandMax = island.getMaxMembers() == null ? worldDefault : island.getMaxMembers(rank);
@@ -519,7 +523,7 @@ public class IslandsManager {
         if (Bukkit.getPlayer(island.getOwner()) != null) {
             User owner = User.getInstance(island.getOwner());
             islandMax = owner.getPermissionValue(plugin.getIWM().getPermissionPrefix(island.getWorld())
-                    + "team.maxsize", islandMax);
+                    + perm, islandMax);
         }
         island.setMaxMembers(rank, islandMax == worldDefault ? null : islandMax);
         this.save(island);
@@ -532,6 +536,7 @@ public class IslandsManager {
      * @param rank {@link RanksManager.MEMBER_RANK}, {@link RanksManager.COOP_RANK}, or {@link RanksManager.TRUSTED_RANK}
      * @param maxMembers - max number of members. If negative, then this means unlimited. Null means the world
      * default will be used.
+     * @since 1.16.0
      */
     public void setMaxMembers(@NonNull Island island, int rank, Integer maxMembers) {
         island.setMaxMembers(rank, maxMembers);

--- a/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
@@ -5,6 +5,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+/**
+ * Ranks Manager
+ * Handles ranks and holds constants for various island ranks
+ * @author tastybento
+ *
+ */
 public class RanksManager {
 
     // Constants that define the hard coded rank values

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommandTest.java
@@ -39,6 +39,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
+import world.bentobox.bentobox.managers.RanksManager;
 
 /**
  * @author tastybento
@@ -103,6 +104,8 @@ public class IslandTeamCommandTest {
         when(plugin.getIslands()).thenReturn(im);
         // is owner of island
         when(im.getOwner(any(), any())).thenReturn(uuid);
+        // Max members
+        when(im.getMaxMembers(eq(island), eq(RanksManager.MEMBER_RANK))).thenReturn(3);
         // No team members
         when(im.getMembers(any(), any(UUID.class))).thenReturn(Collections.emptySet());
         // Add members
@@ -111,6 +114,7 @@ public class IslandTeamCommandTest {
         when(island.getMemberSet(anyInt(), any(Boolean.class))).thenReturn(set);
         when(island.getMemberSet(anyInt())).thenReturn(set);
         when(island.getMemberSet()).thenReturn(set);
+        when(island.getOwner()).thenReturn(uuid);
         // island
         when(im.getIsland(any(), eq(uuid))).thenReturn(island);
 
@@ -121,6 +125,7 @@ public class IslandTeamCommandTest {
         // IWM
         when(plugin.getIWM()).thenReturn(iwm);
         when(iwm.getPermissionPrefix(any())).thenReturn("bskyblock.");
+
 
         // Command under test
         tc = new IslandTeamCommand(ic);
@@ -176,7 +181,8 @@ public class IslandTeamCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringIslandIsFull() {
-        when(user.getPermissionValue(eq("bskyblock.team.maxsize"), anyInt())).thenReturn(0);
+        // Max members
+        when(im.getMaxMembers(eq(island), eq(RanksManager.MEMBER_RANK))).thenReturn(0);
         assertTrue(tc.execute(user, "team", Collections.emptyList()));
         verify(user).sendMessage(eq("commands.island.team.invite.errors.island-is-full"));
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
@@ -275,9 +275,27 @@ public class IslandTeamCoopCommandTest {
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
         assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         // Execute
-        when(im.getIsland(any(), Mockito.any(UUID.class))).thenReturn(null);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         verify(user).sendMessage(eq("general.errors.general"));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+     */
+    @Test
+    public void testExecuteTooManyCoops() {
+        Player p = mock(Player.class);
+        when(p.getUniqueId()).thenReturn(notUUID);
+        // Can execute
+        when(pm.getUUID(any())).thenReturn(notUUID);
+        when(im.getMembers(any(), any())).thenReturn(Collections.emptySet());
+        IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
+        assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
+        // Execute
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
+        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
+        verify(user).sendMessage("commands.island.team.coop.is-full");
     }
 
     /**
@@ -293,8 +311,10 @@ public class IslandTeamCoopCommandTest {
         when(im.getMembers(any(), any())).thenReturn(Collections.emptySet());
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
         assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
+        // Up to 3
+        when(im.getMaxMembers(eq(island), eq(RanksManager.COOP_RANK))).thenReturn(3);
         // Execute
-        when(im.getIsland(any(), Mockito.any(UUID.class))).thenReturn(island);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
         assertTrue(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
         verify(user).sendMessage("commands.island.team.coop.success",  TextVariables.NAME, null);
         verify(island).setRank(target, RanksManager.COOP_RANK);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
@@ -29,6 +29,8 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
+import com.google.common.collect.ImmutableSet;
+
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.commands.island.team.Invite.Type;
@@ -125,6 +127,7 @@ public class IslandTeamInviteCommandTest {
         // Island
         islandUUID = UUID.randomUUID();
         when(island.getUniqueId()).thenReturn(islandUUID.toString());
+        when(island.getMemberSet()).thenReturn(ImmutableSet.of(uuid));
 
         // Player has island to begin with
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
@@ -132,6 +135,7 @@ public class IslandTeamInviteCommandTest {
         when(im.getOwner(any(), eq(uuid))).thenReturn(uuid);
         when(island.getRank(any(User.class))).thenReturn(RanksManager.OWNER_RANK);
         when(im.getIsland(any(), eq(user))).thenReturn(island);
+        when(im.getMaxMembers(eq(island), anyInt())).thenReturn(4);
         when(plugin.getIslands()).thenReturn(im);
 
         // Has team
@@ -275,15 +279,13 @@ public class IslandTeamInviteCommandTest {
 
 
     /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#execute(User, String, java.util.List)}.
+     * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecuteFullIsland() {
-        when(user.getPermissionValue(anyString(), anyInt())).thenReturn(0);
-        testCanExecuteSuccess();
-        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("target")));
+    public void testCanExecuteFullIsland() {
+        when(im.getMaxMembers(eq(island), anyInt())).thenReturn(0);
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("target")));
         verify(user).sendMessage(eq("commands.island.team.invite.errors.island-is-full"));
-        verify(user).getPermissionValue(eq("nullteam.maxsize"), eq(0));
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
@@ -281,6 +281,24 @@ public class IslandTeamTrustCommandTest {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
+    public void testExecuteSuccessNoConfirmationTooMany() {
+        // Can execute
+        when(pm.getUUID(any())).thenReturn(notUUID);
+        when(im.getMembers(any(), any())).thenReturn(Collections.emptySet());
+        when(island.getRank(any(User.class))).thenReturn(RanksManager.VISITOR_RANK);
+        IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
+        assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList("target")));
+
+        // Execute
+        when(im.getIsland(any(), Mockito.any(UUID.class))).thenReturn(island);
+        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("target")));
+        verify(user).sendMessage(eq("commands.island.team.trust.is-full"));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+     */
+    @Test
     public void testExecuteSuccessNoConfirmation() {
         User target = User.getInstance(targetPlayer);
         // Can execute
@@ -289,7 +307,8 @@ public class IslandTeamTrustCommandTest {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.VISITOR_RANK);
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
         assertTrue(itl.canExecute(user, itl.getLabel(), Collections.singletonList("target")));
-
+        // Allow 3
+        when(im.getMaxMembers(eq(island), eq(RanksManager.TRUSTED_RANK))).thenReturn(3);
         // Execute
         when(im.getIsland(any(), Mockito.any(UUID.class))).thenReturn(island);
         assertTrue(itl.execute(user, itl.getLabel(), Collections.singletonList("target")));

--- a/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
@@ -153,6 +153,7 @@ public class JoinLeaveListenerTest {
 
         // Island
         when(im.getIsland(any(), any(User.class))).thenReturn(island);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
         when(island.getWorld()).thenReturn(world);
         when(island.getProtectionRange()).thenReturn(50);
         when(island.getOwner()).thenReturn(uuid);

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -1367,7 +1367,7 @@ public class IslandsManagerTest {
         when(island.getOwner()).thenReturn(null);
         // Test
         IslandsManager im = new IslandsManager(plugin);
-        assertEquals(0, im.getMaxMembers(island));
+        assertEquals(0, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
         verify(island).setMaxMembers(eq(null));
     }
 
@@ -1385,8 +1385,8 @@ public class IslandsManagerTest {
         when(Bukkit.getPlayer(any(UUID.class))).thenReturn(null);
         // Test
         IslandsManager im = new IslandsManager(plugin);
-        assertEquals(4, im.getMaxMembers(island));
-        verify(island).setMaxMembers(eq(null));
+        assertEquals(4, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        verify(island).setMaxMembers(eq(RanksManager.MEMBER_RANK), eq(null));
     }
 
     /**
@@ -1403,8 +1403,30 @@ public class IslandsManagerTest {
         when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
         IslandsManager im = new IslandsManager(plugin);
-        assertEquals(4, im.getMaxMembers(island));
-        verify(island).setMaxMembers(eq(null));
+        assertEquals(4, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        verify(island).setMaxMembers(eq(RanksManager.MEMBER_RANK), eq(null));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island)}.
+     */
+    @Test
+    public void testGetMaxMembersOnlineOwnerNoPermsCoopTrust() {
+        Island island = mock(Island.class);
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getWorld()).thenReturn(world);
+        when(island.getMaxMembers()).thenReturn(null);
+        when(iwm.getMaxTeamSize(eq(world))).thenReturn(4);
+        when(iwm.getMaxCoopSize(eq(world))).thenReturn(2);
+        when(iwm.getMaxTrustSize(eq(world))).thenReturn(3);
+        // Online owner
+        when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        assertEquals(2, im.getMaxMembers(island, RanksManager.COOP_RANK));
+        verify(island).setMaxMembers(eq(RanksManager.COOP_RANK), eq(null));
+        assertEquals(3, im.getMaxMembers(island, RanksManager.TRUSTED_RANK));
+        verify(island).setMaxMembers(eq(RanksManager.TRUSTED_RANK), eq(null));
     }
 
     /**
@@ -1415,14 +1437,14 @@ public class IslandsManagerTest {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
-        when(island.getMaxMembers()).thenReturn(10);
+        when(island.getMaxMembers(eq(RanksManager.MEMBER_RANK))).thenReturn(10);
         when(iwm.getMaxTeamSize(eq(world))).thenReturn(4);
         // Online owner
         when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
         IslandsManager im = new IslandsManager(plugin);
-        assertEquals(10, im.getMaxMembers(island));
-        verify(island).setMaxMembers(eq(10));
+        assertEquals(10, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        verify(island).setMaxMembers(eq(RanksManager.MEMBER_RANK), eq(10));
     }
 
     /**
@@ -1433,14 +1455,14 @@ public class IslandsManagerTest {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
-        when(island.getMaxMembers()).thenReturn(10);
+        when(island.getMaxMembers(eq(RanksManager.MEMBER_RANK))).thenReturn(10);
         when(iwm.getMaxTeamSize(eq(world))).thenReturn(40);
         // Online owner
         when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
         IslandsManager im = new IslandsManager(plugin);
-        assertEquals(10, im.getMaxMembers(island));
-        verify(island).setMaxMembers(eq(10));
+        assertEquals(10, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        verify(island).setMaxMembers(eq(RanksManager.MEMBER_RANK), eq(10));
     }
 
     /**
@@ -1464,8 +1486,8 @@ public class IslandsManagerTest {
         when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
         IslandsManager im = new IslandsManager(plugin);
-        assertEquals(8, im.getMaxMembers(island));
-        verify(island).setMaxMembers(eq(8));
+        assertEquals(8, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        verify(island).setMaxMembers(eq(RanksManager.MEMBER_RANK), eq(8));
     }
 
 
@@ -1477,7 +1499,7 @@ public class IslandsManagerTest {
         Island island = mock(Island.class);
         // Test
         IslandsManager im = new IslandsManager(plugin);
-        im.setMaxMembers(island, 40);
-        verify(island).setMaxMembers(eq(40));
+        im.setMaxMembers(island, RanksManager.MEMBER_RANK, 40);
+        verify(island).setMaxMembers(eq(RanksManager.MEMBER_RANK), eq(40));
     }
 }

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,6 +49,7 @@ import org.bukkit.entity.Skeleton;
 import org.bukkit.entity.Slime;
 import org.bukkit.entity.Wither;
 import org.bukkit.entity.Zombie;
+import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.After;
@@ -174,6 +176,7 @@ public class IslandsManagerTest {
         when(user.getPlayer()).thenReturn(player);
         User.setPlugin(plugin);
         // Set up user already
+        when(player.getUniqueId()).thenReturn(uuid);
         User.getInstance(player);
 
         // Locales
@@ -1355,4 +1358,126 @@ public class IslandsManagerTest {
         assertFalse(im.fixIslandCenter(island));
     }
 
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island)}.
+     */
+    @Test
+    public void testGetMaxMembersNoOwner() {
+        Island island = mock(Island.class);
+        when(island.getOwner()).thenReturn(null);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        assertEquals(0, im.getMaxMembers(island));
+        verify(island).setMaxMembers(eq(null));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island)}.
+     */
+    @Test
+    public void testGetMaxMembersOfflineOwner() {
+        Island island = mock(Island.class);
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getWorld()).thenReturn(world);
+        when(island.getMaxMembers()).thenReturn(null);
+        when(iwm.getMaxTeamSize(eq(world))).thenReturn(4);
+        // Offline owner
+        when(Bukkit.getPlayer(any(UUID.class))).thenReturn(null);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        assertEquals(4, im.getMaxMembers(island));
+        verify(island).setMaxMembers(eq(null));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island)}.
+     */
+    @Test
+    public void testGetMaxMembersOnlineOwnerNoPerms() {
+        Island island = mock(Island.class);
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getWorld()).thenReturn(world);
+        when(island.getMaxMembers()).thenReturn(null);
+        when(iwm.getMaxTeamSize(eq(world))).thenReturn(4);
+        // Online owner
+        when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        assertEquals(4, im.getMaxMembers(island));
+        verify(island).setMaxMembers(eq(null));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island)}.
+     */
+    @Test
+    public void testGetMaxMembersOnlineOwnerNoPermsPreset() {
+        Island island = mock(Island.class);
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getWorld()).thenReturn(world);
+        when(island.getMaxMembers()).thenReturn(10);
+        when(iwm.getMaxTeamSize(eq(world))).thenReturn(4);
+        // Online owner
+        when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        assertEquals(10, im.getMaxMembers(island));
+        verify(island).setMaxMembers(eq(10));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island)}.
+     */
+    @Test
+    public void testGetMaxMembersOnlineOwnerNoPermsPresetLessThanDefault() {
+        Island island = mock(Island.class);
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getWorld()).thenReturn(world);
+        when(island.getMaxMembers()).thenReturn(10);
+        when(iwm.getMaxTeamSize(eq(world))).thenReturn(40);
+        // Online owner
+        when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        assertEquals(10, im.getMaxMembers(island));
+        verify(island).setMaxMembers(eq(10));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island)}.
+     */
+    @Test
+    public void testGetMaxMembersOnlineOwnerHasPerm() {
+        Island island = mock(Island.class);
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getWorld()).thenReturn(world);
+        when(island.getMaxMembers()).thenReturn(null);
+        when(iwm.getMaxTeamSize(eq(world))).thenReturn(4);
+        // Permission
+        when(iwm.getPermissionPrefix(any())).thenReturn("bskyblock.");
+        PermissionAttachmentInfo pai = mock(PermissionAttachmentInfo.class);
+        when(pai.getValue()).thenReturn(true);
+        when(pai.getPermission()).thenReturn("bskyblock.team.maxsize.8");
+        Set<PermissionAttachmentInfo> set = Collections.singleton(pai);
+        when(player.getEffectivePermissions()).thenReturn(set);
+        // Online owner
+        when(Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        assertEquals(8, im.getMaxMembers(island));
+        verify(island).setMaxMembers(eq(8));
+    }
+
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#setMaxMembers(Island, Integer)}.
+     */
+    @Test
+    public void testsetMaxMembers() {
+        Island island = mock(Island.class);
+        // Test
+        IslandsManager im = new IslandsManager(plugin);
+        im.setMaxMembers(island, 40);
+        verify(island).setMaxMembers(eq(40));
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/BentoBoxWorld/BentoBox/issues/1690

The goal is to store the maximum number of members an island can have in the island object. The IslandsManager provides a method to obtain this value that also updates it based on the online owner's permissions or default value for the world if the max value is undefined. If there is no value different to the default world value then nothing has to be stored.