### PR TITLE
Add world setting flag for island visitors keep inventory on death

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/VisitorKeepInventoryListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/VisitorKeepInventoryListener.java
@@ -1,0 +1,39 @@
+package world.bentobox.bentobox.listeners.flags.worldsettings;
+
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import world.bentobox.bentobox.api.flags.FlagListener;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.lists.Flags;
+import world.bentobox.bentobox.util.Util;
+
+import java.util.Optional;
+
+/**
+ * Prevents visitors from losing their items if they
+ * die on an island in which they are a visitor.
+ * Handles {@link world.bentobox.bentobox.lists.Flags#VISITOR_KEEP_INVENTORY}.
+ * @author jstnf
+ * @since 1.17.0
+ */
+public class VisitorKeepInventoryListener extends FlagListener {
+
+    @EventHandler (priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onVisitorDeath(PlayerDeathEvent e) {
+        World world = Util.getWorld(e.getEntity().getWorld());
+        if (!getIWM().inWorld(world) || !Flags.VISITOR_KEEP_INVENTORY.isSetForWorld(world)) {
+            // If the player dies outside of the island world, don't do anything
+            return;
+        }
+
+        Optional<Island> island = getIslands().getProtectedIslandAt(e.getEntity().getLocation());
+        if (island.isPresent() && !island.get().getMemberSet().contains(e.getEntity().getUniqueId())) {
+            e.setKeepInventory(true);
+            e.setKeepLevel(true);
+            e.getDrops().clear();
+            e.setDroppedExp(0);
+        }
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/lists/Flags.java
+++ b/src/main/java/world/bentobox/bentobox/lists/Flags.java
@@ -62,6 +62,7 @@ import world.bentobox.bentobox.listeners.flags.worldsettings.PistonPushListener;
 import world.bentobox.bentobox.listeners.flags.worldsettings.RemoveMobsListener;
 import world.bentobox.bentobox.listeners.flags.worldsettings.SpawnerSpawnEggsListener;
 import world.bentobox.bentobox.listeners.flags.worldsettings.TreesGrowingOutsideRangeListener;
+import world.bentobox.bentobox.listeners.flags.worldsettings.VisitorKeepInventoryListener;
 import world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener;
 import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
@@ -526,6 +527,13 @@ public final class Flags {
      */
     public static final Flag PETS_STAY_AT_HOME = new Flag.Builder("PETS_STAY_AT_HOME", Material.TROPICAL_FISH).listener(new PetTeleportListener()).type(Type.WORLD_SETTING).defaultSetting(true).build();
 
+    /**
+     * Toggles whether island visitors keep their items if they die on another player's island.
+     * @since 1.17.0
+     * @see VisitorKeepInventoryListener
+     */
+    public static final Flag VISITOR_KEEP_INVENTORY = new Flag.Builder("VISITOR_KEEP_INVENTORY", Material.TOTEM_OF_UNDYING).listener(new VisitorKeepInventoryListener()).type(Type.WORLD_SETTING).defaultSetting(false).build();
+    
     /**
      * Provides a list of all the Flag instances contained in this class using reflection.
      * Deprecated Flags are ignored.

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1271,6 +1271,15 @@ protection:
         &a back to their island using commands
         &a if they are falling.
       hint: "&c You cannot do that while falling."
+    VISITOR_KEEP_INVENTORY:
+      name: "Visitors keep inventory on death"
+      description: |-
+        &a Prevent players from losing their
+        &a items and experience if they die on
+        &a an island in which they are a visitor.
+        &a
+        &a Island members still lose their items
+        &a if they die on their own island!
     WITHER_DAMAGE:
       name: "Toggle wither damage"
       description: |-


### PR DESCRIPTION
Fixes #1709
Adds the `VISITOR_KEEP_INVENTORY` flag belonging to `WORLD_SETTING`.