### PR TITLE
Fixes an issue with entity teleportation if nether/end worlds are disabled

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/teleports/EntityTeleportListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/teleports/EntityTeleportListener.java
@@ -150,18 +150,9 @@ public class EntityTeleportListener extends AbstractTeleportListener implements 
         // Entities are teleported instantly.
         if (!Bukkit.getAllowNether() && type.equals(Material.NETHER_PORTAL))
         {
-            if (fromWorld == overWorld)
-            {
-                this.portalProcess(
-                    new EntityPortalEvent(entity, event.getLocation(), event.getLocation(), 0),
-                    World.Environment.NETHER);
-            }
-            else
-            {
-                this.portalProcess(
-                    new EntityPortalEvent(entity, event.getLocation(), event.getLocation(), 0),
-                    World.Environment.NORMAL);
-            }
+            this.portalProcess(
+                new EntityPortalEvent(entity, event.getLocation(), event.getLocation(), 0),
+                World.Environment.NETHER);
 
             // Do not process anything else.
             return;
@@ -170,18 +161,9 @@ public class EntityTeleportListener extends AbstractTeleportListener implements 
         // Entities are teleported instantly.
         if (!Bukkit.getAllowEnd() && (type.equals(Material.END_PORTAL) || type.equals(Material.END_GATEWAY)))
         {
-            if (fromWorld == this.getNetherEndWorld(overWorld, World.Environment.THE_END))
-            {
-                this.portalProcess(
-                    new EntityPortalEvent(entity, event.getLocation(), event.getLocation(), 0),
-                    World.Environment.NORMAL);
-            }
-            else
-            {
-                this.portalProcess(
-                    new EntityPortalEvent(entity, event.getLocation(), event.getLocation(), 0),
-                    World.Environment.THE_END);
-            }
+            this.portalProcess(
+                new EntityPortalEvent(entity, event.getLocation(), event.getLocation(), 0),
+                World.Environment.THE_END);
         }
     }
 


### PR DESCRIPTION
There was a bug that used old code (environment switching) for teleportation out of dimension.  The issue should be fixed with calling just calling teleportation with portal environment.