### PR TITLE
Rank Management

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommand.java
@@ -16,6 +16,7 @@ import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 /**
+ * Tells the rank of the player
  * @author tastybento
  *
  */

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -24,206 +24,210 @@ import world.bentobox.bentobox.util.Util;
 
 public class IslandTeamCommand extends CompositeCommand {
 
-    /**
-     * Invited list. Key is the invited party, value is the invite.
-     * @since 1.8.0
-     */
-    private final Map<UUID, Invite> inviteMap;
+	/**
+	 * Invited list. Key is the invited party, value is the invite.
+	 * @since 1.8.0
+	 */
+	private final Map<UUID, Invite> inviteMap;
 
-    public IslandTeamCommand(CompositeCommand parent) {
-        super(parent, "team");
-        inviteMap = new HashMap<>();
-    }
+	public IslandTeamCommand(CompositeCommand parent) {
+		super(parent, "team");
+		inviteMap = new HashMap<>();
+	}
 
-    @Override
-    public void setup() {
-        setPermission("island.team");
-        setOnlyPlayer(true);
-        setDescription("commands.island.team.description");
-        // Register commands
-        new IslandTeamInviteCommand(this);
-        new IslandTeamLeaveCommand(this);
-        new IslandTeamSetownerCommand(this);
-        new IslandTeamKickCommand(this);
-        new IslandTeamInviteAcceptCommand(this);
-        new IslandTeamInviteRejectCommand(this);
-        new IslandTeamCoopCommand(this);
-        new IslandTeamUncoopCommand(this);
-        new IslandTeamTrustCommand(this);
-        new IslandTeamUntrustCommand(this);
-        new IslandTeamPromoteCommand(this, "promote");
-        new IslandTeamPromoteCommand(this, "demote");
-    }
+	@Override
+	public void setup() {
+		setPermission("island.team");
+		setOnlyPlayer(true);
+		setDescription("commands.island.team.description");
+		// Register commands
+		new IslandTeamInviteCommand(this);
+		new IslandTeamLeaveCommand(this);
+		new IslandTeamSetownerCommand(this);
+		new IslandTeamKickCommand(this);
+		new IslandTeamInviteAcceptCommand(this);
+		new IslandTeamInviteRejectCommand(this);
+		if (getPlugin().getRanksManager().rankExists(RanksManager.COOP_RANK_REF)) {
+			new IslandTeamCoopCommand(this);
+			new IslandTeamUncoopCommand(this);
+		}
+		if (getPlugin().getRanksManager().rankExists(RanksManager.TRUSTED_RANK_REF)) {
+			new IslandTeamTrustCommand(this);
+			new IslandTeamUntrustCommand(this);
+		}
+		new IslandTeamPromoteCommand(this, "promote");
+		new IslandTeamPromoteCommand(this, "demote");
+	}
 
-    @Override
-    public boolean execute(User user, String label, List<String> args) {
-        // Player issuing the command must have an island
-        Island island = getIslands().getPrimaryIsland(getWorld(), user.getUniqueId());
-        if (island == null) {
-            user.sendMessage("general.errors.no-island");
-            return false;
-        }
+	@Override
+	public boolean execute(User user, String label, List<String> args) {
+		// Player issuing the command must have an island
+		Island island = getIslands().getPrimaryIsland(getWorld(), user.getUniqueId());
+		if (island == null) {
+			user.sendMessage("general.errors.no-island");
+			return false;
+		}
 
-        UUID playerUUID = user.getUniqueId();
-        // Fire event so add-ons can run commands, etc.
-        if (fireEvent(user, island)) {
-            // Cancelled
-            return false;
-        }
-        Set<UUID> teamMembers = getMembers(getWorld(), user);
-        if (playerUUID.equals(island.getOwner())) {
-            int maxSize = getIslands().getMaxMembers(island, RanksManager.MEMBER_RANK);
-            if (teamMembers.size() < maxSize) {
-                user.sendMessage("commands.island.team.invite.you-can-invite", TextVariables.NUMBER, String.valueOf(maxSize - teamMembers.size()));
-            } else {
-                user.sendMessage("commands.island.team.invite.errors.island-is-full");
-            }
-        }
-        // Show members of island
-        showMembers(island, user);
-        return true;
-    }
+		UUID playerUUID = user.getUniqueId();
+		// Fire event so add-ons can run commands, etc.
+		if (fireEvent(user, island)) {
+			// Cancelled
+			return false;
+		}
+		Set<UUID> teamMembers = getMembers(getWorld(), user);
+		if (playerUUID.equals(island.getOwner())) {
+			int maxSize = getIslands().getMaxMembers(island, RanksManager.MEMBER_RANK);
+			if (teamMembers.size() < maxSize) {
+				user.sendMessage("commands.island.team.invite.you-can-invite", TextVariables.NUMBER, String.valueOf(maxSize - teamMembers.size()));
+			} else {
+				user.sendMessage("commands.island.team.invite.errors.island-is-full");
+			}
+		}
+		// Show members of island
+		showMembers(island, user);
+		return true;
+	}
 
-    private void showMembers(Island island, User user) {
-        // Gather online members
-        long count = island
-                .getMemberSet(RanksManager.MEMBER_RANK)
-                .stream()
-                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).getName()))
-                .count();
+	private void showMembers(Island island, User user) {
+		// Gather online members
+		long count = island
+				.getMemberSet(RanksManager.MEMBER_RANK)
+				.stream()
+				.filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).getName()))
+				.count();
 
-        // List of ranks that we will loop through
-        Integer[] ranks = new Integer[]{RanksManager.OWNER_RANK, RanksManager.SUB_OWNER_RANK, RanksManager.MEMBER_RANK, RanksManager.TRUSTED_RANK, RanksManager.COOP_RANK};
+		// List of ranks that we will loop through
+		Integer[] ranks = new Integer[]{RanksManager.OWNER_RANK, RanksManager.SUB_OWNER_RANK, RanksManager.MEMBER_RANK, RanksManager.TRUSTED_RANK, RanksManager.COOP_RANK};
 
-        // Show header:
-        user.sendMessage("commands.island.team.info.header",
-                "[max]", String.valueOf(getIslands().getMaxMembers(island, RanksManager.MEMBER_RANK)),
-                "[total]", String.valueOf(island.getMemberSet().size()),
-                "[online]", String.valueOf(count));
+		// Show header:
+		user.sendMessage("commands.island.team.info.header",
+				"[max]", String.valueOf(getIslands().getMaxMembers(island, RanksManager.MEMBER_RANK)),
+				"[total]", String.valueOf(island.getMemberSet().size()),
+				"[online]", String.valueOf(count));
 
-        // We now need to get all online "members" of the island - incl. Trusted and coop
-        List<UUID> onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
-                .filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).getName())).toList();
+		// We now need to get all online "members" of the island - incl. Trusted and coop
+		List<UUID> onlineMembers = island.getMemberSet(RanksManager.COOP_RANK).stream()
+				.filter(uuid -> Util.getOnlinePlayerList(user).contains(Bukkit.getOfflinePlayer(uuid).getName())).toList();
 
-        for (int rank : ranks) {
-            Set<UUID> players = island.getMemberSet(rank, false);
-            if (!players.isEmpty()) {
-                if (rank == RanksManager.OWNER_RANK) {
-                    // Slightly special handling for the owner rank
-                    user.sendMessage("commands.island.team.info.rank-layout.owner",
-                            TextVariables.RANK, user.getTranslation(RanksManager.OWNER_RANK_REF));
-                } else {
-                    user.sendMessage("commands.island.team.info.rank-layout.generic",
-                            TextVariables.RANK, user.getTranslation(getPlugin().getRanksManager().getRank(rank)),
-                            TextVariables.NUMBER, String.valueOf(island.getMemberSet(rank, false).size()));
-                }
-                displayOnOffline(user, rank, island, onlineMembers);
-            }
-        }
-    }
+		for (int rank : ranks) {
+			Set<UUID> players = island.getMemberSet(rank, false);
+			if (!players.isEmpty()) {
+				if (rank == RanksManager.OWNER_RANK) {
+					// Slightly special handling for the owner rank
+					user.sendMessage("commands.island.team.info.rank-layout.owner",
+							TextVariables.RANK, user.getTranslation(RanksManager.OWNER_RANK_REF));
+				} else {
+					user.sendMessage("commands.island.team.info.rank-layout.generic",
+							TextVariables.RANK, user.getTranslation(getPlugin().getRanksManager().getRank(rank)),
+							TextVariables.NUMBER, String.valueOf(island.getMemberSet(rank, false).size()));
+				}
+				displayOnOffline(user, rank, island, onlineMembers);
+			}
+		}
+	}
 
