### PR TITLE
fix an exception when cleaning an offline player

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -547,7 +547,7 @@ public class PlayersManager {
         // Remove any tamed animals
         world.getEntitiesByClass(Tameable.class).stream()
         .filter(Tameable::isTamed)
-        .filter(t -> t.getOwner() != null && t.getOwner().equals(target.getPlayer()))
+        .filter(t -> t.getOwner() != null && t.getOwner().getUniqueId().equals(target.getUniqueId()))
         .forEach(t -> t.setOwner(null));
 
         // Remove money inventory etc.


### PR DESCRIPTION
Fix this exception
```
[12:56:19] [Server thread/WARN]: [BentoBox] Task #1520678 for BentoBox v1.19.1-SNAPSHOT-LOCAL generated an exception
java.lang.NullPointerException: User is not a player!
	at java.util.Objects.requireNonNull(Objects.java:233) ~[?:?]
	at world.bentobox.bentobox.api.user.User.getPlayer(User.java:215) ~[BentoBox.jar:?]
	at world.bentobox.bentobox.managers.PlayersManager.lambda$cleanLeavingPlayer$6(PlayersManager.java:550) ~[BentoBox.jar:?]
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178) ~[?:?]
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[?:?]
	at world.bentobox.bentobox.managers.PlayersManager.cleanLeavingPlayer(PlayersManager.java:551) ~[BentoBox.jar:?]
	at world.bentobox.bentobox.api.commands.island.team.IslandTeamKickCommand.kick(IslandTeamKickCommand.java:100) ~[BentoBox.jar:?]
	at world.bentobox.bentobox.api.commands.island.team.IslandTeamKickCommand.lambda$execute$0(IslandTeamKickCommand.java:79) ~[BentoBox.jar:?]
	at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1569) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:495) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1485) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1284) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:321) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```