### PR TITLE
Implement 3 bar charts: addons, gamemodes, hooks

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BStats.java
+++ b/src/main/java/world/bentobox/bentobox/BStats.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.SimpleBarChart;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
@@ -53,6 +54,11 @@ public class BStats {
         // Single Line charts
         registerIslandsCountChart();
         registerIslandsCreatedChart();
+
+        // Bar Charts
+        registerAddonsBarChart();
+        registerGameModeAddonsBarChart();
+        registerHooksBarChart();
     }
 
     private void registerDefaultLanguageChart() {
@@ -161,6 +167,46 @@ public class BStats {
                 }
             });
 
+            return values;
+        }));
+    }
+
+    /**
+     * Sends the enabled addons (except GameModeAddons) of this server as bar chart.
+     * @since 1.17.1
+     */
+    private void registerAddonsBarChart() {
+        metrics.addCustomChart(new SimpleBarChart("addonsBar", () -> {
+            Map<String, Integer> values = new HashMap<>();
+            plugin.getAddonsManager().getEnabledAddons().stream()
+                .filter(addon -> !(addon instanceof GameModeAddon) && addon.getDescription().isMetrics())
+                .forEach(addon -> values.put(addon.getDescription().getName(), 1));
+            return values;
+        }));
+    }
+
+    /**
+     * Sends the enabled GameModeAddons of this server as a bar chart.
+     * @since 1.17.1
+     */
+    private void registerGameModeAddonsBarChart() {
+        metrics.addCustomChart(new SimpleBarChart("gameModeAddonsBar", () -> {
+            Map<String, Integer> values = new HashMap<>();
+            plugin.getAddonsManager().getGameModeAddons().stream()
+                .filter(gameModeAddon -> gameModeAddon.getDescription().isMetrics())
+                .forEach(gameModeAddon -> values.put(gameModeAddon.getDescription().getName(), 1));
+            return values;
+        }));
+    }
+
+    /**
+     * Sends the enabled Hooks of this server as a bar chart.
+     * @since 1.17.1
+     */
+    private void registerHooksBarChart() {
+        metrics.addCustomChart(new SimpleBarChart("hooksBar", () -> {
+            Map<String, Integer> values = new HashMap<>();
+            plugin.getHooks().getHooks().forEach(hook -> values.put(hook.getPluginName(), 1));
             return values;
         }));
     }


### PR DESCRIPTION
BStats supports sending Bar chart data, however, it does not display it via their site directly.
It can be called manually, to view.

PieChart does not work very well for addons and hooks. BarChart however allows viewing each addon separately. 

This change allows sending data to the server about bar charts.

It is based on this message:
https://discord.com/channels/260708924481601539/283352157137272833/802445795735109672