### PR TITLE
Adds multi-island support for the Admin Register and Unregister commands.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
@@ -44,6 +44,11 @@ public class AdminRegisterCommand extends ConfirmableCommand {
             showHelp(this, user);
             return false;
         }
+        // Check world
+        if (!getWorld().equals(user.getWorld())) {
+            user.sendMessage("general.errors.wrong-world");
+            return false;
+        }
         // Get target
         targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.api.commands.admin;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -81,9 +82,8 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        if (targetIsland == null || targetUUID == null) {
-            return true;
-        }
+        Objects.requireNonNull(targetIsland);
+        Objects.requireNonNull(targetUUID);
         // Everything's fine, we can set the island as spawn :)
         askConfirmation(user, () -> unregisterIsland(user));
         return true;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
@@ -2,8 +2,12 @@ package world.bentobox.bentobox.api.commands.admin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
@@ -15,6 +19,9 @@ import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 public class AdminUnregisterCommand extends ConfirmableCommand {
+
+    private Island targetIsland;
+    private @Nullable UUID targetUUID;
 
     public AdminUnregisterCommand(CompositeCommand parent) {
         super(parent, "unregister");
@@ -30,12 +37,12 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
         // If args are not right, show help
-        if (args.size() != 1) {
+        if (args.isEmpty()) {
             showHelp(this, user);
             return false;
         }
         // Get target
-        UUID targetUUID = Util.getUUID(args.get(0));
+        targetUUID = Util.getUUID(args.get(0));
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
             return false;
@@ -44,43 +51,61 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         }
+        // Check if the player has more than one island
+        Map<String, Island> islands = getIslandsXYZ(targetUUID);
+        if (islands.size() == 0) {
+            user.sendMessage("general.errors.player-has-no-island");
+            return false;
+        } else if (args.size() == 1) {
+            // They need to specify which island
+            user.sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
+            user.sendMessage("commands.admin.unregister.errors.specify-island-location");
+            return false;
+        } else if (args.size() != 2) {
+            // Check if the name given works
+            user.sendMessage("commands.admin.unregister.errors.specify-island-location");
+            return false;
+        } else if (!islands.containsKey(args.get(1))) {
+            user.sendMessage("commands.admin.unregister.errors.unknown-island-location");
+            return false;
+        }
+        targetIsland = islands.get(args.get(1));
         return true;
     }
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        // Get target
-        UUID targetUUID = getPlayers().getUUID(args.get(0));
+        if (targetIsland == null || targetUUID == null) {
+            return true;
+        }
         // Everything's fine, we can set the island as spawn :)
-        askConfirmation(user,  () -> unregisterPlayer(user, args.get(0), targetUUID));
+        askConfirmation(user, () -> unregisterIsland(user));
         return true;
     }
 
-    void unregisterPlayer(User user, String targetName, UUID targetUUID) {
+    void unregisterIsland(User user) {
         // Unregister island
-        Island oldIsland = getIslands().getIsland(getWorld(), targetUUID);
-        if (oldIsland == null) return;
         IslandEvent.builder()
-        .island(oldIsland)
-        .location(oldIsland.getCenter())
+        .island(targetIsland)
+        .location(targetIsland.getCenter())
         .reason(IslandEvent.Reason.UNREGISTERED)
         .involvedPlayer(targetUUID)
         .admin(true)
         .build();
         IslandEvent.builder()
-        .island(oldIsland)
+        .island(targetIsland)
         .involvedPlayer(targetUUID)
         .admin(true)
         .reason(IslandEvent.Reason.RANK_CHANGE)
         .rankChange(RanksManager.OWNER_RANK, RanksManager.VISITOR_RANK)
         .build();
         // Remove all island members
-        oldIsland.getMemberSet().forEach(m -> getIslands().removePlayer(getWorld(), m));
+        targetIsland.getMemberSet().forEach(m -> getIslands().removePlayer(targetIsland, m));
         // Remove all island players that reference this island
-        oldIsland.getMembers().clear();
-        getIslands().save(oldIsland);
-        user.sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, Util.xyz(oldIsland.getCenter().toVector()),
-                TextVariables.NAME, targetName);
+        targetIsland.getMembers().clear();
+        getIslands().save(targetIsland);
+        user.sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, Util.xyz(targetIsland.getCenter().toVector()),
+                TextVariables.NAME, getPlayers().getName(targetUUID));
     }
 
     @Override
@@ -89,8 +114,22 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
         if (args.isEmpty()) {
             // Don't show every player on the server. Require at least the first letter
             return Optional.empty();
+        } else if (args.size() == 2) {
+            List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
+            return Optional.of(Util.tabLimit(options, lastArg));
+        } else {
+            // Find out which user
+            UUID uuid = getPlayers().getUUID(args.get(1));
+            if (uuid != null) {
+                return Optional.of(Util.tabLimit(new ArrayList<>(getIslandsXYZ(uuid).keySet()), lastArg));
+            }
         }
-        List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
-        return Optional.of(Util.tabLimit(options, lastArg));
+        return Optional.empty();
     }
