### PR TITLE
Update Compatibility

### DIFF
--- a/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
+++ b/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
@@ -75,6 +75,9 @@ public class ServerCompatibility {
         GLOWSTONE(Compatibility.INCOMPATIBLE),
         SPIGOT(Compatibility.COMPATIBLE),
         PAPER(Compatibility.SUPPORTED),
+        TUINITY(Compatibility.SUPPORTED),
+        AIRPLANE(Compatibility.SUPPORTED),
+        PURPUR(Compatibility.SUPPORTED),
         TACOSPIGOT(Compatibility.NOT_SUPPORTED),
         AKARIN(Compatibility.NOT_SUPPORTED),
         /**


### PR DESCRIPTION
In the recent past, many more people have been using PaperMC forks, Like Tuinity, Airplane, and Purpur.
I have added those 3, as I am personally willing to support them, if nothing else.
Other (stable) forks should be added as they are used.