### PR TITLE
Implement Flag icon changing via Locales file.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
@@ -25,6 +25,8 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.ItemParser;
+
 
 public class Flag implements Comparable<Flag> {
 
@@ -316,6 +318,13 @@ public class Flag implements Comparable<Flag> {
     }
 
     /**
+     * @return a locale reference for the icon of this protection flag
+     */
+    public String getIconReference() {
+        return PROTECTION_FLAGS + this.id + ".icon";
+    }
+
+    /**
      * @return a locale reference for the description of this protection flag
      */
     public String getDescriptionReference() {
@@ -377,7 +386,7 @@ public class Flag implements Comparable<Flag> {
         }
         // Start the flag conversion
         PanelItemBuilder pib = new PanelItemBuilder()
-                .icon(new ItemStack(icon))
+                .icon(ItemParser.parse(user.getTranslation(this.getIconReference()), new ItemStack(icon)))
                 .name(user.getTranslation("protection.panel.flag-item.name-layout", TextVariables.NAME, user.getTranslation(getNameReference())))
                 .clickHandler(clickHandler)
                 .invisible(invisible);

--- a/src/test/java/world/bentobox/bentobox/util/ItemParserTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/ItemParserTest.java
@@ -36,6 +36,7 @@ public class ItemParserTest {
 
     private PotionMeta potionMeta;
     private BannerMeta bannerMeta;
+    private ItemStack defaultItem;
 
     @Before
     public void setUp() throws Exception {
@@ -67,6 +68,7 @@ public class ItemParserTest {
             }
         });
 
+        defaultItem = new ItemStack(Material.STONE);
     }
 
     @After
@@ -77,16 +79,19 @@ public class ItemParserTest {
     @Test
     public void testParseNull() {
         assertNull(ItemParser.parse(null));
+        assertEquals(defaultItem, ItemParser.parse(null, defaultItem));
     }
 
     @Test
     public void testParseBlank() {
         assertNull(ItemParser.parse(""));
+        assertEquals(defaultItem, ItemParser.parse("", defaultItem));
     }
 
     @Test
     public void testParseNoColons() {
         assertNull(ItemParser.parse("NOCOLONS"));
+        assertEquals(defaultItem, ItemParser.parse("NOCOLONS", defaultItem));
     }
 
     /*
@@ -258,6 +263,8 @@ public class ItemParserTest {
     @Test
     public void testParseBadTwoItem() {
         assertNull(ItemParser.parse("STNE:5"));
+        assertEquals(defaultItem, ItemParser.parse("STNE:3", defaultItem));
+        assertEquals(defaultItem, ItemParser.parse("STNE:Z", defaultItem));
     }
 
     @Test
@@ -270,5 +277,8 @@ public class ItemParserTest {
     @Test
     public void testParseBadThreeItem() {
         assertNull(ItemParser.parse("STNE:5:5"));
+        assertEquals(defaultItem, ItemParser.parse("STNE:5:5", defaultItem));
+        assertEquals(defaultItem, ItemParser.parse("STNE:AA:5", defaultItem));
+        assertEquals(defaultItem, ItemParser.parse("WOODEN_SWORD:4:AA", defaultItem));
     }
 }


### PR DESCRIPTION
This commit contains 2 changes:
- An option for Flag to use icon that is defined in locales after "icon" string.
- An option for ItemParser to parse icon or return given value, if parsing was not successful.

The flag option is not ideal, but it is simpler and easier to maintain then adding new config section where icons can be changed, as the locales file already contains a lot of info about each flag.