### PR TITLE
Pregen chunks

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandCreateCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandCreateCommand.java
@@ -11,6 +11,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.BlueprintsManager;
 import world.bentobox.bentobox.managers.island.NewIsland;
+import world.bentobox.bentobox.managers.island.PregenNewIslandLocationStrategy;
 import world.bentobox.bentobox.panels.IslandCreationPanel;
 
 /**
@@ -93,6 +94,7 @@ public class IslandCreateCommand extends CompositeCommand {
             .addon(getAddon())
             .reason(Reason.CREATE)
             .name(name)
+            .locationStrategy(new PregenNewIslandLocationStrategy())
             .build();
         } catch (IOException e) {
             getPlugin().logError("Could not create island for player. " + e.getMessage());

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandResetCommand.java
@@ -16,6 +16,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.BlueprintsManager;
 import world.bentobox.bentobox.managers.island.NewIsland;
 import world.bentobox.bentobox.managers.island.NewIsland.Builder;
+import world.bentobox.bentobox.managers.island.PregenNewIslandLocationStrategy;
 import world.bentobox.bentobox.panels.IslandCreationPanel;
 
 /**
@@ -145,6 +146,7 @@ public class IslandResetCommand extends ConfirmableCommand {
                     .reason(Reason.RESET)
                     .addon(getAddon())
                     .oldIsland(oldIsland)
+                    .locationStrategy(new PregenNewIslandLocationStrategy())
                     .name(name);
             if (noPaste) builder.noPaste();
             builder.build();

--- a/src/main/java/world/bentobox/bentobox/managers/island/PregenNewIslandLocationStrategy.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/PregenNewIslandLocationStrategy.java
@@ -1,0 +1,118 @@
+package world.bentobox.bentobox.managers.island;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.scheduler.BukkitTask;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Provides island locations and pregenerates future chunks to speed up island teleportation
+ * @author tastybento
+ * @since 1.17.0
+ *
+ */
+public class PregenNewIslandLocationStrategy implements NewIslandLocationStrategy {
+
+    private static final long TIME = 40;
+    private static final int VD = 16 * Bukkit.getServer().getViewDistance();
+    protected BentoBox plugin = BentoBox.getInstance();
+    protected Queue<Location> queue = new LinkedList<>();
+    protected boolean loading;
+    private BukkitTask task;
+
+    @Override
+    public Location getNextLocation(World world) {
+        Location last = plugin.getIslands().getLast(world);
+        if (last == null) {
+            last = new Location(world,
+                    (double) plugin.getIWM().getIslandXOffset(world) + plugin.getIWM().getIslandStartX(world),
+                    plugin.getIWM().getIslandHeight(world),
+                    (double) plugin.getIWM().getIslandZOffset(world) + plugin.getIWM().getIslandStartZ(world));
+        }
+        // Find a free spot
+        while (isIsland(last)) {
+            nextGridLocation(last);
+        }        
+        plugin.getIslands().setLast(last);
+        // Make a queue to load
+        Location loc = last.clone();
+        for (int i = 0; i < 5; i++) {
+            nextGridLocation(loc);
+            if (!Util.isChunkGenerated(loc)) {
+                for (int x = loc.getBlockX() - VD; x <= loc.getBlockX() + VD; x += 16) {
+                    for (int z = loc.getBlockZ() - VD; z <= loc.getBlockZ() + VD; z += 16) {
+                        queue.add(new Location(loc.getWorld(), x, loc.getBlockY(), z));
+                    }  
+                }
+                queue.add(loc.clone());
+            }
+        }
+        // Load chunks
+        task = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+            if (!loading && !queue.isEmpty()) {
+                Location l = queue.poll();
+                if (Util.isChunkGenerated(l)) {
+                    loading = true;
+                    BentoBox.getInstance().logDebug("Generating chunk at " + l);
+                    Util.getChunkAtAsync(l).thenRun(() -> loading = false);
+                }
+            }
+            if (queue.isEmpty()) {
+                task.cancel();
+            }
+        }, TIME, TIME);
+        return last;
+    }
+
+
+
+    /**
+     * Checks if there is an island or blocks at this location
+     *
+     * @param location - the location
+     * @return true if island known
+     */
+    protected boolean isIsland(Location location) {
+        return plugin.getIslands().getIslandAt(location).isPresent();
+    }
+
+    /**
+     * Finds the next free island spot based off the last known island.
+     * Uses island_distance setting from the config file. Builds up in a grid fashion.
+     *
+     * @param lastIsland - last island location
+     */
+    private void nextGridLocation(final Location lastIsland) {
+        int x = lastIsland.getBlockX();
+        int z = lastIsland.getBlockZ();
+        int d = plugin.getIWM().getIslandDistance(lastIsland.getWorld()) * 2;
+        if (x < z) {
+            if (-1 * x < z) {
+                lastIsland.setX(lastIsland.getX() + d);
+                return;
+            }
+            lastIsland.setZ(lastIsland.getZ() + d);
+            return;
+        }
+        if (x > z) {
+            if (-1 * x >= z) {
+                lastIsland.setX(lastIsland.getX() - d);
+                return;
+            }
+            lastIsland.setZ(lastIsland.getZ() - d);
+            return;
+        }
+        if (x <= 0) {
+            lastIsland.setZ(lastIsland.getZ() + d);
+            return;
+        }
+        lastIsland.setZ(lastIsland.getZ() - d);
+        return;
+    }
+}


### PR DESCRIPTION
This is an experimental PR that performs some pre-loading of chunks about 10 seconds after an island is created or reset. It aims to keep a buffer of 5 islands available ahead of the current one. This might help reduce CPU during the initial joining of the server. 

This change only runs on Paper because it relies on the PaperLibb async chunk loading.

The very first island generated on a server usually at 0,0 will kick off 5 islands-worth of generation. After that, each new island should only need to generate one additional island because there will be a buffer of 5 available. 

The chunks that are pregenerated are determined by the server's view distance. If that is small, then fewer chunks need to be generated around the new island location. 

I am not sure how this will perform. In theory it should work, but it needs some server to test it. Attached is a binary version for testing:

[BentoBox-1.16.2-SNAPSHOT-LOCAL.jar.zip](https://github.com/BentoBoxWorld/BentoBox/files/6253013/BentoBox-1.16.2-SNAPSHOT-LOCAL.jar.zip)
