### PR TITLE
Fixes a bug with undetectable sub-commands.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -182,13 +182,13 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
         this.parent = parent;
         subCommandLevel = parent.getLevel() + 1;
         // Add this sub-command to the parent
-        parent.getSubCommands().put(label, this);
+        parent.getSubCommands().put(label.toLowerCase(java.util.Locale.ENGLISH), this);
         setAliases(new ArrayList<>(Arrays.asList(aliases)));
         subCommands = new LinkedHashMap<>();
         subCommandAliases = new LinkedHashMap<>();
         // Add aliases to the parent for this command
         for (String alias : aliases) {
-            parent.getSubCommandAliases().put(alias, this);
+            parent.getSubCommandAliases().put(alias.toLowerCase(java.util.Locale.ENGLISH), this);
         }
         setUsage("");
         // Inherit permission prefix


### PR DESCRIPTION
CompositeCommand had a bug that prevented subCommands to be found if the top label contains capital letters.
It happened, because in https://github.com/BentoBoxWorld/BentoBox/blob/develop/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java#L379 we use lowerCased input, while the subCommand map contains a value with capital letters.
This should be fixed now.

#1706