### PR TITLE
Unregisters worlds with MV on shutdown.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -52,7 +55,7 @@ import world.bentobox.bentobox.versions.ServerCompatibility;
  * Main BentoBox class
  * @author tastybento, Poslovitch
  */
-public class BentoBox extends JavaPlugin {
+public class BentoBox extends JavaPlugin implements Listener {
 
     private static BentoBox instance;
 
@@ -227,7 +230,7 @@ public class BentoBox extends JavaPlugin {
         // Make sure all worlds are already registered to Multiverse.
         hooksManager.registerHook(new MultiverseCoreHook());
         hooksManager.registerHook(new MyWorldsHook());
-        islandWorldManager.registerWorldsToMultiverse();
+        islandWorldManager.registerWorldsToMultiverse(true);
 
         // TODO: re-enable after implementation
         //hooksManager.registerHook(new DynmapHook());
@@ -300,6 +303,8 @@ public class BentoBox extends JavaPlugin {
         manager.registerEvents(new BannedCommands(this), this);
         // Death counter
         manager.registerEvents(new DeathListener(this), this);
+        // MV unregister
+        manager.registerEvents(this, this);
         // Island Delete Manager
         islandChunkDeletionManager = new IslandChunkDeletionManager(this);
         islandDeletionManager = new IslandDeletionManager(this);
@@ -320,6 +325,15 @@ public class BentoBox extends JavaPlugin {
         }
         if (islandsManager != null) {
             islandsManager.shutdown();
+        }
+
+    }
+
+    @EventHandler
+    public void onServerStop(ServerCommandEvent e) {
+        if (islandWorldManager != null && (e.getCommand().equalsIgnoreCase("stop") || e.getCommand().equalsIgnoreCase("restart"))) {
+            // Unregister any MV worlds            if () {
+            islandWorldManager.registerWorldsToMultiverse(false);
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/hooks/MultiverseCoreHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/MultiverseCoreHook.java
@@ -50,6 +50,12 @@ public class MultiverseCoreHook extends Hook implements WorldManagementHook {
     }
 
     @Override
+    public void unregisterWorld(World world) {
+        String cmd = "mv remove " + world.getName();
+        Bukkit.getServer().dispatchCommand(Bukkit.getServer().getConsoleSender(), cmd);
+    }
+
+    @Override
     public boolean hook() {
         return true; // The hook process shouldn't fail
     }

--- a/src/main/java/world/bentobox/bentobox/hooks/WorldManagementHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/WorldManagementHook.java
@@ -13,8 +13,17 @@ public interface WorldManagementHook {
     /**
      * Register the world with the World Management hook
      *
+     *
      * @param world - world to register
      * @param islandWorld - if true, then this is an island world
      */
     void registerWorld(World world, boolean islandWorld);
+
+    /**
+     * Unregisters a world.
+     * @param world - world to unregister
+     */
+    default void unregisterWorld(World world) {
+        // Do nothing
+    }
 }

--- a/src/test/java/world/bentobox/bentobox/managers/IslandWorldManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandWorldManagerTest.java
@@ -114,7 +114,7 @@ public class IslandWorldManagerTest {
      */
     @Test
     public void testRegisterWorldsToMultiverse() {
-        iwm.registerWorldsToMultiverse();
+        iwm.registerWorldsToMultiverse(true);
     }
 
     /**


### PR DESCRIPTION
Fixes #2149

There is a bug in MV (I think) where it doesn't properly set the generator for a world if it already knows about the world. If the MV config is deleted, after the server is shutdown, or the `mv remove` command is run on the worlds before shutdown, then everything is okay, but it's a pain for admins to have to run that remove command manually every time.

I think the issue is an MV bug. It used to work but now doesn't and if you reboot your server with AcidIsland for example, you get super flat world generation. I could file a bug with MV, but I'm trying a workaround. I wonder why we don't hear any bugs on this. Maybe MV is not used much nowadays? MyWorlds works fine BTW.

I suspect the incompatibility is because BentoBox loads worlds after Multiverse, so that the generators are unknown (you can see in the log thatMV tries really early) on start up. This seems to cause MV to stop caring about the world and even issuing the `mv modify set generator BentoBox` command does not work. The generator is just not picked up at all. The only way to force MV to detect it is to remove the world from it via command or just deleting the config.

This "fix" runs the mv remove command on shutdown. As plugins are not allowed to run tasks or commands in onDisable, it has to catch the "stop" or "restart" commands using an event. This works, and it's the only way to do this AFAIK. Not great though.