### PR TITLE
Add Citizens to Softdepend list for NPC support

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,6 +13,7 @@ load: STARTUP
 loadbefore: [Pladdon, Multiverse-Core, Residence]
 
 softdepend:
+  - Citizens
   - Vault
   - PlaceholderAPI
   - dynmap


### PR DESCRIPTION
I'm attempting to add Citizens NPCs to bentobox, and this allows for Citizens API use.