### PR TITLE
Try to address issue with deleted status

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
@@ -129,6 +129,8 @@ public class AdminRegisterCommand extends ConfirmableCommand {
         if (island.isSpawn()) {
             getIslands().clearSpawn(island.getWorld());
         }
+        // Remove deletion status if it has been assigned.
+        island.setDeleted(false);
         user.sendMessage("commands.admin.register.registered-island", TextVariables.XYZ,
                 Util.xyz(island.getCenter().toVector()), TextVariables.NAME, targetName);
         user.sendMessage("general.success");


### PR DESCRIPTION
When an admin registers the island for a user, and it is not in the deletion process, then registry should remove `deleted` status for island, if it has been assigned.