### PR TITLE
Implements ability for Player Heads to use CMD

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/PanelItem.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/PanelItem.java
@@ -206,7 +206,7 @@ public class PanelItem {
             meta.addItemFlags(ItemFlag.HIDE_PLACED_ON);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 
-            if (originalMeta.hasCustomModelDataComponent()) {
+            if (originalMeta != null && originalMeta.hasCustomModelDataComponent()) {
                 meta.setCustomModelDataComponent(originalMeta.getCustomModelDataComponent());
             }
 

--- a/src/main/java/world/bentobox/bentobox/api/panels/PanelItem.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/PanelItem.java
@@ -193,6 +193,8 @@ public class PanelItem {
     public void setHead(ItemStack itemStack) {
         // update amount before replacing.
         itemStack.setAmount(this.icon.getAmount());
+        ItemMeta originalMeta = this.icon.getItemMeta();
+
         this.icon = itemStack;
 
         // Get the meta
@@ -203,6 +205,11 @@ public class PanelItem {
             meta.addItemFlags(ItemFlag.HIDE_DESTROYS);
             meta.addItemFlags(ItemFlag.HIDE_PLACED_ON);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+
+            if (originalMeta.hasCustomModelDataComponent()) {
+                meta.setCustomModelDataComponent(originalMeta.getCustomModelDataComponent());
+            }
+
             icon.setItemMeta(meta);
         }
         // Create the final item

--- a/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilder.java
@@ -42,15 +42,27 @@ public class PanelItemBuilder {
         return this;
     }
 
+
+    /**
+     * Assigns icon and player name to the panel item.
+     * @param playerName the name of player head icon.
+     * @param icon the original player head icon
+     * @return PanelItemBuilder
+     */
+    public PanelItemBuilder icon(String playerName, ItemStack icon) {
+        this.icon = icon;
+        this.playerHeadName = playerName;
+        return this;
+    }
+
+
     /**
      * Set icon to player's head
      * @param playerName - player's name
      * @return PanelItemBuilder
      */
     public PanelItemBuilder icon(String playerName) {
-        this.icon = new ItemStack(Material.PLAYER_HEAD);
-        this.playerHeadName = playerName;
-        return this;
+        return this.icon(playerName, new ItemStack(Material.PLAYER_HEAD));
     }
 
     public PanelItemBuilder name(@Nullable String name) {


### PR DESCRIPTION
The player heads never used data from input item stack, and always transformed it into plain PLAYER_HEAD.

This adds new method `PanelItemBuilder#icon(String, ItemStack)` that applies input icon and assigns name.

When skin is assigned to player head, it will copy custom model data from template item, instead of using plain HeadCache data.

This adds ability to solve #2774 in warps addon