### PR TITLE
Add missing templated panel builder method

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/builders/TemplatedPanelBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/builders/TemplatedPanelBuilder.java
@@ -48,6 +48,23 @@ public class TemplatedPanelBuilder
     }
 
 
+
+    /**
+     * Adds the template that must be loaded for Template panel builder.
+     *
+     * @param panelName the gui name
+     * @param templateName the name of the file
+     * @param dataFolder the data folder
+     * @return the template panel builder
+     * @since 1.20.0
+     */
+    public TemplatedPanelBuilder template(String panelName, String templateName, File dataFolder)
+    {
+        this.panelTemplate = TemplateReader.readTemplatePanel(panelName, templateName, dataFolder);
+        return this;
+    }
+
+
     /**
      * Adds the user for template panel builder.
      *


### PR DESCRIPTION
#1932 implemented a feature that allows reading multiple panels from a single file, however, there was a missing builder in TemplatedPanelBuilder class that would allow to use it.

This fixes it and adds the missing builder method.