### PR TITLE
Use a different method to grab the DataObject classes.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxMigrateCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxMigrateCommand.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.commands;
 
 import java.util.List;
+import java.util.Set;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -8,8 +9,7 @@ import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.Database;
-import world.bentobox.bentobox.database.objects.Names;
-import world.bentobox.bentobox.database.objects.Players;
+import world.bentobox.bentobox.database.objects.DataObject;
 
 /**
  * Forces migration from one database to another
@@ -38,16 +38,10 @@ public class BentoBoxMigrateCommand extends ConfirmableCommand {
     @Override
     public boolean execute(User user, String label, List<String> args) {
         this.askConfirmation(user, () -> {
-            // Migrate BentoBox data
-            user.sendMessage("commands.bentobox.migrate.players");
-            new Database<>(getPlugin(), Players.class).loadObjects();
-            user.sendMessage(MIGRATED);
-            user.sendMessage("commands.bentobox.migrate.names");
-            new Database<>(getPlugin(), Names.class).loadObjects();
-            user.sendMessage(MIGRATED);
-            // Migrate addons data
             user.sendMessage("commands.bentobox.migrate.addons");
-            getPlugin().getAddonsManager().getDataObjects().forEach(t -> {
+            Set<Class<? extends DataObject>> classSet = getPlugin().getAddonsManager().getDataObjects();
+            classSet.addAll(Database.getDataobjects());
+            classSet.forEach(t -> {
                 user.sendMessage("commands.bentobox.migrate.class", TextVariables.DESCRIPTION, BentoBox.getInstance().getSettings().getDatabasePrefix() + t.getCanonicalName());
                 new Database<>(getPlugin(), t).loadObjects();
                 user.sendMessage(MIGRATED);

--- a/src/main/java/world/bentobox/bentobox/database/Database.java
+++ b/src/main/java/world/bentobox/bentobox/database/Database.java
@@ -3,7 +3,9 @@ package world.bentobox.bentobox.database;
 import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
@@ -12,6 +14,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.database.objects.DataObject;
 
 /**
  * Handy class to store and load Java POJOs in the Database
@@ -24,15 +27,19 @@ public class Database<T> {
     private final AbstractDatabaseHandler<T> handler;
     private final Logger logger;
     private static DatabaseSetup databaseSetup = DatabaseSetup.getDatabase();
+    private static final Set<Class<? extends DataObject>> dataObjects = new HashSet<>();
 
     /**
      * Construct a database
      * @param plugin - plugin
      * @param type - to store this type
      */
+    @SuppressWarnings("unchecked")
     public Database(BentoBox plugin, Class<T> type)  {
         this.logger = plugin.getLogger();
         handler = databaseSetup.getHandler(type);
+        // Log any database classes
+        dataObjects.add((Class<? extends DataObject>) type);
     }
 
     /**
@@ -40,9 +47,12 @@ public class Database<T> {
      * @param addon - addon requesting
      * @param type - to store this type
      */
+    @SuppressWarnings("unchecked")
     public Database(Addon addon, Class<T> type)  {
         this.logger = addon.getLogger();
         handler = databaseSetup.getHandler(type);
+        // Log any database classes
+        dataObjects.add((Class<? extends DataObject>) type);
     }
 
     /**
@@ -147,6 +157,13 @@ public class Database<T> {
      */
     public void close() {
         handler.close();
+    }
+
+    /**
+     * @return the dataobjects
+     */
+    public static Set<Class<? extends DataObject>> getDataobjects() {
+        return dataObjects;
     }
 
 

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
@@ -716,11 +717,14 @@ public class AddonsManager {
      * @return list of DataObjects
      * @since 1.5.0
      */
-    public List<Class<?>> getDataObjects() {
+    @SuppressWarnings("unchecked")
+    public Set<Class<? extends DataObject>> getDataObjects() {
         return classes.values().stream().filter(DataObject.class::isAssignableFrom)
                 // Do not include config files
-                .filter(c -> !ConfigObject.class.isAssignableFrom(c)).toList();
+                .filter(c -> !ConfigObject.class.isAssignableFrom(c)).map(c -> (Class<? extends DataObject>) c)
+                .collect(Collectors.toSet());
     }
+
 
     /**
      * Notifies all addons that BentoBox has loaded all addons


### PR DESCRIPTION
Previously, when all Addons were Addons and men were men, the DataObjects could be tracked using the BentoBox custom ClassLoader. However, as Addons now can be and usually are loaded using the Bukkit Classloader, this is no longer possible. However, we can track them when a Database class is instantiated and use that. This relies on Addons declaring their database objects. If they have not when the migration command is run, then obviously they cannot be transfered.

Fixes #2276 