### PR TITLE
Adds more options around getting islands and caching

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1657,13 +1657,36 @@ public class IslandsManager {
     /**
      * Try to get an island by its unique id
      * 
-     * @param uniqueId - unique id string
+     * @param uniqueId - unique id of island
      * @return optional island
      * @since 1.3.0
      */
     @NonNull
     public Optional<Island> getIslandById(String uniqueId) {
         return Optional.ofNullable(islandCache.getIslandById(uniqueId));
+    }
+
+    /**
+     * Try to get an island by its unique id. If you are needing to load all the islands to check something
+     * but do not need to have them cached, then use this method and set cache to false.
+     * 
+     * @param uniqueId - unique id of island
+     * @param cache - if false, island will not be cached if it is not already
+     * @return optional island
+     * @since 2.4.0
+     */
+    @NonNull
+    public Optional<Island> getIslandById(String uniqueId, boolean cache) {
+        return Optional.ofNullable(islandCache.getIslandById(uniqueId, cache));
+    }
+
+    /**
+     * Returns if this is a known island uniqueId. Will not load the island from the database if it is not loaded already.
+     * @param uniqueId - unique id of island
+     * @return true if this island exists
+     */
+    public boolean isIslandId(String uniqueId) {
+        return islandCache.isIslandId(uniqueId);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
@@ -430,7 +430,29 @@ public class IslandCache {
     @Nullable
     public Island getIslandById(@NonNull String uniqueId) {
         // Load from cache or database
-        return islandsById.computeIfAbsent(uniqueId, handler::loadObject);
+        return getIslandById(uniqueId, true);
+    }
+
+    /**
+     * Get the island by unique id
+     * 
+     * @param uniqueId unique id of the Island.
+     * @param cache if true, then the Island will be cached if it is not already
+     * @return island or null if none found
+     * @since 2.4.0
+     */
+    @Nullable
+    public Island getIslandById(@NonNull String uniqueId, boolean cache) {
+        Island island = islandsById.get(uniqueId);
+        if (island != null) {
+            return island;
+        }
+
+        island = handler.loadObject(uniqueId);
+        if (cache && island != null) {
+            islandsById.put(uniqueId, island);
+        }
+        return island;
     }
 
     /**
@@ -483,6 +505,15 @@ public class IslandCache {
      */
     public @NonNull List<Island> getIslands(UUID uniqueId) {
         return islandsByUUID.getOrDefault(uniqueId, Collections.emptySet()).stream().map(this::getIslandById).toList();
+    }
+
+    /**
+     * Returns if this is a known island uniqueId. Will not load the island from the database if it is not loaded already.
+     * @param uniqueId - unique id of island
+     * @return true if this island exists
+     */
+    public boolean isIslandId(String uniqueId) {
+        return this.islandsById.containsKey(uniqueId);
     }
 
 }


### PR DESCRIPTION
Sometimes, there is a need to get an island once but not cache it. For example, when loading addons they may need to scan all the islands, but not have them cached.