### PR TITLE
Move database dependencies to the Spigot Libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,11 +230,13 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>
             <version>${mongodb.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>9.1-901-1.jdbc4</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Vault: as their maven repo is down, we need to get it from jitpack -->
         <!-- See https://github.com/MilkBowl/VaultAPI/issues/69 -->

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,6 +28,11 @@ softdepend:
   - HolographicDisplays
   - EconomyPlus
 
+libraries:
+  - mysql:mysql-connector-java:8.0.27
+  - org.mongodb:mongodb-driver:${mongodb.version}
+  - postgresql:postgresql:9.1-901-1.jdbc4
+
 permissions:
   bentobox.admin:
     description: Allows admin command usage


### PR DESCRIPTION
This just moves mongo and postgresql to the spigot library list.

Also, added mysql just in case, because people reported in discord that on some engines it is not included.