### PR TITLE
Mark end portals and gateways as unsafe location.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -269,7 +269,11 @@ public class IslandsManager {
                 || ground.name().contains("SIGN")
                 || ground.name().contains("BANNER")
                 || ground.name().contains("BUTTON")
-                || ground.name().contains("BOAT")) {
+                || ground.name().contains("BOAT")
+                || space1.equals(Material.END_PORTAL)
+                || space2.equals(Material.END_PORTAL)
+                || space1.equals(Material.END_GATEWAY)
+                || space2.equals(Material.END_GATEWAY)) {
             return false;
         }
         // Known unsafe blocks


### PR DESCRIPTION
The end portals and gateways teleports players to a different dimension upon player touches it. So teleportation should consider these positions as unsafe, otherwise player will be teleported to the different dimension instantly.

Fixes #2040