### PR TITLE
Material Type adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,31 @@
     </repositories>
 
     <dependencies>
+        <!-- Mockito (Unit testing) This goes at the top to ensure the dependencies are accurate. -->
+        <!-- This is required for PowerMockito to work and must be placed before it -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.30.2-GA</version>
+       </dependency>
+       <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Spigot API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
@@ -211,25 +236,6 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>${bstats.version}</version>
-        </dependency>
-        <!-- Mockito (Unit testing) -->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.11.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
         <!-- Database -->
         <dependency>

--- a/src/main/java/world/bentobox/bentobox/database/json/BentoboxTypeAdapterFactory.java
+++ b/src/main/java/world/bentobox/bentobox/database/json/BentoboxTypeAdapterFactory.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.database.json;
 import java.util.Map;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -23,6 +24,7 @@ import world.bentobox.bentobox.database.json.adapters.EnumTypeAdapter;
 import world.bentobox.bentobox.database.json.adapters.FlagTypeAdapter;
 import world.bentobox.bentobox.database.json.adapters.ItemStackTypeAdapter;
 import world.bentobox.bentobox.database.json.adapters.LocationTypeAdapter;
+import world.bentobox.bentobox.database.json.adapters.MaterialTypeAdapter;
 import world.bentobox.bentobox.database.json.adapters.PotionEffectTypeAdapter;
 import world.bentobox.bentobox.database.json.adapters.VectorTypeAdapter;
 import world.bentobox.bentobox.database.json.adapters.WorldTypeAdapter;
@@ -55,6 +57,8 @@ public class BentoboxTypeAdapterFactory implements TypeAdapterFactory {
         if (Location.class.isAssignableFrom(rawType)) {
             // Use our current location adapter for backward compatibility
             return (TypeAdapter<T>) new LocationTypeAdapter();
+        } else if (Material.class.isAssignableFrom(rawType)) {
+            return (TypeAdapter<T>) new MaterialTypeAdapter();
         } else if (Biome.class.isAssignableFrom(rawType)) {
             return (TypeAdapter<T>) new BiomeTypeAdapter();
         } else if (Enum.class.isAssignableFrom(rawType)) {

--- a/src/main/java/world/bentobox/bentobox/database/json/adapters/MaterialTypeAdapter.java
+++ b/src/main/java/world/bentobox/bentobox/database/json/adapters/MaterialTypeAdapter.java
@@ -1,0 +1,56 @@
+package world.bentobox.bentobox.database.json.adapters;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Material;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+
+/**
+ * Minecraft 1.20 changed GRASS to SHORT_GRASS. This class provides and backwards compatibility when loading
+ * databased files stored with previous versions. It can be extended in the future if further enum changes are made.
+ * @author tastybento
+ * @since 2.0.0
+ */
+public final class MaterialTypeAdapter extends TypeAdapter<Material>
+{
+    /**
+     * Map that contains string value to the actual Material enum object.
+     */
+    final Map<String, Material> materialMap;
+
+    public MaterialTypeAdapter() {
+        this.materialMap = new HashMap<>();
+
+        // Put in current values.
+        Arrays.stream(Material.values()).forEach(mat -> this.materialMap.put(mat.name(), mat));
+
+        // Put in renamed material values.
+        this.materialMap.put("GRASS", Material.SHORT_GRASS);
+    }
+
+    @Override
+    public Material read(JsonReader input) throws IOException
+    {
+        if (JsonToken.NULL.equals(input.peek())) {
+            input.nextNull();
+            return null;
+        }
+
+        return this.materialMap.get(input.nextString().toUpperCase());
+    }
+
+    @Override
+    public void write(JsonWriter output, Material enumValue) throws IOException {
+        output.value(enumValue != null ? enumValue.name() : null);
+    }
+}
+


### PR DESCRIPTION
Handles the switch from GRASS to SHORT_GRASS and can be used in the future for any other Material enum changes.

Fixes https://github.com/BentoBoxWorld/Level/issues/298