### PR TITLE
Added placeholders for island names and member lists #2329

### DIFF
--- a/src/main/java/world/bentobox/bentobox/lists/GameModePlaceholder.java
+++ b/src/main/java/world/bentobox/bentobox/lists/GameModePlaceholder.java
@@ -17,6 +17,9 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
+/**
+ * Common Game Mode Placeholders
+ */
 public enum GameModePlaceholder {
 
     /* World-related */


### PR DESCRIPTION
Adds `%[game-mode]_island_name_x%` and `%[game-mode]_island_memberlist_x%` where x is a number between 1 and the concurrent island limit set in the game mode settings. If the game mode does not have specific setting for that value, then the BentoBox global number is used as set in BentoBox's config.yml.

Fixes #2329 