### PR TITLE
Fixes a bug with on-join commands

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -222,5 +222,8 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
         if (getIWM().isOnJoinResetXP(getWorld())) {
             user.getPlayer().setTotalExperience(0);
         }
+
+        // Execute commands
+        Util.runCommands(user, getIWM().getOnJoinCommands(getWorld()), "join");
     }
 }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1154,9 +1154,6 @@ public class IslandsManager {
                 // Do nothing
                 return;
             }
-            // Execute commands
-            Util.runCommands(user, plugin.getIWM().getOnJoinCommands(world), "join");
-
             // Remove money inventory etc.
             if (plugin.getIWM().isOnJoinResetEnderChest(world)) {
                 user.getPlayer().getEnderChest().clear();
@@ -1185,6 +1182,9 @@ public class IslandsManager {
 
             // Set the game mode
             user.setGameMode(plugin.getIWM().getDefaultGameMode(world));
+
+            // Execute commands
+            Util.runCommands(user, plugin.getIWM().getOnJoinCommands(world), "join");
         }
         // Remove from mid-teleport set
         goingHome.remove(user.getUniqueId());


### PR DESCRIPTION
Fixes a bug with on-join commands not working when players join the team. #1925

Also, this includes a change that executes the commands after all resets.
This allows to use more things with commands, like give items.