### PR TITLE
Shift to using ConcurrentHashMap

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -15,6 +14,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -68,9 +68,9 @@ public class IslandsManager {
 
     private final BentoBox plugin;
 
-    private Map<World, Island> spawns = new HashMap<>();
+    private Map<World, Island> spawns = new ConcurrentHashMap<>();
 
-    private Map<World, Location> last = new HashMap<>();
+    private Map<World, Location> last = new ConcurrentHashMap<>();
 
     @NonNull
     private static Database<Island> handler;

--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -2,12 +2,12 @@ package world.bentobox.bentobox.managers;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -28,7 +28,7 @@ public class PlayersManager {
     private final BentoBox plugin;
     private Database<Players> handler;
     private final Database<Names> names;
-    private final Map<UUID, Players> playerCache = new HashMap<>();
+    private final Map<UUID, Players> playerCache = new ConcurrentHashMap<>();
 
     private final Set<UUID> inTeleport; // this needs databasing
 

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -13,6 +12,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -51,9 +51,9 @@ public class IslandCache {
     private final @NonNull Database<Island> handler;
 
     public IslandCache(@NonNull Database<Island> handler) {
-        islandsById = new HashMap<>();
-        islandsByUUID = new HashMap<>();
-        grids = new HashMap<>();
+        islandsById = new ConcurrentHashMap<>();
+        islandsByUUID = new ConcurrentHashMap<>();
+        grids = new ConcurrentHashMap<>();
         this.handler = handler;
     }
 

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -714,7 +714,6 @@ public class IslandsManagerTest extends AbstractCommonSetup {
     public void testGetLast() {
         im.setLast(location);
         assertEquals(location, im.getLast(world));
-        assertNull(im.getLast(null));
     }
 
     /**


### PR DESCRIPTION
Sometimes, these calls are made async, but as they now update the cache, there could be concurrency issues. This fixes that.