### PR TITLE
Add API to enable gamemodes to register ownership over additional worlds

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -143,6 +143,16 @@ public class IslandWorldManager {
                 .anyMatch(gm -> gm.getWorldSettings().getFriendlyName().equalsIgnoreCase(name));
     }
 
+    /**
+     * Associate a world with a game mode. This enables game modes to register more worlds than just the standard
+     * overworld, nether, and end worlds.
+     * @param world world
+     * @param gameMode game mode
+     * @since 1.24.0
+     */
+    public void addWorld(World world, GameModeAddon gameMode) {
+        gameModes.put(world, gameMode);
+    }
 
     /**
      * Adds a GameMode to island world manager


### PR DESCRIPTION
This is required for gamemodes like Boxed that have more than the usual 3 worlds, but need to have them registered with plugins like Multiverse through BentoBox. They need a way to tell BentoBox that this world is theirs. Currently, only the standard 3 worlds are registered. In theory this gives addons more flexibility in terms of world generation.