### PR TITLE
Add alternative Addon#getIslandManager method

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
@@ -393,6 +393,16 @@ public abstract class Addon {
     public IslandsManager getIslands() {
         return getPlugin().getIslands();
     }
+    
+    /**
+     * Get Islands Manager
+     * @return Islands manager
+     * @see #getIslands()
+     * @since 1.17.1
+     */
+    public IslandsManager getIslandsManager() {
+        return getPlugin().getIslandsManager();
+    }
 
     /**
      * Get the Addon By Name


### PR DESCRIPTION
We have already done this to the main BentoBox class. But add-ons missed it, and it still has this weird structure: Addon#getIslands().getIslands().

This will just add the same method as it is already in BentoBox class.