### PR TITLE
fix rare null on invitedPlayer

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
@@ -109,6 +109,8 @@ public class IslandTeamInviteCommand extends CompositeCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
+        // Rare case when invited player is null. Could be a race condition.
+        if (invitedPlayer == null) return false;
         // If that player already has an invite out then retract it.
         // Players can only have one invite one at a time - interesting
         if (itc.isInvited(invitedPlayer.getUniqueId())) {


### PR DESCRIPTION
I don't know why. That could be a bad practice where `invitedPlayer` is a class property.
This is a temporary fix.
```
[15:37:13] [Server thread/ERROR]: null
org.bukkit.command.CommandException: Unhandled exception executing 'ob team invite' in world.bentobox.aoneblock.commands.PlayerCommand(ob)
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:182) ~[purpur-api-1.18.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_18_R2.CraftServer.dispatchCommand(CraftServer.java:906) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleCommand(ServerGamePacketListenerImpl.java:2389) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleChat(ServerGamePacketListenerImpl.java:2200) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleChat(ServerGamePacketListenerImpl.java:2181) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundChatPacket.handle(ServerboundChatPacket.java:46) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundChatPacket.a(ServerboundChatPacket.java:6) ~[?:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1426) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:188) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1403) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1396) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:114) ~[?:?]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1530) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1246) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:320) ~[purpur-1.18.2.jar:git-Purpur-1613]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "world.bentobox.bentobox.api.user.User.getUniqueId()" because "this.invitedPlayer" is null
	at world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand.execute(IslandTeamInviteCommand.java:114) ~[BentoBox.jar:?]
	at world.bentobox.bentobox.api.commands.CompositeCommand.call(CompositeCommand.java:273) ~[BentoBox.jar:?]
	at world.bentobox.bentobox.api.commands.CompositeCommand.execute(CompositeCommand.java:246) ~[BentoBox.jar:?]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:172) ~[purpur-api-1.18.2-R0.1-SNAPSHOT.jar:?]
	... 20 more
```