### PR TITLE
This changes the loading to not be on STARTUP

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -169,14 +169,14 @@ public class BentoBox extends JavaPlugin implements Listener {
 
         final long loadTime = System.currentTimeMillis() - loadStart;
 
-        Bukkit.getScheduler().runTask(instance, () -> {
-            try {
-                completeSetup(loadTime);
-            } catch (Exception e) {
-                fireCriticalError(e.getMessage(), "");
-                e.printStackTrace();
-            }
-        });
+        //Bukkit.getScheduler().runTask(instance, () -> {
+        try {
+            completeSetup(loadTime);
+        } catch (Exception e) {
+            fireCriticalError(e.getMessage(), "");
+            e.printStackTrace();
+        }
+        //});
     }
 
     private void completeSetup(long loadTime) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,6 @@ contributors: ["The BentoBoxWorld Community"]
 website: https://bentobox.world
 description: ${project.description}
 
-load: STARTUP
 
 loadbefore: [Pladdon, Multiverse-Core, My_Worlds, Residence]
 


### PR DESCRIPTION
Worlds are then created in onEnable and not one-tick later. This provides compatibility with Residence plugin. See #2213 