### PR TITLE
Check if the currently open panel is equal to the inventory that was …

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
@@ -33,7 +33,7 @@ public class PanelListenerManager implements Listener {
 
         // Open the inventory panel that this player has open (they can only ever have one)
         if (openPanels.containsKey(user.getUniqueId()) &&
-                openPanels.get(user.getUniqueId()).getInventory().equals(event.getInventory())) {
+                openPanels.get(user.getUniqueId()).getInventory().equals(event.getClickedInventory())) {
             // Cancel the event. If they don't want it to be cancelled then the click handler(s) should
             // uncancel it. If gui was from our environment, then cancel event anyway.
             event.setCancelled(true);


### PR DESCRIPTION
…clicked.

This allows players to still move items around in their own inventory, drop items, take items out of bundles etc.