### PR TITLE
Change respawn point to the default home on the island. #2305

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListener.java
@@ -55,7 +55,7 @@ public class IslandRespawnListener extends FlagListener {
      * 
      * @param e - event
      */
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerRespawn(PlayerRespawnEvent e) {
         final UUID worldUUID = respawn.remove(e.getPlayer().getUniqueId());
         if (worldUUID == null) {
@@ -67,11 +67,11 @@ public class IslandRespawnListener extends FlagListener {
             return; // world no longer available
         }
         World w = Util.getWorld(world);
+
         String ownerName = e.getPlayer().getName();
         if (w != null) {
-            final Location respawnLocation = getIslands().getPrimaryIsland(world, e.getPlayer().getUniqueId())
-                    .getSpawnPoint(world.getEnvironment());
-            if (respawnLocation != null) {
+            final Location respawnLocation = getIslands().getHomeLocation(world, e.getPlayer().getUniqueId());
+            if (respawnLocation != null && getIslands().isSafeLocation(respawnLocation)) {
                 e.setRespawnLocation(respawnLocation);
                 // Get the island owner name
                 Island island = BentoBox.getInstance().getIslands().getIsland(w, User.getInstance(e.getPlayer()));

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListenerTest.java
@@ -114,9 +114,10 @@ public class IslandRespawnListenerTest {
         when(iwm.getAddon(any())).thenReturn(opGma);
         safeLocation = mock(Location.class);
         when(safeLocation.getWorld()).thenReturn(world);
-        when(island.getSpawnPoint(Environment.NORMAL)).thenReturn(safeLocation);
+        when(im.getHomeLocation(eq(world), any(UUID.class))).thenReturn(safeLocation);
         when(im.getPrimaryIsland(any(), any())).thenReturn(island);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
+        when(im.isSafeLocation(safeLocation)).thenReturn(true);
         when(plugin.getIslands()).thenReturn(im);
 
         // when(im.getSafeHomeLocation(any(), any(),


### PR DESCRIPTION
Relates to #2305 

This changes the respawn point from the preset "spawn-here" location to the island's default home location. A safety check is also done. If the location isn't available or is unsafe then the server will respawn the user at the default for the server. i.e., it gives up.
