### PR TITLE
Fix purge regions not deleting nether/end region files

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
@@ -224,13 +224,19 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         File base = world.getWorldFolder();
         File overworldRegion = new File(base, REGION);
         File overworldEntities = new File(base, ENTITIES);
-        File overworldPoi = new File(base, "poi");
-        File netherRegion    = new File(base, DIM_1 + File.separator + REGION);
-        File netherEntities  = new File(base, DIM_1 + File.separator + ENTITIES);
-        File netherPoi       = new File(base, DIM_1 + File.separator + POI);
-        File endRegion       = new File(base, "DIM1"  + File.separator + REGION);
-        File endEntities     = new File(base, "DIM1"  + File.separator + ENTITIES);
-        File endPoi          = new File(base, "DIM1"  + File.separator + POI);
+        File overworldPoi = new File(base, POI);
+
+        World netherWorld = getPlugin().getIWM().getNetherWorld(world);
+        File netherBase      = netherWorld != null ? netherWorld.getWorldFolder() : new File(base, DIM_1);
+        File netherRegion    = new File(netherBase, REGION);
+        File netherEntities  = new File(netherBase, ENTITIES);
+        File netherPoi       = new File(netherBase, POI);
+
+        World endWorld = getPlugin().getIWM().getEndWorld(world);
+        File endBase         = endWorld != null ? endWorld.getWorldFolder() : new File(base, "DIM1");
+        File endRegion       = new File(endBase, REGION);
+        File endEntities     = new File(endBase, ENTITIES);
+        File endPoi          = new File(endBase, POI);
 
         // Phase 1: verify none of the files have been updated since the cutoff
         for (Pair<Integer, Integer> coords : deleteableRegions.keySet()) {
@@ -453,22 +459,44 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         World world = this.getWorld();
         File worldDir = world.getWorldFolder();
         File overworldRegion = new File(worldDir, REGION);
-        File netherRegion    = new File(worldDir, DIM_1 + File.separator + REGION);
-        File endRegion       = new File(worldDir, "DIM1"  + File.separator + REGION);
+
+        World netherWorld = getPlugin().getIWM().getNetherWorld(world);
+        File netherRegion = netherWorld != null
+                ? new File(netherWorld.getWorldFolder(), REGION)
+                : new File(worldDir, DIM_1 + File.separator + REGION);
+
+        World endWorld = getPlugin().getIWM().getEndWorld(world);
+        File endRegion = endWorld != null
+                ? new File(endWorld.getWorldFolder(), REGION)
+                : new File(worldDir, "DIM1" + File.separator + REGION);
 
         // Compute cutoff timestamp
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days);
 
-        // List all .mca files in the overworld region folder
-        File[] files = overworldRegion.listFiles((dir, name) -> name.endsWith(".mca"));
-        if (files == null) return regions;
+        // Collect all candidate region names from overworld, nether, and end.
+        // This ensures orphaned nether/end files are caught even if the overworld
+        // file was already deleted by a previous (buggy) purge run.
+        Set<String> candidateNames = new HashSet<>();
 
