### PR TITLE
If sign is waxed (not editable) then no check is required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,10 @@
         <postgresql.version>42.2.18</postgresql.version>
         <hikaricp.version>5.0.1</hikaricp.version>
         <!-- More visible way to change dependency versions -->
-        <spigot.version>1.20-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.20.1-R0.1-SNAPSHOT</spigot.version>
         <!-- Might differ from the last Spigot release for short periods 
             of time -->
-        <paper.version>1.20-R0.1-SNAPSHOT</paper.version>
+        <paper.version>1.20.1-R0.1-SNAPSHOT</paper.version>
         <bstats.version>3.0.0</bstats.version>
         <vault.version>1.7.1</vault.version>
         <placeholderapi.version>2.10.9</placeholderapi.version>

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
@@ -7,6 +7,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -33,7 +34,7 @@ public class BlockInteractionListener extends FlagListener
      *
      * @param e - event
      */
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerInteract(final PlayerInteractEvent e)
     {
         // We only care about the RIGHT_CLICK_BLOCK action.
@@ -43,7 +44,7 @@ public class BlockInteractionListener extends FlagListener
         }
 
         // Check clicked block
-        this.checkClickedBlock(e, e.getPlayer(), e.getClickedBlock().getLocation(), e.getClickedBlock().getType());
+        this.checkClickedBlock(e, e.getPlayer(), e.getClickedBlock());
 
         // Now check for in-hand items
         if (e.getItem() != null && !e.getItem().getType().equals(Material.AIR))
@@ -85,11 +86,12 @@ public class BlockInteractionListener extends FlagListener
      *
      * @param e - event called
      * @param player - player
-     * @param loc - location of clicked block
-     * @param type - material type of clicked block
+     * @param block - block being clicked or used
      */
-    private void checkClickedBlock(Event e, Player player, Location loc, Material type)
+    private void checkClickedBlock(Event e, Player player, Block block)
     {
+        Material type = block.getType();
+        Location loc = block.getLocation();
         // Handle pots
         if (type.name().startsWith("POTTED"))
         {
@@ -133,7 +135,8 @@ public class BlockInteractionListener extends FlagListener
             return;
         }
 
-        if (Tag.SIGNS.isTagged(type)) {
+        if (Tag.SIGNS.isTagged(type) && block instanceof Sign sign && sign.isEditable()) {
+            // If waxed, then sign cannot be edited otherwise check
             this.checkIsland(e, player, loc, Flags.SIGN_EDITING);
             return;
         }
@@ -232,7 +235,7 @@ public class BlockInteractionListener extends FlagListener
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onBlockBreak(final BlockBreakEvent e)
     {
-        this.checkClickedBlock(e, e.getPlayer(), e.getBlock().getLocation(), e.getBlock().getType());
+        this.checkClickedBlock(e, e.getPlayer(), e.getBlock());
     }
 
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
@@ -135,7 +135,7 @@ public class BlockInteractionListener extends FlagListener
             return;
         }
 
-        if (Tag.SIGNS.isTagged(type) && block instanceof Sign sign && sign.isEditable()) {
+        if (Tag.SIGNS.isTagged(type) && block.getState() instanceof Sign sign && !sign.isWaxed()) {
             // If waxed, then sign cannot be edited otherwise check
             this.checkIsland(e, player, loc, Flags.SIGN_EDITING);
             return;

--- a/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
+++ b/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
@@ -221,7 +221,7 @@ public class ServerCompatibility {
         /**
          * @since 1.24.0
          */
-        V1_20(Compatibility.COMPATIBLE),
+        V1_20(Compatibility.INCOMPATIBLE),
         /**
          * @since 1.24.0
          */


### PR DESCRIPTION
Adjusts priority of PlayerInteract listner to NORMAL from LOWEST. ChestShop uses LOW, so should get the listener before BentoBox.

Relates to #2145 