### PR TITLE
Minor changes to portal linking

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/teleports/AbstractTeleportListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/teleports/AbstractTeleportListener.java
@@ -205,12 +205,12 @@ public abstract class AbstractTeleportListener
             int x = Math.abs(island.getProtectionCenter().getBlockX() - location.getBlockX());
             int z = Math.abs(island.getProtectionCenter().getBlockZ() - location.getBlockZ());
 
-            diff = Math.min(this.plugin.getSettings().getSafeSpotSearchRange(),
-                    island.getProtectionRange() - Math.max(x, z));
+            diff = Math.min(this.plugin.getSettings().getMinPortalSearchRadius(),
+                    island.getProtectionRange() + (island.getRange() - island.getProtectionRange())*2 - Math.max(x, z));
         }
         else
         {
-            diff = this.plugin.getSettings().getSafeSpotSearchRange();
+            diff = this.plugin.getSettings().getMinPortalSearchRadius();
         }
 
         return diff;


### PR DESCRIPTION
Included the border between islands in the portal search range, as currently portals at the edge of an islands protection range dont link to anything. This shouldnt cause any problems as there shouldnt be any portals inbetween islands.

Also uses the portal-search-radius config variable as that seems more intuitive.

This is a bit of a band-aid solution, with a bit of luck in the future https://github.com/PaperMC/Paper/pull/12968 can be used instead of this weird island edge, edge case.

Should resolve https://github.com/BentoBoxWorld/BentoBox/issues/2717 and https://github.com/BentoBoxWorld/BentoBox/issues/2716