+
+    private Map<String, Island> getIslandsXYZ(UUID target) {
+        return getIslands().getOwnedIslands(getWorld(), target).stream()
+                .collect(Collectors.toMap(island -> Util.xyz(island.getCenter().toVector()), island -> island));
+    }
+
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
@@ -57,10 +57,15 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         } else if (args.size() == 1) {
-            // They need to specify which island
-            user.sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
-            user.sendMessage("commands.admin.unregister.errors.specify-island-location");
-            return false;
+            if (islands.size() == 1) {
+                targetIsland = islands.values().iterator().next();
+                return true;
+            } else {
+                // They need to specify which island
+                user.sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
+                user.sendMessage("commands.admin.unregister.errors.specify-island-location");
+                return false;
+            }
         } else if (args.size() != 2) {
             // Check if the name given works
             user.sendMessage("commands.admin.unregister.errors.specify-island-location");

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommand.java
@@ -13,6 +13,7 @@ import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.logs.LogEntry;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
@@ -104,10 +105,13 @@ public class AdminUnregisterCommand extends ConfirmableCommand {
         .reason(IslandEvent.Reason.RANK_CHANGE)
         .rankChange(RanksManager.OWNER_RANK, RanksManager.VISITOR_RANK)
         .build();
+        targetIsland.setOwner(null);
         // Remove all island members
         targetIsland.getMemberSet().forEach(m -> getIslands().removePlayer(targetIsland, m));
         // Remove all island players that reference this island
         targetIsland.getMembers().clear();
+        targetIsland.log(new LogEntry.Builder("UNREGISTER").data("player", targetUUID.toString())
+                .data("admin", user.getUniqueId().toString()).build());
         getIslands().save(targetIsland);
         user.sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, Util.xyz(targetIsland.getCenter().toVector()),
                 TextVariables.NAME, getPlayers().getName(targetUUID));

--- a/src/main/java/world/bentobox/bentobox/blueprints/BlueprintPaster.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/BlueprintPaster.java
@@ -36,6 +36,9 @@ import world.bentobox.bentobox.util.Util;
  */
 public class BlueprintPaster {
 
+    /**
+     * This tracks the stages of pasting from loading the chunk, pasting blocks, attachments, entities and then finishing.
+     */
     enum PasteState {
         CHUNK_LOAD,
         CHUNK_LOADING,

--- a/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintBlock.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintBlock.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import com.google.gson.annotations.Expose;
 
 /**
+ * Represents a block to be pasted
  * @author tastybento
  * @since 1.5.0
  */
@@ -19,8 +20,14 @@ public class BlueprintBlock {
 
     @Expose
     private String blockData;
+    /**
+     * Front of sign
+     */
     @Expose
     private List<String> signLines;
+    /**
+     * Back of sign
+     */
     @Expose
     private List<String> signLines2;
     @Expose
@@ -37,8 +44,14 @@ public class BlueprintBlock {
      */
     @Expose
     private List<Pattern> bannerPatterns;
+    /**
+     * Front of sign
+     */
     @Expose
     private boolean glowingText;
+    /**
+     * Back of sign
+     */
     @Expose
     private boolean glowingText2;
 

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -326,16 +326,45 @@ public class IslandsManager {
     }
 
     /**
-     * Gets all the islands for this player in this world. If they are in a team,
-     * the team island is returned.
+     * Gets all the islands for this player in this world including team islands.
      * 
      * @param world world to check
-     * @param uniqueId  user's uuid
+     * @param uniqueId  user's UUID
      * @return List of islands or empty list if none found for user
      */
     @NonNull
     public Set<Island> getIslands(@NonNull World world, UUID uniqueId) {
         return islandCache.getIslands(world, uniqueId);
+    }
+
+    /**
+     * Gets all the islands for this player in this world that this player owns.
+     * 
+     * @param world world to check
+     * @param uniqueId  user's UUID
+     * @return List of islands or empty list if none found for user
+     * @since 2.1.0
+     */
+    @NonNull
+    public Set<Island> getOwnedIslands(@NonNull World world, @NonNull User user) {
+        if (user.getUniqueId() == null) {
+            return Collections.emptySet();
+        }
+        return getOwnedIslands(world, user.getUniqueId());
+    }
+
+    /**
+     * Gets all the islands for this player in this world that this player owns.
+     * 
+     * @param world world to check
+     * @param uniqueId  user's UUID
+     * @return List of islands or empty list if none found for user
+     * @since 2.1.0
+     */
+    @NonNull
+    public Set<Island> getOwnedIslands(@NonNull World world, @NonNull UUID uniqueId) {
+        return islandCache.getIslands(world, uniqueId).stream().filter(island -> uniqueId.equals(island.getOwner()))
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
@@ -171,6 +171,7 @@ public class PlaceholdersManager {
         }
         // Counts
         // Number of online members
+        // {@since 2.1.0}
         registerPlaceholder(addon, "island_online_members_count", user -> {
             if (user == null)
                 return "";

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -99,9 +99,6 @@ public class Util {
         int dist = plugin.getIWM().getIslandDistance(location.getWorld()) * 2;
         long x = Math.round((double) location.getBlockX() / dist) * dist + plugin.getIWM().getIslandXOffset(location.getWorld());
         long z = Math.round((double) location.getBlockZ() / dist) * dist + plugin.getIWM().getIslandZOffset(location.getWorld());
-        if (location.getBlockX() == x && location.getBlockZ() == z) {
-            return location;
-        }
         int y = plugin.getIWM().getIslandHeight(location.getWorld());
         return new Location(location.getWorld(), x, y, z);
     }

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -179,7 +179,7 @@ commands:
       island-is-spawn: "&6 Ostrov je spawn. Jsi si jistý? Potvrď opětovným zadáním
         příkazu."
     unregister:
-      parameters: "<owner>"
+      parameters: <owner> [x,y,z]
       description: odregistrovat vlastníka z ostrova, ale zachovat bloky ostrova
       unregistered-island: "&a Hráč odregistrován z ostrova [xyz]."
     info:

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -188,7 +188,7 @@ commands:
       island-is-spawn: "&6 Die Insel ist der Spawn. Bist du sicher? Gib den Befehl
         zur Bestätigung noch einmal ein."
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: Besitzer von Insel entfernen, aber Inselblöcke behalten
       unregistered-island: "&a Unregistrierter Spieler von der Insel bei [xyz]."
     info:

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -192,13 +192,13 @@ commands:
         for possible errors.'
       island-is-spawn: '&6 Island is spawn. Are you sure? Enter command again to confirm.'
     unregister:
-      parameters: <owner> [x,y,z]
-      description: unregister owner from island, but keep island blocks
+      parameters: "<owner> [x,y,z]"
+      description: "unregister owner from island, but keep island blocks"
       unregistered-island: '&a Unregistered [name] from island at [xyz].'
       errors:
         unknown-island-location: "&c Unknown island location"
         specify-island-location: "&c Specify island location in x,y,z format"
-        player-has-more-than-one-island: "&c Player has more than one island"
+        player-has-more-than-one-island: "&c Player has more than one island. Specify which one."
     info:
       parameters: <player>
       description: get info on where you are or player's island

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -192,9 +192,13 @@ commands:
         for possible errors.'
       island-is-spawn: '&6 Island is spawn. Are you sure? Enter command again to confirm.'
     unregister:
-      parameters: <owner>
+      parameters: <owner> [x,y,z]
       description: unregister owner from island, but keep island blocks
       unregistered-island: '&a Unregistered [name] from island at [xyz].'
+      errors:
+        unknown-island-location: "&c Unknown island location"
+        specify-island-location: "&c Specify island location in x,y,z format"
+        player-has-more-than-one-island: "&c Player has more than one island"
     info:
       parameters: <player>
       description: get info on where you are or player's island

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -190,7 +190,7 @@ commands:
       island-is-spawn: "&6La isla está spawneada. ¿Estás seguro? Ingrese el comando
         nuevamente para confirmar."
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: Desregistrar propietario de isla, pero mantener bloques de islas
       unregistered-island: "&aRemover jugador de la isla registrada en [xyz]."
     info:

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -185,7 +185,7 @@ commands:
       island-is-spawn: "&6 L'île est un spawn. Êtes-vous sûr? Entrez à nouveau la
         commande pour confirmer."
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: désenregistrer le propriétaire de l''île, mais garder les blocs
         de l''île
       unregistered-island: "&b [name] &a a été supprimé de l'île à [xyz]."

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -182,7 +182,7 @@ commands:
       island-is-spawn: "&6 Otok je mrijest. Jesi li siguran? Ponovno unesite naredbu
         za potvrdu."
     unregister:
-      parameters: "<vlasnik>"
+      parameters: "<vlasnik> [x,y,z]"
       description: odjaviti vlasnika s otoka, ali zadržati otočne blokove
       unregistered-island: "&a Neregistrirano [name] otoka na [xyz]."
     info:

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -190,7 +190,7 @@ commands:
       island-is-spawn: "&6 A sziget spawn. biztos vagy ebben? A megerősítéshez írja
         be újra a parancsot."
     unregister:
-      parameters: "<tulajdonos>"
+      parameters: "<tulajdonos> [x,y,z]"
       description: törölje a tulajdonos regisztrációját a szigetről, de tartsa meg
         a szigettömböket
       unregistered-island: "&a Nem regisztrált [name] a következő szigetről: [xyz]."

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -190,7 +190,7 @@ commands:
       island-is-spawn: "&6 Pulau muncul. Apa kamu yakin? Masukkan perintah lagi untuk
         mengonfirmasi."
     unregister:
-      parameters: "<pemilik>"
+      parameters: "<pemilik> [x,y,z]"
       description: batalkan pendaftaran pemilik dari pulau, tetapi pertahankan blok
         pulau
       unregistered-island: "&a [name] tidak terdaftar dari pulau di [xyz]."

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -364,7 +364,7 @@ commands:
       title: "&d=========== Isole nel Cestino ==========="
     unregister:
       description: dissocia un proprietario dall'isola, ma mantenendo i blocchi dell'isola
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       unregistered-island: "&aDisassociato il giocatore dall'isola a [xyz]."
     version:
       description: mostra le versioni di BentoBox e degli addons

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -170,7 +170,7 @@ commands:
       cannot-make-island: "&c島はここに配置できません。申し訳ありません。考えられるエラーについては、コンソールをご覧ください。"
       island-is-spawn: "&6島が生成されます。本気ですか？もう一度コマンドを入力して確認します。"
     unregister:
-      parameters: "<所有者>"
+      parameters: "<所有者> [x,y,z]"
       description: 島から所有者を登録解除するが、島のブロックを維持する
       unregistered-island: "[xyz]で島から未登録のプレーヤー。"
     info:

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -164,7 +164,7 @@ commands:
       cannot-make-island: "&c 섬은 이곳에 만들수 없습니다. 죄송합니다. 콘솔을 참고해주세요."
       island-is-spawn: "&6 섬이 생성되었습니다. 정말로 하시겠습니까? 명령어를 한번더 입력해주세요."
     unregister:
-      parameters: "<주인>"
+      parameters: "<주인> [x,y,z]"
       description: 섬을 주인없는 섬으로 만들지만 섬은 유지됩니다
       unregistered-island: "&a [xyz]에 있는 [name]의 섬을 주인 없는 섬으로 만들었습니다."
     info:

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -385,7 +385,7 @@ commands:
         uz spēlētāja salu no atkritnes."
     unregister:
       description: atreģistrē īpašnieku no salas paturot salas blokus
-      parameters: "<īpašnieks>"
+      parameters: "<īpašnieks> [x,y,z]"
       unregistered-island: "&aSpēlētājs atreģistrēts no salas ar koordinātēm [xyz]."
     version:
       description: attaino BentoBox un papildinājumu versijas

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -186,7 +186,7 @@ commands:
       island-is-spawn: "&6 Eiland wordt uitgezet. Weet je het zeker? Voer de opdracht
         nogmaals in om te bevestigen."
     unregister:
-      parameters: "<eigenaar>"
+      parameters: "<eigenaar> [x,y,z]"
       description: de registratie van de eigenaar van het eiland ongedaan maken, maar
         eilandblokken behouden
       unregistered-island: "&a niet-geregistreerde [name] van het eiland op [xyz]."

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -174,7 +174,7 @@ commands:
       island-is-spawn: '&6 Ta wyspa jest wyspą spawnu. Jesteś pewny? Wpisz ponownie
         tę komendę.'
     unregister:
-      parameters: <właściciel>
+      parameters: "<właściciel> [x,y,z]"
       description: wyrejestruj właściciela z wyspy, ale zachowaj bloki wyspy
       unregistered-island: '&aWyrejestrowano gracza z wyspy [xyz].'
     info:

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -192,7 +192,7 @@ commands:
       island-is-spawn: "&6 Ilha é spawn. Você tem certeza? Digite o comando novamente
         para confirmar."
     unregister:
-      parameters: "<proprietário>"
+      parameters: "<proprietário> [x,y,z]"
       description: Remover o registro de dono da ilha, mas manter os blocos da ilha
       unregistered-island: "&a Registro removido de [name] de ilha em [xyz]."
     info:

--- a/src/main/resources/locales/pt_BR.yml
+++ b/src/main/resources/locales/pt_BR.yml
@@ -173,7 +173,7 @@ commands:
       island-is-spawn: '&6 Essa ilha é o spawn. Você tem certeza? Digite o comando
         novamente para confirmar.'
     unregister:
-      parameters: <dono>
+      parameters: "<dono> [x,y,z]"
       description: desregistrar dono da ilha, mas manter os blocos
       unregistered-island: '&a [name] desregistrado da ilha em [xyz].'
     info:

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -187,7 +187,7 @@ commands:
       island-is-spawn: "&6 Insula este reprodusă. Esti sigur? Introduceți din nou
         comanda pentru a confirma."
     unregister:
-      parameters: "<proprietar>"
+      parameters: "<proprietar> [x,y,z]"
       description: anulați înregistrarea proprietarului de pe insulă, dar păstrați
         blocurile de insule
       unregistered-island: "&a [name] neînregistrat de pe insulă la [xyz]."

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -185,7 +185,7 @@ commands:
       island-is-spawn: "&6Остров является спавном. Вы уверены? Введите команду снова
         для подтверждения."
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: разрегистрирует остров, но сохраняет блоки на острове
       unregistered-island: "&aИгрок [name] разрегистрирован с острова на координатах
         [xyz]."

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -186,7 +186,7 @@ commands:
       island-is-spawn: "&6Başlangıç adası, buna emin misiniz ?Kabul etmek için komutu
         tekrar girin!"
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: Oyuncuyu adadan siler ama ada silinmez.
       unregistered-island: "&aOyuncu başarıyla &e[xyz] &akoordinatlarındaki adadan
         silindi!"

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -185,7 +185,7 @@ commands:
         консоль для можливих помилок."
       island-is-spawn: "&6 Острів ікру. Ти впевнений? Введіть команду ще раз для підтвердження."
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: скасувати реєстрацію власника з острова, але зберегти блоки острова
       unregistered-island: "&a Незареєстрований [name] з острова на [xyz]."
     info:

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -180,7 +180,7 @@ commands:
       island-is-spawn: "&6 Đảo là điểm triệu hồi. Bạn chắc chứ? Nhập lần nữa để xác
         nhận."
     unregister:
-      parameters: "<chủ>"
+      parameters: "<chủ> [x,y,z]"
       description: hủy đăng kí chủ đảo khỏi đảo này. nhưng giữ lại tài nguyên đảo
       unregistered-island: "&a Đã hủy đăng kí [name] khỏi đảo tại [xyz]."
     info:

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -176,7 +176,7 @@ commands:
         &c所处位置为出生点岛屿， 您确定要将玩家注册到这个岛屿上？
         &6请再次输入命令以确认。
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: 注销岛主身份， 但保留岛屿资源。
       unregistered-island: "&a已将岛主 &b[name] &a从位于 &b[xyz] &a的岛屿注销。"
     info:

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -187,7 +187,7 @@ commands:
         &c所處位置為出生點島嶼， 您確定要將玩家注冊到這個島嶼上？
         &6請再次輸入命令以確認。
     unregister:
-      parameters: "<owner>"
+      parameters: "<owner> [x,y,z]"
       description: "將島主註銷但保留方塊"
       unregistered-island: "&a已將位於 [xyz] 的島嶼的玩家註銷。"
     info:

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -95,6 +95,8 @@ public class AdminRegisterCommandTest {
         Settings settings = new Settings();
         // Settings
         when(plugin.getSettings()).thenReturn(settings);
+        // World
+        when(ac.getWorld()).thenReturn(world);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -112,6 +114,7 @@ public class AdminRegisterCommandTest {
         when(user.getUniqueId()).thenReturn(uuid);
         when(user.getPlayer()).thenReturn(p);
         when(user.getName()).thenReturn("tastybento");
+        when(user.getWorld()).thenReturn(world);
         when(user.getTranslation(anyString()))
                 .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
         User.getInstance(p);
@@ -183,6 +186,17 @@ public class AdminRegisterCommandTest {
     public void testCanExecuteNoTarget() {
         assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
+    }
+
+    /**
+     * Test method for
+     * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
+     */
+    @Test
+    public void testCanExecuteWrongWorld() {
+        when(user.getWorld()).thenReturn(mock(World.class));
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        verify(user).sendMessage("general.errors.wrong-world");
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -3,19 +3,24 @@ package world.bentobox.bentobox.api.commands.admin;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -26,12 +31,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -42,6 +49,7 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -49,7 +57,7 @@ import world.bentobox.bentobox.util.Util;
  *
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ Bukkit.class, BentoBox.class, User.class })
+@PrepareForTest({ Bukkit.class, BentoBox.class, Util.class })
 public class AdminRegisterCommandTest {
 
     @Mock
@@ -61,10 +69,19 @@ public class AdminRegisterCommandTest {
     private IslandsManager im;
     @Mock
     private PlayersManager pm;
+    @Mock
+    private Island is;
+    @Mock
+    private Location loc;
 
     private UUID notUUID;
 
     private IslandDeletionManager idm;
+    private AdminRegisterCommand itl;
+    @Mock
+    private World world;
+    @Mock
+    private Block block;
 
     /**
      */
@@ -74,6 +91,10 @@ public class AdminRegisterCommandTest {
         BentoBox plugin = mock(BentoBox.class);
         Whitebox.setInternalState(BentoBox.class, "instance", plugin);
         Util.setPlugin(plugin);
+
+        Settings settings = new Settings();
+        // Settings
+        when(plugin.getSettings()).thenReturn(settings);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -91,7 +112,14 @@ public class AdminRegisterCommandTest {
         when(user.getUniqueId()).thenReturn(uuid);
         when(user.getPlayer()).thenReturn(p);
         when(user.getName()).thenReturn("tastybento");
+        when(user.getTranslation(anyString()))
+                .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+        User.getInstance(p);
         User.setPlugin(plugin);
+
+        // Util
+        PowerMockito.mockStatic(Util.class, Mockito.RETURNS_MOCKS);
+        when(Util.getUUID("tastybento")).thenReturn(uuid);
 
         // Parent command has no aliases
         when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
@@ -131,6 +159,14 @@ public class AdminRegisterCommandTest {
         PluginManager pim = mock(PluginManager.class);
         when(Bukkit.getPluginManager()).thenReturn(pim);
 
+        // Island
+        when(is.getWorld()).thenReturn(world);
+        when(is.getCenter()).thenReturn(loc);
+        when(im.createIsland(any(), eq(uuid))).thenReturn(is);
+        when(loc.getBlock()).thenReturn(block);
+
+        // DUT
+        itl = new AdminRegisterCommand(ac);
     }
 
     @After
@@ -141,81 +177,64 @@ public class AdminRegisterCommandTest {
 
     /**
      * Test method for
-     * {@link AdminRegisterCommand#execute(org.bukkit.command.CommandSender, String, String[])}.
+     * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testExecuteNoTarget() {
-        AdminRegisterCommand itl = new AdminRegisterCommand(ac);
-        assertFalse(itl.execute(user, itl.getLabel(), new ArrayList<>()));
+    public void testCanExecuteNoTarget() {
+        assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
     }
 
     /**
      * Test method for
-     * {@link AdminRegisterCommand#execute(org.bukkit.command.CommandSender, String, String[])}.
+     * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
-        AdminRegisterCommand itl = new AdminRegisterCommand(ac);
+    public void testCanExecuteUnknownPlayer() {
         when(pm.getUUID(any())).thenReturn(null);
-        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
-        verify(user).sendMessage(eq("general.errors.unknown-player"), eq("[name]"), eq("tastybento"));
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento2")));
+        verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "tastybento2");
     }
 
     /**
      * Test method for
-     * {@link AdminRegisterCommand#execute(org.bukkit.command.CommandSender, String, String[])}.
+     * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testExecutePlayerHasIsland() {
-        AdminRegisterCommand itl = new AdminRegisterCommand(ac);
-        when(pm.getUUID(any())).thenReturn(notUUID);
-        when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
-        when(im.inTeam(any(), any())).thenReturn(false);
-        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
-        verify(user).sendMessage(eq("general.errors.player-has-island"));
+    public void testCanExecuteNoIsland() {
+        when(im.getIslandAt(any())).thenReturn(Optional.empty());
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        verify(user).getTranslation("commands.admin.register.no-island-here");
     }
 
-    /**
-     * Test method for {@link AdminRegisterCommand#execute(org.bukkit.command.CommandSender, String, String[])}.
-     */
-    @Test
-    public void testExecuteInTeam() {
-        when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
-        when(im.inTeam(any(), any())).thenReturn(true);
-        when(pm.getUUID(any())).thenReturn(notUUID);
-        AdminRegisterCommand itl = new AdminRegisterCommand(ac);
-        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
-        verify(user).sendMessage("commands.admin.register.cannot-register-team-player");
-    }
 
     /**
-     * Test method for {@link AdminRegisterCommand#execute(org.bukkit.command.CommandSender, String, String[])}.
+     * Test method for {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testExecuteAlreadyOwnedIsland() {
+    public void testCanExecuteAlreadyOwnedIsland() {
         when(im.inTeam(any(), any())).thenReturn(false);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(pm.getUUID(any())).thenReturn(notUUID);
         Location loc = mock(Location.class);
-
+        when(loc.toVector()).thenReturn(new Vector(1, 2, 3));
         // Island has owner
-        Island is = mock(Island.class);
         when(is.getOwner()).thenReturn(uuid);
         when(is.isOwned()).thenReturn(true);
+        when(is.getCenter()).thenReturn(loc);
         Optional<Island> opi = Optional.of(is);
         when(im.getIslandAt(any())).thenReturn(opi);
         when(user.getLocation()).thenReturn(loc);
-        AdminRegisterCommand itl = new AdminRegisterCommand(ac);
-        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
+
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).sendMessage("commands.admin.register.already-owned");
     }
 
     /**
-     * Test method for {@link AdminRegisterCommand#execute(org.bukkit.command.CommandSender, String, String[])}.
+     * Test method for {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testExecuteInDeletionIsland() {
+    public void testCanExecuteInDeletionIsland() {
         when(idm.inDeletion(any())).thenReturn(true);
         when(im.inTeam(any(), any())).thenReturn(false);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
@@ -223,25 +242,20 @@ public class AdminRegisterCommandTest {
         Location loc = mock(Location.class);
 
         // Island has owner
-        Island is = mock(Island.class);
         when(is.getOwner()).thenReturn(uuid);
         Optional<Island> opi = Optional.of(is);
         when(im.getIslandAt(any())).thenReturn(opi);
         when(user.getLocation()).thenReturn(loc);
-        AdminRegisterCommand itl = new AdminRegisterCommand(ac);
-        assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
+
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).sendMessage("commands.admin.register.in-deletion");
     }
 
     /**
-     * Test method for {@link AdminRegisterCommand#execute(org.bukkit.command.CommandSender, String, String[])}.
+     * Test method for {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testExecuteSuccess() {
-        when(im.inTeam(any(), any())).thenReturn(false);
-        when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
-        Island is = mock(Island.class);
-        Location loc = mock(Location.class);
+    public void testCanExecuteSuccess() {
         when(loc.toVector()).thenReturn(new Vector(123,123,432));
         when(is.getCenter()).thenReturn(loc);
         when(im.getIsland(any(), any(UUID.class))).thenReturn(is);
@@ -250,11 +264,48 @@ public class AdminRegisterCommandTest {
         when(user.getLocation()).thenReturn(loc);
         when(pm.getUUID(any())).thenReturn(notUUID);
 
-        AdminRegisterCommand itl = new AdminRegisterCommand(ac);
-        assertTrue(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
-        // Add other verifications
-        verify(user).sendMessage(eq("commands.admin.register.registered-island"), eq(TextVariables.XYZ), eq("123,123,432"), eq("[name]"), eq("tastybento"));
-        verify(user).sendMessage(eq("general.success"));
+        assertTrue(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+    }
+
+    /**
+     * Test method for {@link AdminRegisterCommand#register(User, String)}.
+     */
+    @Test
+    public void testRegister() {
+        testCanExecuteSuccess();
+        when(is.isSpawn()).thenReturn(true);
+        itl.register(user, "tastybento");
+        verify(im).setOwner(user, uuid, is, RanksManager.VISITOR_RANK);
+        verify(im).clearSpawn(world);
+        verify(user).sendMessage("commands.admin.register.registered-island", TextVariables.XYZ, "", TextVariables.NAME,
+                "tastybento");
+        verify(user).sendMessage("general.success");
+    }
+
+    /**
+     * Test method for {@link AdminRegisterCommand#reserve(User, String)}.
+     */
+    @Test
+    public void testReserveCannotMakeIsland() {
+        when(im.createIsland(any(), eq(uuid))).thenReturn(null);
+        testCanExecuteNoIsland();
+        itl.reserve(user, "tastybento");
+        verify(im).createIsland(any(), eq(uuid));
+        verify(user).sendMessage("commands.admin.register.cannot-make-island");
+    }
+
+    /**
+     * Test method for {@link AdminRegisterCommand#reserve(User, String)}.
+     */
+    @Test
+    public void testReserveCanMakeIsland() {
+        testCanExecuteNoIsland();
+        itl.reserve(user, "tastybento");
+        verify(im).createIsland(any(), eq(uuid));
+        verify(user, never()).sendMessage("commands.admin.register.cannot-make-island");
+        verify(block).setType(Material.BEDROCK);
+        verify(user).sendMessage("commands.admin.register.reserved-island", TextVariables.XYZ, "", TextVariables.NAME,
+                "tastybento");
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
@@ -266,6 +266,7 @@ public class AdminUnregisterCommandTest {
         itl.unregisterIsland(user);
         verify(user).sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, "1,2,3",
                 TextVariables.NAME, "name");
+        verify(island).setOwner(null);
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
@@ -6,14 +6,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.framework;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -23,13 +23,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jdt.annotation.NonNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -48,7 +47,6 @@ import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
-import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -56,9 +54,10 @@ import world.bentobox.bentobox.util.Util;
  *
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ Bukkit.class, BentoBox.class, User.class })
+@PrepareForTest({ Bukkit.class, BentoBox.class })
 public class AdminUnregisterCommandTest {
 
+    private UUID uuid = UUID.randomUUID();
     @Mock
     private CompositeCommand ac;
     @Mock
@@ -70,6 +69,15 @@ public class AdminUnregisterCommandTest {
     private UUID notUUID;
     @Mock
     private World world;
+    @Mock
+    private Island island;
+    @Mock
+    private Island island2;
+    @Mock
+    private @NonNull Location location1;
+    @Mock
+    private @NonNull Location location2;
+    private AdminUnregisterCommand itl;
 
     /**
      */
@@ -92,15 +100,18 @@ public class AdminUnregisterCommandTest {
         // Player
         Player p = mock(Player.class);
         when(user.isOp()).thenReturn(false);
-        UUID uuid = UUID.randomUUID();
+
         notUUID = UUID.randomUUID();
         while (notUUID.equals(uuid)) {
             notUUID = UUID.randomUUID();
         }
+        User.setPlugin(plugin);
         when(user.getUniqueId()).thenReturn(uuid);
         when(user.getPlayer()).thenReturn(p);
         when(user.getName()).thenReturn("tastybento");
-        User.setPlugin(plugin);
+        when(pm.getUUID("tastybento")).thenReturn(uuid);
+        User.getInstance(p);
+
 
         // Parent command has no aliases
         when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
@@ -136,6 +147,21 @@ public class AdminUnregisterCommandTest {
         PluginManager pim = mock(PluginManager.class);
         when(Bukkit.getPluginManager()).thenReturn(pim);
 
+        // Islands
+        when(location1.toVector()).thenReturn(new Vector(1, 2, 3));
+        when(location2.toVector()).thenReturn(new Vector(4, 5, 6));
+        when(island.getCenter()).thenReturn(location1);
+        when(island2.getCenter()).thenReturn(location2);
+        when(island.getMemberSet()).thenReturn(ImmutableSet.of(uuid, notUUID));
+        when(island2.getMemberSet()).thenReturn(ImmutableSet.of(uuid, notUUID));
+        when(im.getOwnedIslands(world, uuid)).thenReturn(Set.of(island, island2));
+
+        // Player Manager
+        when(pm.getName(uuid)).thenReturn("name");
+        when(pm.getName(notUUID)).thenReturn("name2");
+
+        itl = new AdminUnregisterCommand(ac);
+
     }
 
     @After
@@ -149,8 +175,7 @@ public class AdminUnregisterCommandTest {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecuteNoTarget() {
-        AdminUnregisterCommand itl = new AdminUnregisterCommand(ac);
+    public void testCanExecuteNoTarget() {
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
         // Show help
     }
@@ -160,8 +185,7 @@ public class AdminUnregisterCommandTest {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
-        AdminUnregisterCommand itl = new AdminUnregisterCommand(ac);
+    public void testCanExecuteUnknownPlayer() {
         String[] name = { "tastybento" };
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), Arrays.asList(name)));
@@ -173,69 +197,85 @@ public class AdminUnregisterCommandTest {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayerNoIsland() {
-        AdminUnregisterCommand itl = new AdminUnregisterCommand(ac);
-        String[] name = { "tastybento" };
-        when(pm.getUUID(any())).thenReturn(notUUID);
-        when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
-        assertFalse(itl.canExecute(user, itl.getLabel(), Arrays.asList(name)));
-        verify(user).sendMessage(Mockito.eq("general.errors.player-has-no-island"));
+    public void testCanExecutePlayerFailNoIsland() {
+        // No island
+        when(im.getOwnedIslands(world, uuid)).thenReturn(Set.of());
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        verify(user).sendMessage("general.errors.player-has-no-island");
+    }
+
+    /**
+     * Test method for
+     * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
+     */
+    @Test
+    public void testCanExecutePlayerFailMoreIsland() {
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        verify(user).sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
+        verify(user).sendMessage("commands.admin.unregister.errors.specify-island-location");
+    }
+
+    /**
+     * Test method for
+     * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
+     */
+    @Test
+    public void testCanExecutePlayerFailWrongIsland() {
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "1,2,4")));
+        verify(user).sendMessage("commands.admin.unregister.errors.unknown-island-location");
+    }
+
+    /**
+     * Test method for
+     * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
+     */
+    @Test
+    public void testCanExecuteDiffernetPlayerFailWrongIsland() {
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("BoxManager", "1,2,4")));
+        verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "BoxManager");
+    }
+
+    /**
+     * Test method for
+     * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
+     */
+    @Test
+    public void testExecutePlayerSuccessMultiIsland() {
+        assertTrue(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "1,2,3")));
+        assertTrue(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "4,5,6")));
     }
 
     /**
      * Test method for {@link AdminUnregisterCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccess() {
-        when(im.inTeam(any(), any())).thenReturn(false);
-        Island is = mock(Island.class);
-        Location loc = mock(Location.class);
-        when(loc.toVector()).thenReturn(new Vector(123,123,432));
-        when(is.getCenter()).thenReturn(loc);
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(is);
-        String[] name = {"tastybento"};
-        when(pm.getUUID(any())).thenReturn(notUUID);
-
-        AdminUnregisterCommand itl = new AdminUnregisterCommand(ac);
-        assertTrue(itl.execute(user, itl.getLabel(), Arrays.asList(name)));
+    public void testExecuteSuccessOneIsland() {
+        when(im.getOwnedIslands(world, uuid)).thenReturn(Set.of(island));
+        itl.canExecute(user, itl.getLabel(), List.of("tastybento"));
+        assertTrue(itl.execute(user, itl.getLabel(), List.of("tastybento")));
         // Add other verifications
         verify(user).sendMessage("commands.confirmation.confirm", "[seconds]", "0");
     }
 
     /**
-     * Test method for {@link AdminUnregisterCommand#unregisterPlayer(User, UUID)}.
+     * Test method for {@link AdminUnregisterCommand#unregisterIsland(User)}
      */
     @Test
-    public void testUnregisterPlayer() {
-        @Nullable
-        Island oldIsland = mock(Island.class);
-        @Nullable
-        Location center = mock(Location.class);
-        when(oldIsland.getCenter()).thenReturn(center);
-        when(center.toVector()).thenReturn(new Vector(1, 2, 3));
-        // Members
-        UUID uuid1 = UUID.randomUUID();
-        UUID uuid2 = UUID.randomUUID();
-        UUID uuid3 = UUID.randomUUID();
-        ImmutableSet<UUID> imSet = ImmutableSet.of(uuid1, uuid2, uuid3);
-        when(oldIsland.getMemberSet()).thenReturn(imSet);
-        // Trusted member
-        UUID uuid4 = UUID.randomUUID();
-        // Map must be mutable because it is cleared
-        Map<UUID, Integer> map = new HashMap<>();
-        map.put(uuid4, RanksManager.TRUSTED_RANK);
-        when(oldIsland.getMembers()).thenReturn(map);
-        // Island
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(oldIsland);
-        AdminUnregisterCommand itl = new AdminUnregisterCommand(ac);
-        UUID targetUUID = UUID.randomUUID();
-        itl.unregisterPlayer(user, "name", targetUUID);
+    public void testUnregisterIsland() {
+        this.testExecuteSuccessOneIsland();
+        itl.unregisterIsland(user);
         verify(user).sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, "1,2,3",
                 TextVariables.NAME, "name");
-        assertTrue(map.isEmpty());
-        verify(im).removePlayer(any(World.class), eq(uuid1));
-        verify(im).removePlayer(any(World.class), eq(uuid2));
-        verify(im).removePlayer(any(World.class), eq(uuid3));
-        verify(im, never()).removePlayer(any(World.class), eq(uuid4));
+    }
+
+    /**
+     * Test method for {@link AdminUnregisterCommand#unregisterIsland(User)}
+     */
+    @Test
+    public void testUnregisterIslandMulti() {
+        this.testExecutePlayerSuccessMultiIsland();
+        itl.unregisterIsland(user);
+        verify(user).sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, "4,5,6",
+                TextVariables.NAME, "name");
     }
 }


### PR DESCRIPTION
Adds multi-island support for the Admin Register and Unregister commands.

As players may have more than one island, the specific island to unregister will be required to be given in x,y,z coordinates, e.g., `/bsbadmin unregister BoxManager 0,80,-1600`.

Fixes #2296 