### PR TITLE
Fixed bug with running onLeave commands

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -96,8 +96,6 @@ public class AdminDeleteCommand extends ConfirmableCommand {
     }
 
     private void cleanUp(User user, User target) {
-        // Execute commands when leaving
-        Util.runCommands(user, getIWM().getOnLeaveCommands(getWorld()), "leave");
         // Remove money inventory etc.
         if (getIWM().isOnLeaveResetEnderChest(getWorld())) {
             target.getPlayer().getEnderChest().clear();
@@ -123,6 +121,8 @@ public class AdminDeleteCommand extends ConfirmableCommand {
             target.getPlayer().setTotalExperience(0);
         }
 
+        // Execute commands when leaving
+        Util.runCommands(target, getIWM().getOnLeaveCommands(getWorld()), "leave");
     }
 
     @Override


### PR DESCRIPTION
In discord, it was reported that running the admin delete command produces a null-pointer if `[player]` placeholder is used.

With fast checking I found out the issue: incorrect user was passed to the command.
Also, I moved runCommands below all resets, so commands could be used to give items, or xp or other stuff that is removed.