### PR TITLE
Fix portal teleportation in dimensions and added respawner listener

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '16'
+          java-version: '17'
       - name: Cache SonarCloud packages
         uses: actions/cache@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <spigot.version>1.18.2-R0.1-SNAPSHOT</spigot.version>
         <!-- Might differ from the last Spigot release for short periods 
             of time -->
-        <paper.version>1.16.5-R0.1-SNAPSHOT</paper.version>
+        <paper.version>1.18.2-R0.1-SNAPSHOT</paper.version>
         <bstats.version>2.2.1</bstats.version>
         <vault.version>1.7</vault.version>
         <placeholderapi.version>2.10.9</placeholderapi.version>
@@ -179,18 +179,18 @@
     </repositories>
 
     <dependencies>
+        <!-- Paper API -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Spigot API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>${spigot.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Paper API -->
-        <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>${paper.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- AuthLib. Used for Head Getter. -->

--- a/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
@@ -168,7 +168,7 @@ public class PortalTeleportationListener implements Listener {
                 if (island.getMembers().containsKey(user.getUniqueId()))
                     e.setRespawnLocation(island.getSpawnPoint(Environment.NORMAL));
             });;
-				}
+        }
     }
 
     /**
@@ -191,7 +191,7 @@ public class PortalTeleportationListener implements Listener {
         }
 
         if (!Bukkit.getServer().getAllowNether()) {
-            e.setCancelled(true);
+                e.setCancelled(true);
         }
 
         if (inTeleport.contains(e.getEntity().getUniqueId())) {
@@ -237,7 +237,7 @@ public class PortalTeleportationListener implements Listener {
             // All done here
             return true;
         }
-        if (e.getCanCreatePortal() && ((env == Environment.THE_END && Bukkit.getAllowEnd()) || (env == Environment.NETHER && Bukkit.getAllowNether()))) {
+        if (e.getCanCreatePortal() && isAllowedOnServer(env)) {
             // Let the server teleport
             return true;
         }
@@ -286,7 +286,7 @@ public class PortalTeleportationListener implements Listener {
         }
 
         Location toLocation = e.getTo();
-				Location toWorldLocation = e.getFrom().toVector().toLocation(toWorld);
+        Location toWorldLocation = e.getFrom().toVector().toLocation(toWorld);
         int toWorldMinHeight = toLocation == null ? 0 : toLocation.getWorld().getMinHeight();
         toWorldLocation.setY(Math.max(e.getFrom().getBlockY(), toWorldMinHeight));
         if (!e.getCanCreatePortal()) {
@@ -393,8 +393,7 @@ public class PortalTeleportationListener implements Listener {
     private void handleFromNetherOrEnd(PlayerEntityPortalEvent e, World overWorld, Environment env) {
         // Standard portals
         if (plugin.getIWM().getAddon(overWorld).map(gm -> isMakePortals(gm, env)
-          && (env == Environment.NETHER && Bukkit.getAllowNether())
-            || (env == Environment.THE_END && Bukkit.getAllowEnd())).orElse(false)) {
+            && isAllowedOnServer(env)).orElse(false)) {
             e.setTo(e.getFrom().toVector().toLocation(overWorld));
             // Find distance from edge of island's protection
             plugin.getIslands().getIslandAt(e.getFrom()).ifPresent(i -> setSeachRadius(e, i));

--- a/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
@@ -261,14 +261,17 @@ public class PortalTeleportationListener implements Listener {
         if (e.getFrom().getWorld() == null || toWorld == null) {
             return null;
         }
+
+				Location toWorldLocation = e.getFrom().toVector().toLocation(toWorld);
+				toWorldLocation.setY(Math.max(e.getFrom().getBlockY(), e.getTo().getWorld().getMinHeight()));
         if (!e.getCanCreatePortal()) {
             // Legacy portaling
-            return e.getIsland().map(i -> i.getSpawnPoint(env)).orElse(e.getFrom().toVector().toLocation(toWorld));
+            return e.getIsland().map(i -> i.getSpawnPoint(env)).orElse(toWorldLocation);
         }
         // Make portals
         // For anywhere other than the end - it is the player's location that is used
         if (!env.equals(Environment.THE_END)) {
-            return e.getFrom().toVector().toLocation(toWorld);
+            return toWorldLocation;
         }
         // If the-end then we want the platform to always be generated in the same place no matter where
         // they enter the portal
@@ -277,7 +280,7 @@ public class PortalTeleportationListener implements Listener {
         final int y = e.getFrom().getBlockY();
         int i = x;
         int j = z;
-        int k = y;
+        int k = Math.max(y, e.getTo().getWorld().getMinHeight());
         // If the from is not a portal, then we have to find it
         if (!e.getFrom().getBlock().getType().equals(Material.END_PORTAL)) {
             // Find the portal - due to speed, it is possible that the player will be below or above the portal

--- a/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
@@ -163,6 +163,8 @@ public class PortalTeleportationListener implements Listener {
             User user = User.getInstance(e.getPlayer());
 
             plugin.getIslands().getProtectedIslandAt(user.getLocation()).ifPresent(island -> {
+                // TODO : Add some hook here for Addons such as "Visit" that could teleport back to
+                // the visit location
                 if (island.getMembers().containsKey(user.getUniqueId()))
                     e.setRespawnLocation(island.getSpawnPoint(Environment.NORMAL));
             });;

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommandTest.java
@@ -170,8 +170,8 @@ public class AdminSettingsCommandTest {
         when(itemFactory.getItemMeta(any())).thenReturn(bannerMeta);
         when(Bukkit.getItemFactory()).thenReturn(itemFactory);
         Inventory inventory = mock(Inventory.class);
-        when(Bukkit.createInventory(eq(null), Mockito.anyInt(), any())).thenReturn(inventory);
-        when(Bukkit.createInventory(eq(null), any(InventoryType.class), any())).thenReturn(inventory);
+        when(Bukkit.createInventory(eq(null), Mockito.anyInt(), anyString())).thenReturn(inventory);
+        when(Bukkit.createInventory(eq(null), any(InventoryType.class), anyString())).thenReturn(inventory);
         // Flags manager
         when(Bukkit.getPluginManager()).thenReturn(pluginManager);
         FlagsManager fm = new FlagsManager(plugin);

--- a/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelBuilderTest.java
@@ -40,7 +40,7 @@ public class PanelBuilderTest {
     public void setUp() throws Exception {
         PowerMockito.mockStatic(Bukkit.class);
         Inventory inv = mock(Inventory.class);
-        when(Bukkit.createInventory(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(inv);
+        when(Bukkit.createInventory(Mockito.any(), Mockito.any(), Mockito.anyString())).thenReturn(inv);
 
     }
 

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
@@ -176,7 +176,7 @@ public class InvincibleVisitorsListenerTest {
         when(top.getSize()).thenReturn(9);
         when(panel.getInventory()).thenReturn(top);
 
-        when(Bukkit.createInventory(any(), anyInt(), any())).thenReturn(top);
+        when(Bukkit.createInventory(any(), anyInt(), anyString())).thenReturn(top);
     }
 
     @After

--- a/src/test/java/world/bentobox/bentobox/panels/BlueprintManagementPanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/BlueprintManagementPanelTest.java
@@ -80,7 +80,7 @@ public class BlueprintManagementPanelTest {
         ItemFactory itemFac = mock(ItemFactory.class);
         when(Bukkit.getItemFactory()).thenReturn(itemFac);
         // Panel inventory
-        when(Bukkit.createInventory(any(), Mockito.anyInt(), any())).thenReturn(inv);
+        when(Bukkit.createInventory(any(), Mockito.anyInt(), anyString())).thenReturn(inv);
 
         // Player
         Player player = mock(Player.class);

--- a/src/test/java/world/bentobox/bentobox/panels/IslandCreationPanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/IslandCreationPanelTest.java
@@ -142,7 +142,7 @@ public class IslandCreationPanelTest {
         when(plugin.getIWM()).thenReturn(iwm);
 
         // Panel inventory
-        when(Bukkit.createInventory(any(), Mockito.anyInt(), any())).thenReturn(inv);
+        when(Bukkit.createInventory(any(), Mockito.anyInt(), anyString())).thenReturn(inv);
 
         // Item Factory (needed for ItemStack)
         ItemFactory itemF = mock(ItemFactory.class);

--- a/src/test/java/world/bentobox/bentobox/panels/LanguagePanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/LanguagePanelTest.java
@@ -106,7 +106,7 @@ public class LanguagePanelTest {
 
         // Panel
         PowerMockito.mockStatic(Bukkit.class);
-        when(Bukkit.createInventory(any(), Mockito.anyInt(), any())).thenReturn(inv);
+        when(Bukkit.createInventory(any(), Mockito.anyInt(), anyString())).thenReturn(inv);
 
         // Item Factory (needed for ItemStack)
         ItemFactory itemF = mock(ItemFactory.class);


### PR DESCRIPTION
**Added a new listener `onPlayerRespawn`:**
Entering an End Portal in the_end doesn't trigger `onPlayerTeleport` but `onPlayerRespawn`, I needed to use latest paper-api's in order to get the `RespawnFlags` and make this work
(added a todo in this listener : hooking addons such as `Visits` to change the respawn location)

**Fix**
fixes #1977
Also fixes portal teleportation when dimensions are disabled at the system level
(bonus players in creative teleport instantly)

**Problem**
Bukkit is now compiled with a more recent runtime, it needs to be updated