### PR TITLE
Return empty string instead of error

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/github/objects/repositories/GitHubFile.java
+++ b/src/main/java/world/bentobox/bentobox/api/github/objects/repositories/GitHubFile.java
@@ -21,12 +21,17 @@ public class GitHubFile {
 
     /**
      * Returns the content of this file.
-     * @return the content of this file in Base64
-     * @throws IllegalAccessException if the connection to the GitHub API could not be established.
+     * @return the content of this file in Base64 or nothing if the connection to the GitHub API could not be established.
      * @throws IOException - If an error occurs during the request.
      */
-    public String getContent() throws IllegalAccessException, IOException {
-        JsonObject response = api.fetch(path);
+    public String getContent() throws IllegalAccessException {
+        JsonObject response;
+        try {
+            response = api.fetch(path);
+        } catch (IOException e) {
+            // Cannot get a connection for some reason
+            return "";
+        }
         return response.get("content").getAsString();
     }
 }

--- a/src/test/java/world/bentobox/bentobox/util/ItemParserTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/ItemParserTest.java
@@ -143,6 +143,12 @@ public class ItemParserTest {
             // TODO Auto-generated method stub
             return 0;
         }
+
+        @Override
+        public Stream keyStream() {
+            // TODO Auto-generated method stub
+            return null;
+        }
     }
 
     @After


### PR DESCRIPTION
Missing files, etc. were not reported by previous library, so this mimics the operation so as to not generate scary stack traces. Fixes #2667 