-    private void displayOnOffline(User user, int rank, Island island, List<UUID> onlineMembers) {
-        for (UUID member : island.getMemberSet(rank, false)) {
-            OfflinePlayer offlineMember = Bukkit.getOfflinePlayer(member);
-            if (onlineMembers.contains(member)) {
-                // the player is online
-                user.sendMessage("commands.island.team.info.member-layout.online",
-                        TextVariables.NAME, offlineMember.getName());
-            } else {
-                // A bit of handling for the last joined date
-                Instant lastJoined = Instant.ofEpochMilli(offlineMember.getLastPlayed());
-                Instant now = Instant.now();
+	private void displayOnOffline(User user, int rank, Island island, List<UUID> onlineMembers) {
+		for (UUID member : island.getMemberSet(rank, false)) {
+			OfflinePlayer offlineMember = Bukkit.getOfflinePlayer(member);
+			if (onlineMembers.contains(member)) {
+				// the player is online
+				user.sendMessage("commands.island.team.info.member-layout.online",
+						TextVariables.NAME, offlineMember.getName());
+			} else {
+				// A bit of handling for the last joined date
+				Instant lastJoined = Instant.ofEpochMilli(offlineMember.getLastPlayed());
+				Instant now = Instant.now();
 
-                Duration duration = Duration.between(lastJoined, now);
-                String lastSeen;
-                final String reference = "commands.island.team.info.last-seen.layout";
-                if (duration.toMinutes() < 60L) {
-                    lastSeen = user.getTranslation(reference,
-                            TextVariables.NUMBER, String.valueOf(duration.toMinutes()),
-                            TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.minutes"));
-                } else if (duration.toHours() < 24L) {
-                    lastSeen = user.getTranslation(reference,
-                            TextVariables.NUMBER, String.valueOf(duration.toHours()),
-                            TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.hours"));
-                } else {
-                    lastSeen = user.getTranslation(reference,
-                            TextVariables.NUMBER, String.valueOf(duration.toDays()),
-                            TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.days"));
-                }
+				Duration duration = Duration.between(lastJoined, now);
+				String lastSeen;
+				final String reference = "commands.island.team.info.last-seen.layout";
+				if (duration.toMinutes() < 60L) {
+					lastSeen = user.getTranslation(reference,
+							TextVariables.NUMBER, String.valueOf(duration.toMinutes()),
+							TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.minutes"));
+				} else if (duration.toHours() < 24L) {
+					lastSeen = user.getTranslation(reference,
+							TextVariables.NUMBER, String.valueOf(duration.toHours()),
+							TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.hours"));
+				} else {
+					lastSeen = user.getTranslation(reference,
+							TextVariables.NUMBER, String.valueOf(duration.toDays()),
+							TextVariables.UNIT, user.getTranslation("commands.island.team.info.last-seen.days"));
+				}
 
-                if(island.getMemberSet(RanksManager.MEMBER_RANK, true).contains(member)) {
-                    user.sendMessage("commands.island.team.info.member-layout.offline",
-                            TextVariables.NAME, offlineMember.getName(),
-                            "[last_seen]", lastSeen);
-                } else {
-                    // This will prevent anyone that is trusted or below to not have a last-seen status
-                    user.sendMessage("commands.island.team.info.member-layout.offline-not-last-seen",
-                            TextVariables.NAME, offlineMember.getName());
-                }
-            }
-        }
+				if(island.getMemberSet(RanksManager.MEMBER_RANK, true).contains(member)) {
+					user.sendMessage("commands.island.team.info.member-layout.offline",
+							TextVariables.NAME, offlineMember.getName(),
+							"[last_seen]", lastSeen);
+				} else {
+					// This will prevent anyone that is trusted or below to not have a last-seen status
+					user.sendMessage("commands.island.team.info.member-layout.offline-not-last-seen",
+							TextVariables.NAME, offlineMember.getName());
+				}
+			}
+		}
 
-    }
+	}
 
-    private boolean fireEvent(User user, Island island) {
-        IslandBaseEvent e = TeamEvent.builder()
-                .island(island)
-                .reason(TeamEvent.Reason.INFO)
-                .involvedPlayer(user.getUniqueId())
-                .build();
-        return e.getNewEvent().map(IslandBaseEvent::isCancelled)
-                .orElse(e.isCancelled());
-    }
+	private boolean fireEvent(User user, Island island) {
+		IslandBaseEvent e = TeamEvent.builder()
+				.island(island)
+				.reason(TeamEvent.Reason.INFO)
+				.involvedPlayer(user.getUniqueId())
+				.build();
+		return e.getNewEvent().map(IslandBaseEvent::isCancelled)
+				.orElse(e.isCancelled());
+	}
 
-    /**
-     * Add an invite
-     * @param type - type of invite
-     * @param inviter - uuid of inviter
-     * @param invitee - uuid of invitee
-     * @since 1.8.0
-     */
-    public void addInvite(Invite.Type type, @NonNull UUID inviter, @NonNull UUID invitee, @NonNull Island island) {
-        inviteMap.put(invitee, new Invite(type, inviter, invitee, island));
-    }
+	/**
+	 * Add an invite
+	 * @param type - type of invite
+	 * @param inviter - uuid of inviter
+	 * @param invitee - uuid of invitee
+	 * @since 1.8.0
+	 */
+	public void addInvite(Invite.Type type, @NonNull UUID inviter, @NonNull UUID invitee, @NonNull Island island) {
+		inviteMap.put(invitee, new Invite(type, inviter, invitee, island));
+	}
 
-    /**
-     * Check if a player has been invited
-     * @param invitee - UUID of invitee to check
-     * @return true if invited, false if not
-     * @since 1.8.0
-     */
-    public boolean isInvited(@NonNull UUID invitee) {
-        return inviteMap.containsKey(invitee);
-    }
+	/**
+	 * Check if a player has been invited
+	 * @param invitee - UUID of invitee to check
+	 * @return true if invited, false if not
+	 * @since 1.8.0
+	 */
+	public boolean isInvited(@NonNull UUID invitee) {
+		return inviteMap.containsKey(invitee);
+	}
 
-    /**
-     * Get whoever invited invitee
-     * @param invitee - uuid
-     * @return UUID of inviter, or null if invitee has not been invited
-     * @since 1.8.0
-     */
-    @Nullable
-    public UUID getInviter(UUID invitee) {
-        return isInvited(invitee) ? inviteMap.get(invitee).getInviter() : null;
-    }
+	/**
+	 * Get whoever invited invitee
+	 * @param invitee - uuid
+	 * @return UUID of inviter, or null if invitee has not been invited
+	 * @since 1.8.0
+	 */
+	@Nullable
+	public UUID getInviter(UUID invitee) {
+		return isInvited(invitee) ? inviteMap.get(invitee).getInviter() : null;
+	}
 
-    /**
-     * Gets the invite for an invitee.
-     * @param invitee - UUID of invitee
-     * @return invite or null if none
-     * @since 1.8.0
-     */
-    @Nullable
-    public Invite getInvite(UUID invitee) {
-        return inviteMap.get(invitee);
-    }
+	/**
+	 * Gets the invite for an invitee.
+	 * @param invitee - UUID of invitee
+	 * @return invite or null if none
+	 * @since 1.8.0
+	 */
+	@Nullable
+	public Invite getInvite(UUID invitee) {
+		return inviteMap.get(invitee);
+	}
 
-    /**
-     * Removes a pending invite.
-     * @param invitee - UUID of invited user
-     * @since 1.8.0
-     */
-    public void removeInvite(@NonNull UUID invitee) {
-        inviteMap.remove(invitee);
-    }
+	/**
+	 * Removes a pending invite.
+	 * @param invitee - UUID of invited user
+	 * @since 1.8.0
+	 */
+	public void removeInvite(@NonNull UUID invitee) {
+		inviteMap.remove(invitee);
+	}
 }

--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -42,748 +42,801 @@ import world.bentobox.bentobox.database.objects.Players;
 import world.bentobox.bentobox.util.Util;
 
 /**
- * Combines {@link Player}, {@link OfflinePlayer} and {@link CommandSender} to provide convenience methods related to
- * localization and generic interactions.
+ * Combines {@link Player}, {@link OfflinePlayer} and {@link CommandSender} to
+ * provide convenience methods related to localization and generic interactions.
  * <br/>
- * Therefore, a User could usually be a Player, an OfflinePlayer or the server's console.
- * Preliminary checks should be performed before trying to run methods that relies on a specific implementation.
- * <br/><br/>
- * It is good practice to use the User instance whenever possible instead of Player or CommandSender.
+ * Therefore, a User could usually be a Player, an OfflinePlayer or the server's
+ * console. Preliminary checks should be performed before trying to run methods
+ * that relies on a specific implementation. <br/>
+ * <br/>
+ * It is good practice to use the User instance whenever possible instead of
+ * Player or CommandSender.
  *
  * @author tastybento
  */
 public class User implements MetaDataAble {
 
-    private static final Map<UUID, User> users = new HashMap<>();
-
-    // Used for particle validation
-    private static final Map<Particle, Class<?>> VALIDATION_CHECK;
-    static {
-        Map<Particle, Class<?>> v = new EnumMap<>(Particle.class);
-        v.put(Particle.REDSTONE, Particle.DustOptions.class);
-        v.put(Particle.ITEM_CRACK, ItemStack.class);
-        v.put(Particle.BLOCK_CRACK, BlockData.class);
-        v.put(Particle.BLOCK_DUST, BlockData.class);
-        v.put(Particle.FALLING_DUST, BlockData.class);
-        v.put(Particle.BLOCK_MARKER, BlockData.class);
-        v.put(Particle.DUST_COLOR_TRANSITION, DustTransition.class);
-        v.put(Particle.VIBRATION, Vibration.class);
-        v.put(Particle.SCULK_CHARGE, Float.class);
-        v.put(Particle.SHRIEK, Integer.class);
-        v.put(Particle.LEGACY_BLOCK_CRACK, BlockData.class);
-        v.put(Particle.LEGACY_BLOCK_DUST, BlockData.class);
-        v.put(Particle.LEGACY_FALLING_DUST, BlockData.class);
-        VALIDATION_CHECK = Collections.unmodifiableMap(v);
-    }
-
-    /**
-     * Clears all users from the user list
-     */
-    public static void clearUsers() {
-        users.clear();
-    }
-
-    /**
-     * Gets an instance of User from a CommandSender
-     * @param sender - command sender, e.g. console
-     * @return user - user
-     */
-    @NonNull
-    public static User getInstance(@NonNull CommandSender sender) {
-        if (sender instanceof Player p) {
-            return getInstance(p);
-        }
-        // Console
-        return new User(sender);
-    }
-
-    /**
-     * Gets an instance of User from a Player object.
-     * @param player - the player
-     * @return user - user
-     */
-    @NonNull
-    public static User getInstance(@NonNull Player player) {
-        if (users.containsKey(player.getUniqueId())) {
-            return users.get(player.getUniqueId());
-        }
-        return new User(player);
-    }
-
-    /**
-     * Gets an instance of User from a UUID. This will always return a user object.
-     * If the player is offline then the getPlayer value will be null.
-     * @param uuid - UUID
-     * @return user - user
-     */
-    @NonNull
-    public static User getInstance(@NonNull UUID uuid) {
-        if (users.containsKey(uuid)) {
-            return users.get(uuid);
-        }
-        // Return a user instance
-        return new User(uuid);
-    }
-
-    /**
-     * Gets an instance of User from an OfflinePlayer
-     * @param offlinePlayer offline Player
-     * @return user
-     * @since 1.3.0
-     */
-    @NonNull
-    public static User getInstance(@NonNull OfflinePlayer offlinePlayer) {
-        if (users.containsKey(offlinePlayer.getUniqueId())) {
-            return users.get(offlinePlayer.getUniqueId());
-        }
-        return new User(offlinePlayer);
-    }
-
-    /**
-     * Removes this player from the User cache and player manager cache
-     * @param player the player
-     */
-    public static void removePlayer(Player player) {
-        if (player != null) {
-            users.remove(player.getUniqueId());
-            BentoBox.getInstance().getPlayers().removePlayer(player);
-        }
-    }
-
-    // ----------------------------------------------------
-
-    private static BentoBox plugin = BentoBox.getInstance();
-
-    @Nullable
-    private final Player player;
-    private OfflinePlayer offlinePlayer;
-    private final UUID playerUUID;
-    @Nullable
-    private final CommandSender sender;
-
-    private Addon addon;
-
-    private User(@Nullable CommandSender sender) {
-        player = null;
-        playerUUID = null;
-        this.sender = sender;
-    }
-
-    private User(@NonNull Player player) {
-        this.player = player;
-        offlinePlayer = player;
-        sender = player;
-        playerUUID = player.getUniqueId();
-        users.put(playerUUID, this);
-    }
-
-    private User(@NonNull OfflinePlayer offlinePlayer) {
-        this.player = offlinePlayer.isOnline() ? offlinePlayer.getPlayer() : null;
-        this.playerUUID = offlinePlayer.getUniqueId();
-        this.sender = offlinePlayer.isOnline() ? offlinePlayer.getPlayer() : null;
-        this.offlinePlayer = offlinePlayer;
-    }
-
-    private User(UUID playerUUID) {
-        player = Bukkit.getPlayer(playerUUID);
-        this.playerUUID = playerUUID;
-        sender = player;
-        offlinePlayer = Bukkit.getOfflinePlayer(playerUUID);
-    }
-
-    /**
-     * Used for testing
-     * @param p - plugin
-     */
-    public static void setPlugin(BentoBox p) {
-        plugin = p;
-    }
-
-    public Set<PermissionAttachmentInfo> getEffectivePermissions() {
-        return sender.getEffectivePermissions();
-    }
-
-    /**
-     * Get the user's inventory
-     * @return player's inventory
-     */
-    @NonNull
-    public PlayerInventory getInventory() {
-        return Objects.requireNonNull(player, "getInventory can only be called for online players!").getInventory();
-    }
-
-    /**
-     * Get the user's location
-     * @return location
-     */
-    @NonNull
-    public Location getLocation() {
-        return Objects.requireNonNull(player, "getLocation can only be called for online players!").getLocation();
-    }
-
-    /**
-     * Get the user's name
-     * @return player's name
-     */
-    @NonNull
-    public String getName() {
-        return player != null ? player.getName() : plugin.getPlayers().getName(playerUUID);
-    }
-
-    /**
-     * Get the user's display name
-     * @return player's display name if the player is online otherwise just their name
-     * @since 1.22.1
-     */
-    @NonNull
-    public String getDisplayName() {
-        return player != null ? player.getDisplayName() : plugin.getPlayers().getName(playerUUID);
-    }
-
-    /**
-     * Check if the User is a player before calling this method. {@link #isPlayer()}
-     * @return the player
-     */
-    @NonNull
-    public Player getPlayer() {
-        return Objects.requireNonNull(player, "User is not a player!");
-    }
-
-    /**
-     * @return true if this user is a player, false if not, e.g., console
-     */
-    public boolean isPlayer() {
-        return player != null;
-    }
-
-    /**
-     * Use {@link #isOfflinePlayer()} before calling this method
-     * @return the offline player
-     * @since 1.3.0
-     */
-    @NonNull
-    public OfflinePlayer getOfflinePlayer() {
-        return Objects.requireNonNull(offlinePlayer, "User is not an OfflinePlayer!");
-    }
-
-    /**
-     * @return true if this user is an OfflinePlayer, false if not, e.g., console
-     * @since 1.3.0
-     */
-    public boolean isOfflinePlayer() {
-        return offlinePlayer != null;
-    }
-
-    @Nullable
-    public CommandSender getSender() {
-        return sender;
-    }
-
-    public UUID getUniqueId() {
-        return playerUUID;
-    }
-
-    /**
-     * @param permission permission string
-     * @return true if permission is empty or null or if the player has that permission or if the player is op.
-     */
-    public boolean hasPermission(@Nullable String permission) {
-        return permission == null || permission.isEmpty() || isOp() || sender.hasPermission(permission);
-    }
-
-    /**
-     * Removes permission from user
-     * @param name - Name of the permission to remove
-     * @return true if successful
-     * @since 1.5.0
-     */
-    public boolean removePerm(String name) {
-        for (PermissionAttachmentInfo p : player.getEffectivePermissions()) {
-            if (p.getPermission().equals(name) && p.getAttachment() != null) {
-                player.removeAttachment(p.getAttachment());
-                break;
-            }
-        }
-        player.recalculatePermissions();
-        return !player.hasPermission(name);
-    }
-
-    /**
-     * Add a permission to user
-     * @param name - Name of the permission to attach
-     * @return The PermissionAttachment that was just created
-     * @since 1.5.0
-     */
-    public PermissionAttachment addPerm(String name) {
-        return player.addAttachment(plugin, name, true);
-    }
-
-    public boolean isOnline() {
-        return player != null && player.isOnline();
-    }
-
-    /**
-     * Checks if user is Op
-     * @return true if user is Op
-     */
-    public boolean isOp() {
-        if (sender != null) {
-            return sender.isOp();
-        }
-        if (playerUUID != null && offlinePlayer != null) {
-            return offlinePlayer.isOp();
-        }
-        return false;
-    }
-
-    /**
-     * Get the maximum value of a numerical permission setting.
-     * If a player is given an explicit negative number then this is treated as "unlimited" and returned immediately.
-     * @param permissionPrefix the start of the perm, e.g., {@code plugin.mypermission}
-     * @param defaultValue the default value; the result may be higher or lower than this
-     * @return max value
-     */
-    public int getPermissionValue(String permissionPrefix, int defaultValue) {
-        // If requester is console, then return the default value
-        if (!isPlayer()) return defaultValue;
-
-        // If there is a dot at the end of the permissionPrefix, remove it
-        if (permissionPrefix.endsWith(".")) {
-            permissionPrefix = permissionPrefix.substring(0, permissionPrefix.length()-1);
-        }
-
-        final String permPrefix = permissionPrefix + ".";
-
-        List<String> permissions = player.getEffectivePermissions().stream()
-                .filter(PermissionAttachmentInfo::getValue) // Must be a positive permission, not a negative one
-                .map(PermissionAttachmentInfo::getPermission)
-                .filter(permission -> permission.startsWith(permPrefix))
-                .toList();
-
-        if (permissions.isEmpty()) return defaultValue;
-
-        return iteratePerms(permissions, permPrefix, defaultValue);
-
-    }
-
-    private int iteratePerms(List<String> permissions, String permPrefix, int defaultValue) {
-        int value = 0;
-        for (String permission : permissions) {
-            if (permission.contains(permPrefix + "*")) {
-                // 'Star' permission
-                return defaultValue;
-            } else {
-                String[] spl = permission.split(permPrefix);
-                if (spl.length > 1) {
-                    if (!NumberUtils.isNumber(spl[1])) {
-                        plugin.logError("Player " + player.getName() + " has permission: '" + permission + "' <-- the last part MUST be a number! Ignoring...");
-                    } else {
-                        int v = Integer.parseInt(spl[1]);
-                        if (v < 0) {
-                            return v;
-                        }
-                        value = Math.max(value, v);
-                    }
-                }
-            }
-        }
-
-        return value;
-    }
-
-    /**
-     * Gets a translation for a specific world
-     * @param world - world of translation
-     * @param reference - reference found in a locale file
-     * @param variables - variables to insert into translated string. Variables go in pairs, for example
-     *                  "[name]", "tastybento"
-     * @return Translated string with colors converted, or the reference if nothing has been found
-     * @since 1.3.0
-     */
-    public String getTranslation(World world, String reference, String... variables) {
-        // Get translation.
-        String addonPrefix = plugin.getIWM()
-                .getAddon(world).map(a -> a.getDescription().getName().toLowerCase(Locale.ENGLISH) + ".").orElse("");
-        return Util.translateColorCodes(translate(addonPrefix, reference, variables));
-    }
-
-    /**
-     * Gets a translation of this reference for this user with colors converted. Translations may be overridden by Addons
-     * by using the same reference prefixed by the addon name (from the Addon Description) in lower case.
-     * @param reference - reference found in a locale file
-     * @param variables - variables to insert into translated string. Variables go in pairs, for example
-     *                  "[name]", "tastybento"
-     * @return Translated string with colors converted, or the reference if nothing has been found
-     */
-    public String getTranslation(String reference, String... variables) {
-        // Get addonPrefix
-        String addonPrefix = addon == null ? "" : addon.getDescription().getName().toLowerCase(Locale.ENGLISH) + ".";
-        return Util.translateColorCodes(translate(addonPrefix, reference, variables));
-    }
-
-    /**
-     * Gets a translation of this reference for this user without colors translated. Translations may be overridden by Addons
-     * by using the same reference prefixed by the addon name (from the Addon Description) in lower case.
-     * @param reference - reference found in a locale file
-     * @param variables - variables to insert into translated string. Variables go in pairs, for example
-     *                  "[name]", "tastybento"
-     * @return Translated string or the reference if nothing has been found
-     * @since 1.17.4
-     */
-    public String getTranslationNoColor(String reference, String... variables) {
-        // Get addonPrefix
-        String addonPrefix = addon == null ? "" : addon.getDescription().getName().toLowerCase(Locale.ENGLISH) + ".";
-        return translate(addonPrefix, reference, variables);
-    }
-
-    private String translate(String addonPrefix, String reference, String[] variables) {
-        // Try to get the translation for this specific addon
-        String translation = plugin.getLocalesManager().get(this, addonPrefix + reference);
-
-        if (translation == null) {
-            // No luck, try to get the generic translation
-            translation = plugin.getLocalesManager().get(this, reference);
-            if (translation == null) {
-                // Nothing found. Replace vars (probably will do nothing) and return
-                return replaceVars(reference, variables);
-            }
-        }
-
-        // If this is a prefix, just gather and return the translation
-        if (!reference.startsWith("prefixes.")) {
-            // Replace the prefixes
-            return replacePrefixes(translation, variables);
-        }
-        return translation;
-    }
-
-    private String replacePrefixes(String translation, String[] variables) {
-        for (String prefix : plugin.getLocalesManager().getAvailablePrefixes(this)) {
-            String prefixTranslation = getTranslation("prefixes." + prefix);
-            // Replace the [gamemode] text variable
-            prefixTranslation = prefixTranslation.replace("[gamemode]", addon != null ? addon.getDescription().getName() : "[gamemode]");
-            // Replace the [friendly_name] text variable
-            prefixTranslation = prefixTranslation.replace("[friendly_name]", isPlayer() ? plugin.getIWM().getFriendlyName(getWorld()) : "[friendly_name]");
-
-            // Replace the prefix in the actual message
-            translation = translation.replace("[prefix_" + prefix + "]", prefixTranslation);
-        }
-
-        // Then replace variables
-        if (variables.length > 1) {
-            for (int i = 0; i < variables.length; i += 2) {
-                // Prevent a NPE if the substituting variable is null
-                if (variables[i + 1] != null) {
-                    translation = translation.replace(variables[i], variables[i + 1]);
-                }
-            }
-        }
-
-        // Then replace Placeholders, this will only work if this is a player
-        if (player != null) {
-            translation = plugin.getPlaceholdersManager().replacePlaceholders(player, translation);
-        }
-        return translation;
-    }
-
-    private String replaceVars(String reference, String[] variables) {
-
-        // Then replace variables
-        if (variables.length > 1) {
-            for (int i = 0; i < variables.length; i += 2) {
-                reference = reference.replace(variables[i], variables[i + 1]);
-            }
-        }
-
-        // Then replace Placeholders, this will only work if this is a player
-        if (player != null) {
-            reference = plugin.getPlaceholdersManager().replacePlaceholders(player, reference);
-        }
-
-        // If no translation has been found, return the reference for debug purposes.
-        return reference;
-    }
-
-    /**
-     * Gets a translation of this reference for this user.
-     * @param reference - reference found in a locale file
-     * @param variables - variables to insert into translated string. Variables go in pairs, for example
-     *                  "[name]", "tastybento"
-     * @return Translated string with colors converted, or a blank String if nothing has been found
-     */
-    public String getTranslationOrNothing(String reference, String... variables) {
-        String translation = getTranslation(reference, variables);
-        return translation.equals(reference) ? "" : translation;
-    }
-
-    /**
-     * Send a message to sender if message is not empty.
-     * @param reference - language file reference
-     * @param variables - CharSequence target, replacement pairs
-     */
-    public void sendMessage(String reference, String... variables) {
-        String message = getTranslation(reference, variables);
-        if (!ChatColor.stripColor(message).trim().isEmpty()) {
-            sendRawMessage(message);
-        }
-    }
-
-    /**
-     * Sends a message to sender without any modification (colors, multi-lines, placeholders).
-     * @param message - the message to send
-     */
-    public void sendRawMessage(String message) {
-        if (sender != null) {
-            sender.sendMessage(message);
-        } else {
-            // Offline player fire event
-            Bukkit.getPluginManager().callEvent(new OfflineMessageEvent(this.playerUUID, message));
-        }
-    }
-
-    /**
-     * Sends a message to sender if message is not empty and if the same wasn't sent within the previous Notifier.NOTIFICATION_DELAY seconds.
-     * @param reference - language file reference
-     * @param variables - CharSequence target, replacement pairs
-     *
-     * @see Notifier
-     */
-    public void notify(String reference, String... variables) {
-        String message = getTranslation(reference, variables);
-        if (!ChatColor.stripColor(message).trim().isEmpty() && sender != null) {
-            plugin.getNotifier().notify(this, message);
-        }
-    }
-
-    /**
-     * Sends a message to sender if message is not empty and if the same wasn't sent within the previous Notifier.NOTIFICATION_DELAY seconds.
-     * @param world - the world the translation should come from
-     * @param reference - language file reference
-     * @param variables - CharSequence target, replacement pairs
-     *
-     * @see Notifier
-     * @since 1.3.0
-     */
-    public void notify(World world, String reference, String... variables) {
-        String message = getTranslation(world, reference, variables);
-        if (!ChatColor.stripColor(message).trim().isEmpty() && sender != null) {
-            plugin.getNotifier().notify(this, message);
-        }
-    }
-
-    /**
-     * Sets the user's game mode
-     * @param mode - GameMode
-     */
-    public void setGameMode(GameMode mode) {
-        player.setGameMode(mode);
-    }
-
-    /**
-     * Teleports user to this location. If the user is in a vehicle, they will exit first.
-     * @param location - the location
-     */
-    public void teleport(Location location) {
-        player.teleport(location);
-    }
-
-    /**
-     * Gets the current world this entity resides in
-     * @return World - world
-     */
-    @NonNull
-    public World getWorld() {
-        Objects.requireNonNull(player, "Cannot be called on a non-player User!");
-        return Objects.requireNonNull(player.getWorld(), "Player's world cannot be null!");
-    }
-
-    /**
-     * Closes the user's inventory
-     */
-    public void closeInventory() {
-        player.closeInventory();
-    }
-
-    /**
-     * Get the user's locale
-     * @return Locale
-     */
-    public Locale getLocale() {
-        if (sender instanceof Player && !plugin.getPlayers().getLocale(playerUUID).isEmpty()) {
-            return Locale.forLanguageTag(plugin.getPlayers().getLocale(playerUUID));
-        }
-        return Locale.forLanguageTag(plugin.getSettings().getDefaultLanguage());
-    }
-
-    /**
-     * Forces an update of the user's complete inventory.
-     * Deprecated, but there is no current alternative.
-     */
-    public void updateInventory() {
-        player.updateInventory();
-    }
-
-    /**
-     * Performs a command as the player
-     * @param command - command to execute
-     * @return true if the command was successful, otherwise false
-     */
-    public boolean performCommand(String command) {
-        PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(getPlayer(), command);
-        Bukkit.getPluginManager().callEvent(event);
-
-        // only perform the command, if the event wasn't cancelled by an other plugin:
-        if (!event.isCancelled()) {
-            return getPlayer().performCommand(event.getMessage());
-        }
-        // Cancelled, but it was recognized, so return true
-        return true;
-    }
-
-    /**
-     * Checks if a user is in one of the game worlds
-     * @return true if user is, false if not
-     */
-    public boolean inWorld() {
-        return plugin.getIWM().inWorld(getLocation());
-    }
-
-    /**
-     * Spawn particles to the player.
-     * They are only displayed if they are within the server's view distance.
-     * @param particle Particle to display.
-     * @param dustOptions Particle.DustOptions for the particle to display.
-     *                    Cannot be null when particle is {@link Particle#REDSTONE}.
-     * @param x X coordinate of the particle to display.
-     * @param y Y coordinate of the particle to display.
-     * @param z Z coordinate of the particle to display.
-     */
-    public void spawnParticle(Particle particle, @Nullable Object dustOptions, double x, double y, double z)
-    {
-        Class<?> expectedClass = VALIDATION_CHECK.get(particle);
-        if (expectedClass == null) throw new IllegalArgumentException("Unexpected value: " + particle);
-
-        if (!(expectedClass.isInstance(dustOptions))) {
-            throw new IllegalArgumentException("A non-null " + expectedClass.getSimpleName() + " must be provided when using Particle." + particle + " as particle.");
-        }
-
-        // Check if this particle is beyond the viewing distance of the server
-        if (this.player != null
-                && this.player.getLocation().toVector().distanceSquared(new Vector(x, y, z)) <
-                (Bukkit.getServer().getViewDistance() * 256 * Bukkit.getServer().getViewDistance()))
-        {
-            if (particle.equals(Particle.REDSTONE))
-            {
-                player.spawnParticle(particle, x, y, z, 1, 0, 0, 0, 1, dustOptions);
-            }
-            else if (dustOptions != null)
-            {
-                player.spawnParticle(particle, x, y, z, 1, dustOptions);
-            }
-            else
-            {
-                // This will never be called unless the value in VALIDATION_CHECK is null in the future
-                player.spawnParticle(particle, x, y, z, 1);
-            }
-        }
-    }
-
-
-    /**
-     * Spawn particles to the player.
-     * They are only displayed if they are within the server's view distance.
-     * Compatibility method for older usages.
-     * @param particle Particle to display.
-     * @param dustOptions Particle.DustOptions for the particle to display.
-     *                    Cannot be null when particle is {@link Particle#REDSTONE}.
-     * @param x X coordinate of the particle to display.
-     * @param y Y coordinate of the particle to display.
-     * @param z Z coordinate of the particle to display.
-     */
-    public void spawnParticle(Particle particle, Particle.DustOptions dustOptions, double x, double y, double z)
-    {
-        this.spawnParticle(particle, (Object) dustOptions, x, y, z);
-    }
-
-
-    /**
-     * Spawn particles to the player.
-     * They are only displayed if they are within the server's view distance.
-     * @param particle Particle to display.
-     * @param dustOptions Particle.DustOptions for the particle to display.
-     *                    Cannot be null when particle is {@link Particle#REDSTONE}.
-     * @param x X coordinate of the particle to display.
-     * @param y Y coordinate of the particle to display.
-     * @param z Z coordinate of the particle to display.
-     */
-    public void spawnParticle(Particle particle, Particle.DustOptions dustOptions, int x, int y, int z)
-    {
-        this.spawnParticle(particle, dustOptions, (double) x, (double) y, (double) z);
-    }
-
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((playerUUID == null) ? 0 : playerUUID.hashCode());
-        return result;
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (!(obj instanceof User other)) {
-            return false;
-        }
-        if (playerUUID == null) {
-            return other.playerUUID == null;
-        } else return playerUUID.equals(other.playerUUID);
-    }
-
-    /**
-     * Set the addon context when a command is executed
-     * @param addon - the addon executing the command
-     */
-    public void setAddon(Addon addon) {
-        this.addon = addon;
-    }
-
-    /**
-     * Get all the meta data for this user
-     * @return the metaData
-     * @since 1.15.4
-     */
-    @Override
-    public Optional<Map<String, MetaDataValue>> getMetaData() {
-        Players p = plugin
-                .getPlayers()
-                .getPlayer(playerUUID);
-        return Objects.requireNonNull(p, "Unknown player for " + playerUUID).getMetaData();
-    }
-
-    /**
-     * @param metaData the metaData to set
-     * @since 1.15.4
-     */
-    @Override
-    public void setMetaData(Map<String, MetaDataValue> metaData) {
-        Players p = plugin
-                .getPlayers()
-                .getPlayer(playerUUID);
-
-        Objects.requireNonNull(p, "Unknown player for " + playerUUID).setMetaData(metaData);
-    }
+	private static final Map<UUID, User> users = new HashMap<>();
+
+	// Used for particle validation
+	private static final Map<Particle, Class<?>> VALIDATION_CHECK;
+	static {
+		Map<Particle, Class<?>> v = new EnumMap<>(Particle.class);
+		v.put(Particle.REDSTONE, Particle.DustOptions.class);
+		v.put(Particle.ITEM_CRACK, ItemStack.class);
+		v.put(Particle.BLOCK_CRACK, BlockData.class);
+		v.put(Particle.BLOCK_DUST, BlockData.class);
+		v.put(Particle.FALLING_DUST, BlockData.class);
+		v.put(Particle.BLOCK_MARKER, BlockData.class);
+		v.put(Particle.DUST_COLOR_TRANSITION, DustTransition.class);
+		v.put(Particle.VIBRATION, Vibration.class);
+		v.put(Particle.SCULK_CHARGE, Float.class);
+		v.put(Particle.SHRIEK, Integer.class);
+		v.put(Particle.LEGACY_BLOCK_CRACK, BlockData.class);
+		v.put(Particle.LEGACY_BLOCK_DUST, BlockData.class);
+		v.put(Particle.LEGACY_FALLING_DUST, BlockData.class);
+		VALIDATION_CHECK = Collections.unmodifiableMap(v);
+	}
+
+	/**
+	 * Clears all users from the user list
+	 */
+	public static void clearUsers() {
+		users.clear();
+	}
+
+	/**
+	 * Gets an instance of User from a CommandSender
+	 * 
+	 * @param sender - command sender, e.g. console
+	 * @return user - user
+	 */
+	@NonNull
+	public static User getInstance(@NonNull CommandSender sender) {
+		if (sender instanceof Player p) {
+			return getInstance(p);
+		}
+		// Console
+		return new User(sender);
+	}
+
+	/**
+	 * Gets an instance of User from a Player object.
+	 * 
+	 * @param player - the player
+	 * @return user - user
+	 */
+	@NonNull
+	public static User getInstance(@NonNull Player player) {
+		if (users.containsKey(player.getUniqueId())) {
+			return users.get(player.getUniqueId());
+		}
+		return new User(player);
+	}
+
+	/**
+	 * Gets an instance of User from a UUID. This will always return a user object.
+	 * If the player is offline then the getPlayer value will be null.
+	 * 
+	 * @param uuid - UUID
+	 * @return user - user
+	 */
+	@NonNull
+	public static User getInstance(@NonNull UUID uuid) {
+		if (users.containsKey(uuid)) {
+			return users.get(uuid);
+		}
+		// Return a user instance
+		return new User(uuid);
+	}
+
+	/**
+	 * Gets an instance of User from an OfflinePlayer
+	 * 
+	 * @param offlinePlayer offline Player
+	 * @return user
+	 * @since 1.3.0
+	 */
+	@NonNull
+	public static User getInstance(@NonNull OfflinePlayer offlinePlayer) {
+		if (users.containsKey(offlinePlayer.getUniqueId())) {
+			return users.get(offlinePlayer.getUniqueId());
+		}
+		return new User(offlinePlayer);
+	}
+
+	/**
+	 * Removes this player from the User cache and player manager cache
+	 * 
+	 * @param player the player
+	 */
+	public static void removePlayer(Player player) {
+		if (player != null) {
+			users.remove(player.getUniqueId());
+			BentoBox.getInstance().getPlayers().removePlayer(player);
+		}
+	}
+
+	// ----------------------------------------------------
+
+	private static BentoBox plugin = BentoBox.getInstance();
+
+	@Nullable
+	private final Player player;
+	private OfflinePlayer offlinePlayer;
+	private final UUID playerUUID;
+	@Nullable
+	private final CommandSender sender;
+
+	private Addon addon;
+
+	private User(@Nullable CommandSender sender) {
+		player = null;
+		playerUUID = null;
+		this.sender = sender;
+	}
+
+	private User(@NonNull Player player) {
+		this.player = player;
+		offlinePlayer = player;
+		sender = player;
+		playerUUID = player.getUniqueId();
+		users.put(playerUUID, this);
+	}
+
+	private User(@NonNull OfflinePlayer offlinePlayer) {
+		this.player = offlinePlayer.isOnline() ? offlinePlayer.getPlayer() : null;
+		this.playerUUID = offlinePlayer.getUniqueId();
+		this.sender = offlinePlayer.isOnline() ? offlinePlayer.getPlayer() : null;
+		this.offlinePlayer = offlinePlayer;
+	}
+
+	private User(UUID playerUUID) {
+		player = Bukkit.getPlayer(playerUUID);
+		this.playerUUID = playerUUID;
+		sender = player;
+		offlinePlayer = Bukkit.getOfflinePlayer(playerUUID);
+	}
+
+	/**
+	 * Used for testing
+	 * 
+	 * @param p - plugin
+	 */
+	public static void setPlugin(BentoBox p) {
+		plugin = p;
+	}
+
+	public Set<PermissionAttachmentInfo> getEffectivePermissions() {
+		return sender.getEffectivePermissions();
+	}
+
+	/**
+	 * Get the user's inventory
+	 * 
+	 * @return player's inventory
+	 */
+	@NonNull
+	public PlayerInventory getInventory() {
+		return Objects.requireNonNull(player, "getInventory can only be called for online players!").getInventory();
+	}
+
+	/**
+	 * Get the user's location
+	 * 
+	 * @return location
+	 */
+	@NonNull
+	public Location getLocation() {
+		return Objects.requireNonNull(player, "getLocation can only be called for online players!").getLocation();
+	}
+
+	/**
+	 * Get the user's name
+	 * 
+	 * @return player's name
+	 */
+	@NonNull
+	public String getName() {
+		return player != null ? player.getName() : plugin.getPlayers().getName(playerUUID);
+	}
+
+	/**
+	 * Get the user's display name
+	 * 
+	 * @return player's display name if the player is online otherwise just their
+	 *         name
+	 * @since 1.22.1
+	 */
+	@NonNull
+	public String getDisplayName() {
+		return player != null ? player.getDisplayName() : plugin.getPlayers().getName(playerUUID);
+	}
+
+	/**
+	 * Check if the User is a player before calling this method. {@link #isPlayer()}
+	 * 
+	 * @return the player
+	 */
+	@NonNull
+	public Player getPlayer() {
+		return Objects.requireNonNull(player, "User is not a player!");
+	}
+
+	/**
+	 * @return true if this user is a player, false if not, e.g., console
+	 */
+	public boolean isPlayer() {
+		return player != null;
+	}
+
+	/**
+	 * Use {@link #isOfflinePlayer()} before calling this method
+	 * 
+	 * @return the offline player
+	 * @since 1.3.0
+	 */
+	@NonNull
+	public OfflinePlayer getOfflinePlayer() {
+		return Objects.requireNonNull(offlinePlayer, "User is not an OfflinePlayer!");
+	}
+
+	/**
+	 * @return true if this user is an OfflinePlayer, false if not, e.g., console
+	 * @since 1.3.0
+	 */
+	public boolean isOfflinePlayer() {
+		return offlinePlayer != null;
+	}
+
+	@Nullable
+	public CommandSender getSender() {
+		return sender;
+	}
+
+	public UUID getUniqueId() {
+		return playerUUID;
+	}
+
+	/**
+	 * @param permission permission string
+	 * @return true if permission is empty or null or if the player has that
+	 *         permission or if the player is op.
+	 */
+	public boolean hasPermission(@Nullable String permission) {
+		return permission == null || permission.isEmpty() || isOp() || sender.hasPermission(permission);
+	}
+
+	/**
+	 * Removes permission from user
+	 * 
+	 * @param name - Name of the permission to remove
+	 * @return true if successful
+	 * @since 1.5.0
+	 */
+	public boolean removePerm(String name) {
+		for (PermissionAttachmentInfo p : player.getEffectivePermissions()) {
+			if (p.getPermission().equals(name) && p.getAttachment() != null) {
+				player.removeAttachment(p.getAttachment());
+				break;
+			}
+		}
+		player.recalculatePermissions();
+		return !player.hasPermission(name);
+	}
+
+	/**
+	 * Add a permission to user
+	 * 
+	 * @param name - Name of the permission to attach
+	 * @return The PermissionAttachment that was just created
+	 * @since 1.5.0
+	 */
+	public PermissionAttachment addPerm(String name) {
+		return player.addAttachment(plugin, name, true);
+	}
+
+	public boolean isOnline() {
+		return player != null && player.isOnline();
+	}
+
+	/**
+	 * Checks if user is Op
+	 * 
+	 * @return true if user is Op
+	 */
+	public boolean isOp() {
+		if (sender != null) {
+			return sender.isOp();
+		}
+		if (playerUUID != null && offlinePlayer != null) {
+			return offlinePlayer.isOp();
+		}
+		return false;
+	}
+
+	/**
+	 * Get the maximum value of a numerical permission setting. If a player is given
+	 * an explicit negative number then this is treated as "unlimited" and returned
+	 * immediately.
+	 * 
+	 * @param permissionPrefix the start of the perm, e.g.,
+	 *                         {@code plugin.mypermission}
+	 * @param defaultValue     the default value; the result may be higher or lower
+	 *                         than this
+	 * @return max value
+	 */
+	public int getPermissionValue(String permissionPrefix, int defaultValue) {
+		// If requester is console, then return the default value
+		if (!isPlayer())
+			return defaultValue;
+
+		// If there is a dot at the end of the permissionPrefix, remove it
+		if (permissionPrefix.endsWith(".")) {
+			permissionPrefix = permissionPrefix.substring(0, permissionPrefix.length() - 1);
+		}
+
+		final String permPrefix = permissionPrefix + ".";
+
+		List<String> permissions = player.getEffectivePermissions().stream().filter(PermissionAttachmentInfo::getValue) // Must
+																														// be
+																														// a
+																														// positive
+																														// permission,
+																														// not
+																														// a
+																														// negative
+																														// one
+				.map(PermissionAttachmentInfo::getPermission).filter(permission -> permission.startsWith(permPrefix))
+				.toList();
+
+		if (permissions.isEmpty())
+			return defaultValue;
+
+		return iteratePerms(permissions, permPrefix, defaultValue);
+
+	}
+
+	private int iteratePerms(List<String> permissions, String permPrefix, int defaultValue) {
+		int value = 0;
+		for (String permission : permissions) {
+			if (permission.contains(permPrefix + "*")) {
+				// 'Star' permission
+				return defaultValue;
+			} else {
+				String[] spl = permission.split(permPrefix);
+				if (spl.length > 1) {
+					if (!NumberUtils.isNumber(spl[1])) {
+						plugin.logError("Player " + player.getName() + " has permission: '" + permission
+								+ "' <-- the last part MUST be a number! Ignoring...");
+					} else {
+						int v = Integer.parseInt(spl[1]);
+						if (v < 0) {
+							return v;
+						}
+						value = Math.max(value, v);
+					}
+				}
+			}
+		}
+
+		return value;
+	}
+
+	/**
+	 * Gets a translation for a specific world
+	 * 
+	 * @param world     - world of translation
+	 * @param reference - reference found in a locale file
+	 * @param variables - variables to insert into translated string. Variables go
+	 *                  in pairs, for example "[name]", "tastybento"
+	 * @return Translated string with colors converted, or the reference if nothing
+	 *         has been found
+	 * @since 1.3.0
+	 */
+	public String getTranslation(World world, String reference, String... variables) {
+		// Get translation.
+		String addonPrefix = plugin.getIWM().getAddon(world)
+				.map(a -> a.getDescription().getName().toLowerCase(Locale.ENGLISH) + ".").orElse("");
+		return Util.translateColorCodes(translate(addonPrefix, reference, variables));
+	}
+
+	/**
+	 * Gets a translation of this reference for this user with colors converted.
+	 * Translations may be overridden by Addons by using the same reference prefixed
+	 * by the addon name (from the Addon Description) in lower case.
+	 * 
+	 * @param reference - reference found in a locale file
+	 * @param variables - variables to insert into translated string. Variables go
+	 *                  in pairs, for example "[name]", "tastybento"
+	 * @return Translated string with colors converted, or the reference if nothing
+	 *         has been found
+	 */
+	public String getTranslation(String reference, String... variables) {
+		// Get addonPrefix
+		String addonPrefix = addon == null ? "" : addon.getDescription().getName().toLowerCase(Locale.ENGLISH) + ".";
+		return Util.translateColorCodes(translate(addonPrefix, reference, variables));
+	}
+
+	/**
+	 * Gets a translation of this reference for this user without colors translated.
+	 * Translations may be overridden by Addons by using the same reference prefixed
+	 * by the addon name (from the Addon Description) in lower case.
+	 * 
+	 * @param reference - reference found in a locale file
+	 * @param variables - variables to insert into translated string. Variables go
+	 *                  in pairs, for example "[name]", "tastybento"
+	 * @return Translated string or the reference if nothing has been found
+	 * @since 1.17.4
+	 */
+	public String getTranslationNoColor(String reference, String... variables) {
+		// Get addonPrefix
+		String addonPrefix = addon == null ? "" : addon.getDescription().getName().toLowerCase(Locale.ENGLISH) + ".";
+		return translate(addonPrefix, reference, variables);
+	}
+
+	private String translate(String addonPrefix, String reference, String[] variables) {
+		// Try to get the translation for this specific addon
+		String translation = plugin.getLocalesManager().get(this, addonPrefix + reference);
+
+		if (translation == null) {
+			// No luck, try to get the generic translation
+			translation = plugin.getLocalesManager().get(this, reference);
+			if (translation == null) {
+				// Nothing found. Replace vars (probably will do nothing) and return
+				return replaceVars(reference, variables);
+			}
+		}
+
+		// If this is a prefix, just gather and return the translation
+		if (!reference.startsWith("prefixes.")) {
+			// Replace the prefixes
+			return replacePrefixes(translation, variables);
+		}
+		return translation;
+	}
+
+	private String replacePrefixes(String translation, String[] variables) {
+		for (String prefix : plugin.getLocalesManager().getAvailablePrefixes(this)) {
+			String prefixTranslation = getTranslation("prefixes." + prefix);
+			// Replace the [gamemode] text variable
+			prefixTranslation = prefixTranslation.replace("[gamemode]",
+					addon != null ? addon.getDescription().getName() : "[gamemode]");
+			// Replace the [friendly_name] text variable
+			prefixTranslation = prefixTranslation.replace("[friendly_name]",
+					isPlayer() ? plugin.getIWM().getFriendlyName(getWorld()) : "[friendly_name]");
+
+			// Replace the prefix in the actual message
+			translation = translation.replace("[prefix_" + prefix + "]", prefixTranslation);
+		}
+
+		// Then replace variables
+		if (variables.length > 1) {
+			for (int i = 0; i < variables.length; i += 2) {
+				// Prevent a NPE if the substituting variable is null
+				if (variables[i + 1] != null) {
+					translation = translation.replace(variables[i], variables[i + 1]);
+				}
+			}
+		}
+
+		// Then replace Placeholders, this will only work if this is a player
+		if (player != null) {
+			translation = plugin.getPlaceholdersManager().replacePlaceholders(player, translation);
+		}
+		return translation;
+	}
+
+	private String replaceVars(String reference, String[] variables) {
+
+		// Then replace variables
+		if (variables.length > 1) {
+			for (int i = 0; i < variables.length; i += 2) {
+				reference = reference.replace(variables[i], variables[i + 1]);
+			}
+		}
+
+		// Then replace Placeholders, this will only work if this is a player
+		if (player != null) {
+			reference = plugin.getPlaceholdersManager().replacePlaceholders(player, reference);
+		}
+
+		// If no translation has been found, return the reference for debug purposes.
+		return reference;
+	}
+
+	/**
+	 * Gets a translation of this reference for this user.
+	 * 
+	 * @param reference - reference found in a locale file
+	 * @param variables - variables to insert into translated string. Variables go
+	 *                  in pairs, for example "[name]", "tastybento"
+	 * @return Translated string with colors converted, or a blank String if nothing
+	 *         has been found
+	 */
+	public String getTranslationOrNothing(String reference, String... variables) {
+		String translation = getTranslation(reference, variables);
+		return translation.equals(reference) ? "" : translation;
+	}
+
+	/**
+	 * Send a message to sender if message is not empty.
+	 * 
+	 * @param reference - language file reference
+	 * @param variables - CharSequence target, replacement pairs
+	 */
+	public void sendMessage(String reference, String... variables) {
+		String message = getTranslation(reference, variables);
+		if (!ChatColor.stripColor(message).trim().isEmpty()) {
+			sendRawMessage(message);
+		}
+	}
+
+	/**
+	 * Sends a message to sender without any modification (colors, multi-lines,
+	 * placeholders).
+	 * 
+	 * @param message - the message to send
+	 */
+	public void sendRawMessage(String message) {
+		if (sender != null) {
+			sender.sendMessage(message);
+		} else {
+			// Offline player fire event
+			Bukkit.getPluginManager().callEvent(new OfflineMessageEvent(this.playerUUID, message));
+		}
+	}
+
+	/**
+	 * Sends a message to sender if message is not empty and if the same wasn't sent
+	 * within the previous Notifier.NOTIFICATION_DELAY seconds.
+	 * 
+	 * @param reference - language file reference
+	 * @param variables - CharSequence target, replacement pairs
+	 *
+	 * @see Notifier
+	 */
+	public void notify(String reference, String... variables) {
+		String message = getTranslation(reference, variables);
+		if (!ChatColor.stripColor(message).trim().isEmpty() && sender != null) {
+			plugin.getNotifier().notify(this, message);
+		}
+	}
+
+	/**
+	 * Sends a message to sender if message is not empty and if the same wasn't sent
+	 * within the previous Notifier.NOTIFICATION_DELAY seconds.
+	 * 
+	 * @param world     - the world the translation should come from
+	 * @param reference - language file reference
+	 * @param variables - CharSequence target, replacement pairs
+	 *
+	 * @see Notifier
+	 * @since 1.3.0
+	 */
+	public void notify(World world, String reference, String... variables) {
+		String message = getTranslation(world, reference, variables);
+		if (!ChatColor.stripColor(message).trim().isEmpty() && sender != null) {
+			plugin.getNotifier().notify(this, message);
+		}
+	}
+
+	/**
+	 * Sets the user's game mode
+	 * 
+	 * @param mode - GameMode
+	 */
+	public void setGameMode(GameMode mode) {
+		player.setGameMode(mode);
+	}
+
+	/**
+	 * Teleports user to this location. If the user is in a vehicle, they will exit
+	 * first.
+	 * 
+	 * @param location - the location
+	 */
+	public void teleport(Location location) {
+		player.teleport(location);
+	}
+
+	/**
+	 * Gets the current world this entity resides in
+	 * 
+	 * @return World - world
+	 */
+	@NonNull
+	public World getWorld() {
+		Objects.requireNonNull(player, "Cannot be called on a non-player User!");
+		return Objects.requireNonNull(player.getWorld(), "Player's world cannot be null!");
+	}
+
+	/**
+	 * Closes the user's inventory
+	 */
+	public void closeInventory() {
+		player.closeInventory();
+	}
+
+	/**
+	 * Get the user's locale
+	 * 
+	 * @return Locale
+	 */
+	public Locale getLocale() {
+		if (sender instanceof Player && !plugin.getPlayers().getLocale(playerUUID).isEmpty()) {
+			return Locale.forLanguageTag(plugin.getPlayers().getLocale(playerUUID));
+		}
+		return Locale.forLanguageTag(plugin.getSettings().getDefaultLanguage());
+	}
+
+	/**
+	 * Forces an update of the user's complete inventory. Deprecated, but there is
+	 * no current alternative.
+	 */
+	public void updateInventory() {
+		player.updateInventory();
+	}
+
+	/**
+	 * Performs a command as the player
+	 * 
+	 * @param command - command to execute
+	 * @return true if the command was successful, otherwise false
+	 */
+	public boolean performCommand(String command) {
+		PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(getPlayer(), command);
+		Bukkit.getPluginManager().callEvent(event);
+
+		// only perform the command, if the event wasn't cancelled by an other plugin:
+		if (!event.isCancelled()) {
+			return getPlayer().performCommand(
+					event.getMessage().startsWith("/") ? event.getMessage().substring(1) : event.getMessage());
+		}
+		// Cancelled, but it was recognized, so return true
+		return true;
+	}
+
+	/**
+	 * Checks if a user is in one of the game worlds
+	 * 
+	 * @return true if user is, false if not
+	 */
+	public boolean inWorld() {
+		return plugin.getIWM().inWorld(getLocation());
+	}
+
+	/**
+	 * Spawn particles to the player. They are only displayed if they are within the
+	 * server's view distance.
+	 * 
+	 * @param particle    Particle to display.
+	 * @param dustOptions Particle.DustOptions for the particle to display. Cannot
+	 *                    be null when particle is {@link Particle#REDSTONE}.
+	 * @param x           X coordinate of the particle to display.
+	 * @param y           Y coordinate of the particle to display.
+	 * @param z           Z coordinate of the particle to display.
+	 */
+	public void spawnParticle(Particle particle, @Nullable Object dustOptions, double x, double y, double z) {
+		Class<?> expectedClass = VALIDATION_CHECK.get(particle);
+		if (expectedClass == null)
+			throw new IllegalArgumentException("Unexpected value: " + particle);
+
+		if (!(expectedClass.isInstance(dustOptions))) {
+			throw new IllegalArgumentException("A non-null " + expectedClass.getSimpleName()
+					+ " must be provided when using Particle." + particle + " as particle.");
+		}
+
+		// Check if this particle is beyond the viewing distance of the server
+		if (this.player != null && this.player.getLocation().toVector().distanceSquared(new Vector(x, y,
+				z)) < (Bukkit.getServer().getViewDistance() * 256 * Bukkit.getServer().getViewDistance())) {
+			if (particle.equals(Particle.REDSTONE)) {
+				player.spawnParticle(particle, x, y, z, 1, 0, 0, 0, 1, dustOptions);
+			} else if (dustOptions != null) {
+				player.spawnParticle(particle, x, y, z, 1, dustOptions);
+			} else {
+				// This will never be called unless the value in VALIDATION_CHECK is null in the
+				// future
+				player.spawnParticle(particle, x, y, z, 1);
+			}
+		}
+	}
+
+	/**
+	 * Spawn particles to the player. They are only displayed if they are within the
+	 * server's view distance. Compatibility method for older usages.
+	 * 
+	 * @param particle    Particle to display.
+	 * @param dustOptions Particle.DustOptions for the particle to display. Cannot
+	 *                    be null when particle is {@link Particle#REDSTONE}.
+	 * @param x           X coordinate of the particle to display.
+	 * @param y           Y coordinate of the particle to display.
+	 * @param z           Z coordinate of the particle to display.
+	 */
+	public void spawnParticle(Particle particle, Particle.DustOptions dustOptions, double x, double y, double z) {
+		this.spawnParticle(particle, (Object) dustOptions, x, y, z);
+	}
+
+	/**
+	 * Spawn particles to the player. They are only displayed if they are within the
+	 * server's view distance.
+	 * 
+	 * @param particle    Particle to display.
+	 * @param dustOptions Particle.DustOptions for the particle to display. Cannot
+	 *                    be null when particle is {@link Particle#REDSTONE}.
+	 * @param x           X coordinate of the particle to display.
+	 * @param y           Y coordinate of the particle to display.
+	 * @param z           Z coordinate of the particle to display.
+	 */
+	public void spawnParticle(Particle particle, Particle.DustOptions dustOptions, int x, int y, int z) {
+		this.spawnParticle(particle, dustOptions, (double) x, (double) y, (double) z);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((playerUUID == null) ? 0 : playerUUID.hashCode());
+		return result;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof User other)) {
+			return false;
+		}
+		if (playerUUID == null) {
+			return other.playerUUID == null;
+		} else
+			return playerUUID.equals(other.playerUUID);
+	}
+
+	/**
+	 * Set the addon context when a command is executed
+	 * 
+	 * @param addon - the addon executing the command
+	 */
+	public void setAddon(Addon addon) {
+		this.addon = addon;
+	}
+
+	/**
+	 * Get all the meta data for this user
+	 * 
+	 * @return the metaData
+	 * @since 1.15.4
+	 */
+	@Override
+	public Optional<Map<String, MetaDataValue>> getMetaData() {
+		Players p = plugin.getPlayers().getPlayer(playerUUID);
+		return Objects.requireNonNull(p, "Unknown player for " + playerUUID).getMetaData();
+	}
+
+	/**
+	 * @param metaData the metaData to set
+	 * @since 1.15.4
+	 */
+	@Override
+	public void setMetaData(Map<String, MetaDataValue> metaData) {
+		Players p = plugin.getPlayers().getPlayer(playerUUID);
+
+		Objects.requireNonNull(p, "Unknown player for " + playerUUID).setMetaData(metaData);
+	}
 
 }

--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxCommand.java
@@ -25,6 +25,7 @@ public class BentoBoxCommand extends CompositeCommand {
         new BentoBoxLocaleCommand(this);
         new BentoBoxHelpCommand(this);
         new BentoBoxPermsCommand(this);
+        new BentoBoxRankCommand(this);
         // Database names with a 2 in them are migration databases
         if (getPlugin().getSettings().getDatabaseType().name().contains("2")) {
             new BentoBoxMigrateCommand(this);

--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxRankCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxRankCommand.java
@@ -1,0 +1,141 @@
+package world.bentobox.bentobox.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.RanksManager;
+
+/**
+ * Manages ranks
+ *
+ * @author tastybento
+ * @since 2.0.0
+ */
+public class BentoBoxRankCommand extends CompositeCommand {
+
+	private int rankValue;
+	private String firstElement;
+	private final RanksManager rm;
+
+	/**
+	 * Rank management. Add and remove
+	 * @param parent command parent
+	 */
+	public BentoBoxRankCommand(CompositeCommand parent) {
+		super(parent, "rank");
+		rm = getPlugin().getRanksManager();
+	}
+
+	@Override
+	public void setup() {
+		setPermission("bentobox.admin.rank");
+		setDescription("commands.bentobox.rank.description");
+		this.setParametersHelp("commands.bentobox.rank.parameters");
+	}
+
+	@Override
+	public boolean canExecute(User user, String label, List<String> args) {
+
+		if (args.isEmpty()) {
+			// Show help
+			showHelp(this, user);
+			return false;
+		}
+		// Check if the first element is "add" or "remove" or "list"
+		firstElement = args.get(0);
+		if (!("list".equals(firstElement) || "add".equals(firstElement) || "remove".equals(firstElement))) {
+			// Show help
+			showHelp(this, user);
+			return false;
+		}
+
+		if ("remove".equals(firstElement) && args.size() != 2) {
+			// Show help
+			showHelp(this, user);
+			return false;
+		}
+
+		// If the first element is "add", then check if the third element is an integer
+		if ("add".equals(firstElement)) {
+			// Check if there is a third element
+			if (args.size() < 3) {
+				// Show help
+				showHelp(this, user);
+				return false;
+			}
+
+			// Check if the third element is an integer
+			String thirdElement = args.get(2);
+			try {
+				rankValue = Integer.parseInt(thirdElement);
+			} catch (NumberFormatException e) {
+				// Show help
+				showHelp(this, user);
+				return false;
+			}
+		}
+
+		// If all checks passed, return true
+		return true;
+	}
+
+	@Override
+	public boolean execute(User user, String label, List<String> args) {
+
+		if ("list".equals(firstElement)) {
+			showRanks(user);
+			return true;
+		}
+		if ("add".equals(firstElement)) {
+			if (rm.addRank(args.get(1), rankValue)) {    			
+				user.sendMessage("commands.bentobox.rank.add.success", "[rank]", args.get(1), TextVariables.NUMBER, String.valueOf(rankValue));
+				showRanks(user);
+			} else {
+				user.sendMessage("commands.bentobox.rank.add.failure", "[rank]", args.get(1), TextVariables.NUMBER, String.valueOf(rankValue));
+				return false;
+			}
+		} else {
+			if (rm.removeRank(args.get(1))) {
+				user.sendMessage("commands.bentobox.rank.remove.success", "[rank]", args.get(1));
+				showRanks(user);
+			} else {
+				user.sendMessage("commands.bentobox.rank.remove.failure", "[rank]", args.get(1));
+				return false;
+			}
+		}    	
+		return true;
+	}
+
+	private void showRanks(User user) {
+		user.sendMessage("commands.bentobox.rank.list");
+		rm.getRanks().forEach((ref, rank) -> {
+			user.sendRawMessage(user.getTranslation(ref) + ": " + ref + " " + String.valueOf(rank));
+		});
+
+	}
+
+	@Override
+	public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
+		if (args.size() <=1) {
+			return Optional.empty();
+		}
+		firstElement = args.get(1);
+		if (args.size() <= 2) {
+			return Optional.of(List.of("add","remove","list"));
+		}
+		if (args.size() > 1 && "add".equals(firstElement)) {
+			List<String> options = new ArrayList<>(RanksManager.DEFAULT_RANKS.keySet());
+			options.removeIf(rm.getRanks().keySet()::contains);
+			return Optional.of(options);
+		} 
+		if (args.size() > 1 && "remove".equals(firstElement)) {
+			return Optional.of(new ArrayList<>(rm.getRanks().keySet()));
+		}
+		return Optional.empty();
+
+	}
+}

--- a/src/main/java/world/bentobox/bentobox/database/objects/RankObject.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/RankObject.java
@@ -1,0 +1,45 @@
+package world.bentobox.bentobox.database.objects;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * Stores data on ranks
+ */
+@Table(name = "Ranks")
+public class RankObject implements DataObject {
+	
+	public static final String ID = "BentoBox-Ranks";
+	
+	public RankObject(Map<String, Integer> rankReference) {
+		super();
+		this.rankReference = rankReference;
+	}
+
+	@Expose
+	private Map<String, Integer> rankReference;
+
+	@Override
+	public String getUniqueId() {
+		return ID;
+	}
+
+	@Override
+	public void setUniqueId(String uniqueId) {
+		// Nothing to do
+	}
+
+	public Map<String, Integer> getRankReference() {
+		return Objects.requireNonNullElse(rankReference, new LinkedHashMap<>());
+	}
+
+	public void setRankReference(Map<String, Integer> rankReference) {
+		this.rankReference = rankReference;
+	}
+
+	
+	
+}

--- a/src/main/java/world/bentobox/bentobox/database/objects/Ranks.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Ranks.java
@@ -10,11 +10,11 @@ import com.google.gson.annotations.Expose;
  * Stores data on ranks
  */
 @Table(name = "Ranks")
-public class RankObject implements DataObject {
+public class Ranks implements DataObject {
 	
 	public static final String ID = "BentoBox-Ranks";
 	
-	public RankObject(Map<String, Integer> rankReference) {
+	public Ranks(Map<String, Integer> rankReference) {
 		super();
 		this.rankReference = rankReference;
 	}

--- a/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
@@ -5,6 +5,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNull;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.database.Database;
+import world.bentobox.bentobox.database.objects.RankObject;
+
 /**
  * Ranks Manager
  * Handles ranks and holds constants for various island ranks
@@ -13,149 +19,159 @@ import java.util.stream.Collectors;
  */
 public class RanksManager {
 
-    // Constants that define the hard coded rank values
-    public static final String ADMIN_RANK_REF = "ranks.admin";
-    public static final String MOD_RANK_REF = "ranks.mod";
-    public static final String OWNER_RANK_REF = "ranks.owner";
-    public static final String SUB_OWNER_RANK_REF = "ranks.sub-owner";
-    public static final String MEMBER_RANK_REF = "ranks.member";
-    public static final String TRUSTED_RANK_REF = "ranks.trusted";
-    public static final String COOP_RANK_REF = "ranks.coop";
-    public static final String VISITOR_RANK_REF = "ranks.visitor";
-    public static final String BANNED_RANK_REF = "ranks.banned";
-    public static final int ADMIN_RANK = 10000;
-    public static final int MOD_RANK = 5000;
-    public static final int OWNER_RANK = 1000;
-    public static final int SUB_OWNER_RANK = 900;
-    public static final int MEMBER_RANK = 500;
-    public static final int TRUSTED_RANK = 400;
-    public static final int COOP_RANK = 200;
-    public static final int VISITOR_RANK = 0;
-    public static final int BANNED_RANK = -1;
+	// Constants that define the hard coded rank values
+	public static final String ADMIN_RANK_REF = "ranks.admin";
+	public static final String MOD_RANK_REF = "ranks.mod";
+	public static final String OWNER_RANK_REF = "ranks.owner";
+	public static final String SUB_OWNER_RANK_REF = "ranks.sub-owner";
+	public static final String MEMBER_RANK_REF = "ranks.member";
+	public static final String TRUSTED_RANK_REF = "ranks.trusted";
+	public static final String COOP_RANK_REF = "ranks.coop";
+	public static final String VISITOR_RANK_REF = "ranks.visitor";
+	public static final String BANNED_RANK_REF = "ranks.banned";
+	public static final int ADMIN_RANK = 10000;
+	public static final int MOD_RANK = 5000;
+	public static final int OWNER_RANK = 1000;
+	public static final int SUB_OWNER_RANK = 900;
+	public static final int MEMBER_RANK = 500;
+	public static final int TRUSTED_RANK = 400;
+	public static final int COOP_RANK = 200;
+	public static final int VISITOR_RANK = 0;
+	public static final int BANNED_RANK = -1;
 
-    // The store of ranks
-    private LinkedHashMap<String, Integer> ranks = new LinkedHashMap<>();
+	// The store of ranks
+	private LinkedHashMap<String, Integer> ranks = new LinkedHashMap<>();
 
-    public RanksManager() {
-        // Hard coded ranks
-        ranksPut(ADMIN_RANK_REF, ADMIN_RANK);
-        ranksPut(MOD_RANK_REF, MOD_RANK);
-        ranksPut(OWNER_RANK_REF, OWNER_RANK);
-        ranksPut(SUB_OWNER_RANK_REF, SUB_OWNER_RANK);
-        ranksPut(MEMBER_RANK_REF, MEMBER_RANK);
-        ranksPut(TRUSTED_RANK_REF, TRUSTED_RANK);
-        ranksPut(COOP_RANK_REF, COOP_RANK);
-        ranksPut(VISITOR_RANK_REF, VISITOR_RANK);
-        ranksPut(BANNED_RANK_REF, BANNED_RANK);
-    }
+	@NonNull
+	private Database<RankObject> handler;
 
-    /**
-     * Try to add a new rank. Owner, member, visitor and banned ranks cannot be changed.
-     * @param reference - a reference that can be found in a locale file
-     * @param value - the rank value
-     * @return true if the rank was successfully added
-     */
-    public boolean addRank(String reference, int value) {
-        if (reference.equalsIgnoreCase(OWNER_RANK_REF)
-                || reference.equalsIgnoreCase(SUB_OWNER_RANK_REF)
-                || reference.equalsIgnoreCase(TRUSTED_RANK_REF)
-                || reference.equalsIgnoreCase(COOP_RANK_REF)
-                || reference.equalsIgnoreCase(MEMBER_RANK_REF)
-                || reference.equalsIgnoreCase(VISITOR_RANK_REF)
-                || reference.equalsIgnoreCase(BANNED_RANK_REF)
-                || reference.equalsIgnoreCase(ADMIN_RANK_REF)
-                || reference.equalsIgnoreCase(MOD_RANK_REF)) {
-            return false;
-        }
-        ranksPut(reference, value);
+	public RanksManager() {
+		// Set up the database handler to store and retrieve Island classes
+		handler = new Database<>(BentoBox.getInstance(), RankObject.class);
+		if (!handler.objectExists(RankObject.ID)) {
+			// Make the initial object
+			ranksPut(ADMIN_RANK_REF, ADMIN_RANK);
+			ranksPut(MOD_RANK_REF, MOD_RANK);
+			ranksPut(OWNER_RANK_REF, OWNER_RANK);
+			ranksPut(SUB_OWNER_RANK_REF, SUB_OWNER_RANK);
+			ranksPut(MEMBER_RANK_REF, MEMBER_RANK);
+			ranksPut(TRUSTED_RANK_REF, TRUSTED_RANK);
+			ranksPut(COOP_RANK_REF, COOP_RANK);
+			ranksPut(VISITOR_RANK_REF, VISITOR_RANK);
+			ranksPut(BANNED_RANK_REF, BANNED_RANK);
+			handler.saveObject(new RankObject(ranks));
+		} else {
+			handler.loadObject(RankObject.ID).getRankReference().forEach(this::ranksPut);
+		}
+	}
 
-        return true;
-    }
+	/**
+	 * Try to add a new rank. Owner, member, visitor and banned ranks cannot be changed.
+	 * @param reference - a reference that can be found in a locale file
+	 * @param value - the rank value
+	 * @return true if the rank was successfully added
+	 */
+	public boolean addRank(String reference, int value) {
+		if (reference.equalsIgnoreCase(OWNER_RANK_REF)
+				|| reference.equalsIgnoreCase(SUB_OWNER_RANK_REF)
+				|| reference.equalsIgnoreCase(TRUSTED_RANK_REF)
+				|| reference.equalsIgnoreCase(COOP_RANK_REF)
+				|| reference.equalsIgnoreCase(MEMBER_RANK_REF)
+				|| reference.equalsIgnoreCase(VISITOR_RANK_REF)
+				|| reference.equalsIgnoreCase(BANNED_RANK_REF)
+				|| reference.equalsIgnoreCase(ADMIN_RANK_REF)
+				|| reference.equalsIgnoreCase(MOD_RANK_REF)) {
+			return false;
+		}
+		ranksPut(reference, value);
 
-    private void ranksPut(String reference, int value) {
-        ranks.put(reference, value);
-        // Sort
-        ranks = ranks.entrySet().stream()
-                .sorted(Map.Entry.comparingByValue())
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
-    }
+		return true;
+	}
 
-    /**
-     * Try to remove a rank. Owner, member, visitor and banned ranks cannot be removed.
-     * @param reference - a reference that can be found in a locale file
-     * @return true if removed
-     */
-    public boolean removeRank(String reference) {
-        return !reference.equalsIgnoreCase(OWNER_RANK_REF)
-                && !reference.equalsIgnoreCase(SUB_OWNER_RANK_REF)
-                && !reference.equalsIgnoreCase(TRUSTED_RANK_REF)
-                && !reference.equalsIgnoreCase(COOP_RANK_REF)
-                && !reference.equalsIgnoreCase(MEMBER_RANK_REF)
-                && !reference.equalsIgnoreCase(VISITOR_RANK_REF)
-                && !reference.equalsIgnoreCase(BANNED_RANK_REF)
-                && !reference.equalsIgnoreCase(ADMIN_RANK_REF)
-                && !reference.equalsIgnoreCase(MOD_RANK_REF) && (ranks.remove(reference) != null);
+	private void ranksPut(String reference, int value) {
+		ranks.put(reference, value);
+		// Sort
+		ranks = ranks.entrySet().stream()
+				.sorted(Map.Entry.comparingByValue())
+				.collect(Collectors.toMap(
+						Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+	}
 
-    }
+	/**
+	 * Try to remove a rank. Owner, member, visitor and banned ranks cannot be removed.
+	 * @param reference - a reference that can be found in a locale file
+	 * @return true if removed
+	 */
+	public boolean removeRank(String reference) {
+		return !reference.equalsIgnoreCase(OWNER_RANK_REF)
+				&& !reference.equalsIgnoreCase(SUB_OWNER_RANK_REF)
+				&& !reference.equalsIgnoreCase(TRUSTED_RANK_REF)
+				&& !reference.equalsIgnoreCase(COOP_RANK_REF)
+				&& !reference.equalsIgnoreCase(MEMBER_RANK_REF)
+				&& !reference.equalsIgnoreCase(VISITOR_RANK_REF)
+				&& !reference.equalsIgnoreCase(BANNED_RANK_REF)
+				&& !reference.equalsIgnoreCase(ADMIN_RANK_REF)
+				&& !reference.equalsIgnoreCase(MOD_RANK_REF) && (ranks.remove(reference) != null);
 
-    /**
-     * Get the rank value for this reference
-     * @param reference - locale reference to the name of this rank
-     * @return rank value or zero if this is an unknown rank
-     */
-    public int getRankValue(String reference) {
-        return ranks.getOrDefault(reference, VISITOR_RANK);
-    }
+	}
 
-    /**
-     * Get the ranks. Ranks are listed in ascending order
-     * @return immutable map of ranks
-     */
-    public Map<String, Integer> getRanks() {
-        return new LinkedHashMap<>(ranks);
-    }
+	/**
+	 * Get the rank value for this reference
+	 * @param reference - locale reference to the name of this rank
+	 * @return rank value or zero if this is an unknown rank
+	 */
+	public int getRankValue(String reference) {
+		return ranks.getOrDefault(reference, VISITOR_RANK);
+	}
+
+	/**
+	 * Get the ranks. Ranks are listed in ascending order
+	 * @return immutable map of ranks
+	 */
+	public Map<String, Integer> getRanks() {
+		return new LinkedHashMap<>(ranks);
+	}
 
 
-    /**
-     * Gets the next rank value above the current rank. Highest is {@link RanksManager#OWNER_RANK}
-     * @param currentRank - current rank value
-     * @return Optional rank value
-     */
-    public int getRankUpValue(int currentRank) {
-        return getRanks().values().stream().mapToInt(x -> {
-            if (x > currentRank) {
-                return x;
-            }
-            return OWNER_RANK;
-        }).min().orElse(currentRank);
-    }
+	/**
+	 * Gets the next rank value above the current rank. Highest is {@link RanksManager#OWNER_RANK}
+	 * @param currentRank - current rank value
+	 * @return Optional rank value
+	 */
+	public int getRankUpValue(int currentRank) {
+		return getRanks().values().stream().mapToInt(x -> {
+			if (x > currentRank) {
+				return x;
+			}
+			return OWNER_RANK;
+		}).min().orElse(currentRank);
+	}
 
-    /**
-     * Gets the previous rank value below the current rank. Lowest is {@link RanksManager#VISITOR_RANK}
-     * @param currentRank - current rank value
-     * @return Optional rank value
-     */
-    public int getRankDownValue(int currentRank) {
-        return getRanks().values().stream().mapToInt(x -> {
-            if (x < currentRank) {
-                return x;
-            }
-            return VISITOR_RANK;
-        }).max().orElse(currentRank);
-    }
+	/**
+	 * Gets the previous rank value below the current rank. Lowest is {@link RanksManager#VISITOR_RANK}
+	 * @param currentRank - current rank value
+	 * @return Optional rank value
+	 */
+	public int getRankDownValue(int currentRank) {
+		return getRanks().values().stream().mapToInt(x -> {
+			if (x < currentRank) {
+				return x;
+			}
+			return VISITOR_RANK;
+		}).max().orElse(currentRank);
+	}
 
-    /**
-     * Gets the reference to the rank name for value
-     * @param rank - value
-     * @return Reference
-     */
-    public String getRank(int rank) {
-        for (Entry<String, Integer> en : ranks.entrySet()) {
-            if (rank == en.getValue()) {
-                return en.getKey();
-            }
-        }
-        return "";
-    }
+	/**
+	 * Gets the reference to the rank name for value
+	 * @param rank - value
+	 * @return Reference
+	 */
+	public String getRank(int rank) {
+		for (Entry<String, Integer> en : ranks.entrySet()) {
+			if (rank == en.getValue()) {
+				return en.getKey();
+			}
+		}
+		return "";
+	}
 }

--- a/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.managers;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -41,6 +42,15 @@ public class RanksManager {
 
 	// The store of ranks
 	private LinkedHashMap<String, Integer> ranks = new LinkedHashMap<>();
+	public static final Map<String, Integer> DEFAULT_RANKS = Map.of(ADMIN_RANK_REF, ADMIN_RANK,
+			MOD_RANK_REF, MOD_RANK,
+			OWNER_RANK_REF, OWNER_RANK,
+			SUB_OWNER_RANK_REF, SUB_OWNER_RANK,
+			MEMBER_RANK_REF, MEMBER_RANK,
+			TRUSTED_RANK_REF, TRUSTED_RANK,
+			COOP_RANK_REF, COOP_RANK,
+			VISITOR_RANK_REF, VISITOR_RANK,
+			BANNED_RANK_REF, BANNED_RANK);
 
 	@NonNull
 	private Database<RankObject> handler;
@@ -50,19 +60,13 @@ public class RanksManager {
 		handler = new Database<>(BentoBox.getInstance(), RankObject.class);
 		if (!handler.objectExists(RankObject.ID)) {
 			// Make the initial object
-			ranksPut(ADMIN_RANK_REF, ADMIN_RANK);
-			ranksPut(MOD_RANK_REF, MOD_RANK);
-			ranksPut(OWNER_RANK_REF, OWNER_RANK);
-			ranksPut(SUB_OWNER_RANK_REF, SUB_OWNER_RANK);
-			ranksPut(MEMBER_RANK_REF, MEMBER_RANK);
-			ranksPut(TRUSTED_RANK_REF, TRUSTED_RANK);
-			ranksPut(COOP_RANK_REF, COOP_RANK);
-			ranksPut(VISITOR_RANK_REF, VISITOR_RANK);
-			ranksPut(BANNED_RANK_REF, BANNED_RANK);
+			DEFAULT_RANKS.forEach((ref, rank) -> ranksPut(ref, rank));
 			handler.saveObject(new RankObject(ranks));
 		} else {
-			handler.loadObject(RankObject.ID).getRankReference().forEach(this::ranksPut);
+			// Load the ranks from the database
+			Objects.requireNonNull(handler.loadObject(RankObject.ID)).getRankReference().forEach(this::ranksPut);
 		}
+		
 	}
 
 	/**
@@ -81,15 +85,7 @@ public class RanksManager {
 	 * @return true if the rank was successfully added
 	 */
 	public boolean addRank(String reference, int value) {
-		if (reference.equalsIgnoreCase(OWNER_RANK_REF)
-				|| reference.equalsIgnoreCase(SUB_OWNER_RANK_REF)
-				|| reference.equalsIgnoreCase(TRUSTED_RANK_REF)
-				|| reference.equalsIgnoreCase(COOP_RANK_REF)
-				|| reference.equalsIgnoreCase(MEMBER_RANK_REF)
-				|| reference.equalsIgnoreCase(VISITOR_RANK_REF)
-				|| reference.equalsIgnoreCase(BANNED_RANK_REF)
-				|| reference.equalsIgnoreCase(ADMIN_RANK_REF)
-				|| reference.equalsIgnoreCase(MOD_RANK_REF)) {
+		if (rankExists(reference)) {
 			return false;
 		}
 		ranksPut(reference, value);
@@ -112,15 +108,7 @@ public class RanksManager {
 	 * @return true if removed
 	 */
 	public boolean removeRank(String reference) {
-		return !reference.equalsIgnoreCase(OWNER_RANK_REF)
-				&& !reference.equalsIgnoreCase(SUB_OWNER_RANK_REF)
-				&& !reference.equalsIgnoreCase(TRUSTED_RANK_REF)
-				&& !reference.equalsIgnoreCase(COOP_RANK_REF)
-				&& !reference.equalsIgnoreCase(MEMBER_RANK_REF)
-				&& !reference.equalsIgnoreCase(VISITOR_RANK_REF)
-				&& !reference.equalsIgnoreCase(BANNED_RANK_REF)
-				&& !reference.equalsIgnoreCase(ADMIN_RANK_REF)
-				&& !reference.equalsIgnoreCase(MOD_RANK_REF) && (ranks.remove(reference) != null);
+		return ranks.remove(reference) != null;
 
 	}
 

--- a/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
@@ -10,7 +10,7 @@ import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.Database;
-import world.bentobox.bentobox.database.objects.RankObject;
+import world.bentobox.bentobox.database.objects.Ranks;
 
 /**
  * Ranks Manager
@@ -53,18 +53,18 @@ public class RanksManager {
 			BANNED_RANK_REF, BANNED_RANK);
 
 	@NonNull
-	private Database<RankObject> handler;
+	private Database<Ranks> handler;
 
 	public RanksManager() {
 		// Set up the database handler to store and retrieve Island classes
-		handler = new Database<>(BentoBox.getInstance(), RankObject.class);
-		if (!handler.objectExists(RankObject.ID)) {
+		handler = new Database<>(BentoBox.getInstance(), Ranks.class);
+		if (!handler.objectExists(Ranks.ID)) {
 			// Make the initial object
 			DEFAULT_RANKS.forEach((ref, rank) -> ranksPut(ref, rank));
-			handler.saveObject(new RankObject(ranks));
+			handler.saveObject(new Ranks(ranks));
 		} else {
 			// Load the ranks from the database
-			Objects.requireNonNull(handler.loadObject(RankObject.ID)).getRankReference().forEach(this::ranksPut);
+			Objects.requireNonNull(handler.loadObject(Ranks.ID)).getRankReference().forEach(this::ranksPut);
 		}
 		
 	}

--- a/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
@@ -66,6 +66,15 @@ public class RanksManager {
 	}
 
 	/**
+	 * Check if a rank exists
+	 * @param reference YAML reference to rank, e.g., ranks.trusted
+	 * @return true if the rank exists
+	 */
+	public boolean rankExists(String reference) {
+		return ranks.containsKey(reference);
+	}
+	
+	/**
 	 * Try to add a new rank. Owner, member, visitor and banned ranks cannot be changed.
 	 * @param reference - a reference that can be found in a locale file
 	 * @param value - the rank value

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -498,7 +498,16 @@ commands:
       addons: '[prefix_bentobox]&6 Migrating addons'
       class: '[prefix_bentobox]&6 Migrating [description]'
       migrated: '[prefix_bentobox]&a Migrated'
-  
+    rank:
+      description: 'list, add, or remove ranks'
+      parameters: '&a [list | add | remove] [rank reference] [rank value]'
+      add:
+        success: '&a Added [rank] with value [number]'
+        failure: '&c Failed to add [rank] with value [number]. Maybe a duplicate?'
+      remove:
+        success: '&a Removed [rank]'
+        failure: '&c Failed to remove [rank]. Unknown rank.'
+      list: '&a Registered ranks are as follows:'
   confirmation:
     confirm: '&c Type command again within &b [seconds]s&c  to confirm.'
     previous-request-cancelled: '&6 Previous confirmation request cancelled.'

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
@@ -23,7 +23,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +32,6 @@ import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -46,6 +44,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -54,205 +53,196 @@ import world.bentobox.bentobox.util.Util;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, Util.class})
-public class AdminInfoCommandTest {
+public class AdminInfoCommandTest extends RanksManagerBeforeClassTest {
 
-    @Mock
-    private CompositeCommand ic;
-    @Mock
-    private User user;
-    @Mock
-    private IslandsManager im;
-    @Mock
-    private PlayersManager pm;
+	@Mock
+	private CompositeCommand ic;
+	@Mock
+	private User user;
+	@Mock
+	private IslandsManager im;
+	@Mock
+	private PlayersManager pm;
 
-    private Island island;
+	private Island island;
 
-    private AdminInfoCommand iic;
+	private AdminInfoCommand iic;
 
-    @Mock
-    private Player player;
-    @Mock
-    private World world;
-    @Mock
-    private PlaceholdersManager phm;
-    @Mock
-    private @NonNull Location location;
-    @Mock
-    private IslandWorldManager iwm;
+	@Mock
+	private Player player;
+	@Mock
+	private World world;
+	@Mock
+	private PlaceholdersManager phm;
+	@Mock
+	private @NonNull Location location;
+	@Mock
+	private IslandWorldManager iwm;
 
-    /**
-     */
-    @Before
-    public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+	/**
+	 */
+	 @Before
+	 public void setUp() throws Exception {
+		 super.setUp();
 
-        // IWM
-        when(plugin.getIWM()).thenReturn(iwm);
-        when(plugin.getRanksManager()).thenReturn(new RanksManager());
+		 // IWM
+		 when(plugin.getIWM()).thenReturn(iwm);
+		 RanksManager rm = new RanksManager();
+		 when(plugin.getRanksManager()).thenReturn(rm);
 
-        // Bukkit
-        PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
-        // Command manager
-        CommandsManager cm = mock(CommandsManager.class);
-        when(plugin.getCommandsManager()).thenReturn(cm);
+		 // Bukkit
+		 PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
+		 // Command manager
+		 CommandsManager cm = mock(CommandsManager.class);
+		 when(plugin.getCommandsManager()).thenReturn(cm);
 
-        // Player
-        when(player.isOp()).thenReturn(false);
-        UUID uuid = UUID.randomUUID();
-        when(user.getUniqueId()).thenReturn(uuid);
-        when(user.getName()).thenReturn("tastybento");
-        when(user.getWorld()).thenReturn(world);
-        when(user.getPlayer()).thenReturn(player);
-        when(user.isPlayer()).thenReturn(true);
-        //user = User.getInstance(player);
-        // Set the User class plugin as this one
-        User.setPlugin(plugin);
+		 // Player
+		 when(player.isOp()).thenReturn(false);
+		 UUID uuid = UUID.randomUUID();
+		 when(user.getUniqueId()).thenReturn(uuid);
+		 when(user.getName()).thenReturn("tastybento");
+		 when(user.getWorld()).thenReturn(world);
+		 when(user.getPlayer()).thenReturn(player);
+		 when(user.isPlayer()).thenReturn(true);
+		 //user = User.getInstance(player);
+		 // Set the User class plugin as this one
+		 User.setPlugin(plugin);
 
-        // Locales
-        LocalesManager lm = mock(LocalesManager.class);
-        when(lm.get(any(), any())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(1, String.class));
-        when(plugin.getLocalesManager()).thenReturn(lm);
-        // Return the same string
-        when(phm.replacePlaceholders(any(), anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(1, String.class));
-        when(plugin.getPlaceholdersManager()).thenReturn(phm);
-        // Translate
-        when(user.getTranslation(anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
-        when(user.getTranslation(anyString(), anyString(), anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+		 // Locales
+		 LocalesManager lm = mock(LocalesManager.class);
+		 when(lm.get(any(), any())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(1, String.class));
+		 when(plugin.getLocalesManager()).thenReturn(lm);
+		 // Return the same string
+		 when(phm.replacePlaceholders(any(), anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(1, String.class));
+		 when(plugin.getPlaceholdersManager()).thenReturn(phm);
+		 // Translate
+		 when(user.getTranslation(anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+		 when(user.getTranslation(anyString(), anyString(), anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
 
-        // Island manager
-        island = new Island(location, uuid, 100);
-        island.setRange(400);
-        when(location.toVector()).thenReturn(new Vector(1,2,3));
-        when(plugin.getIslands()).thenReturn(im);
-        Optional<Island> optionalIsland = Optional.of(island);
-        when(im.getIslandAt(any())).thenReturn(optionalIsland);
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
+		 // Island manager
+		 island = new Island(location, uuid, 100);
+		 island.setRange(400);
+		 when(location.toVector()).thenReturn(new Vector(1,2,3));
+		 when(plugin.getIslands()).thenReturn(im);
+		 Optional<Island> optionalIsland = Optional.of(island);
+		 when(im.getIslandAt(any())).thenReturn(optionalIsland);
+		 when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
 
-        // Players manager
-        when(plugin.getPlayers()).thenReturn(pm);
-        when(pm.getUUID(any())).thenReturn(uuid);
+		 // Players manager
+		 when(plugin.getPlayers()).thenReturn(pm);
+		 when(pm.getUUID(any())).thenReturn(uuid);
 
 
-        // Command
-        iic = new AdminInfoCommand(ic);
-    }
+		 // Command
+		 iic = new AdminInfoCommand(ic);
+	 }
 
-    /**
-     */
-    @After
-    public void tearDown() {
-        User.clearUsers();
-        Mockito.framework().clearInlineMocks();
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#setup()}.
+	  */
+	 @Test
+	 public void testSetup() {
+		 assertEquals("mod.info", iic.getPermission());
+		 assertFalse(iic.isOnlyPlayer());
+		 assertEquals("commands.admin.info.parameters", iic.getParameters());
+		 assertEquals("commands.admin.info.description", iic.getDescription());
+	 }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#setup()}.
-     */
-    @Test
-    public void testSetup() {
-        assertEquals("mod.info", iic.getPermission());
-        assertFalse(iic.isOnlyPlayer());
-        assertEquals("commands.admin.info.parameters", iic.getParameters());
-        assertEquals("commands.admin.info.description", iic.getDescription());
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	  */
+	 @Test
+	 public void testExecuteUserStringListOfStringTooManyArgs() {
+		 assertFalse(iic.execute(user, "", Arrays.asList("hdhh", "hdhdhd")));
+		 verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
+	 }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringTooManyArgs() {
-        assertFalse(iic.execute(user, "", Arrays.asList("hdhh", "hdhdhd")));
-        verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	  */
+	 @Test
+	 public void testExecuteUserStringListOfStringNoArgsConsole() {
+		 CommandSender console = mock(CommandSender.class);
+		 User sender = User.getInstance(console);
+		 assertFalse(iic.execute(sender, "", Collections.emptyList()));
+		 verify(user, never()).sendMessage("commands.help.header", "[label]", "commands.help.console");
+	 }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringNoArgsConsole() {
-        CommandSender console = mock(CommandSender.class);
-        User sender = User.getInstance(console);
-        assertFalse(iic.execute(sender, "", Collections.emptyList()));
-        verify(user, never()).sendMessage("commands.help.header", "[label]", "commands.help.console");
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	  */
+	 @Test
+	 public void testExecuteUserStringListOfStringNoArgsNoIsland() {
+		 when(im.getIslandAt(any())).thenReturn(Optional.empty());
+		 assertTrue(iic.execute(user, "", Collections.emptyList()));
+		 verify(user).sendMessage("commands.admin.info.no-island");
+	 }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringNoArgsNoIsland() {
-        when(im.getIslandAt(any())).thenReturn(Optional.empty());
-        assertTrue(iic.execute(user, "", Collections.emptyList()));
-        verify(user).sendMessage("commands.admin.info.no-island");
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	  */
+	 @Test
+	 public void testExecuteUserStringListOfStringNoArgsSuccess() {
+		 assertTrue(iic.execute(user, "", Collections.emptyList()));
+		 verify(user).sendMessage("commands.admin.info.title");
+		 verify(user).sendMessage(eq("commands.admin.info.island-uuid"), eq("[uuid]"), any());
+		 verify(user).sendMessage(eq("commands.admin.info.owner"), eq("[owner]"), eq(null), eq("[uuid]"), any());
+		 verify(user).sendMessage(eq("commands.admin.info.last-login"), eq("[date]"), any());
+		 verify(user).sendMessage("commands.admin.info.deaths", "[number]", "0");
+		 verify(user).sendMessage("commands.admin.info.resets-left", "[number]", "0", "[total]", "0");
+		 verify(user).sendMessage("commands.admin.info.team-members-title");
+		 verify(user).sendMessage("commands.admin.info.team-owner-format", "[name]", null, "[rank]", "ranks.owner");
+		 verify(user).sendMessage("commands.admin.info.island-protection-center", "[xyz]", "0,0,0");
+		 verify(user).sendMessage("commands.admin.info.island-center", "[xyz]", "0,0,0");
+		 verify(user).sendMessage("commands.admin.info.island-coords", "[xz1]", "-400,0,-400", "[xz2]", "400,0,400");
+		 verify(user).sendMessage("commands.admin.info.protection-range", "[range]", "100");
+		 verify(user).sendMessage("commands.admin.info.max-protection-range", "[range]", "100");
+		 verify(user).sendMessage("commands.admin.info.protection-coords", "[xz1]", "-100,0,-100", "[xz2]", "99,0,99");
+	 }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringNoArgsSuccess() {
-        assertTrue(iic.execute(user, "", Collections.emptyList()));
-        verify(user).sendMessage("commands.admin.info.title");
-        verify(user).sendMessage(eq("commands.admin.info.island-uuid"), eq("[uuid]"), any());
-        verify(user).sendMessage(eq("commands.admin.info.owner"), eq("[owner]"), eq(null), eq("[uuid]"), any());
-        verify(user).sendMessage(eq("commands.admin.info.last-login"), eq("[date]"), any());
-        verify(user).sendMessage("commands.admin.info.deaths", "[number]", "0");
-        verify(user).sendMessage("commands.admin.info.resets-left", "[number]", "0", "[total]", "0");
-        verify(user).sendMessage("commands.admin.info.team-members-title");
-        verify(user).sendMessage("commands.admin.info.team-owner-format", "[name]", null, "[rank]", "ranks.owner");
-        verify(user).sendMessage("commands.admin.info.island-protection-center", "[xyz]", "0,0,0");
-        verify(user).sendMessage("commands.admin.info.island-center", "[xyz]", "0,0,0");
-        verify(user).sendMessage("commands.admin.info.island-coords", "[xz1]", "-400,0,-400", "[xz2]", "400,0,400");
-        verify(user).sendMessage("commands.admin.info.protection-range", "[range]", "100");
-        verify(user).sendMessage("commands.admin.info.max-protection-range", "[range]", "100");
-        verify(user).sendMessage("commands.admin.info.protection-coords", "[xz1]", "-100,0,-100", "[xz2]", "99,0,99");
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	  */
+	 @Test
+	 public void testExecuteUserStringListOfStringArgsSuccess() {
+		 assertTrue(iic.execute(user, "", Collections.singletonList("tastybento")));
+		 verify(user).sendMessage("commands.admin.info.title");
+		 verify(user).sendMessage(eq("commands.admin.info.island-uuid"), eq("[uuid]"), any());
+		 verify(user).sendMessage(eq("commands.admin.info.owner"), eq("[owner]"), eq(null), eq("[uuid]"), any());
+		 verify(user).sendMessage(eq("commands.admin.info.last-login"), eq("[date]"), any());
+		 verify(user).sendMessage("commands.admin.info.deaths", "[number]", "0");
+		 verify(user).sendMessage("commands.admin.info.resets-left", "[number]", "0", "[total]", "0");
+		 verify(user).sendMessage("commands.admin.info.team-members-title");
+		 verify(user).sendMessage("commands.admin.info.team-owner-format", "[name]", null, "[rank]", "ranks.owner");
+		 verify(user).sendMessage("commands.admin.info.island-protection-center", "[xyz]", "0,0,0");
+		 verify(user).sendMessage("commands.admin.info.island-center", "[xyz]", "0,0,0");
+		 verify(user).sendMessage("commands.admin.info.island-coords", "[xz1]", "-400,0,-400", "[xz2]", "400,0,400");
+		 verify(user).sendMessage("commands.admin.info.protection-range", "[range]", "100");
+		 verify(user).sendMessage("commands.admin.info.max-protection-range", "[range]", "100");
+		 verify(user).sendMessage("commands.admin.info.protection-coords", "[xz1]", "-100,0,-100", "[xz2]", "99,0,99");
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringArgsSuccess() {
-        assertTrue(iic.execute(user, "", Collections.singletonList("tastybento")));
-        verify(user).sendMessage("commands.admin.info.title");
-        verify(user).sendMessage(eq("commands.admin.info.island-uuid"), eq("[uuid]"), any());
-        verify(user).sendMessage(eq("commands.admin.info.owner"), eq("[owner]"), eq(null), eq("[uuid]"), any());
-        verify(user).sendMessage(eq("commands.admin.info.last-login"), eq("[date]"), any());
-        verify(user).sendMessage("commands.admin.info.deaths", "[number]", "0");
-        verify(user).sendMessage("commands.admin.info.resets-left", "[number]", "0", "[total]", "0");
-        verify(user).sendMessage("commands.admin.info.team-members-title");
-        verify(user).sendMessage("commands.admin.info.team-owner-format", "[name]", null, "[rank]", "ranks.owner");
-        verify(user).sendMessage("commands.admin.info.island-protection-center", "[xyz]", "0,0,0");
-        verify(user).sendMessage("commands.admin.info.island-center", "[xyz]", "0,0,0");
-        verify(user).sendMessage("commands.admin.info.island-coords", "[xz1]", "-400,0,-400", "[xz2]", "400,0,400");
-        verify(user).sendMessage("commands.admin.info.protection-range", "[range]", "100");
-        verify(user).sendMessage("commands.admin.info.max-protection-range", "[range]", "100");
-        verify(user).sendMessage("commands.admin.info.protection-coords", "[xz1]", "-100,0,-100", "[xz2]", "99,0,99");
+	 }
 
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	  */
+	 @Test
+	 public void testExecuteUserStringListOfStringArgsNoIsland() {
+		 when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
+		 assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
+		 verify(user).sendMessage("general.errors.player-has-no-island");
+	 }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringArgsNoIsland() {
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
-        assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
-        verify(user).sendMessage("general.errors.player-has-no-island");
-    }
+	 /**
+	  * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	  */
+	 @Test
+	 public void testExecuteUserStringListOfStringArgsUnknownPlayer() {
+		 PowerMockito.mockStatic(Util.class);
+		 when(Util.getUUID(any())).thenReturn(null);
+		 assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
+		 verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringArgsUnknownPlayer() {
-        PowerMockito.mockStatic(Util.class);
-        when(Util.getUUID(any())).thenReturn(null);
-        assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
-        verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
-
-    }
+	 }
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
@@ -19,17 +19,14 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -38,6 +35,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -46,7 +44,7 @@ import world.bentobox.bentobox.util.Util;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, Util.class})
-public class AdminSetrankCommandTest {
+public class AdminSetrankCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ac;
@@ -66,9 +64,7 @@ public class AdminSetrankCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+    	super.setUp();
         Util.setPlugin(plugin);
 
         // Ranks Manager
@@ -102,14 +98,6 @@ public class AdminSetrankCommandTest {
         PowerMockito.mockStatic(Bukkit.class);
         PluginManager pim = mock(PluginManager.class);
         when(Bukkit.getPluginManager()).thenReturn(pim);
-    }
-
-    /**
-     */
-    @After
-    public void tearDown() {
-        User.clearUsers();
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommandTest.java
@@ -29,7 +29,6 @@ import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +38,6 @@ import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -55,6 +53,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -63,7 +62,7 @@ import world.bentobox.bentobox.util.Util;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class, Util.class})
-public class AdminSettingsCommandTest {
+public class AdminSettingsCommandTest extends RanksManagerBeforeClassTest {
 
     private AdminSettingsCommand asc;
     @Mock
@@ -96,9 +95,7 @@ public class AdminSettingsCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+    	super.setUp();
         Util.setPlugin(plugin);
 
         // Command manager
@@ -177,20 +174,12 @@ public class AdminSettingsCommandTest {
         when(plugin.getFlagsManager()).thenReturn(fm);
 
         // RnksManager
-        when(plugin.getRanksManager()).thenReturn(new RanksManager());
+        RanksManager rm = new RanksManager();
+        when(plugin.getRanksManager()).thenReturn(rm);
 
 
 
         asc = new AdminSettingsCommand(ac);
-
-    }
-
-    /**
-     */
-    @After
-    public void tearDown() throws Exception {
-        User.clearUsers();
-        Mockito.framework().clearInlineMocks();
 
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommandTest.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,7 +23,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -34,124 +32,125 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.IslandsManager;
+import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
  *
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Bukkit.class, BentoBox.class})
-public class DefaultPlayerCommandTest {
+@PrepareForTest({ Bukkit.class, BentoBox.class })
+public class DefaultPlayerCommandTest extends RanksManagerBeforeClassTest {
 
-    @Mock
-    GameModeAddon addon;
-    private PlayerCommand dpc;
-    @Mock
-    private WorldSettings ws;
-    @Mock
-    private User user;
-    @Mock
-    private IslandsManager im;
-    @Mock
-    private @Nullable Island island;
+	@Mock
+	GameModeAddon addon;
+	private PlayerCommand dpc;
+	@Mock
+	private WorldSettings ws;
+	@Mock
+	private User user;
+	@Mock
+	private IslandsManager im;
+	@Mock
+	private @Nullable Island island;
 
+	class PlayerCommand extends DefaultPlayerCommand {
 
-    class PlayerCommand extends DefaultPlayerCommand {
+		protected PlayerCommand(GameModeAddon addon) {
+			super(addon);
+		}
 
-        protected PlayerCommand(GameModeAddon addon) {
-            super(addon);
-        }
+	}
 
-    }
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		// RanksManager
+		RanksManager rm = new RanksManager();
+		when(plugin.getRanksManager()).thenReturn(rm);
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @Before
-    public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+		// Addon
 
-        // Addon
+		// User
+		when(user.getUniqueId()).thenReturn(UUID.randomUUID());
+		// IM
+		when(plugin.getIslandsManager()).thenReturn(im);
+		when(plugin.getIslands()).thenReturn(im);
+		when(im.getIsland(any(World.class), any(UUID.class))).thenReturn(island);
 
-        // User
-        when(user.getUniqueId()).thenReturn(UUID.randomUUID());
-        // IM
-        when(plugin.getIslandsManager()).thenReturn(im);
-        when(plugin.getIslands()).thenReturn(im);
-        when(im.getIsland(any(World.class), any(UUID.class))).thenReturn(island);
+		// Command manager
+		CommandsManager cm = mock(CommandsManager.class);
+		when(plugin.getCommandsManager()).thenReturn(cm);
 
-        // Command manager
-        CommandsManager cm = mock(CommandsManager.class);
-        when(plugin.getCommandsManager()).thenReturn(cm);
+		// World Settings
+		when(ws.getDefaultPlayerAction()).thenReturn("go");
+		when(ws.getDefaultNewPlayerAction()).thenReturn("create");
 
-        // World Settings
-        when(ws.getDefaultPlayerAction()).thenReturn("go");
-        when(ws.getDefaultNewPlayerAction()).thenReturn("create");
+		PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
 
-        PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
+		when(ws.getPlayerCommandAliases()).thenReturn("island is");
+		when(addon.getWorldSettings()).thenReturn(ws);
+		dpc = new PlayerCommand(addon);
+		dpc.setWorld(mock(World.class));
 
-        when(ws.getPlayerCommandAliases()).thenReturn("island is");
-        when(addon.getWorldSettings()).thenReturn(ws);
-        dpc = new PlayerCommand(addon);
-        dpc.setWorld(mock(World.class));
+	}
 
-    }
+	/**
+	 * Test method for
+	 * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#DefaultPlayerCommand(world.bentobox.bentobox.api.addons.GameModeAddon)}.
+	 */
+	@Test
+	public void testDefaultPlayerCommand() {
+		assertNotNull(dpc);
+	}
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-    }
+	/**
+	 * Test method for
+	 * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#setup()}.
+	 */
+	@Test
+	public void testSetup() {
+		assertEquals("commands.island.help.description", dpc.getDescription());
+		assertTrue(dpc.isOnlyPlayer());
+		assertEquals("island", dpc.getPermission());
+		// 20 = 19 subcommands + help command
+		assertEquals(20, dpc.getSubCommands().size()); // Update when commands are added or removed
+	}
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#DefaultPlayerCommand(world.bentobox.bentobox.api.addons.GameModeAddon)}.
-     */
-    @Test
-    public void testDefaultPlayerCommand() {
-        assertNotNull(dpc);
-    }
+	/**
+	 * Test method for
+	 * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	 */
+	@Test
+	public void testExecuteUserStringListOfStringUnknownCommand() {
+		assertFalse(dpc.execute(user, "label", List.of("unknown")));
+		verify(user).sendMessage("general.errors.unknown-command", TextVariables.LABEL, "island");
+	}
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#setup()}.
-     */
-    @Test
-    public void testSetup() {
-        assertEquals("commands.island.help.description", dpc.getDescription());
-        assertTrue(dpc.isOnlyPlayer());
-        assertEquals("island", dpc.getPermission());
-        // 20 = 19 subcommands + help command
-        assertEquals(20, dpc.getSubCommands().size()); // Update when commands are added or removed
-    }
+	/**
+	 * Test method for
+	 * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	 */
+	@Test
+	public void testExecuteUserStringListOfStringNullUser() {
+		assertFalse(dpc.execute(null, "label", List.of()));
+	}
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringUnknownCommand() {
-        assertFalse(dpc.execute(user, "label", List.of("unknown")));
-        verify(user).sendMessage("general.errors.unknown-command", TextVariables.LABEL, "island");
-    }
+	/**
+	 * Test method for
+	 * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+	 */
+	@Test
+	public void testExecuteUserStringListOfStringEmptyArgsHasIsland() {
+		assertFalse(dpc.execute(user, "label", List.of()));
+		verify(user).sendMessage("general.errors.use-in-game");
+	}
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringNullUser() {
-        assertFalse(dpc.execute(null, "label", List.of()));
-    }
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    public void testExecuteUserStringListOfStringEmptyArgsHasIsland() {
-        assertFalse(dpc.execute(user, "label", List.of()));
-        verify(user).sendMessage("general.errors.use-in-game");
-    }
-
-    /**
+	/**
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
@@ -161,7 +160,7 @@ public class DefaultPlayerCommandTest {
         verify(user).sendMessage("general.errors.use-in-game");
     }
 
-    /**
+	/**
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
@@ -172,7 +171,7 @@ public class DefaultPlayerCommandTest {
         verify(user).performCommand("label goxxx");
     }
 
-    /**
+	/**
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
@@ -185,7 +184,7 @@ public class DefaultPlayerCommandTest {
         verify(user).performCommand("label createxxx");
     }
 
-    /**
+	/**
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
@@ -196,7 +195,7 @@ public class DefaultPlayerCommandTest {
         verify(user).performCommand("goxxx");
     }
 
-    /**
+	/**
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
@@ -27,7 +27,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +36,6 @@ import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -53,6 +51,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -60,7 +59,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class})
-public class IslandBanCommandTest {
+public class IslandBanCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -83,9 +82,7 @@ public class IslandBanCommandTest {
 
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
         User.setPlugin(plugin);
 
         // Command manager
@@ -172,12 +169,6 @@ public class IslandBanCommandTest {
         // Island Ban Command
         ibc = new IslandBanCommand(ic);
 
-    }
-
-    @After
-    public void tearDown() {
-        User.clearUsers();
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanlistCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanlistCommandTest.java
@@ -21,17 +21,14 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -44,6 +41,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -51,7 +49,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandBanlistCommandTest {
+public class IslandBanlistCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -69,9 +67,7 @@ public class IslandBanlistCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -124,11 +120,6 @@ public class IslandBanlistCommandTest {
         RanksManager rm = new RanksManager();
         when(plugin.getRanksManager()).thenReturn(rm);
 
-    }
-
-    @After
-    public void tearDown() {
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommandTest.java
@@ -23,7 +23,6 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.NonNull;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +31,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -46,6 +44,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -53,7 +52,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandDeletehomeCommandTest {
+public class IslandDeletehomeCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -79,9 +78,7 @@ public class IslandDeletehomeCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -145,15 +142,6 @@ public class IslandDeletehomeCommandTest {
         PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
 
         idh = new IslandDeletehomeCommand(ic);
-    }
-
-    /**
-     * @throws java.lang.Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        User.clearUsers();
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
@@ -26,7 +26,6 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +35,6 @@ import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -53,6 +51,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -60,7 +59,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandExpelCommandTest {
+public class IslandExpelCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -88,9 +87,7 @@ public class IslandExpelCommandTest {
 
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
         User.setPlugin(plugin);
 
         // Command manager
@@ -164,14 +161,6 @@ public class IslandExpelCommandTest {
 
         // Class
         iec = new IslandExpelCommand(ic);
-    }
-
-    /**
-     */
-    @After
-    public void tearDown() {
-        User.clearUsers();
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandInfoCommandTest.java
@@ -23,7 +23,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.NonNull;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +32,6 @@ import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -46,6 +44,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -54,7 +53,7 @@ import world.bentobox.bentobox.util.Util;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, Util.class})
-public class IslandInfoCommandTest {
+public class IslandInfoCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -84,13 +83,12 @@ public class IslandInfoCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // IWM
         when(plugin.getIWM()).thenReturn(iwm);
-        when(plugin.getRanksManager()).thenReturn(new RanksManager());
+        RanksManager rm = new RanksManager();
+        when(plugin.getRanksManager()).thenReturn(rm);
 
         // Bukkit
         PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
@@ -137,14 +135,6 @@ public class IslandInfoCommandTest {
 
         // Command
         iic = new IslandInfoCommand(ic);
-    }
-
-    /**
-     */
-    @After
-    public void tearDown() {
-        User.clearUsers();
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommandTest.java
@@ -24,7 +24,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +32,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -46,6 +44,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -53,7 +52,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandUnbanCommandTest {
+public class IslandUnbanCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -71,9 +70,7 @@ public class IslandUnbanCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
         User.setPlugin(plugin);
 
         // Command manager
@@ -133,11 +130,6 @@ public class IslandUnbanCommandTest {
         when(plugin.getRanksManager()).thenReturn(rm);
 
 
-    }
-
-    @After
-    public void tearDown() {
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommandTest.java
@@ -18,7 +18,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.plugin.PluginManager;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +25,6 @@ import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -40,6 +38,7 @@ import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -47,7 +46,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamCommandTest {
+public class IslandTeamCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -81,9 +80,7 @@ public class IslandTeamCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -125,16 +122,14 @@ public class IslandTeamCommandTest {
         // IWM
         when(plugin.getIWM()).thenReturn(iwm);
         when(iwm.getPermissionPrefix(any())).thenReturn("bskyblock.");
+        
+        // RanksManager
+        RanksManager rm = new RanksManager();
+        when(plugin.getRanksManager()).thenReturn(rm);
 
 
         // Command under test
         tc = new IslandTeamCommand(ic);
-    }
-
-    /**
-     */
-    @After
-    public void tearDown() throws Exception {
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +26,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -43,6 +41,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -50,7 +49,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamCoopCommandTest {
+public class IslandTeamCoopCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private IslandTeamCommand ic;
@@ -69,9 +68,7 @@ public class IslandTeamCoopCommandTest {
 
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -143,11 +140,6 @@ public class IslandTeamCoopCommandTest {
         RanksManager rm = new RanksManager();
         when(plugin.getRanksManager()).thenReturn(rm);
 
-    }
-
-    @After
-    public void tearDown() {
-        User.clearUsers();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
@@ -29,7 +29,6 @@ import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -46,6 +45,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -53,7 +53,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamInviteCommandTest {
+public class IslandTeamInviteCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private IslandTeamCommand ic;
@@ -86,10 +86,8 @@ public class IslandTeamInviteCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
-
+        super.setUp();
+        
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
         when(plugin.getCommandsManager()).thenReturn(cm);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
@@ -25,7 +25,6 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +33,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
@@ -55,13 +53,14 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamKickCommandTest {
+public class IslandTeamKickCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private CompositeCommand ic;
@@ -94,9 +93,7 @@ public class IslandTeamKickCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -194,10 +191,6 @@ public class IslandTeamKickCommandTest {
         when(island.getRank(notUUID)).thenReturn(RanksManager.MEMBER_RANK);
     }
 
-    @After
-    public void tearDown() {
-        User.clearUsers();
-    }
 
     /**
      * Test method for {@link IslandTeamKickCommand#execute(User, String, java.util.List)}

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommandTest.java
@@ -20,7 +20,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +28,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -44,6 +42,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -51,7 +50,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamPromoteCommandTest {
+public class IslandTeamPromoteCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     Player player;
@@ -82,9 +81,7 @@ public class IslandTeamPromoteCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -143,14 +140,6 @@ public class IslandTeamPromoteCommandTest {
         ipc = new IslandTeamPromoteCommand(ic, "promote");
         idc = new IslandTeamPromoteCommand(ic, "demote");
 
-    }
-
-    /**
-     * @throws java.lang.Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        User.clearUsers();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +27,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -44,6 +42,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -51,7 +50,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamTrustCommandTest {
+public class IslandTeamTrustCommandTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private IslandTeamCommand ic;
@@ -74,9 +73,7 @@ public class IslandTeamTrustCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+    	super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -154,11 +151,6 @@ public class IslandTeamTrustCommandTest {
         RanksManager rm = new RanksManager();
         when(plugin.getRanksManager()).thenReturn(rm);
 
-    }
-
-    @After
-    public void tearDown() {
-        User.clearUsers();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommandTest.java
@@ -30,7 +30,6 @@ import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -44,6 +43,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -51,7 +51,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamUncoopCommandTest {
+public class IslandTeamUncoopCommandTest extends RanksManagerBeforeClassTest {
 
     private CompositeCommand ic;
     private UUID uuid;
@@ -67,9 +67,7 @@ public class IslandTeamUncoopCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        super.setUp();
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommandTest.java
@@ -29,7 +29,6 @@ import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
@@ -43,6 +42,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, User.class })
-public class IslandTeamUntrustCommandTest {
+public class IslandTeamUntrustCommandTest extends RanksManagerBeforeClassTest {
 
     private CompositeCommand ic;
     private UUID uuid;
@@ -66,10 +66,8 @@ public class IslandTeamUntrustCommandTest {
      */
     @Before
     public void setUp() throws Exception {
-        // Set up plugin
-        BentoBox plugin = mock(BentoBox.class);
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
-
+        super.setUp();
+        
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
         when(plugin.getCommandsManager()).thenReturn(cm);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandRankClickListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandRankClickListenerTest.java
@@ -25,7 +25,6 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.Inventory;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,7 +34,6 @@ import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -50,6 +48,7 @@ import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 import world.bentobox.bentobox.panels.settings.SettingsTab;
 import world.bentobox.bentobox.util.Util;
 
@@ -59,15 +58,13 @@ import world.bentobox.bentobox.util.Util;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, BentoBox.class, Util.class})
-public class CommandRankClickListenerTest {
+public class CommandRankClickListenerTest extends RanksManagerBeforeClassTest {
     @Mock
     private User user;
     @Mock
     private World world;
     @Mock
     private TabbedPanel panel;
-    @Mock
-    private BentoBox plugin;
     @Mock
     private IslandWorldManager iwm;
     @Mock
@@ -94,11 +91,11 @@ public class CommandRankClickListenerTest {
      */
     @Before
     public void setUp() throws Exception {
+    	super.setUp();
 
         // Bukkit
         PowerMockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
-        // Set up plugin
-        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+        
         // Island
         when(island.getOwner()).thenReturn(uuid);
         when(island.isAllowed(user, Flags.CHANGE_SETTINGS)).thenReturn(true);
@@ -144,14 +141,6 @@ public class CommandRankClickListenerTest {
         map.put("test", cc);
         when(cm.getCommands()).thenReturn(map);
         crcl = new CommandRankClickListener();
-    }
-
-    /**
-     * @throws java.lang.Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-        Mockito.framework().clearInlineMocks();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/lists/GameModePlaceholderTest.java
+++ b/src/test/java/world/bentobox/bentobox/lists/GameModePlaceholderTest.java
@@ -23,7 +23,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.collect.ImmutableSet;
 
-import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.TestWorldSettings;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
@@ -33,13 +32,14 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.managers.RanksManagerBeforeClassTest;
 
 /**
  * @author tastybento
  *
  */
 @RunWith(PowerMockRunner.class)
-public class GameModePlaceholderTest {
+public class GameModePlaceholderTest extends RanksManagerBeforeClassTest {
 
     @Mock
     private GameModeAddon addon;
@@ -53,12 +53,10 @@ public class GameModePlaceholderTest {
     @Mock
     private World world;
     @Mock
-    private BentoBox plugin;
-    @Mock
     private IslandWorldManager iwm;
     @Mock
     private IslandsManager im;
-    private final RanksManager rm = new RanksManager();
+    private RanksManager rm;
     @Mock
     private @Nullable Location location;
 
@@ -67,6 +65,8 @@ public class GameModePlaceholderTest {
      */
     @Before
     public void setUp() throws Exception {
+    	super.setUp();
+    	rm = new RanksManager();
         uuid = UUID.randomUUID();
         when(addon.getPlayers()).thenReturn(pm);
         when(addon.getIslands()).thenReturn(im);

--- a/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
@@ -250,8 +250,6 @@ public class PlayersManagerTest {
         pm = new PlayersManager(plugin);
     }
 
-    /**
-     */
     @After
     public void tearDown() throws Exception {
         User.clearUsers();

--- a/src/test/java/world/bentobox/bentobox/managers/RanksManagerBeforeClassTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/RanksManagerBeforeClassTest.java
@@ -1,0 +1,84 @@
+package world.bentobox.bentobox.managers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.beans.IntrospectionException;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
+import world.bentobox.bentobox.database.DatabaseSetup;
+
+/**
+ * @author tastybento
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BentoBox.class, DatabaseSetup.class,})
+public abstract class RanksManagerBeforeClassTest {
+
+    private static AbstractDatabaseHandler<Object> h;
+    
+    @Mock
+    public BentoBox plugin;
+
+    @SuppressWarnings("unchecked")
+    @BeforeClass
+    public static void beforeClass() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+        // This has to be done beforeClass otherwise the tests will interfere with each other
+        h = mock(AbstractDatabaseHandler.class);
+        // Database
+        PowerMockito.mockStatic(DatabaseSetup.class);
+        DatabaseSetup dbSetup = mock(DatabaseSetup.class);
+        when(DatabaseSetup.getDatabase()).thenReturn(dbSetup);
+        when(dbSetup.getHandler(any())).thenReturn(h);
+        when(h.saveObject(any())).thenReturn(CompletableFuture.completedFuture(true));
+    }
+
+    /**
+     */
+    @Before
+    public void setUp() throws Exception {
+        // Set up plugin
+        Whitebox.setInternalState(BentoBox.class, "instance", plugin);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+    	User.clearUsers();
+        Mockito.framework().clearInlineMocks();
+        deleteAll(new File("database"));
+        deleteAll(new File("database_backup"));
+    }
+    
+    private void deleteAll(File file) throws IOException {
+        if (file.exists()) {
+            Files.walk(file.toPath())
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
+        }
+
+    }
+
+}

--- a/src/test/java/world/bentobox/bentobox/managers/RanksManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/RanksManagerTest.java
@@ -6,31 +6,32 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import world.bentobox.bentobox.database.DatabaseSetup;
 
 /**
  * @author tastybento
  *
  */
-public class RanksManagerTest {
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DatabaseSetup.class,})
+public class RanksManagerTest extends RanksManagerBeforeClassTest {
 
     public static RanksManager ranksManager;
-
+    
     /**
      */
     @Before
     public void setUp() throws Exception {
+    	super.setUp();
         ranksManager = new RanksManager();
     }
-
-    @After
-    public void tearDown() {
-        Mockito.framework().clearInlineMocks();
-    }
-
+    
     /**
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#addRank(java.lang.String, int)}.
      */


### PR DESCRIPTION
This enables ranks to be managed via commands. For example, an admin could remove the Trusted rank, as requested in #1798