### PR TITLE
Removed PaperLib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- Non-minecraft related dependencies -->
         <powermock.version>2.0.9</powermock.version>
         <!-- Database related dependencies -->
@@ -146,6 +148,10 @@
             <url>https://jitpack.io</url>
         </repository>
         <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots</url>
         </repository>
@@ -156,10 +162,6 @@
         <repository>
             <id>dynmap-repo</id>
             <url>https://repo.mikeprimm.com/</url>
-        </repository>
-        <repository>
-            <id>papermc</id>
-            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <!-- This is a temporary reference as the Maven Shade plugin 
@@ -239,6 +241,13 @@
             <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- Paper API -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Spigot API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
@@ -275,19 +284,12 @@
              <artifactId>spigot</artifactId>
              <version>1.20.2-R0.1-SNAPSHOT</version>
              <scope>provided</scope>
-        </dependency> 
+        </dependency>
         <dependency>
              <groupId>org.spigotmc...</groupId>
              <artifactId>spigot</artifactId>
              <version>1.20.1-R0.1-SNAPSHOT</version>
              <scope>provided</scope>
-        </dependency>
-        <!-- Paper API -->
-        <dependency>
-            <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>${paper.version}</version>
-            <scope>provided</scope>
         </dependency>
         <!-- Metrics -->
         <dependency>
@@ -362,13 +364,6 @@
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.annotation</artifactId>
             <version>2.2.600</version>
-        </dependency>
-        <!-- PaperLib -->
-        <dependency>
-            <groupId>io.papermc</groupId>
-            <artifactId>paperlib</artifactId>
-            <version>1.0.6</version>
-            <scope>compile</scope>
         </dependency>
         <!-- LangUtils -->
         <dependency>
@@ -466,10 +461,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
-                <configuration>
-                    <release>${java.version}</release>
-                    <!-- <source>${java.version}</source> <target>${java.version}</target> -->
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
@@ -13,7 +13,6 @@ import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.NonNull;
 
-import io.papermc.lib.PaperLib;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.flags.FlagListener;
 import world.bentobox.bentobox.api.user.User;
