### PR TITLE
Center default home

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -1724,7 +1724,7 @@ public class Island implements DataObject, MetaDataAble {
     public Location getHome(final String nameToLookFor) {
         return getHomes().entrySet().stream().filter(en -> en.getKey().equalsIgnoreCase(nameToLookFor))
                 .map(Entry::getValue)
-                .findFirst().orElse(getProtectionCenter());
+                .findFirst().orElse(getProtectionCenter().clone().add(new Vector(0.5D, 0D, 0.5D)));
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PlaceBlocksListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/PlaceBlocksListener.java
@@ -16,7 +16,6 @@ import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
-import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.flags.FlagListener;
 import world.bentobox.bentobox.lists.Flags;
 
@@ -69,7 +68,6 @@ public class PlaceBlocksListener extends FlagListener
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onHangingPlace(final HangingPlaceEvent e)
     {
-        BentoBox.getInstance().logDebug(e.getEventName());
         this.checkIsland(e, e.getPlayer(), e.getBlock().getLocation(), Flags.PLACE_BLOCKS);
     }
 


### PR DESCRIPTION
As requested on Discord - places player in the center of the block when starting an island. Seen especially on OneBlock where there is no spawn_here sign.