### PR TITLE
Add minor optimizations for chunk copying

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/HooksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/HooksManager.java
@@ -1,7 +1,8 @@
 package world.bentobox.bentobox.managers;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNull;
@@ -18,18 +19,18 @@ public class HooksManager {
     /**
      * List of successfully registered hooks.
      */
-    private final List<Hook> hooks;
+    private final Map<String, Hook> hooks;
 
     public HooksManager(BentoBox plugin) {
         this.plugin = plugin;
-        this.hooks = new ArrayList<>();
+        this.hooks = new HashMap<>();
     }
 
     public void registerHook(@NonNull Hook hook) {
         if (hook.isPluginAvailable()) {
             plugin.log("Hooking with " + hook.getPluginName() + "...");
             if (hook.hook()) {
-                hooks.add(hook);
+                hooks.put(hook.getPluginName(), hook);
             } else {
                 plugin.logError("Could not hook with " + hook.getPluginName() + ((hook.getFailureCause() != null) ? " because: " + hook.getFailureCause() : "") + ". Skipping...");
             }
@@ -43,10 +44,10 @@ public class HooksManager {
      * @return list of successfully registered hooks.
      */
     public List<Hook> getHooks() {
-        return hooks;
+        return List.copyOf(hooks.values());
     }
 
     public Optional<Hook> getHook(String pluginName) {
-        return hooks.stream().filter(hook -> hook.getPluginName().equals(pluginName)).findFirst();
+        return Optional.ofNullable(hooks.get(pluginName));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
+++ b/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.nms;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -184,6 +185,8 @@ public abstract class CopyWorldRegenerator implements WorldRegenerator {
         double baseZ = toChunk.getZ() << 4;
         int minHeight = toChunk.getWorld().getMinHeight();
         int maxHeight = toChunk.getWorld().getMaxHeight();
+        Optional<SlimefunHook> slimefunHook = plugin.getHooks().getHook("Slimefun").map(SlimefunHook.class::cast);
+        Optional<ItemsAdderHook> itemsAdderHook = plugin.getHooks().getHook("ItemsAdder").map(ItemsAdderHook.class::cast);
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
                 if (limitBox != null && !limitBox.contains(baseX + x, 0, baseZ + z)) {
@@ -197,10 +200,8 @@ public abstract class CopyWorldRegenerator implements WorldRegenerator {
                     }
                     // Delete any 3rd party blocks
                     Location loc = new Location(toChunk.getWorld(), baseX + x, y, baseZ + z);
-                    plugin.getHooks().getHook("Slimefun")
-                            .ifPresent(hook -> ((SlimefunHook) hook).clearBlockInfo(loc, true));
-                    plugin.getHooks().getHook("ItemsAdder")
-                            .ifPresent(hook -> ((ItemsAdderHook) hook).clearBlockInfo(loc));
+                    slimefunHook.ifPresent(hook -> hook.clearBlockInfo(loc, true));
+                    itemsAdderHook.ifPresent(hook -> hook.clearBlockInfo(loc));
                 }
             }
         }


### PR DESCRIPTION
### Brief
It should be beneficial to retrieve hooks for Slimefun, ItemsAdder once per chunk instead of doing lookup inside of loops. Use of HashMap should be also beneficial to prevent iterations over all persisted hooks inside HooksManager.