### PR TITLE
Add variable parsing on reference text

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -431,6 +431,19 @@ public class User implements MetaDataAble {
         if (translation == null) {
             translation = plugin.getLocalesManager().get(this, reference);
             if (translation == null) {
+                
+                // Then replace variables
+                if (variables.length > 1) {
+                    for (int i = 0; i < variables.length; i += 2) {
+                        reference = reference.replace(variables[i], variables[i + 1]);
+                    }
+                }
+
+                // Then replace Placeholders, this will only work if this is a player
+                if (player != null) {
+                    reference = plugin.getPlaceholdersManager().replacePlaceholders(player, reference);
+                }
+                
                 // If no translation has been found, return the reference for debug purposes.
                 return reference;
             }


### PR DESCRIPTION
This solves the issue in customizable GUI's where variables are defined directly into the panel button name and description instead of providing the link to the locale. 

Not all users want to specify all text into a locale, and they would not get parsed variables just because of that. This change fixes it and it does not give any bad situations even if the reference is just missing text in the locale, as there will be nothing for parsing.