### PR TITLE
Add island object to Panel for context.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommand.java
@@ -242,8 +242,8 @@ public class AdminSettingsCommand extends CompositeCommand {
         new TabbedPanelBuilder()
         .user(user)
         .world(island.getWorld())
-        .tab(1, new SettingsTab(user, island, Flag.Type.PROTECTION))
-        .tab(2, new SettingsTab(user, island, Flag.Type.SETTING))
+                .island(island).tab(1, new SettingsTab(user, Flag.Type.PROTECTION))
+                .tab(2, new SettingsTab(user, Flag.Type.SETTING))
         .startingSlot(1)
         .size(54)
         .build().openPanel();

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
@@ -47,9 +47,9 @@ public class IslandSettingsCommand extends CompositeCommand {
     public boolean execute(User user, String label, List<String> args) {
         new TabbedPanelBuilder()
         .user(user)
+                .island(island)
         .world(island.getWorld())
-        .tab(1, new SettingsTab(user, island, Flag.Type.PROTECTION))
-        .tab(2, new SettingsTab(user, island, Flag.Type.SETTING))
+                .tab(1, new SettingsTab(user, Flag.Type.PROTECTION)).tab(2, new SettingsTab(user, Flag.Type.SETTING))
         .startingSlot(1)
         .size(54)
         .hideIfEmpty()

--- a/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
@@ -13,6 +13,7 @@ import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.listeners.PanelListenerManager;
 import world.bentobox.bentobox.util.heads.HeadGetter;
 import world.bentobox.bentobox.util.heads.HeadRequester;
@@ -30,6 +31,7 @@ public class Panel implements HeadRequester, InventoryHolder {
     private User user;
     private String name;
     private World world;
+    private Island island;
 
     /**
      * Various types of Panels that can be created that use InventoryTypes.
@@ -232,6 +234,20 @@ public class Panel implements HeadRequester, InventoryHolder {
      */
     public void setWorld(World world) {
         this.world = world;
+    }
+
+    /**
+     * @return the island
+     */
+    public Island getIsland() {
+        return island;
+    }
+
+    /**
+     * @param island the island to set
+     */
+    protected void setIsland(Island island) {
+        this.island = island;
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/api/panels/Tab.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/Tab.java
@@ -15,6 +15,19 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 public interface Tab {
 
+    /**
+     * @return the tabbed panel that owns this tab
+     */
+    default TabbedPanel getParentPanel() {
+        return null;
+    }
+
+    /**
+     * @param parent set the tabbed panel that owns this tab
+     */
+    default void setParentPanel(TabbedPanel parent) {
+    }
+
     // The icon that should be shown at the top of the tabbed panel
     PanelItem getIcon();
 

--- a/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
@@ -44,6 +44,8 @@ public class TabbedPanel extends Panel implements PanelListener {
     public TabbedPanel(TabbedPanelBuilder tpb) {
         this.tpb = tpb;
         this.setWorld(tpb.getWorld());
+        // Set island context in Panel
+        this.setIsland(tpb.getIsland());
     }
 
     /* (non-Javadoc)
@@ -208,4 +210,5 @@ public class TabbedPanel extends Panel implements PanelListener {
     public void setActiveTab(int activeTab) {
         this.activeTab = activeTab;
     }
+
 }

--- a/src/main/java/world/bentobox/bentobox/api/panels/builders/TabbedPanelBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/builders/TabbedPanelBuilder.java
@@ -9,6 +9,7 @@ import org.bukkit.World;
 import world.bentobox.bentobox.api.panels.Tab;
 import world.bentobox.bentobox.api.panels.TabbedPanel;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 
 /**
  * Builds {@link TabbedPanel}'s
@@ -23,6 +24,17 @@ public class TabbedPanelBuilder {
     private World world;
     private User user;
     private boolean hideIfEmpty;
+    private Island island;
+
+    /**
+     * Set the island related to this panel
+     * @param island island
+     * @return PanelBuilder - PanelBuilder
+     */
+    public TabbedPanelBuilder island(Island island) {
+        this.island = island;
+        return this;
+    }
 
     /**
      * Forces panel to be a specific number of slots.
@@ -97,7 +109,10 @@ public class TabbedPanelBuilder {
         if (!tabs.isEmpty() && !tabs.containsKey(startingSlot)) {
             startingSlot = ((TreeMap<Integer, Tab>)tabs).firstKey();
         }
-        return new TabbedPanel(this);
+        TabbedPanel tp = new TabbedPanel(this);
+        // Set tab parents
+        tabs.values().forEach(tab -> tab.setParentPanel(tp));
+        return tp;
     }
 
     /**
@@ -142,6 +157,12 @@ public class TabbedPanelBuilder {
         return hideIfEmpty;
     }
 
+    /**
+     * @return the island
+     */
+    public Island getIsland() {
+        return island;
+    }
 
 
 }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
@@ -48,8 +48,10 @@ public class GeoMobLimitTab implements Tab, ClickHandler {
     private final User user;
     private final EntityLimitTabType type;
     private final World world;
+    private TabbedPanel parent;
 
     /**
+     * @param parent - tabbed panel that owns this panel
      * @param user - user viewing the tab
      * @param type - type of tab to show - Geo limit or Mob limit
      * @param world - world where this tab is being used
@@ -60,7 +62,6 @@ public class GeoMobLimitTab implements Tab, ClickHandler {
         this.type = type;
         this.world = world;
     }
-
 
     @Override
     public boolean onClick(Panel panel, User user, ClickType clickType, int slot) {
@@ -138,6 +139,16 @@ public class GeoMobLimitTab implements Tab, ClickHandler {
             }
         }
         return pib.build();
+    }
+
+    @Override
+    public TabbedPanel getParentPanel() {
+        return parent;
+    }
+
+    @Override
+    public void setParentPanel(TabbedPanel parent) {
+        this.parent = parent;
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
+++ b/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
@@ -44,6 +44,7 @@ public class SettingsTab implements Tab, ClickHandler {
     protected User user;
     protected World world;
     protected Island island;
+    protected TabbedPanel parent;
 
     /**
      * Show a tab of settings
@@ -51,9 +52,9 @@ public class SettingsTab implements Tab, ClickHandler {
      * @param island - the island
      * @param type - flag type
      */
-    public SettingsTab(User user, Island island, Type type) {
+    public SettingsTab(User user, Type type) {
         this.user = user;
-        this.island = island;
+        this.island = parent.getIsland();
         this.type = type;
         this.world = island.getWorld();
     }
@@ -124,7 +125,9 @@ public class SettingsTab implements Tab, ClickHandler {
             plugin.getPlayers().setFlagsDisplayMode(user.getUniqueId(), plugin.getPlayers().getFlagsDisplayMode(user.getUniqueId()).getNext());
             flags = getFlags();
         }
-        return flags.stream().map((f -> f.toPanelItem(plugin, user, island, plugin.getIWM().getHiddenFlags(world).contains(f.getID())))).toList();
+        return flags.stream().map(
+                (f -> f.toPanelItem(plugin, user, island, plugin.getIWM().getHiddenFlags(world).contains(f.getID()))))
+                .toList();
     }
 
     @Override
@@ -221,6 +224,16 @@ public class SettingsTab implements Tab, ClickHandler {
             user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_OFF, 1F, 1F);
         }
         return true;
+    }
+
+    @Override
+    public TabbedPanel getParentPanel() {
+        return parent;
+    }
+
+    @Override
+    public void setParentPanel(TabbedPanel parent) {
+        this.parent = parent;
     }
 
 }


### PR DESCRIPTION
This PR adds an Island reference in Panel.  By sticking the Island context in Panel itself, other panels should be able to get it too. 

Tabs, TabbedPanel, and TabbedPanelBuilder support it. Basically, in the building phase, the island is specified and it ends up in Panel. Tabs can then get it by accessing their parent, i.e. TabbedPanel#getIsland(), which is a Panel#getIsland().

The Tab object was enhanced to reference a parent TabbedPanel in the builder. It is late assigned after building. This enables tabs to get the parent, and therefore get the Island object from the Panel.

default methods were used to support backward compatibility, so that if the island isn't specified, then it doesn't matter. However, new API can use it.