### PR TITLE
Extend ranked commands

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -30,6 +30,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -52,6 +53,12 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      * True if command is a configurable rank
      */
     private boolean configurableRankCommand = false;
+
+    /**
+     * Make default command rank as owner rank.
+     * @since 1.20.0
+     */
+    private int defaultCommandRank = RanksManager.OWNER_RANK;
 
     /**
      * True if command is hidden from help and tab complete
@@ -782,6 +789,26 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      */
     public void setConfigurableRankCommand() {
         this.configurableRankCommand = true;
+    }
+
+    /**
+     * Sets default command rank.
+     *
+     * @param rank the rank
+     * @since 1.20.0
+     */
+    public void setDefaultCommandRank(int rank) {
+        this.defaultCommandRank = rank;
+    }
+
+    /**
+     * Gets default command rank.
+     *
+     * @return the default command rank
+     * @since 1.20.0
+     */
+    public int getDefaultCommandRank() {
+        return this.defaultCommandRank;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommand.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.api.commands.island;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -11,6 +12,7 @@ import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -32,6 +34,8 @@ public class IslandDeletehomeCommand extends ConfirmableCommand {
         setOnlyPlayer(true);
         setParametersHelp("commands.island.deletehome.parameters");
         setDescription("commands.island.deletehome.description");
+        setConfigurableRankCommand();
+        setDefaultCommandRank(RanksManager.MEMBER_RANK);
     }
 
     @Override
@@ -46,6 +50,15 @@ public class IslandDeletehomeCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.no-island");
             return false;
         }
+
+        // check command permission
+        int rank = Objects.requireNonNull(island).getRank(user);
+        if (rank < island.getRankCommand(getUsage())) {
+            user.sendMessage("general.errors.insufficient-rank",
+                TextVariables.RANK, user.getTranslation(getPlugin().getRanksManager().getRank(rank)));
+            return false;
+        }
+
         // Check if the name is known
         if (!getIslands().isHomeLocation(island, String.join(" ", args))) {
             user.sendMessage("commands.island.go.unknown-home");

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandRenamehomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandRenamehomeCommand.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.api.commands.island;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.bukkit.conversations.ConversationFactory;
@@ -14,6 +15,7 @@ import world.bentobox.bentobox.api.commands.admin.conversations.NamePrompt;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -35,6 +37,8 @@ public class IslandRenamehomeCommand extends ConfirmableCommand {
         setOnlyPlayer(true);
         setParametersHelp("commands.island.renamehome.parameters");
         setDescription("commands.island.renamehome.description");
+        setConfigurableRankCommand();
+        setDefaultCommandRank(RanksManager.MEMBER_RANK);
     }
 
     @Override
@@ -57,6 +61,14 @@ public class IslandRenamehomeCommand extends ConfirmableCommand {
             this.showHelp(this, user);
             return false;
         }
+
+        // check command permission
+        int rank = Objects.requireNonNull(island).getRank(user);
+        if (rank < island.getRankCommand(getUsage())) {
+            user.sendMessage("general.errors.insufficient-rank", TextVariables.RANK, user.getTranslation(getPlugin().getRanksManager().getRank(rank)));
+            return false;
+        }
+
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.api.commands.island;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -10,6 +11,8 @@ import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.RanksManager;
+
 
 public class IslandSethomeCommand extends ConfirmableCommand {
 
@@ -24,6 +27,8 @@ public class IslandSethomeCommand extends ConfirmableCommand {
         setPermission("island.sethome");
         setOnlyPlayer(true);
         setDescription("commands.island.sethome.description");
+        setConfigurableRankCommand();
+        setDefaultCommandRank(RanksManager.MEMBER_RANK);
     }
 
     @Override
@@ -38,6 +43,13 @@ public class IslandSethomeCommand extends ConfirmableCommand {
             user.sendMessage("commands.island.sethome.must-be-on-your-island");
             return false;
         }
+
+        int rank = Objects.requireNonNull(island).getRank(user);
+        if (rank < island.getRankCommand(getUsage())) {
+            user.sendMessage("general.errors.insufficient-rank", TextVariables.RANK, user.getTranslation(getPlugin().getRanksManager().getRank(rank)));
+            return false;
+        }
+
         // Check number of homes
         int maxHomes = getIslands().getMaxHomes(island);
         if (getIslands().getNumberOfHomesIfAdded(island, String.join(" ", args)) > maxHomes) {


### PR DESCRIPTION
This pull request contains 2 features:

1. Implements CompositeCommand creators to specify default rank for each command.
2. Add more ranked commands to the list:
    - sethome command
    - renamehome command
    - deletehome command
    - setname command
    - resetname command

Implementing this PR will allow to extend protection abilities for island owners, as well as simplify protection creation in other addons. Instead of writing custom flags, addon makers could mark the command as a configurable rank command with a specified default rank.