### PR TITLE
Uses seed worlds for deletion purposes

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
@@ -138,7 +138,6 @@ public class CleanSuperFlatListener extends FlagListener {
         {
             return true;
         }
-
         // Check if super-flat must even be working.
         if (!this.getIWM().inWorld(world) ||
             !Flags.CLEAN_SUPER_FLAT.isSetForWorld(world) ||

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
@@ -95,7 +95,7 @@ public class CleanSuperFlatListener extends FlagListener {
         
         if (this.task == null || this.task.isCancelled())
         {
-            this.task = Bukkit.getScheduler().runTaskTimer(this.plugin, () -> this.cleanChunk(world, cg), 0L, 1L);
+            this.task = Bukkit.getScheduler().runTaskTimer(this.plugin, () -> this.cleanChunk(world), 0L, 1L);
         }
     }
 
@@ -105,7 +105,7 @@ public class CleanSuperFlatListener extends FlagListener {
      * @param world The world that must be cleared.
      * @param cg Chunk generator.
      */
-    private void cleanChunk(World world, ChunkGenerator cg)
+    private void cleanChunk(World world)
     {
         if (!this.chunkQueue.isEmpty())
         {

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
@@ -1,6 +1,5 @@
 package world.bentobox.bentobox.listeners.flags.worldsettings;
 
-import java.security.SecureRandom;
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -13,7 +12,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.generator.ChunkGenerator;
-import org.bukkit.generator.ChunkGenerator.ChunkData;
 import org.bukkit.scheduler.BukkitTask;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -22,8 +20,8 @@ import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.events.BentoBoxReadyEvent;
 import world.bentobox.bentobox.api.flags.FlagListener;
 import world.bentobox.bentobox.lists.Flags;
-import world.bentobox.bentobox.util.MyBiomeGrid;
-import world.bentobox.bentobox.util.Pair;
+import world.bentobox.bentobox.nms.WorldRegenerator;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * Cleans super-flat world chunks or normal nether chunks if they generate accidentally
@@ -35,11 +33,10 @@ public class CleanSuperFlatListener extends FlagListener {
     private final BentoBox plugin = BentoBox.getInstance();
 
     /**
-     * Stores pairs of X,Z coordinates of chunks that need to be regenerated.
-     * @since 1.1
+     * Stores chunks that need to be regenerated.
      */
     @NonNull
-    private final Queue<@NonNull Pair<@NonNull Integer, @NonNull Integer>> chunkQueue = new LinkedList<>();
+    private final Queue<Chunk> chunkQueue = new LinkedList<>();
 
     /**
      * Task that runs each tick to regenerate chunks that are in the {@link #chunkQueue}.
@@ -56,8 +53,15 @@ public class CleanSuperFlatListener extends FlagListener {
      */
     private boolean ready;
 
+    private WorldRegenerator regenerator;
+
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onBentoBoxReady(BentoBoxReadyEvent e) {
+        this.regenerator = Util.getRegenerator();
+        if (regenerator == null) {
+            plugin.logError("Could not start CleanSuperFlat because of NMS error");
+            return;
+        }
         ready = true;
     }
 
@@ -71,7 +75,6 @@ public class CleanSuperFlatListener extends FlagListener {
             return;
         }
         
-        MyBiomeGrid grid = new MyBiomeGrid(world.getEnvironment());
         ChunkGenerator cg = plugin.getAddonsManager().getDefaultWorldGenerator(world.getName(), "");
         
         if (cg == null) 
@@ -88,11 +91,11 @@ public class CleanSuperFlatListener extends FlagListener {
         }
         
         // Add to queue
-        this.chunkQueue.add(new Pair<>(e.getChunk().getX(), e.getChunk().getZ()));
+        this.chunkQueue.add(e.getChunk());
         
         if (this.task == null || this.task.isCancelled())
         {
-            this.task = Bukkit.getScheduler().runTaskTimer(this.plugin, () -> this.cleanChunk(world, cg, grid), 0L, 1L);
+            this.task = Bukkit.getScheduler().runTaskTimer(this.plugin, () -> this.cleanChunk(world, cg), 0L, 1L);
         }
     }
 
@@ -101,37 +104,19 @@ public class CleanSuperFlatListener extends FlagListener {
      * This method clears the chunk from queue in the given world
      * @param world The world that must be cleared.
      * @param cg Chunk generator.
-     * @param grid Biome Grid.
      */
-    private void cleanChunk(World world, ChunkGenerator cg, MyBiomeGrid grid)
+    private void cleanChunk(World world, ChunkGenerator cg)
     {
-        SecureRandom random = new SecureRandom();
-
         if (!this.chunkQueue.isEmpty())
         {
-            Pair<Integer, Integer> chunkXZ = this.chunkQueue.poll();
+            Chunk chunk = this.chunkQueue.poll();
 
-            ChunkData cd = cg.generateChunkData(world, random, chunkXZ.getKey(), chunkXZ.getValue(), grid);
-            Chunk chunk = world.getChunkAt(chunkXZ.getKey(), chunkXZ.getValue());
-
-            for (int x = 0; x < 16; x++)
-            {
-                for (int z = 0; z < 16; z++)
-                {
-                    for (int y = world.getMinHeight(); y < world.getMaxHeight(); y++)
-                    {
-                        chunk.getBlock(x, y, z).setBlockData(cd.getBlockData(x, y, z), false);
-                    }
-                }
-            }
-
-            // Run populators
-            cg.getDefaultPopulators(world).forEach(pop -> pop.populate(world, random, chunk));
-
+            regenerator.regenerateChunk(chunk);
+            
             if (this.plugin.getSettings().isLogCleanSuperFlatChunks())
             {
                 this.plugin.log("Regenerating superflat chunk in " + world.getName() +
-                    " at (" + chunkXZ.x + ", " + chunkXZ.z + ") " +
+                    " at (" + chunk.getX() + ", " + chunk.getZ() + ") " +
                     "(" + this.chunkQueue.size() + " chunk(s) remaining in the queue)");
             }
         }
@@ -140,6 +125,7 @@ public class CleanSuperFlatListener extends FlagListener {
             this.task.cancel();
         }
     }
+    
 
     /**
      * Check if chunk should be cleaned or not

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -23,6 +23,9 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Difficulty;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -300,6 +303,8 @@ public class AddonsManager {
             if (addon instanceof GameModeAddon gameMode) {
                 // Create the gameWorlds
                 gameMode.createWorlds();
+                // Create the seed worlds
+                createSeedWorlds(gameMode);
                 plugin.getIWM().addGameMode(gameMode);
                 // Save and load blueprints
                 plugin.getBlueprintsManager().extractDefaultBlueprints(gameMode);
@@ -324,6 +329,29 @@ public class AddonsManager {
             // Unhandled exception. We'll give a bit of debug here.
             handleAddonError(addon, e);
         }
+    }
+
+    /**
+     * Create seed worlds, which are used for deletion
+     * @param gameMode
+     */
+    private void createSeedWorlds(GameModeAddon gameMode) {
+        if (gameMode.getOverWorld() != null) {
+            seedWorld(gameMode, gameMode.getOverWorld());
+        }
+        if (gameMode.getNetherWorld() != null) {
+            seedWorld(gameMode, gameMode.getNetherWorld());
+        }
+        if (gameMode.getEndWorld() != null) {
+            seedWorld(gameMode, gameMode.getEndWorld());
+        }
+    }
+
+    private void seedWorld(GameModeAddon gameMode, @Nullable World world) {
+        @SuppressWarnings("deprecation")
+        WorldCreator wc = WorldCreator.name("seeds/" + world.getName()).type(world.getWorldType()).environment(world.getEnvironment());
+        World w = gameMode.getWorldSettings().isUseOwnGenerator() ? wc.createWorld() : wc.generator(world.getGenerator()).createWorld();
+        w.setDifficulty(Difficulty.PEACEFUL);       
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -26,6 +26,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
+import org.bukkit.WorldType;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -348,8 +349,8 @@ public class AddonsManager {
     }
 
     private void seedWorld(GameModeAddon gameMode, @Nullable World world) {
-        @SuppressWarnings("deprecation")
-        WorldCreator wc = WorldCreator.name("seeds/" + world.getName()).type(world.getWorldType()).environment(world.getEnvironment());
+        // Use the Flat type of world because this is a copy and no vanilla creation is required
+        WorldCreator wc = WorldCreator.name("seeds/" + world.getName()).type(WorldType.FLAT).environment(world.getEnvironment());
         World w = gameMode.getWorldSettings().isUseOwnGenerator() ? wc.createWorld() : wc.generator(world.getGenerator()).createWorld();
         w.setDifficulty(Difficulty.PEACEFUL);       
     }

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -348,7 +348,7 @@ public class AddonsManager {
         }
     }
 
-    private void seedWorld(GameModeAddon gameMode, @Nullable World world) {
+    private void seedWorld(GameModeAddon gameMode, @NonNull World world) {
         // Use the Flat type of world because this is a copy and no vanilla creation is required
         WorldCreator wc = WorldCreator.name("seeds/" + world.getName()).type(WorldType.FLAT).environment(world.getEnvironment());
         World w = gameMode.getWorldSettings().isUseOwnGenerator() ? wc.createWorld() : wc.generator(world.getGenerator()).createWorld();

--- a/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
+++ b/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
@@ -113,8 +113,7 @@ public abstract class CopyWorldRegenerator implements WorldRegenerator {
                 copyChunkDataToChunk(chunkTo, chunkFrom, di != null ? di.getBox() : null);
 
             } catch (InterruptedException | ExecutionException e) {
-                e.printStackTrace();
-                
+                Thread.currentThread().interrupt();                
             }
         });
         return CompletableFuture.allOf(cleanFuture, copyFuture);

--- a/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
+++ b/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
@@ -1,0 +1,166 @@
+package world.bentobox.bentobox.nms;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.BoundingBox;
+
+import io.papermc.lib.PaperLib;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.database.objects.IslandDeletion;
+
+/**
+ * Regenerates by using a seed world. The seed world is created using the same generator as the game
+ * world so that features created by metods like generateNoise or generateCaves can be regenerated.
+ * @author tastybento
+ *
+ */
+public abstract class CopyWorldRegenerator implements WorldRegenerator {
+    private final BentoBox plugin;
+
+    protected CopyWorldRegenerator() {
+        this.plugin = BentoBox.getInstance();
+    }
+
+    /**
+     * Update the low-level chunk information for the given block to the new block ID and data.  This
+     * change will not be propagated to clients until the chunk is refreshed to them.
+     *
+     * @param chunk        - chunk to be changed
+     * @param x            - x coordinate within chunk 0 - 15
+     * @param y            - y coordinate within chunk 0 - world height, e.g. 255
+     * @param z            - z coordinate within chunk 0 - 15
+     * @param blockData    - block data to set the block
+     * @param applyPhysics - apply physics or not
+     */
+    protected abstract void setBlockInNativeChunk(Chunk chunk, int x, int y, int z, BlockData blockData, boolean applyPhysics);
+
+    @Override
+    public CompletableFuture<Void> regenerate(GameModeAddon gm, IslandDeletion di, World world) {
+        CompletableFuture<Void> bigFuture = new CompletableFuture<>();
+        new BukkitRunnable() {
+            private int chunkX = di.getMinXChunk();
+            private int chunkZ = di.getMinZChunk();
+            CompletableFuture<Void> currentTask = CompletableFuture.completedFuture(null);
+
+            @Override
+            public void run() {
+                if (!currentTask.isDone()) return;
+                if (isEnded(chunkX)) {
+                    cancel();
+                    bigFuture.complete(null);
+                    return;
+                }
+                List<CompletableFuture<Void>> newTasks = new ArrayList<>();
+                for (int i = 0; i < plugin.getSettings().getDeleteSpeed(); i++) {
+                    if (isEnded(chunkX)) {
+                        break;
+                    }
+                    final int x = chunkX;
+                    final int z = chunkZ;
+                    newTasks.add(regenerateChunk(gm, di, world, x, z));
+                    chunkZ++;
+                    if (chunkZ > di.getMaxZChunk()) {
+                        chunkZ = di.getMinZChunk();
+                        chunkX++;
+                    }
+                }
+                currentTask = CompletableFuture.allOf(newTasks.toArray(new CompletableFuture[0]));
+            }
+
+            private boolean isEnded(int chunkX) {
+                return chunkX > di.getMaxXChunk();
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+        return bigFuture;
+    }
+
+    private CompletableFuture<Void> regenerateChunk(GameModeAddon gm, IslandDeletion di, World world, int chunkX, int chunkZ) {
+
+        CompletableFuture<Chunk> seedWorldFuture = getSeedWorldChunk(world, chunkX, chunkZ);
+
+        // Set up a future to get the chunk requests using Paper's Lib. If Paper is used, this should be done async
+        CompletableFuture<Chunk> chunkFuture = PaperLib.getChunkAtAsync(world, chunkX, chunkZ);
+
+        CompletableFuture<Void> cleanFuture = cleanChunk(chunkFuture, di);
+
+        CompletableFuture<Void> copyFuture = CompletableFuture.allOf(cleanFuture, chunkFuture, seedWorldFuture);
+        
+        copyFuture.thenRun(() -> {
+            try {
+                Chunk chunkToDelete = chunkFuture.get();
+                Chunk chunkToCopy = seedWorldFuture.get();
+                copyChunkDataToChunk(chunkToDelete, chunkToCopy, di.getBox());
+
+            } catch (InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+                
+            }
+        });
+        return CompletableFuture.allOf(cleanFuture, copyFuture);
+    }
+
+    private CompletableFuture<Chunk> getSeedWorldChunk(World world, int chunkX, int chunkZ) {
+        World seed = Bukkit.getWorld("seeds/" + world.getName());
+        if (seed == null) return CompletableFuture.completedFuture(null);     
+        return PaperLib.getChunkAtAsync(seed, chunkX, chunkZ);
+    }
+
+    /**
+     * Cleans up the chunk of inventories and entities
+     * @param chunkFuture the future chunk to be cleaned
+     * @param di island deletion data
+     * @return future completion of this task
+     */
+    private CompletableFuture<Void> cleanChunk(CompletableFuture<Chunk> chunkFuture, IslandDeletion di) {
+        // when it is complete, then run through all the tile entities in the chunk and clear them, e.g., chests are emptied
+        CompletableFuture<Void> invFuture = chunkFuture.thenAccept(chunk ->
+        Arrays.stream(chunk.getTileEntities()).filter(InventoryHolder.class::isInstance)
+        .filter(te -> di.inBounds(te.getLocation().getBlockX(), te.getLocation().getBlockZ()))
+        .forEach(te -> ((InventoryHolder) te).getInventory().clear())
+                );
+        
+        // Similarly, when the chunk is loaded, remove all the entities in the chunk apart from players
+        CompletableFuture<Void> entitiesFuture = chunkFuture.thenAccept(chunk -> {
+            // Remove all entities in chunk, including any dropped items as a result of clearing the blocks above
+            Arrays.stream(chunk.getEntities())
+            .filter(e -> !(e instanceof Player) && di.inBounds(e.getLocation().getBlockX(), e.getLocation().getBlockZ()))
+            .forEach(Entity::remove);
+        });
+        return CompletableFuture.allOf(invFuture, entitiesFuture);
+    }
+
+    private void copyChunkDataToChunk(Chunk chunk, Chunk chunkData, BoundingBox limitBox) {
+        double baseX = chunk.getX() << 4;
+        double baseZ = chunk.getZ() << 4;
+        int minHeight = chunk.getWorld().getMinHeight();
+        int maxHeight = chunk.getWorld().getMaxHeight();
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                if (!limitBox.contains(baseX + x, 0, baseZ + z)) {
+                    continue;
+                }
+                for (int y = minHeight; y < maxHeight; y++) {
+                    setBlockInNativeChunk(chunk, x, y, z, chunkData.getBlock(x, y, z).getBlockData(), false);
+                    // 3D biomes, 4 blocks separated
+                    if (x % 4 == 0 && y % 4 == 0 && z % 4 == 0) {
+                        chunk.getBlock(x, y, z).setBiome(chunkData.getBlock(x, y, z).getBiome());
+                    }
+                }
+            }
+        }
+        // TODO: Copy chest contents and entities
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/nms/WorldRegenerator.java
+++ b/src/main/java/world/bentobox/bentobox/nms/WorldRegenerator.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.nms;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.bukkit.Chunk;
 import org.bukkit.World;
 
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -20,4 +21,11 @@ public interface WorldRegenerator {
      * @return the completable future
      */
     CompletableFuture<Void> regenerate(GameModeAddon gm, IslandDeletion di, World world);
+
+    /**
+     * Regenerate a specific chunk to what it should be. Mainly used by clear super flat.
+     * @param chunk chunk to be regenerated
+     * @return future when it is done
+     */
+    CompletableFuture<Void> regenerateChunk(Chunk chunk);
 }

--- a/src/main/java/world/bentobox/bentobox/nms/fallback/WorldRegeneratorImpl.java
+++ b/src/main/java/world/bentobox/bentobox/nms/fallback/WorldRegeneratorImpl.java
@@ -3,13 +3,13 @@ package world.bentobox.bentobox.nms.fallback;
 import org.bukkit.Chunk;
 import org.bukkit.block.data.BlockData;
 
-import world.bentobox.bentobox.nms.SimpleWorldRegenerator;
+import world.bentobox.bentobox.nms.CopyWorldRegenerator;
 
 /**
  * @author tastybento
  *
  */
-public class WorldRegeneratorImpl extends SimpleWorldRegenerator {
+public class WorldRegeneratorImpl extends CopyWorldRegenerator {
 
     @Override
     protected void setBlockInNativeChunk(Chunk chunk, int x, int y, int z, BlockData blockData, boolean applyPhysics) {

--- a/src/main/java/world/bentobox/bentobox/nms/v1_19_R2/WorldRegeneratorImpl.java
+++ b/src/main/java/world/bentobox/bentobox/nms/v1_19_R2/WorldRegeneratorImpl.java
@@ -10,10 +10,10 @@ import net.minecraft.core.BlockPosition;
 import net.minecraft.world.level.World;
 import net.minecraft.world.level.block.state.IBlockData;
 import net.minecraft.world.level.chunk.Chunk;
-import world.bentobox.bentobox.nms.SimpleWorldRegenerator;
+import world.bentobox.bentobox.nms.CopyWorldRegenerator;
 
 
-public class WorldRegeneratorImpl extends SimpleWorldRegenerator {
+public class WorldRegeneratorImpl extends CopyWorldRegenerator {
 
     private static final IBlockData AIR = ((CraftBlockData) Bukkit.createBlockData(Material.AIR)).getState();
 

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListenerTest.java
@@ -1,7 +1,6 @@
 package world.bentobox.bentobox.listeners.flags.worldsettings;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -11,17 +10,14 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.generator.ChunkGenerator;
-import org.bukkit.generator.ChunkGenerator.ChunkData;
 import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -44,7 +40,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.managers.AddonsManager;
 import world.bentobox.bentobox.managers.IslandWorldManager;
-import world.bentobox.bentobox.util.MyBiomeGrid;
+import world.bentobox.bentobox.nms.WorldRegenerator;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -66,6 +62,8 @@ public class CleanSuperFlatListenerTest {
     private CleanSuperFlatListener l;
     @Mock
     private BukkitScheduler scheduler;
+    @Mock
+    private WorldRegenerator regenerator;
 
     /**
      * @throws java.lang.Exception
@@ -83,8 +81,10 @@ public class CleanSuperFlatListenerTest {
         when(world.getEnvironment()).thenReturn(World.Environment.NORMAL);
         when(world.getName()).thenReturn("world");
 
-        PowerMockito.mockStatic(Util.class);
+        PowerMockito.mockStatic(Util.class, Mockito.RETURNS_MOCKS);
         when(Util.getWorld(any())).thenReturn(world);
+        // Regenerator
+        when(Util.getRegenerator()).thenReturn(regenerator);
 
         // World Settings
         when(plugin.getIWM()).thenReturn(iwm);
@@ -125,13 +125,12 @@ public class CleanSuperFlatListenerTest {
         AddonsManager am = mock(AddonsManager.class);
         @Nullable
         ChunkGenerator cg = mock(ChunkGenerator.class);
-        ChunkData cd = mock(ChunkData.class);
-        when(cg.generateChunkData(any(World.class), any(Random.class), anyInt(), anyInt(), any(MyBiomeGrid.class))).thenReturn(cd);
-        BlockData bd = mock(BlockData.class);
-        when(cd.getBlockData(anyInt(), anyInt(), anyInt())).thenReturn(bd);
 
         when(plugin.getAddonsManager()).thenReturn(am);
         when(am.getDefaultWorldGenerator(anyString(), anyString())).thenReturn(cg);
+        
+        
+        
     }
 
     @After


### PR DESCRIPTION
This is another approach to doing island deletion. It comes out of my work on Boxed that uses world copying. This approach is quite simple though:

1. After a GameModeAddon creates worlds, BentoBox makes a copy of them in a `seeds` world folder. This is just to make them quickly accessible later. 
2. When an island is deleted, the usual approach is used, but instead of asking the addon to create `ChunkData` (which is deprecated), the chunk from the seed world is retrieved and used as the source. `BlockData` and biomes are copied over. It is also possible to copy chest contents and entities, but for now, I don't bother. The code to do this is in Boxed, but I wanted to get feedback first.

I tested it with the new AcidIsland branch (https://github.com/BentoBoxWorld/AcidIsland/tree/update_chunk_gen) [AcidIsland-1.17.0-SNAPSHOT-LOCAL.jar.zip](https://github.com/BentoBoxWorld/BentoBox/files/10609243/AcidIsland-1.17.0-SNAPSHOT-LOCAL.jar.zip) which creates an ocean floor under the islands and it works well. 

Upsides:
- The new API for generating worlds can be used by GameModeAddons to generate worlds.
- It's pretty similar to what happens now, but doesn't use deprecated methods.

Downsides:
- There is a copy of the seed world (overworld, nether, and end) however, this may be pretty empty depending on the game.
- I haven't tried to handle `useOwnGenerator` yet.
- Anything else?

Please review and comment.
