### PR TITLE
Separators, AddonClassLoader fixes and uni tests fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,29 +371,23 @@
                         --add-opens java.base/java.math=ALL-UNNAMED
                         --add-opens java.base/java.io=ALL-UNNAMED
                         --add-opens java.base/java.util=ALL-UNNAMED
-                        --add-opens
-                        java.base/java.util.stream=ALL-UNNAMED
+                        --add-opens java.base/java.util.stream=ALL-UNNAMED
                         --add-opens java.base/java.text=ALL-UNNAMED
-                        --add-opens
-                        java.base/java.util.regex=ALL-UNNAMED
-                        --add-opens
-                        java.base/java.nio.channels.spi=ALL-UNNAMED
+                        --add-opens java.base/java.util.regex=ALL-UNNAMED
+                        --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
                         --add-opens java.base/sun.nio.ch=ALL-UNNAMED
                         --add-opens java.base/java.net=ALL-UNNAMED
-                        --add-opens
-                        java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
                         --add-opens java.base/sun.nio.fs=ALL-UNNAMED
                         --add-opens java.base/sun.nio.cs=ALL-UNNAMED
                         --add-opens java.base/java.nio.file=ALL-UNNAMED
-                        --add-opens
-                        java.base/java.nio.charset=ALL-UNNAMED
-                        --add-opens
-                        java.base/java.lang.reflect=ALL-UNNAMED
-                        --add-opens
-                        java.logging/java.util.logging=ALL-UNNAMED
+                        --add-opens java.base/java.nio.charset=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.logging/java.util.logging=ALL-UNNAMED
                         --add-opens java.base/java.lang.ref=ALL-UNNAMED
                         --add-opens java.base/java.util.jar=ALL-UNNAMED
                         --add-opens java.base/java.util.zip=ALL-UNNAMED
+                        --add-opens=java.base/java.security=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
@@ -263,7 +263,7 @@ public abstract class Addon {
             throw new IllegalArgumentException("ResourcePath cannot be null or empty");
         }
 
-        jarResource = jarResource.replace('\\', '/');
+        jarResource = jarResource.replace("\\", File.separator).replace("/", File.separator);
         try (JarFile jar = new JarFile(file)) {
             JarEntry jarConfig = jar.getJarEntry(jarResource);
             if (jarConfig != null) {
@@ -308,7 +308,7 @@ public abstract class Addon {
             throw new IllegalArgumentException("jarResource cannot be null or empty");
         }
         YamlConfiguration result = new YamlConfiguration();
-        jarResource = jarResource.replace('\\', '/');
+        jarResource = jarResource.replace("\\", File.separator).replace("/", File.separator);
         try (JarFile jar = new JarFile(file)) {
             JarEntry jarConfig = jar.getJarEntry(jarResource);
             if (jarConfig != null) {
@@ -330,7 +330,7 @@ public abstract class Addon {
             throw new IllegalArgumentException("ResourcePath cannot be null or empty");
         }
 
-        jarResource = jarResource.replace('\\', '/');
+        jarResource = jarResource.replace("\\", File.separator).replace("/", File.separator);
         try (JarFile jar = new JarFile(file)) {
             JarEntry jarConfig = jar.getJarEntry(jarResource);
             if (jarConfig != null) {

--- a/src/test/java/world/bentobox/bentobox/api/addons/AddonClassLoaderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/addons/AddonClassLoaderTest.java
@@ -300,40 +300,44 @@ public class AddonClassLoaderTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#findClass(java.lang.String)}.
      */
     @Test
-    public void testFindClassString() throws MalformedURLException {
+    public void testFindClassString() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         assertNull(acl.findClass(""));
         assertNull(acl.findClass("world.bentobox.bentobox"));
+        acl.close();
     }
 
     /**
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#findClass(java.lang.String, boolean)}.
      */
     @Test
-    public void testFindClassStringBoolean() throws MalformedURLException {
+    public void testFindClassStringBoolean() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         assertNull(acl.findClass("", false));
         assertNull(acl.findClass("world.bentobox.bentobox", false));
+        acl.close();
     }
 
     /**
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#getAddon()}.
      */
     @Test
-    public void testGetAddon() throws MalformedURLException {
+    public void testGetAddon() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         Addon addon = acl.getAddon();
         assertEquals(addon, testAddon);
+        acl.close();
     }
 
     /**
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#getClasses()}.
      */
     @Test
-    public void testGetClasses() throws MalformedURLException {
+    public void testGetClasses() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         Set<String> set = acl.getClasses();
         assertTrue(set.isEmpty());
+        acl.close();
     }
 
 }


### PR DESCRIPTION
 - Fixed separators to also work on Windows
 - Added missing `--add-opens=java.base/java.security=ALL-UNNAMED`
 - Added proper closing of AddonClassLoader