### PR TITLE
Bbox admin perms command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,10 @@
         <postgresql.version>42.2.18</postgresql.version>
         <hikaricp.version>5.0.1</hikaricp.version>
         <!-- More visible way to change dependency versions -->
-        <spigot.version>1.20-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.20.1-R0.1-SNAPSHOT</spigot.version>
         <!-- Might differ from the last Spigot release for short periods 
             of time -->
-        <paper.version>1.20-R0.1-SNAPSHOT</paper.version>
+        <paper.version>1.20.1-R0.1-SNAPSHOT</paper.version>
         <bstats.version>3.0.0</bstats.version>
         <vault.version>1.7.1</vault.version>
         <placeholderapi.version>2.10.9</placeholderapi.version>

--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -49,6 +49,13 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
     private boolean onlyPlayer = false;
 
     /**
+     * True if the command is only for the console
+     * @since 1.24.0
+     */
+    private boolean onlyConsole = false;
+
+
+    /**
      * True if command is a configurable rank
      */
     private boolean configurableRankCommand = false;
@@ -257,8 +264,12 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      */
     public boolean call(User user, String cmdLabel, List<String> cmdArgs) {
         // Check for console and permissions
-        if (onlyPlayer && !user.isPlayer()) {
+        if (isOnlyPlayer() && !user.isPlayer()) {
             user.sendMessage("general.errors.use-in-game");
+            return false;
+        }
+        if (isOnlyConsole() && user.isPlayer()) {
+            user.sendMessage("general.errors.use-in-console");
             return false;
         }
 
@@ -514,6 +525,14 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
     }
 
     /**
+     * Check if this command is only for consoles.
+     * @return true or false
+     */
+    public boolean isOnlyConsole() {
+        return onlyConsole;
+    }
+
+    /**
      * Sets whether this command should only be run by players.
      * If this is set to {@code true}, this command will only be runnable by objects implementing {@link Player}.
      * <br/><br/>
@@ -523,6 +542,18 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      */
     public void setOnlyPlayer(boolean onlyPlayer) {
         this.onlyPlayer = onlyPlayer;
+    }
+
+    /**
+     * Sets whether this command should only be run in the console.
+     * This is for commands that dump a lot of data or are for debugging.
+     * The default value provided when instantiating this CompositeCommand is {@code false}.
+     * Therefore, this method should only be used in case you want to explicitly edit the value.
+     * @param onlyConsole {@code true} if this command should only be run in the console.
+     * @since 1.24.0
+     */
+    public void setOnlyConsole(boolean onlyConsole) {
+        this.onlyConsole = onlyConsole;
     }
 
     /**
@@ -623,16 +654,17 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
     @Override
     @NonNull
     public List<String> tabComplete(final @NonNull CommandSender sender, final @NonNull String alias, final String[] args) {
-        List<String> options = new ArrayList<>();
         // Get command object based on args entered so far
         CompositeCommand command = getCommandFromArgs(args);
         // Check for console and permissions
-        if (command.isOnlyPlayer() && !(sender instanceof Player)) {
-            return options;
+        if ((command.isOnlyPlayer() && !(sender instanceof Player))
+                || (command.isOnlyConsole() && sender instanceof Player)) {
+            return List.of();
         }
         if (command.getPermission() != null && !command.getPermission().isEmpty() && !sender.hasPermission(command.getPermission()) && !sender.isOp()) {
-            return options;
+            return List.of();
         }
+        List<String> options = new ArrayList<>();
         // Add any tab completion from the subcommand
         options.addAll(command.tabComplete(User.getInstance(sender), alias, new LinkedList<>(Arrays.asList(args))).orElseGet(ArrayList::new));
         if (command.hasSubCommands()) {
@@ -654,17 +686,26 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
     }
 
     /**
-     * Returns a list containing all the labels of the subcommands for the provided CompositeCommand excluding any hidden commands
+     * Returns a list containing all the labels of the subcommands for the provided
+     * CompositeCommand excluding any hidden commands
      * @param sender the CommandSender
      * @param command the CompositeCommand to get the subcommands from
      * @return a list of subcommands labels or an empty list.
      */
     @NonNull
     private List<String> getSubCommandLabels(@NonNull CommandSender sender, @NonNull CompositeCommand command) {
-        return command.getSubCommands().values().stream()
-                .filter(cmd -> !cmd.isHidden())
-                .filter(cmd -> !cmd.isOnlyPlayer() || sender.isOp() || (sender instanceof Player && cmd.getPermission() != null && (cmd.getPermission().isEmpty() || sender.hasPermission(cmd.getPermission()))) )
-                .map(CompositeCommand::getLabel).toList();
+        List<String> result = new ArrayList<>();
+        for (CompositeCommand cc: command.getSubCommands().values()) {
+            // Player or not
+            if (sender instanceof Player) {
+                if (!cc.isHidden() && !cc.isOnlyConsole() && (cc.getPermission().isEmpty() || sender.hasPermission(cc.getPermission()))) {
+                    result.add(cc.getLabel());
+                }
+            } else if (!cc.isOnlyPlayer()) {
+                result.add(cc.getLabel());
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCopyCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCopyCommand.java
@@ -19,7 +19,7 @@ public class AdminBlueprintCopyCommand extends CompositeCommand
     @Override
     public void setup()
     {
-        inheritPermission();
+        setPermission("admin.blueprint.copy");
         setParametersHelp("commands.admin.blueprint.copy.parameters");
         setDescription("commands.admin.blueprint.copy.description");
     }
@@ -37,7 +37,7 @@ public class AdminBlueprintCopyCommand extends CompositeCommand
         AdminBlueprintCommand parent = (AdminBlueprintCommand) getParent();
 
         BlueprintClipboard clipboard =
-            parent.getClipboards().computeIfAbsent(user.getUniqueId(), v -> new BlueprintClipboard());
+                parent.getClipboards().computeIfAbsent(user.getUniqueId(), v -> new BlueprintClipboard());
 
         boolean copyAir = args.stream().anyMatch(key -> key.equalsIgnoreCase("air"));
         boolean copyBiome = args.stream().anyMatch(key -> key.equalsIgnoreCase("biome"));

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintDeleteCommand.java
@@ -26,7 +26,7 @@ public class AdminBlueprintDeleteCommand extends ConfirmableCommand
     @Override
     public void setup()
     {
-        this.inheritPermission();
+        setPermission("admin.blueprint.delete");
         this.setParametersHelp("commands.admin.blueprint.delete.parameters");
         this.setDescription("commands.admin.blueprint.delete.description");
     }
@@ -47,10 +47,10 @@ public class AdminBlueprintDeleteCommand extends ConfirmableCommand
         if (this.getPlugin().getBlueprintsManager().getBlueprints(this.getAddon()).containsKey(blueprintName))
         {
             this.askConfirmation(user, user.getTranslation("commands.admin.blueprint.delete.confirmation"),
-                () -> {
-                    this.getPlugin().getBlueprintsManager().deleteBlueprint(this.getAddon(), blueprintName);
-                    user.sendMessage("commands.admin.blueprint.delete.success", TextVariables.NAME, blueprintName);
-                });
+                    () -> {
+                        this.getPlugin().getBlueprintsManager().deleteBlueprint(this.getAddon(), blueprintName);
+                        user.sendMessage("commands.admin.blueprint.delete.success", TextVariables.NAME, blueprintName);
+                    });
             return true;
         }
         else

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintListCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintListCommand.java
@@ -22,7 +22,7 @@ public class AdminBlueprintListCommand extends CompositeCommand
     @Override
     public void setup()
     {
-        this.inheritPermission();
+        setPermission("admin.blueprint.list");
         this.setDescription("commands.admin.blueprint.list.description");
     }
 
@@ -54,8 +54,8 @@ public class AdminBlueprintListCommand extends CompositeCommand
         FilenameFilter blueprintFilter = (File dir, String name) -> name.endsWith(BlueprintsManager.BLUEPRINT_SUFFIX);
 
         List<String> blueprintList = Arrays.stream(Objects.requireNonNull(blueprints.list(blueprintFilter))).
-            map(name -> name.substring(0, name.length() - BlueprintsManager.BLUEPRINT_SUFFIX.length())).
-            toList();
+                map(name -> name.substring(0, name.length() - BlueprintsManager.BLUEPRINT_SUFFIX.length())).
+                toList();
 
         if (blueprintList.isEmpty())
         {

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintLoadCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintLoadCommand.java
@@ -17,7 +17,7 @@ public class AdminBlueprintLoadCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.blueprint.load");
         setParametersHelp("commands.admin.blueprint.load.parameters");
         setDescription("commands.admin.blueprint.load.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintOriginCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintOriginCommand.java
@@ -19,7 +19,7 @@ public class AdminBlueprintOriginCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.blueprint.origin");
         setParametersHelp("commands.admin.blueprint.origin.parameters");
         setDescription("commands.admin.blueprint.origin.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPasteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPasteCommand.java
@@ -15,7 +15,7 @@ public class AdminBlueprintPasteCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.blueprint.paste");
         setParametersHelp("commands.admin.blueprint.paste.parameters");
         setDescription("commands.admin.blueprint.paste.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPos1Command.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPos1Command.java
@@ -15,7 +15,7 @@ public class AdminBlueprintPos1Command extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.blueprint.pos1");
         setParametersHelp("commands.admin.blueprint.pos1.parameters");
         setDescription("commands.admin.blueprint.pos1.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPos2Command.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintPos2Command.java
@@ -15,7 +15,7 @@ public class AdminBlueprintPos2Command extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.blueprint.pos2");
         setParametersHelp("commands.admin.blueprint.pos2.parameters");
         setDescription("commands.admin.blueprint.pos2.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintRenameCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintRenameCommand.java
@@ -27,7 +27,7 @@ public class AdminBlueprintRenameCommand extends ConfirmableCommand
     @Override
     public void setup()
     {
-        this.inheritPermission();
+        setPermission("admin.blueprint.rename");
         this.setParametersHelp("commands.admin.blueprint.rename.parameters");
         this.setDescription("commands.admin.blueprint.rename.description");
     }
@@ -83,8 +83,8 @@ public class AdminBlueprintRenameCommand extends ConfirmableCommand
         {
             // Ask for confirmation to overwrite
             this.askConfirmation(user,
-                user.getTranslation("commands.admin.blueprint.file-exists"),
-                () -> this.rename(user, from, to, args.get(1)));
+                    user.getTranslation("commands.admin.blueprint.file-exists"),
+                    () -> this.rename(user, from, to, args.get(1)));
         }
         else
         {
@@ -102,11 +102,11 @@ public class AdminBlueprintRenameCommand extends ConfirmableCommand
         this.getPlugin().getBlueprintsManager().renameBlueprint(this.getAddon(), blueprint, fileName, displayName);
 
         user.sendMessage("commands.admin.blueprint.rename.success",
-            "[old]",
-            blueprintName,
-            TextVariables.NAME,
-            blueprint.getName(),
-            "[display]",
-            blueprint.getDisplayName());
+                "[old]",
+                blueprintName,
+                TextVariables.NAME,
+                blueprint.getName(),
+                "[display]",
+                blueprint.getDisplayName());
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintSaveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintSaveCommand.java
@@ -25,7 +25,7 @@ public class AdminBlueprintSaveCommand extends ConfirmableCommand
     @Override
     public void setup()
     {
-        this.inheritPermission();
+        setPermission("admin.blueprint.save");
         this.setParametersHelp("commands.admin.blueprint.save.parameters");
         this.setDescription("commands.admin.blueprint.save.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsAddCommand.java
@@ -22,7 +22,7 @@ public class AdminDeathsAddCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.deaths.add");
         setDescription("commands.admin.deaths.add.description");
         setParametersHelp("commands.admin.deaths.add.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsRemoveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsRemoveCommand.java
@@ -22,7 +22,7 @@ public class AdminDeathsRemoveCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.deaths.remove");
         setDescription("commands.admin.deaths.remove.description");
         setParametersHelp("commands.admin.deaths.remove.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsResetCommand.java
@@ -21,7 +21,7 @@ public class AdminDeathsResetCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.deaths.reset");
         setDescription("commands.admin.deaths.reset.description");
         setParametersHelp("commands.admin.deaths.reset.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/deaths/AdminDeathsSetCommand.java
@@ -21,7 +21,7 @@ public class AdminDeathsSetCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.deaths.set");
         setDescription("commands.admin.deaths.set.description");
         setParametersHelp("commands.admin.deaths.set.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeProtectCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeProtectCommand.java
@@ -16,7 +16,7 @@ public class AdminPurgeProtectCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.purge.protect");
         setOnlyPlayer(true);
         setDescription("commands.admin.purge.protect.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeStatusCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeStatusCommand.java
@@ -19,7 +19,7 @@ public class AdminPurgeStatusCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.purge.status");
         setOnlyPlayer(false);
         setParametersHelp("commands.admin.purge.status.parameters");
         setDescription("commands.admin.purge.status.description");

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeStopCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeStopCommand.java
@@ -13,7 +13,7 @@ public class AdminPurgeStopCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.purge.stop");
         setOnlyPlayer(false);
         setDescription("commands.admin.purge.stop.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeUnownedCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeUnownedCommand.java
@@ -17,7 +17,7 @@ public class AdminPurgeUnownedCommand extends ConfirmableCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.purge.unowned");
         setOnlyPlayer(false);
         setParametersHelp("commands.admin.purge.unowned.parameters");
         setDescription("commands.admin.purge.unowned.description");

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeAddCommand.java
@@ -25,7 +25,7 @@ public class AdminRangeAddCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.range.add");
         setDescription("commands.admin.range.add.description");
         setParametersHelp("commands.admin.range.add.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveCommand.java
@@ -25,7 +25,7 @@ public class AdminRangeRemoveCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.range.remove");
         setDescription("commands.admin.range.remove.description");
         setParametersHelp("commands.admin.range.remove.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsAddCommand.java
@@ -22,7 +22,7 @@ public class AdminResetsAddCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.resets.add");
         setDescription("commands.admin.resets.add.description");
         setParametersHelp("commands.admin.resets.add.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsRemoveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsRemoveCommand.java
@@ -22,7 +22,7 @@ public class AdminResetsRemoveCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.resets.remove");
         setDescription("commands.admin.resets.remove.description");
         setParametersHelp("commands.admin.resets.remove.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsResetCommand.java
@@ -22,7 +22,7 @@ public class AdminResetsResetCommand extends ConfirmableCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.resets.remove");
         setDescription("commands.admin.resets.reset.description");
         setParametersHelp("commands.admin.resets.reset.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsSetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/resets/AdminResetsSetCommand.java
@@ -16,7 +16,7 @@ public class AdminResetsSetCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        inheritPermission();
+        setPermission("admin.resets.set");
         setDescription("commands.admin.resets.set.description");
         setParametersHelp("commands.admin.resets.set.parameters");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommand.java
@@ -21,7 +21,7 @@ public class AdminTeamAddCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("mod.team");
+        setPermission("mod.team.add");
         setParametersHelp("commands.admin.team.add.parameters");
         setDescription("commands.admin.team.add.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommand.java
@@ -20,7 +20,7 @@ public class AdminTeamDisbandCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("mod.team");
+        setPermission("mod.team.disband");
         setParametersHelp("commands.admin.team.disband.parameters");
         setDescription("commands.admin.team.disband.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamFixCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamFixCommand.java
@@ -14,7 +14,7 @@ public class AdminTeamFixCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("mod.team");
+        setPermission("mod.team.fix");
         setDescription("commands.admin.team.fix.description");
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommand.java
@@ -30,7 +30,7 @@ public class AdminTeamKickCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("mod.team");
+        setPermission("mod.team.kick");
         setParametersHelp("commands.admin.team.kick.parameters");
         setDescription("commands.admin.team.kick.description");
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
@@ -25,7 +25,7 @@ public class AdminTeamSetownerCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("mod.team");
+        setPermission("mod.team.setowner");
         setParametersHelp("commands.admin.team.setowner.parameters");
         setDescription("commands.admin.team.setowner.description");
     }

--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxAboutCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxAboutCommand.java
@@ -28,7 +28,7 @@ public class BentoBoxAboutCommand extends CompositeCommand {
     @Override
     public boolean execute(User user, String label, List<String> args) {
         user.sendRawMessage("About " + BentoBox.getInstance().getDescription().getName() + " v" + BentoBox.getInstance().getDescription().getVersion() + ":");
-        user.sendRawMessage("Copyright (c) 2017 - 2021 Tastybento, Poslovitch and the BentoBoxWorld contributors");
+        user.sendRawMessage("Copyright (c) 2017 - 2023 Tastybento, Poslovitch and the BentoBoxWorld contributors");
         user.sendRawMessage("See https://www.eclipse.org/legal/epl-2.0/ for license information.");
         return true;
     }

--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxCommand.java
@@ -24,6 +24,7 @@ public class BentoBoxCommand extends CompositeCommand {
         new BentoBoxReloadCommand(this);
         new BentoBoxLocaleCommand(this);
         new BentoBoxHelpCommand(this);
+        new BentoBoxPermsCommand(this);
         // Database names with a 2 in them are migration databases
         if (getPlugin().getSettings().getDatabaseType().name().contains("2")) {
             new BentoBoxMigrateCommand(this);

--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxPermsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxPermsCommand.java
@@ -26,8 +26,10 @@ public class BentoBoxPermsCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("bentobox.perms");
-        this.isOnlyConsole();
+        setPermission("bentobox.admin.perms");
+        setParametersHelp("commands.bentobox.perms.parameters");
+        setDescription("commands.bentobox.perms.description");
+        this.setOnlyConsole(true);
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxPermsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxPermsCommand.java
@@ -1,0 +1,80 @@
+package world.bentobox.bentobox.commands;
+
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.permissions.Permission;
+
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.user.User;
+
+/**
+ * Displays permissions that have been set by BentoBox.
+ *
+ * @author tastybento
+ */
+public class BentoBoxPermsCommand extends CompositeCommand {
+
+    /**
+     * Info command
+     * @param parent - command parent
+     */
+    public BentoBoxPermsCommand(CompositeCommand parent) {
+        super(parent, "perms");
+    }
+
+    @Override
+    public void setup() {
+        setPermission("bentobox.perms");
+        this.isOnlyConsole();
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        // Loop all the known top-level commands
+        getPlugin().getCommandsManager().getCommands().values().stream().distinct().forEach(cc -> {
+            if (cc.getAddon() == null) {
+                user.sendMessage("*** BentoBox effective perms:");
+            } else if (cc.getAddon() instanceof GameModeAddon gma) {
+                user.sendRawMessage("**** " + gma.getDescription().getName() + " effective perms:");
+            } else {
+                user.sendRawMessage("**** " + cc.getAddon().getDescription().getName() + " effective perms:");
+            }
+            user.sendRawMessage("permissions:");
+            printData(user, cc, cc.getLabel());
+            printSubCommandData(user, cc, cc.getLabel());
+        });
+        return true;
+    }
+
+    private void printData(User user, CompositeCommand cc, String label) {
+        if (cc.getPermission().isBlank()) return;
+        String desc = user.getTranslation(cc.getWorld(), cc.getDescription());
+        user.sendRawMessage("  " + cc.getPermission() + ":");
+        user.sendRawMessage("    description: Allow use of '/" + label + "' command - " + desc);
+        Permission p = Bukkit.getPluginManager().getPermission(cc.getPermission());
+        if (p != null) {
+            user.sendRawMessage("    default: " + p.getDefault().name());
+        } else {
+            user.sendRawMessage("    default: OP"); // If not def
+        }
+
+    }
+
+    /**
+     * Iterates over sub-commands
+     * @param user user
+     * @param parent parent command
+     * @param label
+     */
+    private void printSubCommandData(User user, CompositeCommand parent, String label) {
+        for (CompositeCommand cc : parent.getSubCommands().values()) {
+            if (cc.getLabel().equalsIgnoreCase("help")) continue; // Ignore the help command
+            String newLabel = label + " " + cc.getLabel();
+            printData(user, cc, newLabel);
+            printSubCommandData(user, cc, newLabel);
+        }
+
+    }
+}

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -21,6 +21,7 @@ general:
     no-permission: "&c You don't have the permission to execute this command (&7 [permission]&c )."
     insufficient-rank: "&c Your rank is not high enough to do that! (&7 [rank]&c )"
     use-in-game: "&c This command is only available in-game."
+    use-in-console: "&c This command is only available in the console."
     no-team: "&c You do not have a team!"
     no-island: "&c You do not have an island!"
     player-has-island: "&c Player already has an island!"
@@ -428,6 +429,8 @@ commands:
       success: "&a Successfully reset [name]'s island name."
   bentobox:
     description: "BentoBox admin command"
+    perms:
+      description: "displays the effective perms for BentoBox and Addons in a YAML format"
     about:
       description: "displays copyright and license information"
     reload:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -60,4 +60,6 @@ permissions:
   bentobox.version:
     description: Allows to use /bentobox version
     default: op
-  
+  bentobox.perms:
+    description: Allow use of '/bentobox perms' command
+    default: OP 

--- a/src/test/java/world/bentobox/bentobox/commands/BentoBoxPermsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/commands/BentoBoxPermsCommandTest.java
@@ -1,0 +1,192 @@
+package world.bentobox.bentobox.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.plugin.PluginManager;
+import org.eclipse.jdt.annotation.NonNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+import world.bentobox.bentobox.managers.IslandWorldManager;
+import world.bentobox.bentobox.managers.LocalesManager;
+import world.bentobox.bentobox.managers.PlaceholdersManager;
+
+/**
+ * @author tastybento
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Bukkit.class, BentoBox.class, User.class })
+public class BentoBoxPermsCommandTest {
+
+    @Mock
+    private BentoBox plugin;
+    @Mock
+    private CompositeCommand ac;
+    @Mock
+    private User user;
+    @Mock
+    private LocalesManager lm;
+
+    BentoBoxPermsCommand cmd;
+    @Mock
+    private PlaceholdersManager phm;
+    @Mock
+    private PluginManager pim;
+    @Mock
+    private Permission perm;
+
+    private PermissionDefault defaultPerm = PermissionDefault.OP;
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        // Set up plugin
+        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+
+        // Command manager
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+        @NonNull
+        Map<String, CompositeCommand> cmdMap = new HashMap<>();
+        cmdMap.put("test", ac);
+        when(cm.getCommands()).thenReturn(cmdMap);
+
+
+        // Parent command has no aliases
+        when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
+        when(ac.getSubCommands()).thenReturn(new HashMap<>());
+        when(ac.getLabel()).thenReturn("bbox");
+        when(ac.getTopLabel()).thenReturn("bbox");
+        when(ac.getPermission()).thenReturn("admin.bbox");
+        when(ac.getDescription()).thenReturn("description");
+
+
+        // User
+        when(user.getTranslation(Mockito.anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+        when(user.isPlayer()).thenReturn(false);
+        User.setPlugin(plugin);
+
+        // Bukkit
+        PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
+        when(perm.getDefault()).thenReturn(defaultPerm);
+        when(pim.getPermission(anyString())).thenReturn(perm);
+        when(Bukkit.getPluginManager()).thenReturn(pim);
+
+        // Placeholders
+        when(phm.replacePlaceholders(any(), anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(1, String.class));
+
+        // BentoBox
+        when(plugin.getLocalesManager()).thenReturn(lm);
+        when(plugin.getPlaceholdersManager()).thenReturn(phm);
+        IslandWorldManager iwm = mock(IslandWorldManager.class);
+        when(plugin.getIWM()).thenReturn(iwm);
+
+        // Commands for perms
+
+
+        cmd = new BentoBoxPermsCommand(ac);
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        Mockito.framework().clearInlineMocks();
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.commands.BentoBoxPermsCommand#BentoBoxPermsCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
+     */
+    @Test
+    public void testBentoBoxPermsCommand() {
+        assertNotNull(cmd);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.commands.BentoBoxPermsCommand#setup()}.
+     */
+    @Test
+    public void testSetup() {
+        assertTrue(cmd.isOnlyConsole());
+        assertFalse(cmd.isOnlyPlayer());
+        assertEquals("bentobox.admin.perms", cmd.getPermission());
+        assertEquals("commands.bentobox.perms.description", cmd.getDescription());
+        assertEquals("commands.bentobox.perms.parameters", cmd.getParameters());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.commands.BentoBoxPermsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+     */
+    @Test
+    public void testExecuteUserStringListOfString() {
+        assertTrue(cmd.execute(user, "perms", List.of()));
+        verify(user).sendMessage("*** BentoBox effective perms:");
+        verify(user).sendRawMessage("permissions:");
+        verify(user).sendRawMessage("  admin.bbox:");
+        verify(user).sendRawMessage("    description: Allow use of '/bbox' command - null");
+        verify(user).sendRawMessage("  bentobox.admin.perms:");
+        verify(user).sendRawMessage("    description: Allow use of '/bbox perms' command - null");
+        verify(user, times(2)).sendRawMessage("    default: OP");
+
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.commands.BentoBoxPermsCommand#execute(Player, java.lang.String, String[])}.
+     */
+    @Test
+    public void testExecuteUserStringListOfStringConsole() {
+        String[] args = new String[1];
+        args[0] = "";
+        CommandSender p = mock(CommandSender.class);
+        assertTrue(cmd.execute(p, "perms", args));
+        verify(p, never()).sendMessage("general.errors.use-in-console");
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.commands.BentoBoxPermsCommand#execute(Player, java.lang.String, String[])}.
+     */
+    @Test
+    public void testExecuteUserStringListOfStringIsPlayer() {
+        when(user.isPlayer()).thenReturn(true);
+        String[] args = new String[1];
+        args[0] = "";
+        Player p = mock(Player.class);
+        assertFalse(cmd.execute(p, "perms", args));
+        verify(p).sendMessage("general.errors.use-in-console");
+    }
+}


### PR DESCRIPTION
This adds a `bbox perms` command that will output in YAML format the effective perms for all addons and BentoBox itself. This output can be used to update the respective addon.yml's or plugin.yml's. It does not (yet) substitute in [gamemode] but that might be added. 

The idea is to identify all the permissions that are available so that these can also be shared in documentation so that admins can more effectively manage permissions.

This PR also adds some API to CompositeCommand to enable commands to be console-only. This is similar to the player-only API. The goal of this is to prevent spammy commands designed for console output (mostly debug stuff) to not be used in-game. This is used by the perms command.

