### PR TITLE
Fixes a bug with end platform generation

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
@@ -271,7 +271,14 @@ public class PortalTeleportationListener implements Listener {
         // Find the maximum x and z corner
         for (; (i < x + 5) && e.getWorld().getBlockAt(i, k, z).getType().equals(Material.END_PORTAL); i++);
         for (; (j < z + 5) && e.getWorld().getBlockAt(x, k, j).getType().equals(Material.END_PORTAL); j++);
-        return new Location(toWorld, i, k, j);
+        
+        // Mojang end platform generation is:
+        // AIR
+        // AIR
+        // OBSIDIAN
+        // and player is placed on second air block above obsidian.
+        // If Y coordinate is below 2, then obsidian platform is not generated and player falls in void.
+        return new Location(toWorld, i, Math.max(2, k), j);
     }
 
 


### PR DESCRIPTION
If a player has end portal at Y=0 or Y=1, then they were spawned in the void, if makePortals option was enabled.
It happens because end portals are generated with 2 air layers above the obsidian platform. So minimal location is necessary to be at least 2 (2 for air and obsidian at 0).