### PR TITLE
Implement ACTION defining by ACTION TYPE

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/reader/TemplateReader.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/reader/TemplateReader.java
@@ -360,6 +360,24 @@ public class TemplateReader
                             itemRecord.addAction(actionData);
                         }
                     }
+                    else
+                    {
+                        ConfigurationSection actionDataSection = actionSection.getConfigurationSection(actionKey);
+
+                        if (actionDataSection != null && actionDataSection.contains("click-type"))
+                        {
+                            clickType = Enums.getIfPresent(ClickType.class,
+                                actionDataSection.getString("click-type", "UNKNOWN").toUpperCase()).
+                                or(ClickType.UNKNOWN);
+                            
+                            ItemTemplateRecord.ActionRecords actionData =
+                                new ItemTemplateRecord.ActionRecords(clickType,
+                                    actionKey,
+                                    actionDataSection.getString("content"),
+                                    actionDataSection.getString("tooltip"));
+                            itemRecord.addAction(actionData);
+                        }
+                    }
                 });
             }
         }


### PR DESCRIPTION
This change implements a new way how to define actions via a custom panel template.

Previously there were 2 options how to define an action:
- by click-type
- as an array list

This adds the third type: by action type. It means that now developers could code that action is the main key for defining what happens when button is clicked:
```
    actions:
       visit:
          click-type: LEFT
          tooltip: Tooltip text for left click action
```