### PR TITLE
replace hardcoded file separator

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/addons/Pladdon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/Pladdon.java
@@ -15,7 +15,7 @@ import com.google.common.io.Files;
  */
 public abstract class Pladdon extends JavaPlugin {
 
-    private static final String ADDONS_FOLDER = "BentoBox/addons";
+    private static final String ADDONS_FOLDER = "BentoBox" + File.separator + "addons";
 
     /**
      * This must return a new instance of the addon. It is called when the Pladdon is loaded.
@@ -33,7 +33,7 @@ public abstract class Pladdon extends JavaPlugin {
     }
 
     protected void moveJar() {
-        getLogger().severe(getFile().getName() + " must be in the BentoBox/addons folder! Trying to move it there...");
+        getLogger().severe(getFile().getName() + " must be in the " + ADDONS_FOLDER + " folder! Trying to move it there...");
         File addons = new File(getFile().getParent(), ADDONS_FOLDER);
         if (addons.exists() || addons.mkdirs()) {
             File to = new File(addons, getFile().getName());
@@ -44,7 +44,7 @@ public abstract class Pladdon extends JavaPlugin {
 
                 } catch (IOException ex) {
                     getLogger().severe("Failed to move it. " + ex.getMessage());
-                    getLogger().severe("Move " + getFile().getName() + " manually into the BentoBox/addons folder. Then restart server.");
+                    getLogger().severe("Move " + getFile().getName() + " manually into the " + ADDONS_FOLDER + " folder. Then restart server.");
                 }
             } else {
                 getLogger().warning(getFile().getName() + " already is in the addons folder. Delete the one in the plugins folder.");


### PR DESCRIPTION
Running  BentoBox v1.23.2-SNAPSHOT-b2384 on a windows server, you get the following on startup:

![image](https://user-images.githubusercontent.com/6975392/233319929-f70d5be1-dfb0-436c-9b2f-f35434e729eb.png)

The addons are in the correct folder, but the folder pathname is hardcoded in unix format so gets confused on a windows based server. 

This pr just replaces the hardcoded separator to be OS independent.
