### PR TITLE
Register BentoBox World Generator option with MyWorlds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <placeholderapi.version>2.10.9</placeholderapi.version>
         <githubapi.version>d5f5e0bbd8</githubapi.version>
         <dynmap.version>3.0-SNAPSHOT</dynmap.version>
+        <myworlds.version>1.19-v2</myworlds.version>
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- Do not change unless you want different name for local builds. -->
@@ -181,6 +182,11 @@
             <id>nms-repo</id>
             <url>https://repo.codemc.io/repository/nms/</url>
         </repository>
+        <!-- Used for MyWorlds hook -->
+        <repository>
+            <id>MG-Dev Jenkins CI Maven Repository</id>
+            <url>https://ci.mg-dev.eu/plugin/repository/everything</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -264,6 +270,12 @@
             <groupId>us.dynmap</groupId>
             <artifactId>dynmap-api</artifactId>
             <version>${dynmap.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.bergerkiller.bukkit</groupId>
+            <artifactId>MyWorlds</artifactId>
+            <version>${myworlds.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Shaded APIs -->

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -20,6 +20,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.commands.BentoBoxCommand;
 import world.bentobox.bentobox.database.DatabaseSetup;
 import world.bentobox.bentobox.hooks.MultiverseCoreHook;
+import world.bentobox.bentobox.hooks.MyWorldsHook;
 import world.bentobox.bentobox.hooks.VaultHook;
 import world.bentobox.bentobox.hooks.placeholders.PlaceholderAPIHook;
 import world.bentobox.bentobox.listeners.BannedCommands;
@@ -225,6 +226,7 @@ public class BentoBox extends JavaPlugin {
         // Register Multiverse hook - MV loads AFTER BentoBox
         // Make sure all worlds are already registered to Multiverse.
         hooksManager.registerHook(new MultiverseCoreHook());
+        hooksManager.registerHook(new MyWorldsHook());
         islandWorldManager.registerWorldsToMultiverse();
 
         // TODO: re-enable after implementation

--- a/src/main/java/world/bentobox/bentobox/hooks/MultiverseCoreHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/MultiverseCoreHook.java
@@ -14,7 +14,7 @@ import world.bentobox.bentobox.api.hooks.Hook;
  *
  * @author Poslovitch
  */
-public class MultiverseCoreHook extends Hook {
+public class MultiverseCoreHook extends Hook implements WorldManagementHook {
 
     private static final String MULTIVERSE_SET_GENERATOR = "mv modify set generator ";
     private static final String MULTIVERSE_IMPORT = "mv import ";
@@ -28,6 +28,7 @@ public class MultiverseCoreHook extends Hook {
      * @param world - world to register
      * @param islandWorld - if true, then this is an island world
      */
+    @Override
     public void registerWorld(World world, boolean islandWorld) {
         if (islandWorld) {
             // Only register generator if one is defined in the addon (is not null)

--- a/src/main/java/world/bentobox/bentobox/hooks/MyWorldsHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/MyWorldsHook.java
@@ -1,0 +1,76 @@
+package world.bentobox.bentobox.hooks;
+
+import java.util.logging.Level;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+
+import com.bergerkiller.bukkit.mw.WorldConfigStore;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.hooks.Hook;
+
+/**
+ * Provides implementation and interfacing to interact with MyWorlds.
+ *
+ * @author bergerkiller (Irmo van den Berge)
+ */
+public class MyWorldsHook extends Hook implements WorldManagementHook {
+
+    public MyWorldsHook() {
+        super("My_Worlds", Material.FILLED_MAP);
+    }
+
+    /**
+     * Register the world with MyWorlds
+     *
+     * @param world - world to register
+     * @param islandWorld - if true, then this is an island world
+     */
+    @Override
+    public void registerWorld(World world, boolean islandWorld) {
+        if (islandWorld) {
+            // Only register generator if one is defined in the addon (is not null)
+            boolean hasGenerator = BentoBox.getInstance().getIWM().getAddon(world).map(gm -> gm.getDefaultWorldGenerator(world.getName(), "") != null).orElse(false);
+            setUseBentoboxGenerator(world, hasGenerator);
+        } else {
+            // Set the generator to null - this will remove any previous registration
+            setUseBentoboxGenerator(world, false);
+        }
+    }
+
+    private void setUseBentoboxGenerator(World world, boolean hasGenerator) {
+        String name = hasGenerator ? BentoBox.getInstance().getName() : null;
+
+        try {
+            WorldConfigStore.get(world).setChunkGeneratorName(name);
+
+            // Alternative Reflection way to do it, if a MyWorlds dependency isn't available at
+            // compile time.
+            /*
+            // WorldConfigStore -> public static WorldConfig get(World world);
+            Object worldConfig = Class.forName("com.bergerkiller.bukkit.mw.WorldConfigStore")
+                    .getMethod("get", World.class)
+                    .invoke(null, world);
+
+            // WorldConfig -> public void setChunkGeneratorName(String name);
+            Class.forName("com.bergerkiller.bukkit.mw.WorldConfig")
+                    .getMethod("setChunkGeneratorName", String.class)
+                    .invoke(worldConfig, name);
+             */
+        } catch (Throwable t) {
+            BentoBox.getInstance().getLogger().log(Level.SEVERE,
+                    "Failed to register world " + world.getName() + " with MyWorlds", t);
+        }
+    }
+
+    @Override
+    public boolean hook() {
+        return true; // The hook process shouldn't fail
+    }
+
+    @Override
+    public String getFailureCause() {
+        return null; // The hook process shouldn't fail
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/hooks/WorldManagementHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/WorldManagementHook.java
@@ -1,0 +1,20 @@
+package world.bentobox.bentobox.hooks;
+
+import org.bukkit.World;
+
+/**
+ * Hook for a type of Multi-World management plugin that must be made
+ * aware of the correct configuration of a BentoBox World.
+ *
+ * @author bergerkiller (Irmo van den Berge)
+ */
+public interface WorldManagementHook {
+
+    /**
+     * Register the world with the World Management hook
+     *
+     * @param world - world to register
+     * @param islandWorld - if true, then this is an island world
+     */
+    void registerWorld(World world, boolean islandWorld);
+}

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -25,7 +25,8 @@ import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.flags.Flag;
-import world.bentobox.bentobox.hooks.MultiverseCoreHook;
+import world.bentobox.bentobox.api.hooks.Hook;
+import world.bentobox.bentobox.hooks.WorldManagementHook;
 import world.bentobox.bentobox.lists.Flags;
 
 /**
@@ -51,31 +52,34 @@ public class IslandWorldManager {
 
     public void registerWorldsToMultiverse() {
         gameModes.values().stream().distinct().forEach(gm -> {
-            registerToMultiverse(gm.getOverWorld(), true);
+            registerToWorldManagementPlugins(gm.getOverWorld(), true);
             if (gm.getWorldSettings().isNetherGenerate()) {
-                registerToMultiverse(gm.getNetherWorld(), gm.getWorldSettings().isNetherIslands());
+                registerToWorldManagementPlugins(gm.getNetherWorld(), gm.getWorldSettings().isNetherIslands());
             }
             if (gm.getWorldSettings().isEndGenerate()) {
-                registerToMultiverse(gm.getEndWorld(), gm.getWorldSettings().isEndIslands());
+                registerToWorldManagementPlugins(gm.getEndWorld(), gm.getWorldSettings().isEndIslands());
             }
         });
     }
 
     /**
-     * Registers a world with Multiverse if Multiverse is available.
+     * Registers a world with world management plugins
      *
      * @param world the World to register
      * @param islandWorld true if this is an island world
      */
-    private void registerToMultiverse(@NonNull World world, boolean islandWorld) {
+    private void registerToWorldManagementPlugins(@NonNull World world, boolean islandWorld) {
         if (plugin.getHooks() != null) {
-            plugin.getHooks().getHook("Multiverse-Core").ifPresent(hook -> {
-                if (Bukkit.isPrimaryThread()) {
-                    ((MultiverseCoreHook) hook).registerWorld(world, islandWorld);
-                } else {
-                    Bukkit.getScheduler().runTask(plugin, () -> ((MultiverseCoreHook) hook).registerWorld(world, islandWorld));
+            for (Hook hook : plugin.getHooks().getHooks()) {
+                if (hook instanceof WorldManagementHook) {
+                    final WorldManagementHook worldManagementHook = (WorldManagementHook) hook;
+                    if (Bukkit.isPrimaryThread()) {
+                        worldManagementHook.registerWorld(world, islandWorld);
+                    } else {
+                        Bukkit.getScheduler().runTask(plugin, () -> worldManagementHook.registerWorld(world, islandWorld));
+                    }
                 }
-            });
+            }
         }
     }
 
@@ -156,17 +160,17 @@ public class IslandWorldManager {
         // Add worlds to map
         gameModes.put(world, gameMode);
         // Call Multiverse
-        registerToMultiverse(world, true);
+        registerToWorldManagementPlugins(world, true);
         if (settings.isNetherGenerate()) {
             gameModes.put(gameMode.getNetherWorld(), gameMode);
             if (settings.isNetherIslands()) {
-                registerToMultiverse(gameMode.getNetherWorld(), true);
+                registerToWorldManagementPlugins(gameMode.getNetherWorld(), true);
             }
         }
         if (settings.isEndGenerate()) {
             gameModes.put(gameMode.getEndWorld(), gameMode);
             if (settings.isEndIslands()) {
-                registerToMultiverse(gameMode.getEndWorld(), true);
+                registerToWorldManagementPlugins(gameMode.getEndWorld(), true);
             }
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,7 +10,7 @@ description: ${project.description}
 
 load: STARTUP
 
-loadbefore: [Pladdon, Multiverse-Core, Residence]
+loadbefore: [Pladdon, Multiverse-Core, My_Worlds, Residence]
 
 softdepend:
   - Citizens


### PR DESCRIPTION
Because BentoBox uses addons which provide chunk generators, MyWorlds failed to identify the plugin belonging to these generators automatically. As such, it needs a hook like the one used for Multiverse to set world configuration to use BentoBox.

Fixes #2038 