### PR TITLE
Add project hit check to HurtingListener

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EggListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EggListener.java
@@ -32,7 +32,7 @@ public class EggListener extends FlagListener {
      * Handle visitor chicken egg hitting
      * @param e - event
      */
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onEggHit(ProjectileHitEvent e) {
         if (e.getEntity() instanceof Egg egg) {
             if (egg.getShooter() instanceof Player player) {

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
@@ -275,4 +275,6 @@ public class HurtingListener extends FlagListener {
             }
 
         }
+
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
@@ -21,6 +21,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.LingeringPotionSplashEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
@@ -234,4 +234,44 @@ public class HurtingListener extends FlagListener {
             firedFireworks.put(e.getProjectile(), e.getEntity());
         }
     }
+    
+        /**
+     * Handle visitor projectile hitting
+     *
+     * @param e - event
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onProjectileHit(ProjectileHitEvent e) {
+        if (e.getEntity().getShooter() instanceof Player attacker) {
+            if (e.getHitEntity() instanceof LivingEntity entity) {
+                // Monsters being hit
+                if (Util.isHostileEntity(entity)) {
+                    if (!checkIsland(e, attacker, entity.getLocation(), Flags.HURT_MONSTERS)) {
+                        e.setCancelled(true);
+                        return;
+                    }
+                }
+                // Tamed animals being hit
+                if (Util.isTamableEntity(entity)) {
+                    if (!checkIsland(e, attacker, entity.getLocation(), Flags.HURT_TAMED_ANIMALS)) {
+                        e.setCancelled(true);
+                        return;
+                    }
+                }
+                // Mobs being hit
+                if (Util.isPassiveEntity(entity)) {
+                    if (!checkIsland(e, attacker, entity.getLocation(), Flags.HURT_ANIMALS)) {
+                        e.setCancelled(true);
+                        return;
+                    }
+                }
+                // Villagers being hit
+                if (entity instanceof AbstractVillager) {
+                    if (!checkIsland(e, attacker, entity.getLocation(), Flags.HURT_VILLAGERS)) {
+                        e.setCancelled(true);
+                    }
+                }
+            }
+
+        }
 }


### PR DESCRIPTION
Using this event can cover most of the projectiles that may cause damage to creatures, including snowballs, eggs, arrows, tridents, etc., with a higher priority.