### PR TITLE
2046 null player placeholder support

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/placeholders/placeholderapi/BasicPlaceholderExpansion.java
+++ b/src/main/java/world/bentobox/bentobox/api/placeholders/placeholderapi/BasicPlaceholderExpansion.java
@@ -9,7 +9,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.placeholders.PlaceholderReplacer;
 import world.bentobox.bentobox.api.user.User;
 

--- a/src/main/java/world/bentobox/bentobox/api/placeholders/placeholderapi/BasicPlaceholderExpansion.java
+++ b/src/main/java/world/bentobox/bentobox/api/placeholders/placeholderapi/BasicPlaceholderExpansion.java
@@ -6,8 +6,10 @@ import java.util.Map;
 
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.placeholders.PlaceholderReplacer;
 import world.bentobox.bentobox.api.user.User;
 
@@ -42,9 +44,9 @@ abstract class BasicPlaceholderExpansion extends PlaceholderExpansion {
     }
 
     @Override
-    public String onPlaceholderRequest(Player p, @NonNull String placeholder) {
-        if (placeholders.containsKey(placeholder) && p != null) {
-            return placeholders.get(placeholder).onReplace(User.getInstance(p));
+    public String onPlaceholderRequest(@Nullable Player p, @NonNull String placeholder) {
+        if (placeholders.containsKey(placeholder)) {
+            return placeholders.get(placeholder).onReplace(p != null ? User.getInstance(p) : null);
         }
         return null;
     }

--- a/src/main/java/world/bentobox/bentobox/hooks/placeholders/PlaceholderAPIHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/placeholders/PlaceholderAPIHook.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 import world.bentobox.bentobox.BentoBox;
@@ -109,7 +110,10 @@ public class PlaceholderAPIHook extends PlaceholderHook {
      */
     @Override
     @NonNull
-    public String replacePlaceholders(@NonNull Player player, @NonNull String string) {
+    public String replacePlaceholders(@Nullable Player player, @NonNull String string) {
+        if (player == null) {
+            return PlaceholderAPI.setPlaceholders(player, removeGMPlaceholder(string));
+        }
         // Transform [gamemode] in string to the game mode description name, or remove it for the default replacement
         String newString = BentoBox.getInstance().getIWM().getAddon(player.getWorld()).map(gm ->
         string.replace(TextVariables.GAMEMODE, gm.getDescription().getName().toLowerCase())

--- a/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
@@ -116,12 +116,12 @@ public class PlaceholdersManager {
 
     /**
      * Replaces the placeholders in this String and returns it.
-     * @param player the Player to get the placeholders for.
+     * @param player the Player to get the placeholders for or null for non-player-specific placeholders
      * @param string the String to replace the placeholders in.
      * @return the String with placeholders replaced, or the identical String if no placeholders were available.
      * @since 1.5.0
      */
-    public String replacePlaceholders(@NonNull Player player, @NonNull String string) {
+    public String replacePlaceholders(@Nullable Player player, @NonNull String string) {
         return getPlaceholderAPIHook().map(papi -> papi.replacePlaceholders(player, string)).orElse(string);
     }
 
@@ -131,6 +131,6 @@ public class PlaceholdersManager {
      */
     public void unregisterAll() {
         getPlaceholderAPIHook().ifPresent(PlaceholderAPIHook::unregisterAll);
-        
+
     }
 }


### PR DESCRIPTION
I adjusted BasicPlaceholderExpansion.java to handle and allow null players, which is used then the placeholder is not referring to a player and often is used with NPC's like Citizens. However, weirdly, this code is what PAPI uses, so I'm not sure what the purpose is of https://github.com/BentoBoxWorld/BentoBox/blob/develop/src/main/java/world/bentobox/bentobox/hooks/placeholders/PlaceholderAPIHook.java because although it seems to be hooked, it's never actually called. Even the registration functions are never called.
Maybe this is a different bug!