### PR TITLE
Check if unique name contains chars not supported in regex expression

### DIFF
--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
@@ -51,6 +51,13 @@ public class NamePrompt extends StringPrompt {
         if (ChatColor.stripColor(input).length() > 32) {
             context.getForWhom().sendRawMessage("Too long");
             return this;
+
+            /*Check if unique name contains chars not supported in regex expression
+            Cannot start, contain, or end with special char, cannot contain any numbers.
+            Can only contain - for word separation*/
+        }else if (ChatColor.stripColor(input).matches("^[a-zA-Z]+(?:-[a-zA-Z]+)*$")) {
+             context.getForWhom().sendRawMessage(user.getTranslation("commands.admin.blueprint.management.name.invalid-char-in-unique-name"));
+            return this;
         }
         if (bb == null || !bb.getUniqueId().equals(BlueprintsManager.DEFAULT_BUNDLE_NAME)) {
             // Make a uniqueid

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
@@ -55,7 +55,7 @@ public class NamePrompt extends StringPrompt {
             /*Check if unique name contains chars not supported in regex expression
             Cannot start, contain, or end with special char, cannot contain any numbers.
             Can only contain - for word separation*/
-        }else if (ChatColor.stripColor(input).matches("^[a-zA-Z]+(?:-[a-zA-Z]+)*$")) {
+        }else if (!ChatColor.stripColor(input).matches("^[a-zA-Z]+(?:-[a-zA-Z]+)*$")) {
              context.getForWhom().sendRawMessage(user.getTranslation("commands.admin.blueprint.management.name.invalid-char-in-unique-name"));
             return this;
         }

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -340,6 +340,7 @@ commands:
           prompt: Napiš jméno, nebo 'quit' ke zrušení
           too-long: '&c Příliš dlouhé'
           pick-a-unique-name: Prosím, zvol více jedinečný název
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Povedlo se!
           conversation-prefix: '>'
         description:

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -391,6 +391,7 @@ commands:
           prompt: Gib einen Namen ein, oder 'quit' zum Beenden
           too-long: "&c Zu lang"
           pick-a-unique-name: Wähle bitte einen eindeutigeren Namen
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Erfolg!
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -367,6 +367,7 @@ commands:
           prompt: "Enter a name, or 'quit' to quit"
           too-long: "&c Too long"
           pick-a-unique-name: "Please pick a more unique name"
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: "Success!"
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -362,6 +362,7 @@ commands:
           prompt: Ingrese un nombre o 'quit' para salir
           too-long: "&cDemasiado largo"
           pick-a-unique-name: Elige un nombre más exclusivo
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: "¡Éxito!"
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -86,6 +86,7 @@ commands:
         name:
           conversation-prefix: ">"
           pick-a-unique-name: Veuillez choisir un nom plus unique
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           prompt: Entrez un nom, ou "quitter" pour quitter
           quit: quitter
           success: Succès !

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -78,6 +78,7 @@ commands:
         name:
           conversation-prefix: ">"
           pick-a-unique-name: Scegli un nome unico
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           prompt: Inserisci un nome, o 'quit' per uscire
           success: Successo!
           too-long: "&cTroppo lungo"

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -328,6 +328,7 @@ commands:
           prompt: 名前を入力するか、「quit」で終了します
           too-long: "&c長すぎる"
           pick-a-unique-name: よりユニークな名前を選んでください
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: 成功！
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -337,6 +337,7 @@ commands:
           prompt: 이름을 입력하세요, quit를 입력하여 종료할수 있습니다
           too-long: "&c 너무 깁니다"
           pick-a-unique-name: 더 독특한 이름을 선택하십시오
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: 완료!
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -90,6 +90,7 @@ commands:
         name:
           conversation-prefix: ">"
           pick-a-unique-name: Lūdzu izvēlies unikālu nosaukumu
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           prompt: Ieraksti vārdu vai 'iziet', lai izietu
           quit: iziet
           success: Izdevās!

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -393,6 +393,7 @@ commands:
           prompt: Voer een naam in of 'quit' om te stoppen
           too-long: "&c Te lang"
           pick-a-unique-name: Kies een meer unieke naam
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Succes!
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -345,6 +345,7 @@ commands:
           prompt: Wprowadź nazwę, lub wpisz 'wyjdź', by wyjść
           too-long: '&cNazwa zbyt długa'
           pick-a-unique-name: Wybierz bardziej unikalną nazwę
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Sukces!
           conversation-prefix: '>'
         description:

--- a/src/main/resources/locales/pt_BR.yml
+++ b/src/main/resources/locales/pt_BR.yml
@@ -354,6 +354,7 @@ commands:
           prompt: Digite um nome, ou 'quit' para sair
           too-long: '&c Muito comprido'
           pick-a-unique-name: Por favor escolha um nome único
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Sucesso!
           conversation-prefix: '>'
         description:

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -373,6 +373,7 @@ commands:
           prompt: Introduceți un nume sau „renunțați” pentru a renunța
           too-long: "&c Prea mult"
           pick-a-unique-name: Vă rugăm să alegeți un nume mai unic
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Succes!
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -384,6 +384,7 @@ commands:
           prompt: İsim gir ya da çıkmak için 'quit' yaz.
           too-long: "&cÇok uzun."
           pick-a-unique-name: Lütfen daha benzersiz bir ad seçin
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Başarılı!
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -376,6 +376,7 @@ commands:
           prompt: Enter a name, or 'quit' to quit
           too-long: "&c Too long"
           pick-a-unique-name: Please pick a more unique name
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: Success!
           conversation-prefix: ">"
         description:

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -367,6 +367,7 @@ commands:
           prompt: "&e请输入新名称， 或 “&b quit&e” 来退出编辑。"
           too-long: "&c新名称太长了！"
           pick-a-unique-name: "&c这个名称已存在， 请另选一个不同的名称！"
+          invalid-char-in-unique-name: "Unique name cannot contain, start, or end with special characters, neither contain number! "
           success: "&a成功！"
           conversation-prefix: "&3> &r"
         description:


### PR DESCRIPTION
Cannot start, contain, or end with special char, cannot contain any numbers.
Can only contain - for word separation
Fixed issue earlier reported #1954 