### PR TITLE
Fixes a bug that removed old owner from island

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
@@ -95,7 +95,7 @@ public class IslandTeamSetownerCommand extends CompositeCommand {
         .involvedPlayer(user.getUniqueId())
         .admin(false)
         .reason(IslandEvent.Reason.RANK_CHANGE)
-        .rankChange(RanksManager.OWNER_RANK, RanksManager.VISITOR_RANK)
+        .rankChange(RanksManager.OWNER_RANK, RanksManager.SUB_OWNER_RANK)
         .build();
         getIslands().save(island);
         return true;

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1520,8 +1520,10 @@ public class IslandsManager {
      */
     public void setOwner(User user, UUID targetUUID, Island island) {
         islandCache.setOwner(island, targetUUID);
-        // Remove the old owner from the island
+        // Remove the old owner from the island to clear cache
         plugin.getIslands().removePlayer(island, user.getUniqueId());
+        // Set old owner as sub-owner on island.
+        island.setRank(user, RanksManager.SUB_OWNER_RANK);
 
         user.sendMessage("commands.island.team.setowner.name-is-the-owner", "[name]", plugin.getPlayers().getName(targetUUID));
         plugin.getIWM().getAddon(island.getWorld()).ifPresent(addon -> {

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1520,8 +1520,6 @@ public class IslandsManager {
      */
     public void setOwner(User user, UUID targetUUID, Island island) {
         islandCache.setOwner(island, targetUUID);
-        // Remove the old owner from the island to clear cache
-        plugin.getIslands().removePlayer(island, user.getUniqueId());
         // Set old owner as sub-owner on island.
         island.setRank(user, RanksManager.SUB_OWNER_RANK);
 


### PR DESCRIPTION
These changes fix a bug that was introduced by clearing the island cache from the old owner for 2.0 verison.

This will set the previous owner as sub-owner on the island.