### PR TITLE
Add the protection flag for eggHit.

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EggListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EggListener.java
@@ -1,7 +1,10 @@
 package world.bentobox.bentobox.listeners.flags.protection;
 
+import org.bukkit.entity.Egg;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerEggThrowEvent;
 
 import world.bentobox.bentobox.api.flags.FlagListener;
@@ -22,6 +25,21 @@ public class EggListener extends FlagListener {
     public void onEggThrow(PlayerEggThrowEvent e) {
         if (!checkIsland(e, e.getPlayer(), e.getEgg().getLocation(), Flags.EGGS)) {
             e.setHatching(false);
+        }
+    }
+
+    /**
+     * Handle visitor chicken egg hitting
+     * @param e - event
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onEggHit(ProjectileHitEvent e) {
+        if (e.getEntity() instanceof Egg egg) {
+            if (egg.getShooter() instanceof Player player) {
+                if (!checkIsland(e, player, egg.getLocation(), Flags.EGGS)) {
+                    e.setCancelled(true);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Some plugins will handle the event of the egg hitting (such as the plugin that catches creatures by throwing eggs), modify this flag to ensure compatibility with it.