### PR TITLE
Custom date time format support for /<admin> info <player>

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.database.objects;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -1075,7 +1076,14 @@ public class Island implements DataObject, MetaDataAble {
             // Fixes #getLastPlayed() returning 0 when it is the owner's first connection.
             long lastPlayed = (Bukkit.getServer().getOfflinePlayer(getOwner()).getLastPlayed() != 0) ?
                     Bukkit.getServer().getOfflinePlayer(getOwner()).getLastPlayed() : Bukkit.getServer().getOfflinePlayer(getOwner()).getFirstPlayed();
-            user.sendMessage("commands.admin.info.last-login","[date]", new Date(lastPlayed).toString());
+            String formattedDate;
+            try {
+                String dateTimeFormat = plugin.getLocalesManager().get("commands.admin.info.last-login-date-time-format");
+                formattedDate = new SimpleDateFormat(dateTimeFormat).format(new Date(lastPlayed));
+            } catch (NullPointerException | IllegalArgumentException ignored) {
+                formattedDate = new Date(lastPlayed).toString();
+            }
+            user.sendMessage("commands.admin.info.last-login","[date]", formattedDate);
 
             user.sendMessage("commands.admin.info.deaths", "[number]", String.valueOf(plugin.getPlayers().getDeaths(getWorld(), getOwner())));
             String resets = String.valueOf(plugin.getPlayers().getResets(getWorld(), getOwner()));

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -188,6 +188,7 @@ commands:
       island-uuid: "UUID: [uuid]"
       owner: "Owner: [owner] ([uuid])"
       last-login: "Last login: [date]"
+      last-login-date-time-format: "EEE MMM dd HH:mm:ss zzz yyyy"
       deaths: "Deaths: [number]"
       resets-left: "Resets: [number] (Max: [total])"
       team-members-title: "Team members:"


### PR DESCRIPTION
Fixes #1720
Adds `commands.admin.info.last-login-date-time-format` to Locale
Defaults to value `EEE MMM dd HH:mm:ss zzz yyyy`
Tested with default key, invalid key (resorted to default), and custom key in locale

Only edited `en-US` (I will leave the other locales to the translators)

Example in `zh-CN` with string `last-login-date-time-format: yyyy年M月d日 HH:mm`
![image](https://user-images.githubusercontent.com/11820199/122818003-7e881000-d28d-11eb-85fc-340b05e909c8.png)
