### PR TITLE
Target v2 of Modrinth publish action

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # !!! Make sure to select the correct Java version for your project !!!
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -28,10 +27,8 @@ jobs:
         run: mvn -B clean package --file pom.xml
 
       - name: Upload to Modrinth
-        uses: cloudnode-pro/modrinth-publish@2.0.0
+        uses: cloudnode-pro/modrinth-publish@v2
         with:
-          # Configure the action
-          # api-domain: staging-api.modrinth.com
           token: ${{ secrets.MODRINTH_TOKEN }}
           project: aBVLHiAW
           name: ${{ github.event.release.name }}


### PR DESCRIPTION
Hi! Thanks for using modrinth-publish. To benefit from backwards-compatible SemVer patch & minor releases, we now recommend targeting `v2`.

Alternatively, you can set up [`.github/dependabot.yaml`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) to open a pull request to update to specific versions as they are released.
```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
```