### PR TITLE
Allow the maxhomes to apply per island.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
@@ -53,7 +53,7 @@ public class IslandSethomeCommand extends ConfirmableCommand {
 
         // Check number of homes
 
-        int maxHomes = getIslands().getIslands(getWorld(), user).stream().mapToInt(getIslands()::getMaxHomes).sum();
+        int maxHomes = getIslands().getMaxHomes(island);
         if (getIslands().getNumberOfHomesIfAdded(island, String.join(" ", args)) > maxHomes) {
             user.sendMessage("commands.island.sethome.too-many-homes", TextVariables.NUMBER, String.valueOf(maxHomes));
             user.sendMessage("commands.island.sethome.homes-are");

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
@@ -37,6 +37,7 @@ import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
+import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.CommandsManager;
@@ -193,6 +194,20 @@ public class IslandSethomeCommandTest {
         assertFalse(isc.canExecute(user, "island", Collections.emptyList()));
         verify(user, never()).sendMessage("general.errors.no-island");
         verify(user).sendMessage("commands.island.sethome.must-be-on-your-island");
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+     */
+    @Test
+    public void testCanExecuteTooManyHomes() {
+        when(im.getMaxHomes(island)).thenReturn(10);
+        when(im.getNumberOfHomesIfAdded(eq(island), anyString())).thenReturn(11);
+        IslandSethomeCommand isc = new IslandSethomeCommand(ic);
+        assertFalse(isc.canExecute(user, "island", Collections.emptyList()));
+        verify(user).sendMessage("commands.island.sethome.too-many-homes", TextVariables.NUMBER, "10");
+        verify(user).sendMessage("commands.island.sethome.homes-are");
     }
 
     /**


### PR DESCRIPTION
This switches the number of homes a player can make to be per-island rather than a sum of all islands.