@@ -164,7 +163,7 @@ public class LockAndBanListener extends FlagListener {
             // We'll try to teleport him to the spawn...
             Location l = player.getWorld().getSpawnLocation();
             if (l != null) {
-                PaperLib.teleportAsync(player, l);
+                player.teleportAsync(l);
             }
 
             // Switch him back to the default gamemode. He may die, sorry :(

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -40,7 +40,6 @@ import com.github.puregero.multilib.MultiLib;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import io.papermc.lib.PaperLib;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.events.IslandBaseEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
@@ -1080,7 +1079,7 @@ public class IslandsManager {
                         .ifFail(() -> goingHome.remove(user.getUniqueId())).buildFuture().thenAccept(result::complete);
                 return;
             }
-            PaperLib.teleportAsync(Objects.requireNonNull(player), home).thenAccept(b -> {
+            Objects.requireNonNull(player).teleportAsync(home).thenAccept(b -> {
                 // Only run the commands if the player is successfully teleported
                 if (Boolean.TRUE.equals(b)) {
                     teleported(world, user, name, newIsland, island);
@@ -1469,7 +1468,7 @@ public class IslandsManager {
                     } else {
                         // Move player to spawn
                         getSpawn(w).map(i -> i.getSpawnPoint(w.getEnvironment())).filter(Objects::nonNull)
-                                .ifPresentOrElse(sp -> PaperLib.teleportAsync(p, sp),
+                                .ifPresentOrElse(p::teleportAsync,
                                         () -> plugin.logWarning("Spawn exists but its location is null!"));
 
                     }

--- a/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
+++ b/src/main/java/world/bentobox/bentobox/nms/CopyWorldRegenerator.java
@@ -38,7 +38,6 @@ import org.bukkit.util.BoundingBox;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
-import io.papermc.lib.PaperLib;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.hooks.Hook;
@@ -148,7 +147,7 @@ public abstract class CopyWorldRegenerator implements WorldRegenerator {
         CompletableFuture<Chunk> seedWorldFuture = getSeedWorldChunk(world, chunkX, chunkZ);
 
         // Set up a future to get the chunk requests using Paper's Lib. If Paper is used, this should be done async
-        CompletableFuture<Chunk> chunkFuture = PaperLib.getChunkAtAsync(world, chunkX, chunkZ);
+        CompletableFuture<Chunk> chunkFuture = world.getChunkAtAsync(chunkX, chunkZ);
 
         // If there is no island, do not clean chunk
         CompletableFuture<Void> cleanFuture = di != null ? cleanChunk(chunkFuture, di) : CompletableFuture.completedFuture(null);
@@ -172,7 +171,7 @@ public abstract class CopyWorldRegenerator implements WorldRegenerator {
     private CompletableFuture<Chunk> getSeedWorldChunk(World world, int chunkX, int chunkZ) {
         World seed = Bukkit.getWorld(world.getName() + "/bentobox");
         if (seed == null) return CompletableFuture.completedFuture(null);
-        return PaperLib.getChunkAtAsync(seed, chunkX, chunkZ);
+        return seed.getChunkAtAsync(chunkX, chunkZ);
     }
 
     /**
@@ -374,7 +373,7 @@ public abstract class CopyWorldRegenerator implements WorldRegenerator {
     @SuppressWarnings("deprecation")
     private CompletableFuture<Void> regenerateChunk(GameModeAddon gm, IslandDeletion di, @Nonnull World world,
             int chunkX, int chunkZ) {
-        CompletableFuture<Chunk> chunkFuture = PaperLib.getChunkAtAsync(world, chunkX, chunkZ);
+        CompletableFuture<Chunk> chunkFuture = world.getChunkAtAsync(chunkX, chunkZ);
         CompletableFuture<Void> invFuture = chunkFuture.thenAccept(chunk ->
         Arrays.stream(chunk.getTileEntities()).filter(InventoryHolder.class::isInstance)
         .filter(te -> di.inBounds(te.getLocation().getBlockX(), te.getLocation().getBlockZ()))

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -3,16 +3,11 @@ package world.bentobox.bentobox.util;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,8 +46,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.google.common.base.Enums;
 import com.google.common.base.Optional;
 
-import io.papermc.lib.PaperLib;
-import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotResult;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.nms.PasteHandler;
@@ -376,17 +369,19 @@ public class Util {
 
     /**
      * Teleports an Entity to the target location, loading the chunk asynchronously first if needed.
+     * Paper lib removed.
      * @param entity The Entity to teleport
      * @param location The Location to Teleport to
      * @return Future that completes with the result of the teleport
      */
     @NonNull
     public static CompletableFuture<Boolean> teleportAsync(@Nonnull Entity entity, @Nonnull Location location) {
-        return PaperLib.teleportAsync(entity, location);
+        return entity.teleportAsync(location);
     }
 
     /**
      * Teleports an Entity to the target location, loading the chunk asynchronously first if needed.
+     * Paper lib removed.
      * @param entity The Entity to teleport
      * @param location The Location to Teleport to
      * @param cause The cause for the teleportation
@@ -395,7 +390,7 @@ public class Util {
     @NonNull
     public static CompletableFuture<Boolean> teleportAsync(@Nonnull Entity entity, @Nonnull Location location,
             TeleportCause cause) {
-        return PaperLib.teleportAsync(entity, location, cause);
+        return entity.teleportAsync(location, cause);
     }
 
     /**
@@ -434,6 +429,7 @@ public class Util {
 
     /**
      * Gets the chunk at the target location, loading it asynchronously if needed.
+     * Paper lib removed.
      * @param world World to load chunk for
      * @param x X coordinate of the chunk to load
      * @param z Z coordinate of the chunk to load
@@ -442,7 +438,7 @@ public class Util {
      */
     @NonNull
     public static CompletableFuture<Chunk> getChunkAtAsync(@Nonnull World world, int x, int z, boolean gen) {
-        return PaperLib.getChunkAtAsync(world, x, z, gen);
+        return world.getChunkAtAsync(x, z, gen);
     }
 
     /**
@@ -456,25 +452,28 @@ public class Util {
 
     /**
      * Checks if the chunk has been generated or not. Only works on Paper 1.12+ or any 1.13.1+ version
+     * Paper lib removed.
      * @param world World to check for
      * @param x X coordinate of the chunk to check
      * @param z Z coordinate of the chunk to checl
      * @return If the chunk is generated or not
      */
     public static boolean isChunkGenerated(@Nonnull World world, int x, int z) {
-        return PaperLib.isChunkGenerated(world, x, z);
+        return world.isChunkGenerated(x, z);
     }
 
-    /**
-     * Get's a BlockState, optionally not using a snapshot
-     * @param block The block to get a State of
-     * @param useSnapshot Whether or not to use a snapshot when supported
-     * @return The BlockState
-     */
-    @NonNull
-    public static BlockStateSnapshotResult getBlockState(@Nonnull Block block, boolean useSnapshot) {
-        return PaperLib.getBlockState(block, useSnapshot);
-    }
+//    I cannot find a replacement for this method. Neither is there a similar method, nor an object that does what BlockStateSnapshotResult used to do.
+//    Perhaps I didn't look close enough, but for nothing currently uses this method. If addons/gamemodes rely on this method than not only does need changed but also the addons/gamemodes
+//    /**
+//     * Get's a BlockState, optionally not using a snapshot
+//     * @param block The block to get a State of
+//     * @param useSnapshot Whether or not to use a snapshot when supported
+//     * @return The BlockState
+//     */
+//    @NonNull
+//    public static BlockStateSnapshotResult getBlockState(@Nonnull Block block, boolean useSnapshot) {
+//        return block.getBlockState(block, useSnapshot);
+//    }
 
     /**
      * Detects if the current MC version is at least the following version.
@@ -485,7 +484,7 @@ public class Util {
      * @return Meets the version requested
      */
     public static boolean isVersion(int minor) {
-        return PaperLib.isVersion(minor);
+        return isVersionPaperLib(minor);
     }
 
     /**
@@ -495,7 +494,7 @@ public class Util {
      * @return Meets the version requested
      */
     public static boolean isVersion(int minor, int patch) {
-        return PaperLib.isVersion(minor, patch);
+        return isVersionPaperLib(minor, patch);
     }
 
     /**
@@ -503,7 +502,7 @@ public class Util {
      * @return The Minor Version
      */
     public static int getMinecraftVersion() {
-        return PaperLib.getMinecraftVersion();
+        return version;
     }
 
     /**
@@ -511,7 +510,7 @@ public class Util {
      * @return The Patch Version
      */
     public static int getMinecraftPatchVersion() {
-        return PaperLib.getMinecraftPatchVersion();
+        return patchVersion;
     }
 
     /**
@@ -566,8 +565,9 @@ public class Util {
      * Check if the server has access to the Spigot API
      * @return True for Spigot <em>and</em> Paper environments
      */
+    //Why is this even here?
     public static boolean isSpigot() {
-        return PaperLib.isSpigot();
+        return true;
     }
 
     /**
@@ -575,7 +575,12 @@ public class Util {
      * @return True for Paper environments
      */
     public static boolean isPaper() {
-        return !isJUnitTest() && PaperLib.isPaper();
+        try{
+            Class.forName("com.destroystokyo.paper.ParticleBuilder");
+
+            return !isJUnitTest();
+        }
+        catch (ClassNotFoundException exception){return false;}
     }
 
     /**
@@ -760,7 +765,7 @@ public class Util {
      * @param player - player
      */
     public static void resetHealth(Player player) {
-        double maxHealth = player.getAttribute(Attribute.MAX_HEALTH).getBaseValue();
+        double maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
         player.setHealth(maxHealth);
     }
 
@@ -901,5 +906,54 @@ public class Util {
      */
     public static boolean inTest() {
         return Arrays.stream(Thread.currentThread().getStackTrace()).anyMatch(e -> e.getClassName().endsWith("Test"));
+    }
+
+
+
+
+    //Stuff copied from PaperLib to get the version and patch version
+    //I couldn't find anything related to this information in paper's api
+    //Needs further investigation
+
+    private static int version = 0;
+    private static int patchVersion = 0;
+    private static int preReleaseVersion = -1;
+    private static int releaseCandidateVersion = -1;
+
+    static{
+        Pattern versionPattern = Pattern.compile("(?i)\\(MC: (\\d)\\.(\\d+)\\.?(\\d+?)?(?: (Pre-Release|Release Candidate) )?(\\d)?\\)");
+        Matcher matcher = versionPattern.matcher(Bukkit.getVersion());
+        if (matcher.find()) {
+            MatchResult matchResult = matcher.toMatchResult();
+            try {
+                version = Integer.parseInt(matchResult.group(2), 10);
+            } catch (Exception ignored) {
+            }
+            if (matchResult.groupCount() >= 3) {
+                try {
+                    patchVersion = Integer.parseInt(matchResult.group(3), 10);
+                } catch (Exception ignored) {
+                }
+            }
+            if (matchResult.groupCount() >= 5) {
+                try {
+                    final int ver = Integer.parseInt(matcher.group(5));
+                    if (matcher.group(4).toLowerCase(Locale.ENGLISH).contains("pre")) {
+                        preReleaseVersion = ver;
+                    } else {
+                        releaseCandidateVersion = ver;
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    private static boolean isVersionPaperLib(int minor) {
+        return isVersionPaperLib(minor, 0);
+    }
+
+    private static boolean isVersionPaperLib(int minor, int patch) {
+        return version > minor || (version >= minor && patch >= patch);
     }
 }


### PR DESCRIPTION
PaperLib has been removed from further paper versions. It now needs to be removed and replaced with paper's api.

https://github.com/PaperMC/PaperLib
The repo for it has been archived about a week ago. The README file states:
"PaperLib was meant as a temporary means of using more powerful Paper API while allowing full compatibility with Spigot as was necessary for a lot of people. Now, you're better off directly targeting Paper and uploading your plugin to one of the many other resource sites, such as [Hangar](https://hangar.papermc.io/), [modrinth](https://modrinth.com/), [BuiltByBit](https://builtbybit.com/), or [Polymart](https://polymart.org/)."

This has already affected some users on the newest paper versions and have been reported on the discord chat that they can no longer use BentoBox: 
https://discord.com/channels/272499714048524288/310623455462686720/1322256049998397461
https://discord.com/channels/272499714048524288/310623455462686720/1322003693817561159
https://discord.com/channels/272499714048524288/310623455462686720/1321950945399017575
https://discord.com/channels/272499714048524288/310623455462686720/1321945727773184060
https://discord.com/channels/272499714048524288/310623455462686720/1321661933010812990

IslandsManagerTest needs to be fixed as well, but I have no idea how and I've not touched it.