### PR TITLE
Fix parrot interaction condition

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
@@ -114,13 +114,14 @@ public class HurtingListener extends FlagListener {
      */
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerFeedParrots(PlayerInteractEntityEvent e) {
-        if (e.getRightClicked() instanceof Parrot
-                && (e.getHand().equals(EquipmentSlot.HAND) && e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.COOKIE))
-                || (e.getHand().equals(EquipmentSlot.OFF_HAND) && e.getPlayer().getInventory().getItemInOffHand().getType().equals(Material.COOKIE))) {
-            if (((Parrot) e.getRightClicked()).isTamed()) {
-                checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.HURT_TAMED_ANIMALS);
-            } else {
-                checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.HURT_ANIMALS);
+        if (e.getRightClicked() instanceof Parrot parrot) {
+            if ((e.getHand().equals(EquipmentSlot.HAND) && e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.COOKIE))
+                    || (e.getHand().equals(EquipmentSlot.OFF_HAND) && e.getPlayer().getInventory().getItemInOffHand().getType().equals(Material.COOKIE))) {
+                if (parrot.isTamed()) {
+                    checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.HURT_TAMED_ANIMALS);
+                } else {
+                    checkIsland(e, e.getPlayer(), e.getRightClicked().getLocation(), Flags.HURT_ANIMALS);
+                }
             }
         }
     }


### PR DESCRIPTION
In original condition, if the player right clicked target is not Parrot, but if the hand is offhand and player hold cookie on offhand, the whole condition will pass. So it may has error like below, possibly player right clicked cat and also hold cookie on offhand.

```
[16:48:32 ERROR]: Could not pass event PlayerInteractEntityEvent to BentoBox v2.7.0
java.lang.ClassCastException: class org.bukkit.craftbukkit.entity.CraftCat cannot be cast to class org.bukkit.entity.Parrot (org.bukkit.craftbukkit.entity.CraftCat and org.bukkit.entity.Parrot are in unnamed module of loader java.net.URLClassLoader @1c6b6478)
        at BentoBox-2.7.0.jar/world.bentobox.bentobox.listeners.flags.protection.HurtingListener.onPlayerFeedParrots(HurtingListener.java:120) ~[BentoBox-2.7.0.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor65.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:65) ~[leaf-1.21.1.jar:1.21.1-DEV-9514f2b]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[leaf-1.21.1.jar:1.21.1-DEV-9514f2b]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:629) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl$3.performInteraction(ServerGamePacketListenerImpl.java:2946) ~[leaf-1.21.1.jar:1.21.1-DEV-9514f2b]
```

This pr fix it.
