### PR TITLE
Fixes Glowing Item frames protection

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
@@ -198,8 +198,8 @@ public class BlockInteractionListener extends FlagListener {
         case END_PORTAL_FRAME:
             checkIsland(e, player, loc, Flags.PLACE_BLOCKS);
             break;
-        case GLOW_ITEM_FRAME,
-            ITEM_FRAME:
+        case GLOW_ITEM_FRAME:
+        case ITEM_FRAME:
             checkIsland(e, player, loc, Flags.ITEM_FRAME);
             break;
         case SWEET_BERRY_BUSH:

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
@@ -198,7 +198,8 @@ public class BlockInteractionListener extends FlagListener {
         case END_PORTAL_FRAME:
             checkIsland(e, player, loc, Flags.PLACE_BLOCKS);
             break;
-        case ITEM_FRAME:
+        case GLOW_ITEM_FRAME,
+            ITEM_FRAME:
             checkIsland(e, player, loc, Flags.ITEM_FRAME);
             break;
         case SWEET_BERRY_BUSH:

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PlaceBlocksListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PlaceBlocksListener.java
@@ -52,7 +52,7 @@ public class PlaceBlocksListener extends FlagListener {
      */
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerHitItemFrame(PlayerInteractEntityEvent e) {
-        if (e.getRightClicked().getType().equals(EntityType.ITEM_FRAME)) {
+        if (e.getRightClicked().getType().equals(EntityType.ITEM_FRAME) || e.getRightClicked().getType().equals(EntityType.GLOW_ITEM_FRAME)) {
             if (!checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.PLACE_BLOCKS)) return;
             checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.ITEM_FRAME);
         }

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListenerTest.java
@@ -110,6 +110,7 @@ public class BlockInteractionListenerTest extends AbstractCommonSetup {
         clickedBlocks.put(Material.DRAGON_EGG, Flags.DRAGON_EGG);
         clickedBlocks.put(Material.END_PORTAL_FRAME, Flags.PLACE_BLOCKS);
         clickedBlocks.put(Material.ITEM_FRAME, Flags.ITEM_FRAME);
+        clickedBlocks.put(Material.GLOW_ITEM_FRAME, Flags.ITEM_FRAME);
         clickedBlocks.put(Material.SWEET_BERRY_BUSH, Flags.BREAK_BLOCKS);
         clickedBlocks.put(Material.CAKE, Flags.CAKE);
         clickedBlocks.put(Material.BEEHIVE, Flags.HIVE);


### PR DESCRIPTION
Since 1.17 BentoBox had not protected Glowing Item Frames.

Our testing is amazing :D

Fixes https://github.com/BentoBoxWorld/BSkyBlock/issues/475