-        for (File owFile : files) {
-            // Skip if the overworld file is too recent
-            if (getRegionTimestamp(owFile) >= cutoffMillis) continue;
+        File[] owFiles = overworldRegion.listFiles((dir, name) -> name.endsWith(".mca"));
+        if (owFiles != null) {
+            for (File f : owFiles) candidateNames.add(f.getName());
+        }
+        if (isNether) {
+            File[] nFiles = netherRegion.listFiles((dir, name) -> name.endsWith(".mca"));
+            if (nFiles != null) {
+                for (File f : nFiles) candidateNames.add(f.getName());
+            }
+        }
+        if (isEnd) {
+            File[] eFiles = endRegion.listFiles((dir, name) -> name.endsWith(".mca"));
+            if (eFiles != null) {
+                for (File f : eFiles) candidateNames.add(f.getName());
+            }
+        }
 
+        for (String name : candidateNames) {
             // Parse region coords from filename "r.<x>.<z>.mca"
-            String name = owFile.getName(); // e.g. "r.-2.3.mca"
             String coordsPart = name.substring(2, name.length() - 4);
             String[] parts = coordsPart.split("\\.");
             if (parts.length != 2) continue;  // malformed
@@ -483,18 +511,24 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
 
             boolean include = true;
 
-            // If nether flag is set, require nether region file also older than cutoff
+            // If the overworld file exists and is too recent, skip
+            File owFile = new File(overworldRegion, name);
+            if (owFile.exists() && getRegionTimestamp(owFile) >= cutoffMillis) {
+                include = false;
+            }
+
+            // If nether flag is set, require nether region file (if it exists) to also be older than cutoff
             if (isNether) {
                 File netherFile = new File(netherRegion, name);
-                if (!netherFile.exists() || getRegionTimestamp(netherFile) >= cutoffMillis) {
+                if (netherFile.exists() && getRegionTimestamp(netherFile) >= cutoffMillis) {
                     include = false;
                 }
             }
 
-            // If end flag is set, require end region file also older than cutoff
+            // If end flag is set, require end region file (if it exists) to also be older than cutoff
             if (isEnd) {
                 File endFile = new File(endRegion, name);
-                if (!endFile.exists() || getRegionTimestamp(endFile) >= cutoffMillis) {
+                if (endFile.exists() && getRegionTimestamp(endFile) >= cutoffMillis) {
                     include = false;
                 }
             }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
@@ -188,6 +188,33 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
     }
 
     /**
+     * Resolves the base data folder for a world, accounting for the dimension
+     * subfolder that Minecraft uses for non-overworld environments.
+     * <p>
+     * Overworld data lives directly in the world folder, but Nether data lives
+     * in {@code DIM-1/} and End data lives in {@code DIM1/} subfolders — even
+     * when the world has its own separate folder.
+     *
+     * @param world the world to resolve
+     * @return the base folder containing region/, entities/, poi/ subfolders
+     */
+    private File resolveDataFolder(World world) {
+        File worldFolder = world.getWorldFolder();
+        return switch (world.getEnvironment()) {
+            case NORMAL -> worldFolder;
+            case NETHER -> {
+                File dim = new File(worldFolder, DIM_1);
+                yield dim.isDirectory() ? dim : worldFolder;
+            }
+            case THE_END -> {
+                File dim = new File(worldFolder, "DIM1");
+                yield dim.isDirectory() ? dim : worldFolder;
+            }
+            default -> worldFolder;
+        };
+    }
+
+    /**
      * Deletes a file if it exists, logging an error if deletion fails.
      * Does not log if the parent folder does not exist (normal for entities/poi).
      * @param file the file to delete
@@ -227,13 +254,13 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         File overworldPoi = new File(base, POI);
 
         World netherWorld = getPlugin().getIWM().getNetherWorld(world);
-        File netherBase      = netherWorld != null ? netherWorld.getWorldFolder() : new File(base, DIM_1);
+        File netherBase      = netherWorld != null ? resolveDataFolder(netherWorld) : new File(base, DIM_1);
         File netherRegion    = new File(netherBase, REGION);
         File netherEntities  = new File(netherBase, ENTITIES);
         File netherPoi       = new File(netherBase, POI);
 
         World endWorld = getPlugin().getIWM().getEndWorld(world);
-        File endBase         = endWorld != null ? endWorld.getWorldFolder() : new File(base, "DIM1");
+        File endBase         = endWorld != null ? resolveDataFolder(endWorld) : new File(base, "DIM1");
         File endRegion       = new File(endBase, REGION);
         File endEntities     = new File(endBase, ENTITIES);
         File endPoi          = new File(endBase, POI);
@@ -461,17 +488,39 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         File overworldRegion = new File(worldDir, REGION);
 
         World netherWorld = getPlugin().getIWM().getNetherWorld(world);
-        File netherRegion = netherWorld != null
-                ? new File(netherWorld.getWorldFolder(), REGION)
-                : new File(worldDir, DIM_1 + File.separator + REGION);
+        File netherBase = netherWorld != null
+                ? resolveDataFolder(netherWorld)
+                : new File(worldDir, DIM_1);
+        File netherRegion = new File(netherBase, REGION);
 
         World endWorld = getPlugin().getIWM().getEndWorld(world);
-        File endRegion = endWorld != null
-                ? new File(endWorld.getWorldFolder(), REGION)
-                : new File(worldDir, "DIM1" + File.separator + REGION);
+        File endBase = endWorld != null
+                ? resolveDataFolder(endWorld)
+                : new File(worldDir, "DIM1");
+        File endRegion = new File(endBase, REGION);
 
         // Compute cutoff timestamp
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days);
+
+        // Log resolved paths for diagnostics
+        getPlugin().log("Purge region folders - Overworld: " + overworldRegion.getAbsolutePath()
+                + " (exists=" + overworldRegion.isDirectory() + ")");
+        if (isNether) {
+            getPlugin().log("Purge region folders - Nether: " + netherRegion.getAbsolutePath()
+                    + " (exists=" + netherRegion.isDirectory() + ")");
+        } else {
+            getPlugin().log("Purge region folders - Nether: disabled (isNetherGenerate="
+                    + getPlugin().getIWM().isNetherGenerate(world) + ", isNetherIslands="
+                    + getPlugin().getIWM().isNetherIslands(world) + ")");
+        }
+        if (isEnd) {
+            getPlugin().log("Purge region folders - End: " + endRegion.getAbsolutePath()
+                    + " (exists=" + endRegion.isDirectory() + ")");
+        } else {
+            getPlugin().log("Purge region folders - End: disabled (isEndGenerate="
+                    + getPlugin().getIWM().isEndGenerate(world) + ", isEndIslands="
+                    + getPlugin().getIWM().isEndIslands(world) + ")");
+        }
 
         // Collect all candidate region names from overworld, nether, and end.
         // This ensures orphaned nether/end files are caught even if the overworld
@@ -482,18 +531,23 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         if (owFiles != null) {
             for (File f : owFiles) candidateNames.add(f.getName());
         }
+        getPlugin().log("Purge found " + (owFiles != null ? owFiles.length : 0) + " overworld region files");
         if (isNether) {
             File[] nFiles = netherRegion.listFiles((dir, name) -> name.endsWith(".mca"));
             if (nFiles != null) {
                 for (File f : nFiles) candidateNames.add(f.getName());
             }
+            getPlugin().log("Purge found " + (nFiles != null ? nFiles.length : 0) + " nether region files");
         }
         if (isEnd) {
             File[] eFiles = endRegion.listFiles((dir, name) -> name.endsWith(".mca"));
             if (eFiles != null) {
                 for (File f : eFiles) candidateNames.add(f.getName());
             }
+            getPlugin().log("Purge found " + (eFiles != null ? eFiles.length : 0) + " end region files");
         }
+
+        getPlugin().log("Purge total candidate region coordinates: " + candidateNames.size());
 
         for (String name : candidateNames) {
             // Parse region coords from filename "r.<x>.<z>.mca"


### PR DESCRIPTION
## Summary
- Nether and End worlds store region data in `DIM-1/` and `DIM1/` subfolders within their world folder, but the purge command was looking directly in `worldFolder/region/` which doesn't exist for non-overworld dimensions
- This caused `deleteIfExists()` to silently succeed without deleting anything, explaining why admins saw zero nether size reduction after purging
- Added `resolveDataFolder()` helper that checks the world's `Environment` type and resolves the correct dimension subfolder (`DIM-1` for nether, `DIM1` for end), with fallback to the world folder directly if the subfolder doesn't exist
- Added diagnostic logging that prints resolved paths, whether they exist, and how many `.mca` files are found per dimension — so admins can confirm the fix is working in their server logs

## Test plan
- [ ] Run `purge regions` on a server with nether islands enabled
- [ ] Check server logs for the new diagnostic lines confirming the nether region folder is found with `exists=true` and a non-zero file count
- [ ] Verify the nether world folder size decreases after the purge completes
- [ ] Verify overworld purge still works as before
