### PR TITLE
Templated Panel Title Parameters

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/TemplatedPanel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/TemplatedPanel.java
@@ -46,6 +46,8 @@ public class TemplatedPanel extends Panel
         this.typeIndex = new HashMap<>(builder.getObjectCreatorMap().size());
         this.typeSlotMap = new HashMap<>(builder.getObjectCreatorMap().size());
 
+        this.parameters = builder.getParameters().toArray(new String[0]);
+
         if (this.panelTemplate == null)
         {
             BentoBox.getInstance().logError("Cannot generate panel because template is not loaded.");
@@ -69,7 +71,7 @@ public class TemplatedPanel extends Panel
                 case DROPPER -> this.populateDropperPanel();
             };
 
-        super.makePanel(this.user.getTranslation(this.panelTemplate.title()),
+        super.makePanel(this.user.getTranslation(this.panelTemplate.title(), this.parameters),
             items,
             items.keySet().stream().max(Comparator.naturalOrder()).orElse(9),
             this.user,
@@ -527,4 +529,10 @@ public class TemplatedPanel extends Panel
      * Stores the number of items with given type in whole panel.
      */
     private final Map<String, Integer> typeSlotMap;
+
+    /**
+     * Stores the parameters for panel title object.
+     * @since 1.20.0
+     */
+    private final String[] parameters;
 }

--- a/src/main/java/world/bentobox/bentobox/api/panels/builders/TemplatedPanelBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/builders/TemplatedPanelBuilder.java
@@ -8,11 +8,11 @@ package world.bentobox.bentobox.api.panels.builders;
 
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiFunction;
 
 import org.bukkit.World;
+import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.PanelListener;
@@ -70,6 +70,24 @@ public class TemplatedPanelBuilder
     public TemplatedPanelBuilder world(World world)
     {
         this.world = world;
+        return this;
+    }
+
+
+    /**
+     * Parameters for title of templated panel.
+     *
+     * @param parameters the parameters for title
+     * @return the templated panel builder
+     * @since 1.20.0
+     */
+    public TemplatedPanelBuilder parameters(@NonNull String... parameters)
+    {
+        if (parameters.length > 0)
+        {
+            this.parameters.addAll(Arrays.stream(parameters).toList());
+        }
+
         return this;
     }
 
@@ -151,6 +169,17 @@ public class TemplatedPanelBuilder
 
 
     /**
+     * Get title parameters for panel title.
+     *
+     * @return the list of parameters for title.
+     */
+    public List<String> getParameters()
+    {
+        return this.parameters;
+    }
+
+
+    /**
      * Gets listener.
      *
      * @return the listener
@@ -196,6 +225,11 @@ public class TemplatedPanelBuilder
      * Panel Listener
      */
     private PanelListener listener;
+
+    /**
+     * The list of parameters for title object.
+     */
+    private final List<String> parameters = new ArrayList<>(0);
 
     /**
      * Map that links objects with their panel item creators.


### PR DESCRIPTION
Add an option to add parameters to the templated panel titles.

If addon creators wanted to pass panel title name that relies on some variable, it was not possible to do. This change allows to do it via TemplatedPanelBuilder#parameters method.