### PR TITLE
Faster teleports

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
@@ -15,7 +15,6 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.util.Util;
-import world.bentobox.bentobox.util.teleport.SafeSpotTeleport;
 
 /**
  * @author tastybento
@@ -76,23 +75,14 @@ public class IslandGoCommand extends DelayedTeleportCommand {
             } else {
                 IslandInfo info = names.get(name);
                 getIslands().setPrimaryIsland(user.getUniqueId(), info.island);
-                if (info.islandName) {
-                    this.delayCommand(user, () -> new SafeSpotTeleport.Builder(getPlugin())
-                            .entity(user.getPlayer())
-                            .location(getIslands().getHomeLocation(info.island))
-                            .thenRun(() -> user.sendMessage("general.success"))
-                            .build());
-                } else {
-                    this.delayCommand(user, () -> new SafeSpotTeleport.Builder(getPlugin())
-                            .entity(user.getPlayer())
-                            .location(getIslands().getHomeLocation(info.island, name))
-                            .thenRun(() -> user.sendMessage("general.success"))
-                            .build());
+                if (!info.islandName) {
+                    this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer(), name)
+                            .thenAccept((r) -> getIslands().setPrimaryIsland(user.getUniqueId(), info.island)));
+                    return true;
                 }
             }
-        } else {
-            this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer()));
         }
+        this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer()));
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -1721,9 +1721,20 @@ public class Island implements DataObject, MetaDataAble {
      * @since 1.16.0
      */
     @NonNull
