### PR TITLE
Fixes issue with file exporting in Windows system.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
@@ -263,7 +264,7 @@ public abstract class Addon {
             throw new IllegalArgumentException("ResourcePath cannot be null or empty");
         }
 
-        jarResource = jarResource.replace("\\", File.separator).replace("/", File.separator);
+        jarResource = jarResource.replace('\\', '/');
         try (JarFile jar = new JarFile(file)) {
             JarEntry jarConfig = jar.getJarEntry(jarResource);
             if (jarConfig != null) {
@@ -273,7 +274,9 @@ public abstract class Addon {
                                 "The embedded resource '" + jarResource + "' cannot be found in " + jar.getName());
                     }
                     // There are two options, use the path of the resource or not
-                    File outFile = new File(destinationFolder, jarResource);
+                    File outFile = new File(destinationFolder,
+                        jarResource.replaceAll("/", Matcher.quoteReplacement(File.separator)));
+
                     if (noPath) {
                         outFile = new File(destinationFolder, outFile.getName());
                     }
@@ -308,7 +311,7 @@ public abstract class Addon {
             throw new IllegalArgumentException("jarResource cannot be null or empty");
         }
         YamlConfiguration result = new YamlConfiguration();
-        jarResource = jarResource.replace("\\", File.separator).replace("/", File.separator);
+        jarResource = jarResource.replace('\\', '/');
         try (JarFile jar = new JarFile(file)) {
             JarEntry jarConfig = jar.getJarEntry(jarResource);
             if (jarConfig != null) {
@@ -330,7 +333,7 @@ public abstract class Addon {
             throw new IllegalArgumentException("ResourcePath cannot be null or empty");
         }
 
-        jarResource = jarResource.replace("\\", File.separator).replace("/", File.separator);
+        jarResource = jarResource.replace('\\', '/');
         try (JarFile jar = new JarFile(file)) {
             JarEntry jarConfig = jar.getJarEntry(jarResource);
             if (jarConfig != null) {


### PR DESCRIPTION
JAR files do not store files inside it with a filesystem separator. The only spot where it makes sense to transform "/" into file separator is in output file saving.

This reverts changes made in 13c339ef4fca36b348a30c547d1b92e0e3625641, but "fixes" file separation in output file saving. 