### PR TITLE
Allow Non-Bentobox commands as default player (commands)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommand.java
@@ -117,7 +117,12 @@ public abstract class DefaultPlayerCommand extends CompositeCommand {
                     orElse(false);
         } else {
             // Command is not a known sub command - try to perform it directly - some plugins trap these commands, like Deluxe menus
-            return user.performCommand(label + " " + command);
+            if (command.startsWith("/")) {
+                // If commands starts with Slash, don't append the prefix
+                return user.performCommand(command.substring(1));
+            } else {
+                return user.performCommand(label + " " + command);
+            }
         }
     }
 }

--- a/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
+++ b/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
@@ -75,6 +75,9 @@ public class ServerCompatibility {
         GLOWSTONE(Compatibility.INCOMPATIBLE),
         SPIGOT(Compatibility.COMPATIBLE),
         PAPER(Compatibility.SUPPORTED),
+        TUINITY(Compatibility.SUPPORTED),
+        AIRPLANE(Compatibility.SUPPORTED),
+        PURPUR(Compatibility.SUPPORTED),
         TACOSPIGOT(Compatibility.NOT_SUPPORTED),
         AKARIN(Compatibility.NOT_SUPPORTED),
         /**


### PR DESCRIPTION
This should allow for default-action commands to be prefixed with `/`, allowing non-bentobox commands to run.
this way a default `/is` command could forward to `/panel` (maybe a custom menu, for example)

oops, I seem to have added all of my commits here... any way to revert the other ones?