-    public Location getHome(String name) {
-        Location l = getHomes().get(name.toLowerCase());
-        return l == null ? getProtectionCenter() : l;
+    public Location getHome(final String nameToLookFor) {
+        BentoBox.getInstance().logDebug("name:" + nameToLookFor);
+        final String name2 = "hole";
+        getHomes().forEach((n, location) -> {
+            BentoBox.getInstance()
+                    .logDebug("Home '" + n + "' > " + location + " same as '" + name2 + "'? "
+                            + name2.equals(n) + " " + name2.equalsIgnoreCase(n) + " "
+                            + n.equals(name2) + " " + n.equalsIgnoreCase(name2));
+        });
+        BentoBox.getInstance().logDebug("name:" + nameToLookFor);
+        return getHomes().entrySet().stream().filter(en -> en.getKey().equalsIgnoreCase(name2))
+                .map(Entry::getValue)
+                .findFirst().orElse(getProtectionCenter());
+        //return Objects.requireNonNullElse(l, getProtectionCenter());
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -1722,19 +1722,9 @@ public class Island implements DataObject, MetaDataAble {
      */
     @NonNull
     public Location getHome(final String nameToLookFor) {
-        BentoBox.getInstance().logDebug("name:" + nameToLookFor);
-        final String name2 = "hole";
-        getHomes().forEach((n, location) -> {
-            BentoBox.getInstance()
-                    .logDebug("Home '" + n + "' > " + location + " same as '" + name2 + "'? "
-                            + name2.equals(n) + " " + name2.equalsIgnoreCase(n) + " "
-                            + n.equals(name2) + " " + n.equalsIgnoreCase(name2));
-        });
-        BentoBox.getInstance().logDebug("name:" + nameToLookFor);
-        return getHomes().entrySet().stream().filter(en -> en.getKey().equalsIgnoreCase(name2))
+        return getHomes().entrySet().stream().filter(en -> en.getKey().equalsIgnoreCase(nameToLookFor))
                 .map(Entry::getValue)
                 .findFirst().orElse(getProtectionCenter());
-        //return Objects.requireNonNullElse(l, getProtectionCenter());
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -335,7 +335,6 @@ public class IslandsManager {
      */
     @NonNull
     public Set<Island> getIslands(@NonNull World world, UUID uniqueId) {
-        BentoBox.getInstance().logDebug("Asking the cache");
         return islandCache.getIslands(world, uniqueId);
     }
 
@@ -610,28 +609,20 @@ public class IslandsManager {
                     this.setPrimaryIsland(user.getUniqueId(), island);
                     return "";
                 }).orElse(homeName);
-        BentoBox.getInstance().logDebug("The name is now = " + name);
         // Try the home location first
-        //Location defaultHome = getHomeLocation(world, user);
-        //BentoBox.getInstance().logDebug("defaulthome has been got = " + name);
-        Location namedHome = homeName.isBlank() ? null : getHomeLocation(world, user, name);  // TODO This is where the bug is.
-        BentoBox.getInstance().logDebug("The namedHome location is = " + namedHome);
-        //Location l = namedHome != null ? namedHome : defaultHome;
-        Location l = namedHome;
+        Location defaultHome = getHomeLocation(world, user);
+        Location namedHome = homeName.isBlank() ? null : getHomeLocation(world, user, name);
+        Location l = namedHome != null ? namedHome : defaultHome;
         if (l != null) {
             Util.getChunkAtAsync(l).thenRun(() -> {
                 // Check if it is safe
                 if (isSafeLocation(l)) {
-                    BentoBox.getInstance().logDebug("Safe location found! " + l);
                     result.complete(l);
                     return;
                 }
-                BentoBox.getInstance().logDebug(l + " is not a safe location");
                 // To cover slabs, stairs and other half blocks, try one block above
                 Location lPlusOne = l.clone().add(new Vector(0, 1, 0));
-                BentoBox.getInstance().logDebug("Trying " + lPlusOne);
                 if (isSafeLocation(lPlusOne)) {
-                    BentoBox.getInstance().logDebug("This is safer " + lPlusOne);
                     // Adjust the home location accordingly
                     setHomeLocation(user, lPlusOne, name);
                     result.complete(lPlusOne);
@@ -648,7 +639,6 @@ public class IslandsManager {
     }
 
     private void tryIsland(CompletableFuture<Location> result, Location islandLoc, @NonNull User user, String name) {
-        BentoBox.getInstance().logDebug("We are trying to find another safe location on island at = " + islandLoc);
         Util.getChunkAtAsync(islandLoc).thenRun(() -> {
             World w = islandLoc.getWorld();
             if (isSafeLocation(islandLoc)) {
@@ -681,7 +671,6 @@ public class IslandsManager {
                     }
                 }
             }
-            BentoBox.getInstance().logDebug("Nothing found!");
             result.complete(null);
         });
 
@@ -895,7 +884,6 @@ public class IslandsManager {
      */
     @Nullable
     public Location getHomeLocation(@NonNull World world, @NonNull User user, String name) {
-        BentoBox.getInstance().logDebug("getHomeLocation user name = " + name);
         return getHomeLocation(world, user.getUniqueId(), name);
     }
 
@@ -1084,7 +1072,6 @@ public class IslandsManager {
      * @since 1.16.0
      */
     public CompletableFuture<Boolean> homeTeleportAsync(@NonNull World world, @NonNull Player player, String name) {
-        BentoBox.getInstance().logDebug("homeTeleportAsync name = " + name);
         return homeTeleportAsync(world, player, name, false);
     }
 
@@ -1120,9 +1107,7 @@ public class IslandsManager {
         user.sendMessage("commands.island.go.teleport");
         goingHome.add(user.getUniqueId());
         readyPlayer(player);
-        BentoBox.getInstance().logDebug("Home name = " + name);
         this.getAsyncSafeHomeLocation(world, user, name).thenAccept(home -> {
-            BentoBox.getInstance().logDebug("Got a result from getAsyncSafeHomeLocation: " + home);
             Island island = getIsland(world, user);
             if (home == null) {
                 // Try to fix this teleport location and teleport the player if possible

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
@@ -194,8 +194,14 @@ public class IslandCache {
     public Set<Island> getIslands(@NonNull World world, @NonNull UUID uuid) {
         World w = Util.getWorld(world);
         if (w == null) {
+            BentoBox.getInstance().logDebug("The world was " + world.getName() + " but now is null");
             return new HashSet<>();
         }
+        BentoBox.getInstance().logDebug("The world was " + world.getName() + " and is now " + w.getName());
+        BentoBox.getInstance().logDebug("This player's islands in this world are:");
+        islandsByUUID.get(uuid).stream().filter(i -> w.equals(i.getWorld()))
+                .forEach(i -> BentoBox.getInstance().logDebug(i));
+
         return islandsByUUID.computeIfAbsent(uuid, k -> new HashSet<>()).stream().filter(i -> w.equals(i.getWorld()))
                 .collect(Collectors.toSet());
     }

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
@@ -194,14 +194,8 @@ public class IslandCache {
     public Set<Island> getIslands(@NonNull World world, @NonNull UUID uuid) {
         World w = Util.getWorld(world);
         if (w == null) {
-            BentoBox.getInstance().logDebug("The world was " + world.getName() + " but now is null");
             return new HashSet<>();
         }
-        BentoBox.getInstance().logDebug("The world was " + world.getName() + " and is now " + w.getName());
-        BentoBox.getInstance().logDebug("This player's islands in this world are:");
-        islandsByUUID.get(uuid).stream().filter(i -> w.equals(i.getWorld()))
-                .forEach(i -> BentoBox.getInstance().logDebug(i));
-
         return islandsByUUID.computeIfAbsent(uuid, k -> new HashSet<>()).stream().filter(i -> w.equals(i.getWorld()))
                 .collect(Collectors.toSet());
     }


### PR DESCRIPTION
Fixes #2265

This also fixes a bug with named homes where the named home location was sometimes overwritten by the default home location is the user had more than one island. This was because the getHomes was being checked against each island, and when one didn't have the name of the home, it would instead provide the island's default home. This was incorrectly interpreted to mean the home was there, but it wasn't.