### PR TITLE
Fix NETHER_PORTAL flag bypass when paper misc.enable-nether is false

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListener.java
@@ -93,7 +93,9 @@ public class PlayerTeleportListener extends AbstractTeleportListener implements 
                 // Check again if still in portal
                 if (this.inPortal.contains(uuid))
                 {
-                    // Create new PlayerPortalEvent
+                    // Create new PlayerPortalEvent and post it through the event bus so that
+                    // protection flag listeners (e.g. PortalListener) can inspect and cancel it
+                    // before BentoBox processes the actual teleportation.
                     PlayerPortalEvent en = new PlayerPortalEvent((Player) entity,
                             event.getLocation(),
                             null,
@@ -102,7 +104,7 @@ public class PlayerTeleportListener extends AbstractTeleportListener implements 
                             false,
                             0);
 
-                    this.portalProcess(en, World.Environment.NETHER);
+                    Bukkit.getPluginManager().callEvent(en);
                 }
             }, 40);
             return;
@@ -110,7 +112,9 @@ public class PlayerTeleportListener extends AbstractTeleportListener implements 
         // End portals are instant transfer
         if (!Bukkit.getAllowEnd() && (type.equals(Material.END_PORTAL) || type.equals(Material.END_GATEWAY)))
         {
-            // Create new PlayerPortalEvent
+            // Create new PlayerPortalEvent and post it through the event bus so that
+            // protection flag listeners (e.g. PortalListener) can inspect and cancel it
+            // before BentoBox processes the actual teleportation.
             PlayerPortalEvent en = new PlayerPortalEvent((Player) entity,
                     event.getLocation(),
                     null,
@@ -119,7 +123,7 @@ public class PlayerTeleportListener extends AbstractTeleportListener implements 
                             false,
                             0);
 
-            this.portalProcess(en, World.Environment.THE_END);
+            Bukkit.getPluginManager().callEvent(en);
         }
     }
 

--- a/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.listeners.teleports;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,6 +25,7 @@ import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityPortalEnterEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
@@ -34,6 +36,7 @@ import org.bukkit.util.Vector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import world.bentobox.bentobox.CommonTestSetup;
@@ -301,6 +304,33 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
         verify(Bukkit.getScheduler(), times(1)).runTaskLater(eq(plugin), any(Runnable.class), eq(40L));
     }
 
+    /**
+     * Test that when nether is disabled on the server, the scheduled task fires a PlayerPortalEvent
+     * through the Bukkit event bus (so PortalListener flag checks run) instead of calling
+     * portalProcess() directly.
+     */
+    @Test
+    public void testOnPlayerPortalNetherPortalDisabledCallsEvent() {
+        when(Bukkit.getAllowNether()).thenReturn(false);
+        when(Util.getWorld(location.getWorld())).thenReturn(world);
+        when(plugin.getIWM().inWorld(world)).thenReturn(true);
+        when(block.getType()).thenReturn(Material.NETHER_PORTAL);
+
+        EntityPortalEnterEvent e = new EntityPortalEnterEvent(mockPlayer, location);
+        ptl.onPlayerPortal(e);
+
+        // Capture and execute the scheduled Runnable
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(Bukkit.getScheduler()).runTaskLater(eq(plugin), runnableCaptor.capture(), eq(40L));
+        runnableCaptor.getValue().run();
+
+        // Verify callEvent was called with a PlayerPortalEvent with NETHER_PORTAL cause
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(pim).callEvent(eventCaptor.capture());
+        assertInstanceOf(PlayerPortalEvent.class, eventCaptor.getValue());
+        assertEquals(TeleportCause.NETHER_PORTAL, ((PlayerPortalEvent) eventCaptor.getValue()).getCause());
+    }
+
     @Test
     public void testOnPlayerPortalEndPortalDisabled() {
         // Mock configuration for End disabled
@@ -320,6 +350,12 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
 
         // Verify the event behavior indirectly by confirming the origin world was stored
         assertEquals(location.getWorld(), ptl.getTeleportOrigin().get(mockPlayer.getUniqueId()));
+
+        // Verify callEvent was called with a PlayerPortalEvent with END_PORTAL cause
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(pim).callEvent(eventCaptor.capture());
+        assertInstanceOf(PlayerPortalEvent.class, eventCaptor.getValue());
+        assertEquals(TeleportCause.END_PORTAL, ((PlayerPortalEvent) eventCaptor.getValue()).getCause());
     }
 
     @Test
@@ -341,6 +377,12 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
 
         // Verify the event behavior indirectly by confirming the origin world was stored
         assertEquals(location.getWorld(), ptl.getTeleportOrigin().get(mockPlayer.getUniqueId()));
+
+        // Verify callEvent was called with a PlayerPortalEvent with END_GATEWAY cause
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(pim).callEvent(eventCaptor.capture());
+        assertInstanceOf(PlayerPortalEvent.class, eventCaptor.getValue());
+        assertEquals(TeleportCause.END_GATEWAY, ((PlayerPortalEvent) eventCaptor.getValue()).getCause());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #2796

When `paper-global.yml misc.enable-nether: false` (or `enable-end: false`) is set, Paper does not fire `PlayerPortalEvent` for portals. BentoBox's `EntityPortalEnterEvent` handler compensated by manually constructing a `PlayerPortalEvent` and calling `portalProcess()` on it **directly** — completely bypassing the Bukkit event bus.

This meant `PortalListener` (which enforces the `NETHER_PORTAL` / `END_PORTAL` protection flags) never saw the event, so:
- Visitors could use nether portals even when the flag blocked them
- `/bsb why` returned nothing (no flag check was ever recorded)

**Fix:** replace the direct `portalProcess()` call with `Bukkit.getPluginManager().callEvent(en)`. The event now travels through the event bus normally:

1. `PortalListener` (LOW priority) checks the protection flag and cancels the event if the player lacks permission
2. `PlayerTeleportListener.onPlayerPortalEvent` (HIGH priority, `ignoreCancelled = true`) processes the teleport only if the flag allowed it

The same fix applies to the end portal / end gateway path under `!Bukkit.getAllowEnd()`.

## Test plan

- [ ] Set `paper-global.yml misc.enable-nether: false`, keep the BentoBox skyblock nether world enabled
- [ ] Set the `NETHER_PORTAL` flag to block visitors on an island
- [ ] Verify a visitor with a nether portal on the island cannot enter it (blocked with protection message)
- [ ] Verify `/bsb why` now reports the flag decision
- [ ] Verify island members can still use the portal correctly
- [ ] Run `./gradlew test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)