### PR TITLE
Fix issues relating to #2422

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListener.java
@@ -105,6 +105,7 @@ public class BlockInteractionListener extends FlagListener
         case BEEHIVE, BEE_NEST -> this.checkIsland(e, player, loc, Flags.HIVE);
         case BARREL -> this.checkIsland(e, player, loc, Flags.BARREL);
         case CANDLE -> this.checkIsland(e, player, loc, Flags.CANDLES);
+        case CRAFTER -> this.checkIsland(e, player, loc, Flags.CRAFTER);
         case CHEST, CHEST_MINECART -> this.checkIsland(e, player, loc, Flags.CHEST);
         case TRAPPED_CHEST -> this.checkIsland(e, player, loc, Flags.TRAPPED_CHEST);
         case FLOWER_POT -> this.checkIsland(e, player, loc, Flags.FLOWER_POT);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListener.java
@@ -3,7 +3,6 @@ package world.bentobox.bentobox.listeners.flags.protection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Tag;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.CaveVinesPlant;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EnderCrystal;
@@ -195,25 +194,21 @@ public class BreakBlocksListener extends FlagListener {
      */
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onProjectileHitBreakBlock(ProjectileHitEvent e) {
-        // We want to make sure this is an actual projectile (arrow or trident)
-        if (!(e.getEntity() instanceof Projectile)) {
+        if (e.getHitBlock() == null) {
             return;
         }
 
-        // We want to make sure it hit a CHORUS_FLOWER
-        if (e.getHitBlock() == null || !e.getHitBlock().getType().equals(Material.CHORUS_FLOWER)) {
+        // Check if the hit block is a Chorus Flower or a Decorated Pot
+        if(!(e.getHitBlock().getType().equals(Material.CHORUS_FLOWER) ||
+                e.getHitBlock().getType().equals(Material.DECORATED_POT))) {
             return;
         }
 
         // Find out who fired the arrow
         if (e.getEntity().getShooter() instanceof Player s &&
                 !checkIsland(e, s, e.getHitBlock().getLocation(), Flags.BREAK_BLOCKS)) {
-            final BlockData data = e.getHitBlock().getBlockData();
-            // We seemingly can't prevent the block from being destroyed
-            // So we need to put it back with a slight delay (yup, this is hacky - it makes the block flicker sometimes)
-            e.getHitBlock().setType(Material.AIR); // prevents the block from dropping a chorus flower
-            getPlugin().getServer().getScheduler().runTask(getPlugin(), () -> e.getHitBlock().setBlockData(data, true));
-            // Sorry, this might also cause some ghost blocks!
+
+            e.setCancelled(true); // Prevents the block from being destroyed
         }
     }
 }

--- a/src/main/java/world/bentobox/bentobox/lists/Flags.java
+++ b/src/main/java/world/bentobox/bentobox/lists/Flags.java
@@ -126,6 +126,7 @@ public final class Flags {
     public static final Flag FLOWER_POT = new Flag.Builder("FLOWER_POT", Material.FLOWER_POT).mode(Flag.Mode.ADVANCED).build();
     public static final Flag SHULKER_BOX = new Flag.Builder("SHULKER_BOX", Material.SHULKER_BOX).mode(Flag.Mode.ADVANCED).build();
     public static final Flag TRAPPED_CHEST = new Flag.Builder("TRAPPED_CHEST", Material.TRAPPED_CHEST).mode(Flag.Mode.ADVANCED).build();
+    public static final Flag CRAFTER = new Flag.Builder("CRAFTER", Material.CRAFTER).mode(Flag.Mode.ADVANCED).build();
     // END CONTAINER split
     public static final Flag DISPENSER = new Flag.Builder("DISPENSER", Material.DISPENSER).mode(Flag.Mode.ADVANCED).build();
     public static final Flag DROPPER = new Flag.Builder("DROPPER", Material.DROPPER).mode(Flag.Mode.ADVANCED).build();

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1055,6 +1055,10 @@ protection:
       name: Barrels
       description: Toggle barrel interaction
       hint: Barrel access disabled
+    CRAFTER:
+        name: Crafter
+        description: Toggle use
+        hint: Crafter access disabled
     BLOCK_EXPLODE_DAMAGE:
       description: |-
         &a Allow Bed & Respawn Anchors


### PR DESCRIPTION
- Add protection for crafters
- Add protection against projectiles on Decorated Pots
- Switch to cancelling event instead of hacky existing code
- Remove redundant projectile check