### PR TITLE
Fixes #2378 where an unknown UUID was yielding null instead of ""

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -158,7 +158,7 @@ public class PlayersManager {
             return "";
         }
         return names.loadObjects().stream().filter(n -> n.getUuid().equals(playerUUID)).findFirst()
-                .map(Names::getUniqueId).orElse(null);
+                .map(Names::getUniqueId).orElse("");
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
@@ -389,6 +389,7 @@ public class PlayersManagerTest {
         assertTrue(pm.getName(null).isEmpty());
         String name = pm.getName(uuid);
         assertEquals("tastybento", name);
+        assertEquals("", pm.getName(UUID.randomUUID()));
     }
 
     /**


### PR DESCRIPTION
The OP had reported a bug where the name comparison was failing because of a null. The name lookup should never return a null (it's tagged @NonNull) but the underlying optional check was giving a null instead of "". Changing the return to "" will prevent this issue. However, it is not clear how the owner of an island does not have a name entry in the database, but that is another issue.