### PR TITLE
Implements adding unknown default island flag values in settings.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.api.configuration;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,10 +32,53 @@ public interface WorldSettings extends ConfigObject {
 
     /**
      * @return default rank settings for new islands
+     * @deprecated since 1.21
+     *             Map of Flag, Integer does not allow to load other plugin/addon flags.
+     *             It cannot be replaced with Map of String, Integer due to compatibility issues.
+     * @see WorldSettings#getDefaultIslandFlagNames()
      */
+    @Deprecated
     Map<Flag, Integer> getDefaultIslandFlags();
 
+    /**
+     * Return map of flags ID's linked to default rank for new island.
+     * This is necessary so users could specify any flag names in settings file from other plugins and addons.
+     * Otherwise, Flag reader would mark flag as invalid and remove it.
+     * Default implementation is compatibility layer so GameModes that are not upgraded still works.
+     * @since 1.21
+     * @return default rank settings for new islands.
+     */
+    default Map<String, Integer> getDefaultIslandFlagNames()
+    {
+        Map<String, Integer> flags = new HashMap<>();
+        this.getDefaultIslandFlags().forEach((key, value) -> flags.put(key.getID(), value));
+        return flags;
+    }
+
+    /**
+     * @return default settings for new
+     * @deprecated since 1.21
+     *             Map of Flag, Integer does not allow to load other plugin/addon flags.
+     *             It cannot be replaced with Map of String, Integer due to compatibility issues.
+     * @see WorldSettings#getDefaultIslandSettingNames()
+     */
+    @Deprecated
     Map<Flag, Integer> getDefaultIslandSettings();
+
+    /**
+     * Return map of flags ID's linked to default settings for new island.
+     * This is necessary so users could specify any flag names in settings file from other plugins and addons.
+     * Otherwise, Flag reader would mark flag as invalid and remove it.
+     * Default implementation is compatibility layer so GameModes that are not upgraded still works.
+     * @since 1.21
+     * @return default settings for new islands.
+     */
+    default Map<String, Integer> getDefaultIslandSettingNames()
+    {
+        Map<String, Integer> flags = new HashMap<>();
+        this.getDefaultIslandSettings().forEach((key, value) -> flags.put(key.getID(), value));
+        return flags;
+    }
 
     /**
      * Get the world difficulty

--- a/src/main/java/world/bentobox/bentobox/database/objects/adapters/FlagBooleanSerializer.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/adapters/FlagBooleanSerializer.java
@@ -1,0 +1,65 @@
+package world.bentobox.bentobox.database.objects.adapters;
+
+
+import org.bukkit.configuration.MemorySection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+
+/**
+ * This Serializer migrates Map of String, Boolean to Map of String, Integer in serialization process.
+ * It is necessary because current implementation requires flags to be mapped to Integer value.
+ * @author BONNe
+ */
+public class FlagBooleanSerializer implements AdapterInterface<Map<String, Integer>, Map<String, Boolean>>
+{
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, Integer> deserialize(Object object)
+    {
+        Map<String, Integer> result = new HashMap<>();
+        if (object == null)
+        {
+            return result;
+        }
+        // For YAML
+        if (object instanceof MemorySection section)
+        {
+            for (String key : section.getKeys(false))
+            {
+                result.put(key, section.getBoolean(key) ? 0 : -1);
+            }
+        }
+        else
+        {
+            for (Entry<String, Boolean> en : ((Map<String, Boolean>) object).entrySet())
+            {
+                result.put(en.getKey(), en.getValue() ? 0 : -1);
+            }
+        }
+
+        return result;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, Boolean> serialize(Object object)
+    {
+        Map<String, Boolean> result = new HashMap<>();
+
+        if (object == null)
+        {
+            return result;
+        }
+
+        Map<String, Integer> flags = (Map<String, Integer>) object;
+
+        for (Entry<String, Integer> en : flags.entrySet())
+        {
+            result.put(en.getKey(), en.getValue() >= 0);
+        }
+        return result;
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -171,10 +171,13 @@ public class IslandWorldManager {
         }
 
         // Set default island settings
-        plugin.getFlagsManager().getFlags().stream().filter(f -> f.getType().equals(Flag.Type.PROTECTION))
-        .forEach(f -> settings.getDefaultIslandFlags().putIfAbsent(f, f.getDefaultRank()));
-        plugin.getFlagsManager().getFlags().stream().filter(f -> f.getType().equals(Flag.Type.SETTING))
-        .forEach(f -> settings.getDefaultIslandSettings().putIfAbsent(f, f.getDefaultRank()));
+        plugin.getFlagsManager().getFlags().stream().
+            filter(f -> f.getType().equals(Flag.Type.PROTECTION)).
+            forEach(f -> settings.getDefaultIslandFlagNames().putIfAbsent(f.getID(), f.getDefaultRank()));
+        plugin.getFlagsManager().getFlags().stream().
+            filter(f -> f.getType().equals(Flag.Type.SETTING)).
+            forEach(f -> settings.getDefaultIslandSettingNames().putIfAbsent(f.getID(), f.getDefaultRank()));
+
         Bukkit.getScheduler().runTask(plugin, () -> {
             // Set world difficulty
             Difficulty diff = settings.getDifficulty();
@@ -477,7 +480,9 @@ public class IslandWorldManager {
      * @return Friendly name or world name if world is not a game world
      */
     public String getFriendlyName(@NonNull World world) {
-        return gameModes.containsKey(world) ? gameModes.get(world).getWorldSettings().getFriendlyName() : world.getName();
+        return gameModes.containsKey(world) ?
+            gameModes.get(world).getWorldSettings().getFriendlyName() :
+            world.getName();
     }
 
     /**
@@ -699,8 +704,11 @@ public class IslandWorldManager {
      * @param world - world
      * @return default rank settings for new islands.
      */
-    public Map<Flag, Integer> getDefaultIslandFlags(@NonNull World world) {
-        return gameModes.containsKey(world) ? gameModes.get(world).getWorldSettings().getDefaultIslandFlags() : Collections.emptyMap();
+    public Map<Flag, Integer> getDefaultIslandFlags(@NonNull World world)
+    {
+        return this.gameModes.containsKey(world) ?
+            this.convertToFlags(this.gameModes.get(world).getWorldSettings().getDefaultIslandFlagNames()) :
+            Collections.emptyMap();
     }
 
     /**
@@ -715,12 +723,14 @@ public class IslandWorldManager {
     /**
      * Return island setting defaults for world
      *
-     * @param world
-     *            - world
+     * @param world - world
      * @return default settings for new islands
      */
-    public Map<Flag, Integer> getDefaultIslandSettings(@NonNull World world) {
-        return gameModes.containsKey(world) ? gameModes.get(world).getWorldSettings().getDefaultIslandSettings() : Collections.emptyMap();
+    public Map<Flag, Integer> getDefaultIslandSettings(@NonNull World world)
+    {
+        return this.gameModes.containsKey(world) ?
+            this.convertToFlags(this.gameModes.get(world).getWorldSettings().getDefaultIslandSettingNames()) :
+            Collections.emptyMap();
     }
 
     public boolean isUseOwnGenerator(@NonNull World world) {
@@ -921,4 +931,18 @@ public class IslandWorldManager {
         return gameModes.containsKey(world) && gameModes.get(world).getWorldSettings().isTeleportPlayerToIslandUponIslandCreation();
     }
 
+
+    /**
+     * This method migrates Map of String, Integer to Map of Flag, Integer.
+     * @param flagNamesMap Map that contains flag names to their values.
+     * @return Flag objects to their values.
+     * @since 1.21
+     */
+    private Map<Flag, Integer> convertToFlags(Map<String, Integer> flagNamesMap)
+    {
+        Map<Flag, Integer> flagMap = new HashMap<>();
+        flagNamesMap.forEach((key, value) ->
+            this.plugin.getFlagsManager().getFlag(key).ifPresent(flag -> flagMap.put(flag, value)));
+        return flagMap;
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1333,7 +1333,7 @@ public class IslandsManager {
                 } else {
                     // Successful load
                     // Clean any null flags out of the island - these can occur for various reasons
-                    island.getFlags().keySet().removeIf(f -> f.getID().startsWith("NULL_FLAG"));
+                    island.getFlags().keySet().removeIf(f -> f.startsWith("NULL_FLAG"));
                 }
             }
 

--- a/src/test/java/world/bentobox/bentobox/database/objects/IslandTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/objects/IslandTest.java
@@ -1018,7 +1018,7 @@ public class IslandTest {
      */
     @Test
     public void testSetCooldowns() {
-        i.setCooldowns(Collections.singletonMap(Flags.BREAK_BLOCKS, 123L));
+        i.setCooldowns(Collections.singletonMap(Flags.BREAK_BLOCKS.getID(), 123L));
         assertFalse(i.getCooldowns().isEmpty());
     }
 


### PR DESCRIPTION
In BentoBox was an issue that users were not able to specify default island settings values for flags that are not defined by the BentoBox plugin itself. That was happening because WorldSettings were always initialized before all flags were populated in-game. To avoid that issue I introduced 2 new methods in WorldSettings that should replace existing default flag getters. 

Using Flag ID's instead of Flag objects allows to define and store any flags, even if they will not exist. 

GameMode addons are required to implement new usage to fix the #1830 completely.

Fixes #1830