### PR TITLE
Fix for #2402 player record was deleted on quit

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -160,7 +160,6 @@ public class User implements MetaDataAble {
     public static void removePlayer(Player player) {
         if (player != null) {
             users.remove(player.getUniqueId());
-            BentoBox.getInstance().getPlayers().removePlayer(player);
         }
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -178,7 +178,6 @@ public class UserTest {
         // If the player has been removed from the cache, then code will ask server for player
         // Return null and check if instance is null will show that the player is not in the cache
         when(Bukkit.getPlayer(any(UUID.class))).thenReturn(null);
-        verify(pm).removePlayer(player);
     }
 
     @Test


### PR DESCRIPTION
This was due to the changes to the Player cache. On quit the cache was cleared, but this was also deleting the player from the database.