### PR TITLE
Add WildStacker as SoftDepend to plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,7 +12,7 @@ load: STARTUP
 
 loadbefore: [Multiverse-Core, Residence]
 
-softdepend: [Vault, PlaceholderAPI, dynmap, WorldEdit, WorldBorderAPI, BsbMongo, WorldGeneratorApi, AdvancedChests, LangUtils]
+softdepend: [Vault, PlaceholderAPI, dynmap, WorldEdit, WorldBorderAPI, BsbMongo, WorldGeneratorApi, AdvancedChests, LangUtils, WildStacker]
 
 permissions:
   bentobox.admin:


### PR DESCRIPTION
Someone noticed on Discord that the Level Addon's WildStacker addition doesn't have a SoftDepend, therefore errors.