### PR TITLE
Remove 1.18.2 from supported version list.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/json/adapters/LocationTypeAdapter.java
+++ b/src/main/java/world/bentobox/bentobox/database/json/adapters/LocationTypeAdapter.java
@@ -24,8 +24,9 @@ public class LocationTypeAdapter extends TypeAdapter<Location> {
         out.value(location.getX());
         out.value(location.getY());
         out.value(location.getZ());
-        out.value(location.getYaw());
-        out.value(location.getPitch());
+        // This is required for 1.19-1.19.2 compatibility.
+        out.value((double) location.getYaw());
+        out.value((double) location.getPitch());
         out.endArray();
     }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EntityInteractListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EntityInteractListener.java
@@ -70,11 +70,7 @@ public class EntityInteractListener extends FlagListener {
             {
                 this.checkIsland(e, p, l, Flags.FURNACE);
             }
-            else if (!ServerCompatibility.getInstance().isVersion(
-                ServerCompatibility.ServerVersion.V1_18,
-                ServerCompatibility.ServerVersion.V1_18_1,
-                ServerCompatibility.ServerVersion.V1_18_2) &&
-                e.getPlayer().isSneaking() && e.getRightClicked() instanceof ChestBoat)
+            else if (e.getPlayer().isSneaking() && e.getRightClicked() instanceof ChestBoat)
             {
                 // Access to chest boat since 1.19
                 this.checkIsland(e, p, l, Flags.CHEST);
@@ -96,11 +92,7 @@ public class EntityInteractListener extends FlagListener {
                 this.checkIsland(e, p, l, Flags.NAME_TAG);
             }
         }
-        else if (!ServerCompatibility.getInstance().isVersion(
-            ServerCompatibility.ServerVersion.V1_18,
-            ServerCompatibility.ServerVersion.V1_18_1,
-            ServerCompatibility.ServerVersion.V1_18_2) &&
-            e.getRightClicked() instanceof Allay)
+        else if (e.getRightClicked() instanceof Allay)
         {
             // Allay item giving/taking
             this.checkIsland(e, p, l, Flags.ALLAY);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/InventoryListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/InventoryListener.java
@@ -54,10 +54,7 @@ public class InventoryListener extends FlagListener
             // Prevent opening animal inventories.
             this.checkIsland(event, player, event.getInventory().getLocation(), Flags.MOUNT_INVENTORY);
         }
-        else if (!ServerCompatibility.getInstance().isVersion(ServerCompatibility.ServerVersion.V1_18,
-            ServerCompatibility.ServerVersion.V1_18_1,
-            ServerCompatibility.ServerVersion.V1_18_2) &&
-            inventoryHolder instanceof ChestBoat)
+        else if (inventoryHolder instanceof ChestBoat)
         {
             // Prevent opening chest inventories
             this.checkIsland(event, player, event.getInventory().getLocation(), Flags.CHEST);
@@ -132,8 +129,7 @@ public class InventoryListener extends FlagListener
         {
             this.checkIsland(e, player, e.getInventory().getLocation(), Flags.CHEST);
         }
-        else if (!ServerCompatibility.getInstance().isVersion(ServerCompatibility.ServerVersion.V1_18, ServerCompatibility.ServerVersion.V1_18_1, ServerCompatibility.ServerVersion.V1_18_2) &&
-            inventoryHolder instanceof ChestBoat)
+        else if (inventoryHolder instanceof ChestBoat)
         {
             // TODO: 1.19 added chest boat. Remove compatibility check when 1.18 is dropped.
             this.checkIsland(e, player, e.getInventory().getLocation(), Flags.CHEST);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/SculkSensorListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/SculkSensorListener.java
@@ -35,14 +35,6 @@ public class SculkSensorListener extends FlagListener
             return;
         }
 
-        if (ServerCompatibility.getInstance().isVersion(ServerCompatibility.ServerVersion.V1_18,
-            ServerCompatibility.ServerVersion.V1_18_1,
-            ServerCompatibility.ServerVersion.V1_18_2))
-        {
-            // TODO: 1.18 compatibility exit
-            return;
-        }
-
         if (event.getBlock().getType() == Material.SCULK_SENSOR &&
             event.getEntity() != null &&
             event.getEntity() instanceof Player player)

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/SculkShriekerListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/SculkShriekerListener.java
@@ -35,14 +35,6 @@ public class SculkShriekerListener extends FlagListener
             return;
         }
 
-        if (ServerCompatibility.getInstance().isVersion(ServerCompatibility.ServerVersion.V1_18,
-            ServerCompatibility.ServerVersion.V1_18_1,
-            ServerCompatibility.ServerVersion.V1_18_2))
-        {
-            // TODO: 1.18 compatibility exit
-            return;
-        }
-
         if (event.getBlock().getType() == Material.SCULK_SHRIEKER &&
             event.getEntity() != null &&
             event.getEntity() instanceof Player player)

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -357,19 +357,9 @@ public class Util {
         // Bat extends Mob
         // Most of passive mobs extends Animals
 
-        if (ServerCompatibility.getInstance().isVersion(ServerCompatibility.ServerVersion.V1_18,
-            ServerCompatibility.ServerVersion.V1_18_1,
-            ServerCompatibility.ServerVersion.V1_18_2))
-        {
-            return entity instanceof Animals || entity instanceof IronGolem || entity instanceof Snowman ||
-                entity instanceof WaterMob && !(entity instanceof PufferFish) || entity instanceof Bat;
-        }
-        else
-        {
-            return entity instanceof Animals || entity instanceof IronGolem || entity instanceof Snowman ||
-                entity instanceof WaterMob && !(entity instanceof PufferFish) || entity instanceof Bat ||
-                entity instanceof Allay;
-        }
+        return entity instanceof Animals || entity instanceof IronGolem || entity instanceof Snowman ||
+            entity instanceof WaterMob && !(entity instanceof PufferFish) || entity instanceof Bat ||
+            entity instanceof Allay;
     }
 
     /*

--- a/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
+++ b/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
@@ -189,27 +189,27 @@ public class ServerCompatibility {
         /**
          * @since 1.19.0
          */
-        V1_18(Compatibility.SUPPORTED),
+        V1_18(Compatibility.INCOMPATIBLE),
         /**
          * @since 1.19.0
          */
-        V1_18_1(Compatibility.SUPPORTED),
+        V1_18_1(Compatibility.INCOMPATIBLE),
         /**
          * @since 1.20.1
          */
-        V1_18_2(Compatibility.SUPPORTED),
+        V1_18_2(Compatibility.INCOMPATIBLE),
         /**
          * @since 1.21.0
          */
-        V1_19(Compatibility.COMPATIBLE),
+        V1_19(Compatibility.INCOMPATIBLE),
         /**
          * @since 1.21.0
          */
-        V1_19_1(Compatibility.COMPATIBLE),
+        V1_19_1(Compatibility.INCOMPATIBLE),
         /**
          * @since 1.21.0
          */
-        V1_19_2(Compatibility.COMPATIBLE),
+        V1_19_2(Compatibility.INCOMPATIBLE),
         /**
          * @since 1.22.0
          */

--- a/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
+++ b/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
@@ -201,15 +201,15 @@ public class ServerCompatibility {
         /**
          * @since 1.21.0
          */
-        V1_19(Compatibility.INCOMPATIBLE),
+        V1_19(Compatibility.COMPATIBLE),
         /**
          * @since 1.21.0
          */
-        V1_19_1(Compatibility.INCOMPATIBLE),
+        V1_19_1(Compatibility.COMPATIBLE),
         /**
          * @since 1.21.0
          */
-        V1_19_2(Compatibility.INCOMPATIBLE),
+        V1_19_2(Compatibility.COMPATIBLE),
         /**
          * @since 1.22.0
          */


### PR DESCRIPTION
1.18.2 support was removed with changes in commit 056cff4b6f630fdc5a5b58b3dcb70434511757cf

Also, mark 1.19, 1.19.1, and 1.19.2 as incompatible. It happens because of GSon library changes that prevent BentoBox compiled with Spigot 1.19.3 to run on older versions.

Running on 1.19.2 or below produces error reported in this bug report: #2071