### PR TITLE
Sort player's islands by age so they are always in the same order.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.DelayedTeleportCommand;
@@ -41,7 +40,7 @@ public class IslandGoCommand extends DelayedTeleportCommand {
             user.sendMessage("commands.island.go.teleport");
             return false;
         }
-        Set<Island> islands = getIslands().getIslands(getWorld(), user.getUniqueId());
+        List<Island> islands = getIslands().getIslands(getWorld(), user.getUniqueId());
         if (islands.isEmpty()) {
             user.sendMessage("general.errors.no-island");
             return false;
@@ -86,7 +85,7 @@ public class IslandGoCommand extends DelayedTeleportCommand {
         return true;
     }
 
-    private boolean checkReserved(User user, Set<Island> islands) {
+    private boolean checkReserved(User user, List<Island> islands) {
         for (Island island : islands) {
             if (island.isReserved()) {
                 // Send player to create an island

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommand.java
@@ -3,7 +3,6 @@ package world.bentobox.bentobox.api.commands.island;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
@@ -14,7 +13,7 @@ import world.bentobox.bentobox.util.Util;
 
 public class IslandHomesCommand extends ConfirmableCommand {
 
-    private Set<Island> islands;
+    private List<Island> islands;
 
     public IslandHomesCommand(CompositeCommand islandCommand) {
         super(islandCommand, "homes");

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -1,7 +1,6 @@
 package world.bentobox.bentobox.api.commands.island.team;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -144,7 +143,7 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
         // Remove the invite
         itc.removeInvite(user.getUniqueId());
         // Get the player's island - may be null if the player has no island
-        Set<Island> islands = getIslands().getIslands(getWorld(), user.getUniqueId());
+        List<Island> islands = getIslands().getIslands(getWorld(), user.getUniqueId());
         // Get the team's island
         Island teamIsland = invite.getIsland();
         if (teamIsland == null) {

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -321,7 +321,7 @@ public class IslandsManager {
      * @return List of islands or empty list if none found for user
      */
     @NonNull
-    public Set<Island> getIslands(@NonNull World world, @NonNull User user) {
+    public List<Island> getIslands(@NonNull World world, @NonNull User user) {
         return getIslands(world, user.getUniqueId());
     }
 
@@ -333,7 +333,7 @@ public class IslandsManager {
      * @return List of islands or empty list if none found for user
      */
     @NonNull
-    public Set<Island> getIslands(@NonNull World world, UUID uniqueId) {
+    public List<Island> getIslands(@NonNull World world, UUID uniqueId) {
         return islandCache.getIslands(world, uniqueId);
     }
 

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
@@ -1,10 +1,13 @@
 package world.bentobox.bentobox.managers.island;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -170,7 +173,7 @@ public class IslandCache {
      */
     @Nullable
     public Island get(@NonNull World world, @NonNull UUID uuid) {
-        Set<Island> islands = getIslands(world, uuid);
+        List<Island> islands = getIslands(world, uuid);
         if (islands.isEmpty()) {
             return null;
         }
@@ -190,15 +193,16 @@ public class IslandCache {
      * 
      * @param world world to check. Includes nether and end worlds.
      * @param uuid  player's UUID
-     * @return list of island or empty list if none
+     * @return list of island or empty list if none sorted from oldest to youngest
      */
-    public Set<Island> getIslands(@NonNull World world, @NonNull UUID uuid) {
+    public List<Island> getIslands(@NonNull World world, @NonNull UUID uuid) {
         World w = Util.getWorld(world);
         if (w == null) {
-            return new HashSet<>();
+            return new ArrayList<>();
         }
-        return islandsByUUID.computeIfAbsent(uuid, k -> new HashSet<>()).stream().filter(i -> w.equals(i.getWorld()))
-                .collect(Collectors.toSet());
+        return islandsByUUID.computeIfAbsent(uuid, k -> new HashSet<>()).stream().filter(island -> w.equals(island.getWorld()))
+                .sorted(Comparator.comparingLong(Island::getCreatedDate))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommandTest.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -115,7 +114,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerBeforeClassTest {
         when(island.onIsland(any())).thenReturn(true);
         when(im.getIsland(world, uuid)).thenReturn(island);
         when(im.getIsland(world, user)).thenReturn(island);
-        when(im.getIslands(world, uuid)).thenReturn(Set.of(island));
+        when(im.getIslands(world, uuid)).thenReturn(List.of(island));
         @NotNull
         Map<String, Location> homeMap = new HashMap<>();
         homeMap.put("Home", null);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
@@ -126,7 +126,7 @@ public class IslandGoCommandTest {
         when(ic.getWorld()).thenReturn(world);
 
         // Player has island by default
-        when(im.getIslands(world, uuid)).thenReturn(Set.of(island));
+        when(im.getIslands(world, uuid)).thenReturn(List.of(island));
         when(im.hasIsland(world, uuid)).thenReturn(true);
         // when(im.isOwner(world, uuid)).thenReturn(true);
         when(plugin.getIslands()).thenReturn(im);
@@ -204,7 +204,7 @@ public class IslandGoCommandTest {
      */
     @Test
     public void testExecuteNoArgsNoIsland() {
-        when(im.getIslands(world, uuid)).thenReturn(Set.of());
+        when(im.getIslands(world, uuid)).thenReturn(List.of());
         assertFalse(igc.canExecute(user, igc.getLabel(), Collections.emptyList()));
         verify(player).sendMessage("general.errors.no-island");
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommandTest.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -189,7 +189,7 @@ public class IslandHomesCommandTest {
      */
     @Test
     public void testCanExecute() {
-        when(im.getIslands(world, user)).thenReturn(Set.of(island));
+        when(im.getIslands(world, user)).thenReturn(List.of(island));
         IslandHomesCommand isc = new IslandHomesCommand(ic);
         assertTrue(isc.canExecute(user, "island", Collections.emptyList()));
         verify(user, never()).sendMessage("general.errors.no-island");
@@ -200,7 +200,7 @@ public class IslandHomesCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfString() {
-        when(im.getIslands(world, user)).thenReturn(Set.of(island));
+        when(im.getIslands(world, user)).thenReturn(List.of(island));
         IslandHomesCommand isc = new IslandHomesCommand(ic);
         assertTrue(isc.canExecute(user, "island", Collections.emptyList()));
         assertTrue(isc.execute(user, "island", Collections.emptyList()));

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -104,8 +104,7 @@ public class IslandSethomeCommandTest {
 
         // Island for player to begin with
         when(im.hasIsland(world, user)).thenReturn(true);
-        // when(im.isOwner(world, uuid)).thenReturn(true);
-        when(im.getIslands(world, user)).thenReturn(Set.of(island));
+        when(im.getIslands(world, user)).thenReturn(List.of(island));
         when(plugin.getIslands()).thenReturn(im);
 
         // Has team

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommandTest.java
@@ -77,7 +77,6 @@ public class IslandSetnameCommandTest {
     private IslandSetnameCommand isc;
     @Mock
     private @NonNull World world;
-    private RanksManager rm;
     private Settings settings;
     @Mock
     private PluginManager pim;

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -250,7 +251,7 @@ public class IslandsManagerTest extends AbstractCommonSetup {
         when(islandCache.getIslandAt(any(Location.class))).thenReturn(island);
         when(islandCache.get(any(), any())).thenReturn(island);
         optionalIsland = Optional.ofNullable(island);
-        when(islandCache.getIslands(world, uuid)).thenReturn(Set.of(island));
+        when(islandCache.getIslands(world, uuid)).thenReturn(List.of(island));
 
         // User location
         when(user.getLocation()).thenReturn(location);


### PR DESCRIPTION
This will result in the islands listed always being in the same order.