### PR TITLE
Disable chunk generation on rengeneration

### DIFF
--- a/src/main/java/world/bentobox/bentobox/nms/SimpleWorldRegenerator.java
+++ b/src/main/java/world/bentobox/bentobox/nms/SimpleWorldRegenerator.java
@@ -66,7 +66,12 @@ public abstract class SimpleWorldRegenerator implements WorldRegenerator {
                     }
                     final int x = chunkX;
                     final int z = chunkZ;
-                    newTasks.add(regenerateChunk(gm, di, world, x, z));
+                    
+                    // Only process non-generated chunks
+                    if (world.isChunkGenerated(x, z)) {
+                        newTasks.add(regenerateChunk(gm, di, world, x, z));
+                    }
+                    
                     chunkZ++;
                     if (chunkZ > di.getMaxZChunk()) {
                         chunkZ = di.getMinZChunk();


### PR DESCRIPTION
The SimpleWorldRegenerator generated world new chunks that were not generated before.  It is not necessary, as regeneration should happen only on used chunks.