### PR TITLE
Fixes EXP reset for players onJoin and onLeave

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -109,6 +109,10 @@ public class AdminDeleteCommand extends ConfirmableCommand {
 
         // Reset the XP
         if (getIWM().isOnLeaveResetXP(getWorld())) {
+            // Player collected XP (displayed)
+            target.getPlayer().setLevel(0);
+            target.getPlayer().setExp(0);
+            // Player total XP (not displayed)
             target.getPlayer().setTotalExperience(0);
         }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -218,6 +218,10 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
 
         // Reset the XP
         if (getIWM().isOnJoinResetXP(getWorld())) {
+            // Player collected XP (displayed)
+            user.getPlayer().setLevel(0);
+            user.getPlayer().setExp(0);
+            // Player total XP (not displayed)
             user.getPlayer().setTotalExperience(0);
         }
 

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1177,6 +1177,10 @@ public class IslandsManager {
 
             // Reset the XP
             if (plugin.getIWM().isOnJoinResetXP(world)) {
+                // Player collected XP (displayed)
+                user.getPlayer().setLevel(0);
+                user.getPlayer().setExp(0);
+                // Player total XP (not displayed)
                 user.getPlayer().setTotalExperience(0);
             }
 

--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -489,6 +489,10 @@ public class PlayersManager {
 
         // Reset the XP
         if (plugin.getIWM().isOnLeaveResetXP(world) && target.isPlayer()) {
+            // Player collected XP (displayed)
+            target.getPlayer().setLevel(0);
+            target.getPlayer().setExp(0);
+            // Player total XP (not displayed)
             target.getPlayer().setTotalExperience(0);
         }
         // Save player


### PR DESCRIPTION
The total experience does not reset player collected exp. This fixes that, as it will set level to 0 and progress in towards next level to 0