### PR TITLE
Improve team kick command

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -68,6 +68,14 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.not-in-team");
             return false;
         }
+
+        int targetRank = Objects.requireNonNull(island).getRank(user);
+        if (rank <= targetRank) {
+            user.sendMessage("commands.island.team.kick.cannot-kick-rank", 
+                TextVariables.NAME, getPlayers().getName(targetUUID));
+            return false;
+        }
+        
         if (!getSettings().isKickConfirmation()) {
             kick(user, targetUUID);
             return true;
@@ -89,7 +97,9 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
         if (event.isCancelled()) {
             return;
         }
-        target.sendMessage("commands.island.team.kick.owner-kicked", TextVariables.GAMEMODE, getAddon().getDescription().getName());
+        target.sendMessage("commands.island.team.kick.player-kicked", 
+            TextVariables.GAMEMODE, getAddon().getDescription().getName(),
+            TextVariables.NAME, user.getName());
 
         getIslands().removePlayer(getWorld(), targetUUID);
         // Clean the target player

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -42,10 +42,6 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.no-team");
             return false;
         }
-        if (!user.getUniqueId().equals(getOwner(getWorld(), user))) {
-            user.sendMessage("general.errors.not-owner");
-            return false;
-        }
         // Check rank to use command
         Island island = getIslands().getIsland(getWorld(), user);
         int rank = Objects.requireNonNull(island).getRank(user);

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -652,8 +652,9 @@ commands:
       kick:
         description: "remove a member from your island"
         parameters: "<player>"
-        owner-kicked: "&c The owner kicked you from the island in [gamemode]!"
+        player-kicked: "&c The [name] kicked you from the island in [gamemode]!"
         cannot-kick: "&c You cannot kick yourself!"
+        cannot-kick-rank: "&c Your rank does not allow to kick [name]!"
         success: "&b [name] &a has been kicked from your island."
       demote:
         description: "demote a player on your island down a rank"


### PR DESCRIPTION
There was an issue that prevented non-owners to kick other players from the team, even if command rank allowed it. 

Added a message that shows who kicked a player from the island.

Added protection from same rank players kicking each other. 