### PR TITLE
Remove dead paper forks

### DIFF
--- a/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
+++ b/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
@@ -75,8 +75,6 @@ public class ServerCompatibility {
         GLOWSTONE(Compatibility.INCOMPATIBLE),
         SPIGOT(Compatibility.COMPATIBLE),
         PAPER(Compatibility.SUPPORTED),
-        TUINITY(Compatibility.SUPPORTED),
-        AIRPLANE(Compatibility.SUPPORTED),
         PURPUR(Compatibility.SUPPORTED),
         TACOSPIGOT(Compatibility.NOT_SUPPORTED),
         AKARIN(Compatibility.NOT_SUPPORTED),


### PR DESCRIPTION
Tuinity has since merged with Paper, and is now not a valid fork

Airplane is shutting down / not updating to 1.18.x