### PR TITLE
Multi island

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -467,11 +467,12 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      * @param user the User
      * @return UUID of player's island owner or null if user has no island
      */
+    /*
     @Nullable
     protected UUID getOwner(@NonNull World world, @NonNull User user) {
         return plugin.getIslands().getOwner(world, user.getUniqueId());
     }
-
+     */
     @Override
     public @NonNull String getUsage() {
         return "/" + usage;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -41,14 +41,14 @@ public class AdminDeleteCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
         }
-        UUID owner = getIslands().getOwner(getWorld(), targetUUID);
-        if (owner == null) {
+        Island island = getIslands().getIsland(getWorld(), user);
+        if (island == null) {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         }
 
         // Team members should be kicked before deleting otherwise the whole team will become weird
-        if (getIslands().inTeam(getWorld(), targetUUID) && owner.equals(targetUUID)) {
+        if (getIslands().inTeam(getWorld(), targetUUID) && user.getUniqueId().equals(island.getOwner())) {
             user.sendMessage("commands.admin.delete.cannot-delete-owner");
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandCreateCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandCreateCommand.java
@@ -48,6 +48,11 @@ public class IslandCreateCommand extends CompositeCommand {
             if (island.isReserved()) {
                 return true;
             }
+            // Get how many islands this player has
+            int num = this.getIslands().getNumberOfConcurrentIslands(user.getUniqueId(), getWorld());
+            if (num < this.getIWM().getWorldSettings(getWorld()).getConcurrentIslands()) {
+                return true;
+            }
             // You cannot make an island
             user.sendMessage("general.errors.already-have-island");
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -58,7 +58,7 @@ public class IslandTeamCommand extends CompositeCommand {
     @Override
     public boolean execute(User user, String label, List<String> args) {
         // Player issuing the command must have an island
-        UUID ownerUUID = getOwner(getWorld(), user);
+        UUID ownerUUID = getIslands().getOwner(getWorld(), user.getUniqueId());
         if (ownerUUID == null) {
             user.sendMessage("general.errors.no-island");
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
@@ -37,7 +37,7 @@ public class IslandTeamSetownerCommand extends CompositeCommand {
             user.sendMessage("general.errors.no-team");
             return false;
         }
-        UUID ownerUUID = getOwner(getWorld(), user);
+        UUID ownerUUID = getIslands().getOwner(getWorld(), user.getUniqueId());
         if (ownerUUID == null || !ownerUUID.equals(playerUUID)) {
             user.sendMessage("general.errors.not-owner");
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -634,4 +634,13 @@ public interface WorldSettings extends ConfigObject {
     default boolean isCheckForBlocks() {
         return true;
     }
+
+    /**
+     * Get the number of concurrent islands a player can have in the world
+     * @return 1 by default
+     * @since 1.24.2
+     */
+    default int getConcurrentIslands() {
+        return 5;
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1891,4 +1891,14 @@ public class IslandsManager {
         return goingHome.contains(user.getUniqueId());
     }
 
+    /**
+     * Get the number of concurrent islands for this player
+     * @param uuid UUID of player
+     * @param world world to check
+     * @return number of islands this player owns in this game world
+     */
+    public int getNumberOfConcurrentIslands(UUID uuid, World world) {
+        return islandCache.getAllIslands(world, uuid).size();
+    }
+
 }

--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -10,7 +10,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 
-import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
@@ -189,108 +188,6 @@ public class PlayersManager {
      */
     public boolean isKnown(UUID uniqueID) {
         return uniqueID != null && (playerCache.containsKey(uniqueID) || handler.objectExists(uniqueID.toString()));
-    }
-
-    /**
-     * Sets the home location for the player
-     * @param user - the player
-     * @param location - the location
-     * @param number - a number - 1 is default. Can be any number.
-     * @deprecated Use {@link IslandsManager#setHomeLocation(User, Location, String)}
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public void setHomeLocation(User user, Location location, int number) {
-        setHomeLocation(user.getUniqueId(), location,number);
-    }
-
-    /**
-     * Sets the home location for the player
-     * @param playerUUID - the player's UUID
-     * @param location - the location
-     * @param number - a number - 1 is default. Can be any number.
-     * @deprecated Use {@link IslandsManager#setHomeLocation(UUID, Location, String)}
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public void setHomeLocation(UUID playerUUID, Location location, int number) {
-        addPlayer(playerUUID);
-        playerCache.get(playerUUID).setHomeLocation(location,number);
-    }
-
-    /**
-     * Set the default home location for player
-     * @param playerUUID - the player's UUID
-     * @param location - the location
-     * @deprecated Use {@link IslandsManager#setHomeLocation(UUID, Location)}
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public void setHomeLocation(UUID playerUUID, Location location) {
-        setHomeLocation(playerUUID, location,1);
-    }
-
-    /**
-     * Clears any home locations for player
-     * @param world - world
-     * @param playerUUID - the player's UUID
-     * @deprecated Not used anymore. Home locations are stored on islands.
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public void clearHomeLocations(World world, UUID playerUUID) {
-        addPlayer(playerUUID);
-        playerCache.get(playerUUID).clearHomeLocations(world);
-    }
-
-    /**
-     * Returns the home location, or null if none
-     * @param world - world
-     *
-     * @param user - the player
-     * @param number - a number
-     * @return Home location or null if none
-     * @deprecated Use {@link IslandsManager#getHomeLocation(World, User, String)}
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public Location getHomeLocation(World world, User user, int number) {
-        addPlayer(user.getUniqueId());
-        return playerCache.get(user.getUniqueId()).getHomeLocation(world, number);
-    }
-
-    /**
-     * Returns the home location, or null if none
-     * @param world - world
-     *
-     * @param playerUUID - the player's UUID
-     * @param number - a number
-     * @return Home location or null if none
-     * @deprecated Use {@link IslandsManager#getHomeLocation(World, UUID, String)}
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public Location getHomeLocation(World world, UUID playerUUID, int number) {
-        addPlayer(playerUUID);
-        return playerCache.get(playerUUID).getHomeLocation(world, number);
-    }
-
-    /**
-     * Gets the default home location for player
-     * @param playerUUID - the player's UUID
-     * @return Home location or null if none
-     * @deprecated Use {@link IslandsManager#getHomeLocation(World, UUID)}
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public Location getHomeLocation(World world, UUID playerUUID) {
-        addPlayer(playerUUID);
-        return playerCache.get(playerUUID).getHomeLocation(world, 1);
-    }
-
-    /**
-     * Provides all home locations for player
-     * @param playerUUID - the player's UUID
-     * @return Map of home locations
-     * @deprecated Use {@link IslandsManager#getHomeLocations(world.bentobox.bentobox.database.objects.Island)}
-     */
-    @Deprecated(since="1.18.0", forRemoval=true)
-    public Map<Location, Integer> getHomeLocations(World world, UUID playerUUID) {
-        addPlayer(playerUUID);
-        return playerCache.get(playerUUID).getHomeLocations(world);
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/managers/island/IslandCacheTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/island/IslandCacheTest.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.plugin.PluginAwareness.Flags;
+import org.eclipse.jdt.annotation.NonNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,6 +83,9 @@ public class IslandCacheTest {
 
         // Island
         when(island.getWorld()).thenReturn(world);
+        @NonNull
+        String uniqueId = UUID.randomUUID().toString();
+        when(island.getUniqueId()).thenReturn(uniqueId);
         // Location
         when(location.getWorld()).thenReturn(world);
         when(location.getBlockX()).thenReturn(0);
@@ -250,7 +255,6 @@ public class IslandCacheTest {
         ic.addIsland(island);
 
         assertEquals(owner, ic.getOwner(world, owner));
-        assertNull(ic.getOwner(world, null));
         assertNull(ic.getOwner(world, UUID.randomUUID()));
     }
 
@@ -263,7 +267,6 @@ public class IslandCacheTest {
 
         assertTrue(ic.hasIsland(world, owner));
         assertFalse(ic.hasIsland(world, UUID.randomUUID()));
-        assertFalse(ic.hasIsland(world, null));
     }
 
     /**
@@ -273,7 +276,6 @@ public class IslandCacheTest {
     public void testRemovePlayer() {
         ic.addIsland(island);
         assertTrue(ic.hasIsland(world, owner));
-        ic.removePlayer(world, null);
         assertTrue(ic.hasIsland(world, owner));
         ic.removePlayer(world, UUID.randomUUID());
         assertTrue(ic.hasIsland(world, owner));


### PR DESCRIPTION
This adds the basics for allowing players to have more than one island of their own. 

## What is supported?

- Players can make up to 5 islands of their own using the `/island create` command
- Players can name homes on all of them and go between them (you need to allow multiple homes in the addon config)
- Settings, protections, etc. should world
- Some of the commands have been adapted to handle multiple islands, like some admin commands.

## What hasn't been tested?

- Almost everything!
- Teams
- Not sure if every command works properly. 

## To Do

- [ ] Continue to work through the API to check for issues with more than one island
- [ ] Check the managers
- [ ] Check the commands
- [ ] Check the addons, add config
- [ ] Check the user flow
- [ ] Add commands to support multiple islands, e.g., default go locations?

I'm sure other stuff is required.