### PR TITLE
Fixes wrong protection bounding box

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -803,7 +803,7 @@ public class Island implements DataObject, MetaDataAble {
      * @since 1.5.2
      */
     public BoundingBox getProtectionBoundingBox() {
-        return new BoundingBox(getMinProtectedX(), 0.0D, getMinProtectedZ(), getMaxProtectedX()-1.0D, world.getMaxHeight(), getMaxProtectedZ()-1.0D);
+        return new BoundingBox(getMinProtectedX(), world.getMinHeight(), getMinProtectedZ(), getMaxProtectedX()-1.0D, world.getMaxHeight(), getMaxProtectedZ()-1.0D);
     }
 
     /**
@@ -1661,9 +1661,4 @@ public class Island implements DataObject, MetaDataAble {
                 + ", cooldowns=" + cooldowns + ", commandRanks=" + commandRanks + ", reserved=" + reserved
                 + ", metaData=" + metaData + ", homes=" + homes + ", maxHomes=" + maxHomes + "]";
     }
-
-
-
-
-
 }


### PR DESCRIPTION
#1966 fixed a bounding box size for the whole island, while the protection bounding box was still wrong.

Fixes https://github.com/BentoBoxWorld/BSkyBlock/issues/473