### PR TITLE
Api auto center fix option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>3.8.1</build.version>
+        <build.version>3.8.2</build.version>
         <sonar.organization>bentobox-world</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <server.jars>${project.basedir}/lib</server.jars>

--- a/src/main/java/world/bentobox/bentobox/api/addons/GameModeAddon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/GameModeAddon.java
@@ -179,5 +179,15 @@ public abstract class GameModeAddon extends Addon {
     public boolean isUsesNewChunkGeneration() {
         return false;
     }
+    
+    /**
+     * Indicates whether BentoBox should try to align island centers on a grid, or leave them free form.
+     * Free form is used with some claim-based or player-selected island location addons.
+     * @return true by default
+     * @since 3.8.2
+     */
+    public boolean isFixIslandCenter() {
+        return true;
+    }
 
 }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -41,6 +41,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.IslandBaseEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.Reason;
@@ -1309,7 +1310,8 @@ public class IslandsManager {
                         + island.getRange() + "!\n" + "Island ID in database is " + island.getUniqueId() + ".\n"
                         + "Island distance in config.yml cannot be changed mid-game! Fix config.yml or clean database.");
             } else {
-                if (!plugin.getSettings().isOverrideSafetyCheck()) {
+                // Only try to fix the island center if we have to
+                if (!plugin.getSettings().isOverrideSafetyCheck() && plugin.getIWM().getAddon(island.getWorld()).map(GameModeAddon::isFixIslandCenter).orElse(true)) {
                     // Fix island center if it is off
                     fixIslandCenter(island);
                 }


### PR DESCRIPTION
API added to the GameModeAddon to indicate whether BentoBox should try and align the center of islands to a grid. This may not be wanted by some GameModes as they may be picking the centers randomly or at coordinates picked by a user, e.g., a claim approach.