### PR TITLE
Fixes a bug when Potion metadata was not applied

### DIFF
--- a/src/main/java/world/bentobox/bentobox/util/ItemParser.java
+++ b/src/main/java/world/bentobox/bentobox/util/ItemParser.java
@@ -171,7 +171,7 @@ public class ItemParser {
         boolean isExtended = part[3].equalsIgnoreCase("EXTENDED");
         PotionData data = new PotionData(type, isExtended, isUpgraded);
         potionMeta.setBasePotionData(data);
-
+        result.setItemMeta(potionMeta);
         result.setAmount(Integer.parseInt(part[5]));
         return result;
     }


### PR DESCRIPTION
There was missing potion meta data applying after creating an item. 
This affects both: Potions and Tipped arrows.