### PR TITLE
Fixes bug with Safe Spot Teleport

### DIFF
--- a/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
+++ b/src/main/java/world/bentobox/bentobox/util/teleport/SafeSpotTeleport.java
@@ -226,7 +226,7 @@ public class SafeSpotTeleport {
         // Check the safe spot at the current height
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
-                if (minY >= startY && checkBlock(chunk, x, startY, z)) {
+                if (minY <= startY && checkBlock(chunk, x, startY, z)) {
                     return true;
                 }
                 maxY = Math.max(chunk.getHighestBlockYAt(x, z), maxY);


### PR DESCRIPTION
There was a bug that prevented finding a safe spot if all valid blocks were in height with the `startY` location.

Reported via discord.