### PR TITLE
Fix for Island team kick requires confirmation when using GUI #2311

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommand.java
@@ -557,7 +557,7 @@ public class IslandTeamCommand extends CompositeCommand {
         case RanksManager.TRUSTED_RANK -> this.unTrustCommand.unTrustCmd(user, member.getUniqueId());
         default -> {
             if (kickCommand.canExecute(user, kickCommand.getLabel(), List.of(member.getName()))) {
-                yield kickCommand.execute(user, kickCommand.getLabel(), List.of(member.getName()));
+                yield kickCommand.kick(clicker, member.getUniqueId());
             } else {
                 yield false;
             }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -90,7 +90,10 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
         }
     }
 
-    protected void kick(User user, UUID targetUUID) {
+    protected boolean kick(User user, UUID targetUUID) {
+        if (targetUUID == null) {
+            return false;
+        }
         User target = User.getInstance(targetUUID);
         Island oldIsland = Objects.requireNonNull(getIslands().getIsland(getWorld(), targetUUID)); // Should never be
         // null because of
@@ -99,7 +102,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
         IslandBaseEvent event = TeamEvent.builder().island(oldIsland).reason(TeamEvent.Reason.KICK)
                 .involvedPlayer(targetUUID).build();
         if (event.isCancelled()) {
-            return;
+            return false;
         }
         target.sendMessage("commands.island.team.kick.player-kicked", TextVariables.GAMEMODE,
                 getAddon().getDescription().getName(), TextVariables.NAME, user.getName(), TextVariables.DISPLAY_NAME,
@@ -121,6 +124,7 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
             getParent().getSubCommand("invite").ifPresent(c -> c.setCooldown(oldIsland.getUniqueId(),
                     targetUUID.toString(), getSettings().getInviteCooldown() * 60));
         }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Team kicking via the GUI was requiring a confirmation.