### PR TITLE
Spawn per Island + Soft Safe Spot Teleport

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -308,6 +308,12 @@ public class Settings implements ConfigObject {
     private boolean slowDeletion = false;
 
     @ConfigComment("By default, If the destination is not safe, the plugin will try to search for a safe spot around the destination,")
+    @ConfigComment("This setting will only find a spot on the Y axis.")
+    @ConfigComment("Will create a block platform if here is no block in the Y axis.")
+    @ConfigEntry(path = "island.use-soft-safe-spot-teleport", since = "1.21.0")
+    private boolean useSoftSafeSpotTeleport = false;
+
+    @ConfigComment("By default, If the destination is not safe, the plugin will try to search for a safe spot around the destination,")
     @ConfigComment("then it will try to expand the y-coordinate up and down from the destination.")
     @ConfigComment("This setting limits how far the y-coordinate will be expanded.")
     @ConfigComment("If set to 0 or lower, the plugin will not expand the y-coordinate.")
@@ -913,6 +919,14 @@ public class Settings implements ConfigObject {
 
     public void setSafeSpotSearchVerticalRange(int safeSpotSearchVerticalRange) {
         this.safeSpotSearchVerticalRange = safeSpotSearchVerticalRange;
+    }
+
+    public boolean isUseSoftSafeSpotTeleport() {
+        return useSoftSafeSpotTeleport;
+    }
+
+    public void setUseSoftSafeSpotTeleport(boolean useSoftSafeSpotTeleport) {
+        this.useSoftSafeSpotTeleport = useSoftSafeSpotTeleport;
     }
 
     public boolean isSlowDeletion() {

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetSpawnPointCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetSpawnPointCommand.java
@@ -56,9 +56,9 @@ public class AdminSetSpawnPointCommand extends ConfirmableCommand
 
         if (optionalIsland.isPresent() &&
             (optionalIsland.get().hasNetherIsland() ||
-            !World.Environment.NETHER.equals(user.getLocation().getWorld().getEnvironment())) &&
+            World.Environment.NETHER != user.getLocation().getWorld().getEnvironment()) &&
             (optionalIsland.get().hasEndIsland() ||
-            !World.Environment.THE_END.equals(user.getLocation().getWorld().getEnvironment())))
+            World.Environment.THE_END != user.getLocation().getWorld().getEnvironment()))
         {
             // Everything's fine, we can set the location as spawn point for island :)
             this.askConfirmation(user, user.getTranslation("commands.admin.setspawnpoint.confirmation"),

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSetspawnCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSetspawnCommand.java
@@ -1,0 +1,67 @@
+package world.bentobox.bentobox.api.commands.island;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.bukkit.Location;
+import org.eclipse.jdt.annotation.Nullable;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.ConfirmableCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.RanksManager;
+
+public class IslandSetspawnCommand extends ConfirmableCommand {
+    private @Nullable Island island;
+
+    public IslandSetspawnCommand(CompositeCommand islandCommand) {
+        super(islandCommand, "setspawn");
+    }
+
+    @Override
+    public void setup() {
+        setPermission("island.setspawn");
+        setOnlyPlayer(true);
+        setDescription("commands.island.setspawn.description");
+        setConfigurableRankCommand();
+        setDefaultCommandRank(RanksManager.SUB_OWNER_RANK);
+    }
+
+    @Override
+    public boolean canExecute(User user, String label, List<String> args) {
+        island = getIslands().getIsland(getWorld(), user);
+        // Check island
+        if (island == null || island.getOwner() == null) {
+            user.sendMessage("general.errors.no-island");
+            return false;
+        }
+        if (!island.onIsland(user.getLocation())) {
+            user.sendMessage("commands.island.setspawn.must-be-on-your-island");
+            return false;
+        }
+
+        int rank = Objects.requireNonNull(island).getRank(user);
+        if (rank < island.getRankCommand(getUsage())) {
+            user.sendMessage("general.errors.insufficient-rank", TextVariables.RANK, user.getTranslation(getPlugin().getRanksManager().getRank(rank)));
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        this.askConfirmation(user, user.getTranslation("commands.island.reset.confirmation"), () -> doSetSpawn(user));
+        return true;
+    }
+
+    private void doSetSpawn(User user) {
+        Location userLocation = user.getLocation();
+        userLocation.setX(Math.floor(userLocation.getX())+0.5D);
+        userLocation.setZ(Math.floor(userLocation.getZ())+0.5D);
+        island.setSpawnPoint(userLocation.getWorld().getEnvironment(), userLocation);
+        user.sendMessage("commands.island.setspawn.spawn-set");
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSetspawnCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSetspawnCommand.java
@@ -53,7 +53,7 @@ public class IslandSetspawnCommand extends ConfirmableCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        this.askConfirmation(user, user.getTranslation("commands.island.reset.confirmation"), () -> doSetSpawn(user));
+        this.askConfirmation(user, user.getTranslation("commands.island.setspawn.confirmation"), () -> doSetSpawn(user));
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -568,4 +568,15 @@ public interface WorldSettings extends ConfigObject {
     default boolean isCheckForBlocks() {
         return true;
     }
+
+    /**
+     * By default, the destination will be island's home.
+     * This setting will allow players to do /gamemode setspawn and using
+     * /gamemode will teleport them to their island's spawn
+     * @return true if a check for blocks should happen
+     * @since 1.21.0
+     */
+    default boolean isAllowSpawnPerIsland() {
+        return false;
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -707,13 +707,13 @@ public class Island implements DataObject, MetaDataAble {
 		 * @param player
 		 * @return true if player is a visitor
 		 */
-		private boolean playerIsVisitor(Player player) {
-			if (player.getGameMode() == GameMode.SPECTATOR) {
-				return false;
-			}
+    public boolean playerIsVisitor(Player player) {
+        if (player.getGameMode() == GameMode.SPECTATOR) {
+            return false;
+        }
 
-			return onIsland(player.getLocation()) && getRank(User.getInstance(player)) == RanksManager.VISITOR_RANK;
-		}
+        return onIsland(player.getLocation()) && getRank(User.getInstance(player)) == RanksManager.VISITOR_RANK;
+    }
 
     /**
      * Returns a list of players that are physically inside the island's protection range and that are visitors.
@@ -1247,6 +1247,13 @@ public class Island implements DataObject, MetaDataAble {
         setChanged();
     }
 
+    private Location getWorldLocationFromCenter(World world) {
+        Location center = getCenter();
+        Location loc = center.toVector().toLocation(world);
+        loc.setY(Math.max(center.getY(), world.getMinHeight()));
+        return loc;
+    }
+
     /**
      * Checks whether this island has its nether island generated or not.
      * @return {@code true} if this island has its nether island generated, {@code false} otherwise.
@@ -1254,7 +1261,7 @@ public class Island implements DataObject, MetaDataAble {
      */
     public boolean hasNetherIsland() {
         World nether = BentoBox.getInstance().getIWM().getNetherWorld(getWorld());
-        return nether != null && !getCenter().toVector().toLocation(nether).getBlock().getType().isAir();
+        return nether != null && !getWorldLocationFromCenter(nether).getBlock().getType().isAir();
     }
 
     /**
@@ -1264,7 +1271,7 @@ public class Island implements DataObject, MetaDataAble {
      */
     public boolean hasEndIsland() {
         World end = BentoBox.getInstance().getIWM().getEndWorld(getWorld());
-        return end != null && !getCenter().toVector().toLocation(end).getBlock().getType().isAir();
+        return end != null && !getWorldLocationFromCenter(end).getBlock().getType().isAir();
     }
 
 

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -1250,7 +1250,7 @@ public class Island implements DataObject, MetaDataAble {
     private Location getWorldLocationFromCenter(World world) {
         Location center = getCenter();
         Location loc = center.toVector().toLocation(world);
-        loc.setY(Math.max(center.getY(), world.getMinHeight()));
+        loc.setY(Math.max(center.getY(), world.getMinHeight() + 2));
         return loc;
     }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PortalTeleportationListener.java
@@ -132,12 +132,13 @@ public class PortalTeleportationListener implements Listener {
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onExitPortal(PlayerMoveEvent e) {
-        if (!inPortal.contains(e.getPlayer().getUniqueId())) {
+        UUID uuid = e.getPlayer().getUniqueId();
+        if (!inPortal.contains(uuid) && !inTeleport.contains(uuid)) {
             return;
         }
         if (e.getTo() != null && !e.getTo().getBlock().getType().equals(Material.NETHER_PORTAL)) {
-            inPortal.remove(e.getPlayer().getUniqueId());
-            inTeleport.remove(e.getPlayer().getUniqueId());
+            inPortal.remove(uuid);
+            inTeleport.remove(uuid);
         }
     }
 
@@ -181,11 +182,11 @@ public class PortalTeleportationListener implements Listener {
             e.setCancelled(true);
         }
 
-//        if (inTeleport.contains(e.getEntity().getUniqueId())) {
-//            return false;
-//        }
+       if (inTeleport.contains(e.getEntity().getUniqueId())) {
+           return false;
+       }
 
-//        inTeleport.add(e.getEntity().getUniqueId());
+       inTeleport.add(e.getEntity().getUniqueId());
 
         // STANDARD NETHER OR END
         if (!isIslands(overWorld, env)) {

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -543,6 +543,10 @@ commands:
         not-allowed: "&c You are not allowed to set your home in the End."
         confirmation: "&c Are you sure you want to set your home in the End?"
       parameters: "[home name]"
+    setspawn:
+      description: "set your spawn point in this world"
+      must-be-on-your-island: "&c You must be on your island to set home!"
+      spawn-set: "&6 Your island spawn point has been set to your current location."
     setname:
       description: "set a name for your island"
       name-too-short: "&c Too short. Minimum size is [number] characters."

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -547,6 +547,7 @@ commands:
       description: "set your spawn point in this world"
       must-be-on-your-island: "&c You must be on your island to set home!"
       spawn-set: "&6 Your island spawn point has been set to your current location."
+      confirmation: "&c Are you sure you want to change the spawn point of your island?"
     setname:
       description: "set a name for your island"
       name-too-short: "&c Too short. Minimum size is [number] characters."


### PR DESCRIPTION
**Spawn Per Island**
- added an option to allow spawn points per island by using `/gamemode setspawn`
Using `/gamemode` will teleport to the spawn point instead of the home location
For me it makes sense to have a spawn point different than homes, a nice setting to have per gamemode, it's disabled by default
- Fixed an issue with island's center being in a negative Y coordinate `/admin setspawnpoint` didn't work in other dimensions

**Soft Safe Spot Teleport**
- I made this because I have so many issues with the main `SafeSpotTeleport` never being consistent
You can enable it with a setting, default is disabled
__What it does__
Finding the nearest safe spot only in the Y axis, if no block is found then it will make a glass block on the spawn point
Not perfect, but it does the job done for me, I hope for other people too, could be improved.

**Fixes**
- teleporting other entities than players when `end` and/or `nether` are disabled in `server.properties` 
- inTeleport flag was not removed on the player when using and end portal
- pasting an island on other dimensions when the world's minHeight > islandHeight (It happens when setting `area-height` to a negative coordinate)
 \
To solve this I take the max value between world minHeight (+2) and island's height
  \+ 2 to give some space for bedrock to generate (in the nether for example)
- an enum comparaison
- formatting