### PR TITLE
Fix SonarCloud HIGH severity code smells

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommand.java
@@ -55,68 +55,61 @@ public class AdminMaxHomesCommand extends ConfirmableCommand {
             showHelp(this, user);
             return false;
         }
-        // Check arguments
         if (args.size() == 1) {
-            // Player must be in game
-            if (!user.isPlayer()) {
-                user.sendMessage("general.errors.use-in-game");
-                return false;
-            }
-            // Check world
-            if (user.getWorld() != getWorld()) {
-                user.sendMessage("general.errors.wrong-world");
-                return false;
-            }
-            // Arg must be an integer to return true, otherwise false
-            maxHomes = Ints.tryParse(args.getFirst());
-            if (maxHomes == null || maxHomes < 1) {
-                user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.getFirst());
-                return false;
-            }
-            // Get the island the user is standing on
-            boolean onIsland = getIslands().getIslandAt(user.getLocation()).map(is -> {
-                islands.put("", new IslandInfo(is, false));
-                return true;
-            }).orElse(false);
-            if (!onIsland) {
-                user.sendMessage("general.errors.not-on-island");
-                return false;
-            }
-            return true;
+            return canExecuteStandingOnIsland(user, args);
         }
-        // More than one argument
-        // First arg must be a valid player name
+        return canExecuteWithTarget(user, args);
+    }
+
+    private boolean canExecuteStandingOnIsland(User user, List<String> args) {
+        if (!user.isPlayer()) {
+            user.sendMessage("general.errors.use-in-game");
+            return false;
+        }
+        if (user.getWorld() != getWorld()) {
+            user.sendMessage("general.errors.wrong-world");
+            return false;
+        }
+        maxHomes = Ints.tryParse(args.getFirst());
+        if (maxHomes == null || maxHomes < 1) {
+            user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.getFirst());
+            return false;
+        }
+        boolean onIsland = getIslands().getIslandAt(user.getLocation()).map(is -> {
+            islands.put("", new IslandInfo(is, false));
+            return true;
+        }).orElse(false);
+        if (!onIsland) {
+            user.sendMessage("general.errors.not-on-island");
+            return false;
+        }
+        return true;
+    }
+
+    private boolean canExecuteWithTarget(User user, List<String> args) {
         UUID targetUUID = getPlayers().getUUID(args.getFirst());
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.getFirst());
             return false;
         }
-        // Second arg must be the max homes number
         maxHomes = Ints.tryParse(args.get(1));
         if (maxHomes == null) {
             user.sendMessage("general.errors.must-be-positive-number", TextVariables.NUMBER, args.get(1));
             return false;
         }
-
-        // Get islands
         islands = IslandGoCommand.getNameIslandMap(User.getInstance(targetUUID), getWorld());
         if (islands.isEmpty()) {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         }
         if (args.size() > 2) {
-            // A specific island is mentioned. Parse which one it is and remove the others
-            final String name = String.join(" ", args.subList(2, args.size())); // Join all the args from here with spaces
-
+            final String name = String.join(" ", args.subList(2, args.size()));
             islands.keySet().removeIf(n -> !name.equalsIgnoreCase(n));
-
             if (islands.isEmpty()) {
-                // Failed name check - there are either
                 user.sendMessage("commands.admin.maxhomes.errors.unknown-island", TextVariables.NAME, name);
                 return false;
             }
         }
-
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
@@ -43,6 +43,8 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
     private static final String DIM_1 = "DIM-1";
     private static final String IN_WORLD = " in world ";
     private static final String WILL_BE_DELETED = " will be deleted";
+    private static final String EXISTS_PREFIX = " (exists=";
+    private static final String PURGE_FOUND = "Purge found ";
     
     private volatile boolean inPurge;
     private boolean toBeConfirmed;
@@ -504,10 +506,10 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
 
         // Log resolved paths for diagnostics
         getPlugin().log("Purge region folders - Overworld: " + overworldRegion.getAbsolutePath()
-                + " (exists=" + overworldRegion.isDirectory() + ")");
+                + EXISTS_PREFIX + overworldRegion.isDirectory() + ")");
         if (isNether) {
             getPlugin().log("Purge region folders - Nether: " + netherRegion.getAbsolutePath()
-                    + " (exists=" + netherRegion.isDirectory() + ")");
+                    + EXISTS_PREFIX + netherRegion.isDirectory() + ")");
         } else {
             getPlugin().log("Purge region folders - Nether: disabled (isNetherGenerate="
                     + getPlugin().getIWM().isNetherGenerate(world) + ", isNetherIslands="
@@ -515,7 +517,7 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         }
         if (isEnd) {
             getPlugin().log("Purge region folders - End: " + endRegion.getAbsolutePath()
-                    + " (exists=" + endRegion.isDirectory() + ")");
+                    + EXISTS_PREFIX + endRegion.isDirectory() + ")");
         } else {
             getPlugin().log("Purge region folders - End: disabled (isEndGenerate="
                     + getPlugin().getIWM().isEndGenerate(world) + ", isEndIslands="
@@ -531,20 +533,20 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         if (owFiles != null) {
             for (File f : owFiles) candidateNames.add(f.getName());
         }
-        getPlugin().log("Purge found " + (owFiles != null ? owFiles.length : 0) + " overworld region files");
+        getPlugin().log(PURGE_FOUND + (owFiles != null ? owFiles.length : 0) + " overworld region files");
         if (isNether) {
             File[] nFiles = netherRegion.listFiles((dir, name) -> name.endsWith(".mca"));
             if (nFiles != null) {
                 for (File f : nFiles) candidateNames.add(f.getName());
             }
-            getPlugin().log("Purge found " + (nFiles != null ? nFiles.length : 0) + " nether region files");
+            getPlugin().log(PURGE_FOUND + (nFiles != null ? nFiles.length : 0) + " nether region files");
         }
         if (isEnd) {
             File[] eFiles = endRegion.listFiles((dir, name) -> name.endsWith(".mca"));
             if (eFiles != null) {
                 for (File f : eFiles) candidateNames.add(f.getName());
             }
-            getPlugin().log("Purge found " + (eFiles != null ? eFiles.length : 0) + " end region files");
+            getPlugin().log(PURGE_FOUND + (eFiles != null ? eFiles.length : 0) + " end region files");
         }
 
         getPlugin().log("Purge total candidate region coordinates: " + candidateNames.size());

--- a/src/main/java/world/bentobox/bentobox/api/flags/FlagListener.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/FlagListener.java
@@ -154,14 +154,8 @@ public abstract class FlagListener implements Listener {
 
         // Protection flag
         // Ops or "bypass everywhere" moderators can do anything unless they have switched it off
-        if (!user.getMetaData(AdminSwitchCommand.META_TAG).map(MetaDataValue::asBoolean).orElse(false)
-                && (user.hasPermission(getIWM().getPermissionPrefix(loc.getWorld()) + "mod.bypassprotect")
-                        || user.hasPermission(getIWM().getPermissionPrefix(loc.getWorld()) + "mod.bypass." + flag.getID() + ".everywhere"))) {
-            if (user.isOp()) {
-                report(user, e, loc, flag,  Why.OP);
-            } else {
-                report(user, e, loc, flag,  Why.BYPASS_EVERYWHERE);
-            }
+        if (hasBypassEverywhere(loc, flag)) {
+            report(user, e, loc, flag, user.isOp() ? Why.OP : Why.BYPASS_EVERYWHERE);
             return true;
         }
         // Check if the island is deleted - if so, then nothing is allowed by default
@@ -184,13 +178,18 @@ public abstract class FlagListener implements Listener {
         }
         // The player is in the world, but not on an island, so general world settings apply
         if (flag.isSetForWorld(loc.getWorld())) {
-            report(user, e, loc, flag,  Why.ALLOWED_IN_WORLD);
+            report(user, e, loc, flag, Why.ALLOWED_IN_WORLD);
             return true;
-        } else {
-            report(user, e, loc, flag,  Why.NOT_ALLOWED_IN_WORLD);
-            noGo(e, flag, silent, WORLD_PROTECTED);
-            return false;
         }
+        report(user, e, loc, flag, Why.NOT_ALLOWED_IN_WORLD);
+        noGo(e, flag, silent, WORLD_PROTECTED);
+        return false;
+    }
+
+    private boolean hasBypassEverywhere(Location loc, Flag flag) {
+        return !user.getMetaData(AdminSwitchCommand.META_TAG).map(MetaDataValue::asBoolean).orElse(false)
+                && (user.hasPermission(getIWM().getPermissionPrefix(loc.getWorld()) + "mod.bypassprotect")
+                        || user.hasPermission(getIWM().getPermissionPrefix(loc.getWorld()) + "mod.bypass." + flag.getID() + ".everywhere"));
     }
 
     private boolean processBypass(@NonNull Flag flag, Island island, @NonNull Event e, @NonNull Location loc, boolean silent) {

--- a/src/main/java/world/bentobox/bentobox/api/hooks/NPCHook.java
+++ b/src/main/java/world/bentobox/bentobox/api/hooks/NPCHook.java
@@ -27,7 +27,7 @@ public abstract class NPCHook extends Hook {
 
     public abstract boolean spawnNpc(String yaml, Location pos) throws InvalidConfigurationException;
 
-    public abstract Map<? extends Vector, ? extends List<BlueprintEntity>> getNpcsInArea(World world,
+    public abstract Map<Vector, List<BlueprintEntity>> getNpcsInArea(World world,
             List<Vector> vectorsToCopy, @Nullable Vector origin);
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -641,67 +641,31 @@ public class User implements MetaDataAble {
      * @param message The message to send, containing inline commands in square brackets.
      */
     public void sendRawMessage(String message) {
-        // Create a base TextComponent for the message
         TextComponent baseComponent = new TextComponent();
 
-        // Regex to find inline commands like [run_command: /help] and [hover: click for help!], or unrecognized commands
         Pattern pattern = Pattern.compile("\\[(\\w+): ([^\\]]+)]|\\[\\[(.*?)\\]]");
         Matcher matcher = pattern.matcher(message);
 
-        // Keep track of the current position in the message
         int lastMatchEnd = 0;
         ClickEvent clickEvent = null;
         HoverEvent hoverEvent = null;
 
         while (matcher.find()) {
-            // Add any text before the current match
             if (matcher.start() > lastMatchEnd) {
-                String beforeMatch = message.substring(lastMatchEnd, matcher.start());
-                baseComponent.addExtra(TextComponent.fromLegacy(beforeMatch));
+                baseComponent.addExtra(TextComponent.fromLegacy(message.substring(lastMatchEnd, matcher.start())));
             }
-
-            // Check if it's a recognized command or an unknown bracketed text
             if (matcher.group(1) != null && matcher.group(2) != null) {
-                // Parse the inline command (action) and value
-                String actionType = matcher.group(1).toUpperCase(Locale.ENGLISH); // e.g., RUN_COMMAND, HOVER
-                String actionValue = matcher.group(2); // The command or text to display
-
-                // Apply the first valid click event or hover event encountered
-                switch (actionType) {
-                case "RUN_COMMAND":
-                case "SUGGEST_COMMAND":
-                case "COPY_TO_CLIPBOARD":
-                case "OPEN_URL":
-                    if (clickEvent == null) {
-                        clickEvent = new ClickEvent(ClickEvent.Action.valueOf(actionType), actionValue);
-                    }
-                    break;
-                case "HOVER":
-                    if (hoverEvent == null) {
-                        hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(actionValue));
-                    }
-                    break;
-                default:
-                    // Unrecognized command; preserve it in the output text
-                    baseComponent.addExtra(TextComponent.fromLegacy(matcher.group(0)));
-                }
-
+                clickEvent = parseClickAction(matcher, baseComponent, clickEvent);
+                hoverEvent = parseHoverAction(matcher, hoverEvent);
             } else if (matcher.group(3) != null) {
-                // Unrecognized bracketed text; preserve it in the output
                 baseComponent.addExtra(TextComponent.fromLegacy("[[" + matcher.group(3) + "]]"));
             }
-
-            // Update the last match end position
             lastMatchEnd = matcher.end();
         }
 
-        // Add any remaining text after the last match
         if (lastMatchEnd < message.length()) {
-            String remainingText = message.substring(lastMatchEnd);
-            baseComponent.addExtra(TextComponent.fromLegacy(remainingText));
+            baseComponent.addExtra(TextComponent.fromLegacy(message.substring(lastMatchEnd)));
         }
-
-        // Apply the first encountered ClickEvent and HoverEvent to the entire message
         if (clickEvent != null) {
             baseComponent.setClickEvent(clickEvent);
         }
@@ -709,13 +673,36 @@ public class User implements MetaDataAble {
             baseComponent.setHoverEvent(hoverEvent);
         }
 
-        // Send the final component to the sender
         if (sender != null) {
             sender.spigot().sendMessage(baseComponent);
         } else {
-            // Handle offline player messaging or alternative actions
             Bukkit.getPluginManager().callEvent(new OfflineMessageEvent(this.playerUUID, message));
         }
+    }
+
+    private ClickEvent parseClickAction(Matcher matcher, TextComponent baseComponent, ClickEvent existing) {
+        String actionType = matcher.group(1).toUpperCase(Locale.ENGLISH);
+        String actionValue = matcher.group(2);
+        return switch (actionType) {
+        case "RUN_COMMAND", "SUGGEST_COMMAND", "COPY_TO_CLIPBOARD", "OPEN_URL" ->
+                existing == null ? new ClickEvent(ClickEvent.Action.valueOf(actionType), actionValue) : existing;
+        case "HOVER" -> existing; // handled separately
+        default -> {
+            baseComponent.addExtra(TextComponent.fromLegacy(matcher.group(0)));
+            yield existing;
+        }
+        };
+    }
+
+    private HoverEvent parseHoverAction(Matcher matcher, HoverEvent existing) {
+        if (existing != null) {
+            return existing;
+        }
+        String actionType = matcher.group(1).toUpperCase(Locale.ENGLISH);
+        if ("HOVER".equals(actionType)) {
+            return new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(matcher.group(2)));
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/blueprints/BlueprintClipboard.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/BlueprintClipboard.java
@@ -246,48 +246,50 @@ public class BlueprintClipboard {
     }
 
     private BlueprintBlock bluePrintBlock(Vector pos, Block block, boolean copyBiome) {
-        // Block state
         BlockState blockState = block.getState();
         BlueprintBlock b = new BlueprintBlock(block.getBlockData().getAsString());
 
         if (copyBiome) {
-            // Biome
             b.setBiome(block.getBiome());
         }
-
-        // Signs
         if (blockState instanceof Sign sign) {
             for (Side side : Side.values()) {
                 b.setSignLines(side, Arrays.asList(sign.getSide(side).getLines()));
                 b.setGlowingText(side, sign.getSide(side).isGlowingText());
             }
         }
-        // Set block data
         if (blockState.getBlockData() instanceof Attachable) {
-            // Placeholder for attachment
             bpBlocks.put(pos, new BlueprintBlock("minecraft:air"));
-            // Check for ItemsAdder block
-            plugin.getHooks().getHook("ItemsAdder").ifPresent(hook -> {
-                String iab = ItemsAdderHook.getInCustomRegion(block.getLocation());
-                if (iab != null) {
-                    b.setItemsAdderBlock(iab);
-                }
-            });
+            setItemsAdder(b, block);
             bpAttachable.put(pos, b);
             return null;
         }
 
-        if (block.getType().equals(Material.BEDROCK)) {
-            // Find the highest bedrock
-            if(blueprint.getBedrock() == null) {
-                blueprint.setBedrock(pos);
-            } else {
-                if (pos.getBlockY() > blueprint.getBedrock().getBlockY()) {
-                    blueprint.setBedrock(pos);
-                }
-            }
+        updateBedrock(pos, block);
+        serializeInventory(b, blockState);
+        if (blockState instanceof CreatureSpawner spawner) {
+            b.setCreatureSpawner(getSpawner(spawner));
         }
-        // Chests
+        if (blockState instanceof TrialSpawner spawner) {
+            b.setTrialSpawner(new BlueprintTrialSpawner(spawner.isOminous(),
+                    spawner.isOminous() ? spawner.getOminousConfiguration() : spawner.getNormalConfiguration()));
+        }
+        if (blockState instanceof Banner banner) {
+            b.setBannerPatterns(banner.getPatterns());
+        }
+        setItemsAdder(b, block);
+
+        return b;
+    }
+
+    private void updateBedrock(Vector pos, Block block) {
+        if (block.getType().equals(Material.BEDROCK)
+                && (blueprint.getBedrock() == null || pos.getBlockY() > blueprint.getBedrock().getBlockY())) {
+            blueprint.setBedrock(pos);
+        }
+    }
+
+    private void serializeInventory(BlueprintBlock b, BlockState blockState) {
         if (blockState instanceof InventoryHolder ih) {
             b.setInventory(new HashMap<>());
             for (int i = 0; i < ih.getInventory().getSize(); i++) {
@@ -297,30 +299,15 @@ public class BlueprintClipboard {
                 }
             }
         }
-        if (blockState instanceof CreatureSpawner spawner) {
-            b.setCreatureSpawner(getSpawner(spawner));
-        }
-        if (blockState instanceof TrialSpawner spawner) {
-            if (spawner.isOminous()) {
-                b.setTrialSpawner(new BlueprintTrialSpawner(true, spawner.getOminousConfiguration()));
-            } else {
-                b.setTrialSpawner(new BlueprintTrialSpawner(false, spawner.getNormalConfiguration()));
-            }
-        }
-        // Banners
-        if (blockState instanceof Banner banner) {
-            b.setBannerPatterns(banner.getPatterns());
-        }
+    }
 
-        // ItemsAdder
+    private void setItemsAdder(BlueprintBlock b, Block block) {
         plugin.getHooks().getHook("ItemsAdder").ifPresent(hook -> {
             String iab = ItemsAdderHook.getInCustomRegion(block.getLocation());
             if (iab != null) {
                 b.setItemsAdderBlock(iab);
             }
         });
-
-        return b;
     }
 
     private BlueprintCreatureSpawner getSpawner(CreatureSpawner spawner) {

--- a/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntity.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntity.java
@@ -201,29 +201,28 @@ public class BlueprintEntity {
             this.setAdult(false);
         }
         if (entity instanceof AbstractHorse horse) {
-            this.setDomestication(horse.getDomestication());
-            this.setInventory(new HashMap<>());
-            for (int i = 0; i < horse.getInventory().getSize(); i++) {
-                ItemStack item = horse.getInventory().getItem(i);
-                if (item != null) {
-                    this.getInventory().put(i, item);
-                }
-            }
+            serializeHorseInventory(horse);
         }
-
         if (entity instanceof Horse horse) {
             this.setStyle(horse.getStyle());
         }
-
-        // Display entities
         if (entity instanceof Display disp) {
             this.storeDisplay(disp);
         }
-        // ItemFrames
         if (entity instanceof ItemFrame frame) {
             this.setItemFrame(new ItemFrameRec(frame.getItem(), frame.getRotation(), frame.isFixed(), frame.isVisible(), frame.getItemDropChance()));
         }
+    }
 
+    private void serializeHorseInventory(AbstractHorse horse) {
+        this.setDomestication(horse.getDomestication());
+        this.setInventory(new HashMap<>());
+        for (int i = 0; i < horse.getInventory().getSize(); i++) {
+            ItemStack item = horse.getInventory().getItem(i);
+            if (item != null) {
+                this.getInventory().put(i, item);
+            }
+        }
     }
 
     /**
@@ -256,11 +255,10 @@ public class BlueprintEntity {
         e.setSilent(isSilent());
         e.setInvulnerable(isInvulnerable());
         e.setFireTicks(getFireTicks());
-        
+
         if (e instanceof ItemFrame frame) {
             setFrame(frame);
         }
-
         if (e instanceof Villager villager) {
             setVillager(villager);
         }
@@ -273,6 +271,13 @@ public class BlueprintEntity {
         if (chest != null && e instanceof ChestedHorse chestedHorse) {
             chestedHorse.setCarryingChest(chest);
         }
+        configureAgeable(e);
+        configureHorse(e);
+        // Shift to the in-block location (remove the 0.5 that the location serializer used)
+        e.getLocation().add(new Vector(x - 0.5D, y, z - 0.5D));
+    }
+
+    private void configureAgeable(Entity e) {
         if (adult != null && e instanceof Ageable ageable) {
             if (adult) {
                 ageable.setAdult();
@@ -280,18 +285,18 @@ public class BlueprintEntity {
                 ageable.setBaby();
             }
         }
+    }
+
+    private void configureHorse(Entity e) {
         if (e instanceof AbstractHorse horse) {
             if (domestication != null) horse.setDomestication(domestication);
             if (inventory != null) {
                 inventory.forEach((index, item) -> horse.getInventory().setItem(index, item));
-
             }
         }
         if (style != null && e instanceof Horse horse) {
             horse.setStyle(style);
         }
-        // Shift to the in-block location (remove the 0.5 that the location serializer used)
-        e.getLocation().add(new Vector(x - 0.5D, y, z - 0.5D));
     }
     private void setFrame(ItemFrame frame) {
         if (this.itemFrame == null) {

--- a/src/main/java/world/bentobox/bentobox/hooks/FancyNpcsHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/FancyNpcsHook.java
@@ -276,7 +276,7 @@ public class FancyNpcsHook extends NPCHook {
     }
 
     @Override
-    public Map<? extends Vector, ? extends List<BlueprintEntity>> getNpcsInArea(World world, List<Vector> vectorsToCopy,
+    public Map<Vector, List<BlueprintEntity>> getNpcsInArea(World world, List<Vector> vectorsToCopy,
             @Nullable Vector origin) {
         Map<Vector, List<BlueprintEntity>> bpEntities = new HashMap<>();
         for (Npc npc : FancyNpcsPlugin.get().getNpcManager().getAllNpcs()) {

--- a/src/main/java/world/bentobox/bentobox/hooks/ZNPCsPlusHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/ZNPCsPlusHook.java
@@ -84,7 +84,7 @@ public class ZNPCsPlusHook extends NPCHook {
     }
 
     @Override
-    public Map<? extends Vector, ? extends List<BlueprintEntity>> getNpcsInArea(World world, List<Vector> vectorsToCopy,
+    public Map<Vector, List<BlueprintEntity>> getNpcsInArea(World world, List<Vector> vectorsToCopy,
             @Nullable Vector origin) {
         Map<Vector, List<BlueprintEntity>> bpEntities = new HashMap<>();
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EntityInteractListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/EntityInteractListener.java
@@ -45,77 +45,39 @@ public class EntityInteractListener extends FlagListener {
         Player p = e.getPlayer();
         Location l = e.getRightClicked().getLocation();
 
-        if (e.getRightClicked() instanceof Vehicle)
-        {
-            if (e.getRightClicked() instanceof Animals)
-            {
-                // Animal riding
-                this.checkIsland(e, p, l, Flags.RIDING);
-            }
-            else if (e.getRightClicked() instanceof RideableMinecart)
-            {
-                // Minecart riding
-                this.checkIsland(e, p, l, Flags.MINECART);
-            }
-            else if (e.getRightClicked() instanceof StorageMinecart)
-            {
-                this.checkIsland(e, p, l, Flags.CHEST);
-            }
-            else if (e.getRightClicked() instanceof HopperMinecart)
-            {
-                this.checkIsland(e, p, l, Flags.HOPPER);
-            }
-            else if (e.getRightClicked() instanceof PoweredMinecart)
-            {
-                this.checkIsland(e, p, l, Flags.FURNACE);
-            }
-            else if (e.getPlayer().isSneaking() && e.getRightClicked() instanceof ChestBoat)
-            {
-                // Access to chest boat since 1.19
-                this.checkIsland(e, p, l, Flags.CHEST);
-            }
-            else if (e.getRightClicked() instanceof Boat)
-            {
-                // Boat riding
-                this.checkIsland(e, p, l, Flags.BOAT);
-            }
+        if (e.getRightClicked() instanceof Vehicle) {
+            handleVehicleInteract(e, p, l);
+            return;
         }
-        else if (e.getRightClicked() instanceof Villager && !(e.getRightClicked() instanceof WanderingTrader))
-        {
-            // Villager trading
-            // Check naming and check trading
+        if (e.getRightClicked() instanceof Villager && !(e.getRightClicked() instanceof WanderingTrader)) {
             this.checkIsland(e, p, l, Flags.TRADING);
-
-            if (e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.NAME_TAG))
-            {
-                this.checkIsland(e, p, l, Flags.NAME_TAG);
-            }
-        }
-        else if (e.getRightClicked() instanceof Allay)
-        {
-            // Allay item giving/taking
+        } else if (e.getRightClicked() instanceof Allay
+                || e.getRightClicked().getType().name().equals("COPPER_GOLEM")) {
             this.checkIsland(e, p, l, Flags.ALLAY);
-
-            // Check naming
-            if (e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.NAME_TAG))
-            {
-                this.checkIsland(e, p, l, Flags.NAME_TAG);
-            }
         }
-        else if (e.getRightClicked().getType().name().equals("COPPER_GOLEM"))
-        {
-            // Copper Golem item giving/taking - reuses ALLAY flag since both entities carry items
-            this.checkIsland(e, p, l, Flags.ALLAY);
+        checkNameTag(e, p, l);
+    }
 
-            // Check naming
-            if (e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.NAME_TAG))
-            {
-                this.checkIsland(e, p, l, Flags.NAME_TAG);
-            }
+    private void handleVehicleInteract(PlayerInteractEntityEvent e, Player p, Location l) {
+        if (e.getRightClicked() instanceof Animals) {
+            this.checkIsland(e, p, l, Flags.RIDING);
+        } else if (e.getRightClicked() instanceof RideableMinecart) {
+            this.checkIsland(e, p, l, Flags.MINECART);
+        } else if (e.getRightClicked() instanceof StorageMinecart) {
+            this.checkIsland(e, p, l, Flags.CHEST);
+        } else if (e.getRightClicked() instanceof HopperMinecart) {
+            this.checkIsland(e, p, l, Flags.HOPPER);
+        } else if (e.getRightClicked() instanceof PoweredMinecart) {
+            this.checkIsland(e, p, l, Flags.FURNACE);
+        } else if (e.getPlayer().isSneaking() && e.getRightClicked() instanceof ChestBoat) {
+            this.checkIsland(e, p, l, Flags.CHEST);
+        } else if (e.getRightClicked() instanceof Boat) {
+            this.checkIsland(e, p, l, Flags.BOAT);
         }
-        else if (e.getPlayer().getInventory().getItemInMainHand().getType().equals(Material.NAME_TAG))
-        {
-            // Name tags
+    }
+
+    private void checkNameTag(PlayerInteractEntityEvent e, Player p, Location l) {
+        if (p.getInventory().getItemInMainHand().getType().equals(Material.NAME_TAG)) {
             this.checkIsland(e, p, l, Flags.NAME_TAG);
         }
     }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListener.java
@@ -141,34 +141,33 @@ public class HurtingListener extends FlagListener {
                 if (attacker.equals(entity)) {
                     continue;
                 }
-                // Monsters being hurt
-                if (Util.isHostileEntity(entity) && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_MONSTERS)) {
-                    for (PotionEffect effect : e.getPotion().getEffects()) {
-                        entity.removePotionEffect(effect.getType());
-                    }
-                }
-
-                // Tamed animals being hurt
-                if (Util.isTamableEntity(entity) && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_TAMED_ANIMALS)) {
-                    for (PotionEffect effect : e.getPotion().getEffects()) {
-                        entity.removePotionEffect(effect.getType());
-                    }
-                }
-
-                // Mobs being hurt
-                if (Util.isPassiveEntity(entity) && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_ANIMALS)) {
-                    for (PotionEffect effect : e.getPotion().getEffects()) {
-                        entity.removePotionEffect(effect.getType());
-                    }
-                }
-
-                // Villagers being hurt
-                if (entity instanceof AbstractVillager && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_VILLAGERS)) {
-                    for (PotionEffect effect : e.getPotion().getEffects()) {
-                        entity.removePotionEffect(effect.getType());
-                    }
-                }
+                checkSplashDamage(e, attacker, entity);
             }
+        }
+    }
+
+    private void checkSplashDamage(PotionSplashEvent e, Player attacker, LivingEntity entity) {
+        // Monsters being hurt
+        if (Util.isHostileEntity(entity) && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_MONSTERS)) {
+            removePotionEffects(e, entity);
+        }
+        // Tamed animals being hurt
+        if (Util.isTamableEntity(entity) && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_TAMED_ANIMALS)) {
+            removePotionEffects(e, entity);
+        }
+        // Mobs being hurt
+        if (Util.isPassiveEntity(entity) && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_ANIMALS)) {
+            removePotionEffects(e, entity);
+        }
+        // Villagers being hurt
+        if (entity instanceof AbstractVillager && !checkIsland(e, attacker, entity.getLocation(), Flags.HURT_VILLAGERS)) {
+            removePotionEffects(e, entity);
+        }
+    }
+
+    private void removePotionEffects(PotionSplashEvent e, LivingEntity entity) {
+        for (PotionEffect effect : e.getPotion().getEffects()) {
+            entity.removePotionEffect(effect.getType());
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1328,35 +1328,11 @@ public class IslandsManager {
             if (island == null) {
                 plugin.logWarning("Null island when loading...");
                 continue;
-            } else if (island.isDeleted()) {
-                // TODO delete from database
             }
-            // Check island distance and if incorrect stop BentoBox
-            else if (!plugin.getSettings().isOverrideSafetyCheck()
-                    && plugin.getIWM().getAddon(island.getWorld()).map(GameModeAddon::isEnforceEqualRanges).orElse(true)
-                    && island.getWorld() != null
-                    && plugin.getIWM().inWorld(island.getWorld())
-                    && island.getRange() != plugin.getIWM().getIslandDistance(island.getWorld())) {
-                throw new IOException("Island distance mismatch!\n" + "World '" + island.getWorld().getName()
-                        + "' distance " + plugin.getIWM().getIslandDistance(island.getWorld()) + " != island range "
-                        + island.getRange() + "!\n" + "Island ID in database is " + island.getUniqueId() + ".\n"
-                        + "Island distance in config.yml cannot be changed mid-game! Fix config.yml or clean database.");
+            if (island.isDeleted()) {
+                // TODO delete from database
             } else {
-                // Only try to fix the island center if we have to
-                if (!plugin.getSettings().isOverrideSafetyCheck() && plugin.getIWM().getAddon(island.getWorld()).map(GameModeAddon::isFixIslandCenter).orElse(true)) {
-                    // Fix island center if it is off
-                    fixIslandCenter(island);
-                }
-                islandCache.addIsland(island, true);
-
-                if (island.isSpawn()) {
-                    // Success, set spawn if this is the spawn island.
-                    this.setSpawn(island);
-                } else {
-                    // Successful load
-                    // Clean any null flags out of the island - these can occur for various reasons
-                    island.getFlags().keySet().removeIf(f -> f.startsWith("NULL_FLAG"));
-                }
+                loadIsland(island);
             }
 
             // Update some of their fields
@@ -1365,6 +1341,37 @@ public class IslandsManager {
                         .orElse(""));
             }
         }
+    }
+
+    private void loadIsland(Island island) throws IOException {
+        // Check island distance and if incorrect stop BentoBox
+        if (hasDistanceMismatch(island)) {
+            throw new IOException("Island distance mismatch!\n" + "World '" + island.getWorld().getName()
+                    + "' distance " + plugin.getIWM().getIslandDistance(island.getWorld()) + " != island range "
+                    + island.getRange() + "!\n" + "Island ID in database is " + island.getUniqueId() + ".\n"
+                    + "Island distance in config.yml cannot be changed mid-game! Fix config.yml or clean database.");
+        }
+        // Only try to fix the island center if we have to
+        if (!plugin.getSettings().isOverrideSafetyCheck()
+                && plugin.getIWM().getAddon(island.getWorld()).map(GameModeAddon::isFixIslandCenter).orElse(true)) {
+            fixIslandCenter(island);
+        }
+        islandCache.addIsland(island, true);
+
+        if (island.isSpawn()) {
+            this.setSpawn(island);
+        } else {
+            // Clean any null flags out of the island - these can occur for various reasons
+            island.getFlags().keySet().removeIf(f -> f.startsWith("NULL_FLAG"));
+        }
+    }
+
+    private boolean hasDistanceMismatch(Island island) {
+        return !plugin.getSettings().isOverrideSafetyCheck()
+                && plugin.getIWM().getAddon(island.getWorld()).map(GameModeAddon::isEnforceEqualRanges).orElse(true)
+                && island.getWorld() != null
+                && plugin.getIWM().inWorld(island.getWorld())
+                && island.getRange() != plugin.getIWM().getIslandDistance(island.getWorld());
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/WebManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/WebManager.java
@@ -193,7 +193,7 @@ public class WebManager {
     private String getContent(@NonNull GitHubRepository repo, String fileName) {
         try {
             String content = repo.getContent(fileName).getContent();
-            return new String(DatatypeConverter.parseBase64Binary(content.replaceAll("_", "/")));
+            return new String(DatatypeConverter.parseBase64Binary(content.replace("_", "/")));
         } catch (Exception e) {
             // Silently fail
         }

--- a/src/main/java/world/bentobox/bentobox/panels/PlaceholderListPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/PlaceholderListPanel.java
@@ -13,6 +13,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TemplatedPanel;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
@@ -59,6 +60,8 @@ public class PlaceholderListPanel extends AbstractPanel {
     private static final String PANEL_NAME = "placeholder_list_panel";
     private static final String PLACEHOLDER_TYPE = "PLACEHOLDER";
     private static final String BACK_TYPE = "BACK";
+    private static final String PLACEHOLDER_VAR = "[placeholder]";
+    private static final String COUNT_VAR = "[count]";
     /** Maximum visible characters per lore description line before wrapping. */
     private static final int LORE_LINE_WIDTH = 38;
     /** Number of series members to sample in the lore value preview. */
@@ -136,7 +139,7 @@ public class PlaceholderListPanel extends AbstractPanel {
         panelBuilder.world(user.getWorld());
 
         // Title shows a breadcrumb: "SourceName > segment > segment"
-        panelBuilder.parameters("[name]", buildBreadcrumb());
+        panelBuilder.parameters(TextVariables.NAME, buildBreadcrumb());
 
         panelBuilder.registerTypeBuilder(PLACEHOLDER_TYPE, this::createNodeButton);
         panelBuilder.registerTypeBuilder(BACK_TYPE, this::createBackButton);
@@ -194,13 +197,13 @@ public class PlaceholderListPanel extends AbstractPanel {
         boolean enabled = isEnabled(leaf.key());
 
         builder.name(user.getTranslation("panels.placeholder-list.buttons.leaf.name",
-                "[placeholder]", fullPh));
+                PLACEHOLDER_VAR, fullPh));
 
         List<String> lore = new ArrayList<>();
         if (!leaf.description().isBlank()) {
             wrapText(leaf.description()).forEach(line ->
                     lore.add(user.getTranslation("panels.placeholder-list.buttons.leaf.description",
-                            "[description]", line)));
+                            TextVariables.DESCRIPTION, line)));
         }
         addValueLine(lore, fullPh);
         if (!enabled) {
@@ -217,7 +220,7 @@ public class PlaceholderListPanel extends AbstractPanel {
                 "[label]", node.getLabel()));
         builder.description(
                 user.getTranslation("panels.placeholder-list.buttons.folder.description",
-                        "[count]", String.valueOf(count)),
+                        COUNT_VAR, String.valueOf(count)),
                 user.getTranslation("panels.placeholder-list.buttons.folder.hint"));
     }
 
@@ -228,17 +231,17 @@ public class PlaceholderListPanel extends AbstractPanel {
         int childCount = node.totalPlaceholderCount() - 1; // exclude the leaf itself
 
         builder.name(user.getTranslation("panels.placeholder-list.buttons.leaf.name",
-                "[placeholder]", fullPh));
+                PLACEHOLDER_VAR, fullPh));
 
         List<String> lore = new ArrayList<>();
         if (!leaf.description().isBlank()) {
             wrapText(leaf.description()).forEach(line ->
                     lore.add(user.getTranslation("panels.placeholder-list.buttons.leaf.description",
-                            "[description]", line)));
+                            TextVariables.DESCRIPTION, line)));
         }
         addValueLine(lore, fullPh);
         lore.add(user.getTranslation("panels.placeholder-list.buttons.folder.description",
-                "[count]", String.valueOf(childCount)));
+                COUNT_VAR, String.valueOf(childCount)));
         if (!enabled) {
             lore.add(user.getTranslation("panels.placeholder-list.buttons.leaf.disabled"));
         }
@@ -253,17 +256,17 @@ public class PlaceholderListPanel extends AbstractPanel {
         boolean anyDisabled = series.rawKeys().stream().anyMatch(k -> !isEnabled(k));
 
         builder.name(user.getTranslation("panels.placeholder-list.buttons.series.name",
-                "[placeholder]", fullPh));
+                PLACEHOLDER_VAR, fullPh));
 
         List<String> lore = new ArrayList<>();
         if (!series.description().isBlank()) {
             wrapText(series.description()).forEach(line ->
                     lore.add(user.getTranslation("panels.placeholder-list.buttons.series.description",
-                            "[description]", line)));
+                            TextVariables.DESCRIPTION, line)));
         }
         addSeriesSamples(lore, series);
         lore.add(user.getTranslation("panels.placeholder-list.buttons.series.range",
-                "[count]", String.valueOf(series.rawKeys().size()),
+                COUNT_VAR, String.valueOf(series.rawKeys().size()),
                 "[min]", String.valueOf(series.min()),
                 "[max]", String.valueOf(series.max())));
         if (anyDisabled) {
@@ -283,18 +286,18 @@ public class PlaceholderListPanel extends AbstractPanel {
 
         String seriesPh = "%" + expansionId + "_" + series.displayKey() + "%";
         builder.name(user.getTranslation("panels.placeholder-list.buttons.series.name",
-                "[placeholder]", leafPh + " / " + seriesPh));
+                PLACEHOLDER_VAR, leafPh + " / " + seriesPh));
 
         List<String> lore = new ArrayList<>();
         if (!leaf.description().isBlank()) {
             wrapText(leaf.description()).forEach(line ->
                     lore.add(user.getTranslation("panels.placeholder-list.buttons.leaf.description",
-                            "[description]", line)));
+                            TextVariables.DESCRIPTION, line)));
         }
         addValueLine(lore, leafPh);
         addSeriesSamples(lore, series);
         lore.add(user.getTranslation("panels.placeholder-list.buttons.series.range",
-                "[count]", String.valueOf(series.rawKeys().size()),
+                COUNT_VAR, String.valueOf(series.rawKeys().size()),
                 "[min]", String.valueOf(series.min()),
                 "[max]", String.valueOf(series.max())));
         if (!leafEnabled || anySeriesDisabled) {

--- a/src/main/java/world/bentobox/bentobox/panels/PlaceholderPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/PlaceholderPanel.java
@@ -11,6 +11,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TemplatedPanel;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
@@ -96,10 +97,10 @@ public class PlaceholderPanel extends AbstractPanel {
 
         if (template.description() != null) {
             builder.description(user.getTranslation(template.description(),
-                    "[number]", String.valueOf(count)));
+                    TextVariables.NUMBER, String.valueOf(count)));
         } else {
             builder.description(user.getTranslation("panels.placeholder.buttons.bentobox.description",
-                    "[number]", String.valueOf(count)));
+                    TextVariables.NUMBER, String.valueOf(count)));
         }
 
         builder.clickHandler((panel, u, clickType, i) -> {
@@ -133,20 +134,20 @@ public class PlaceholderPanel extends AbstractPanel {
 
         if (template.title() != null) {
             builder.name(user.getTranslation(template.title(),
-                    "[name]", addon.getDescription().getName()));
+                    TextVariables.NAME, addon.getDescription().getName()));
         } else {
             builder.name(user.getTranslation("panels.placeholder.buttons.addon.name",
-                    "[name]", addon.getDescription().getName()));
+                    TextVariables.NAME, addon.getDescription().getName()));
         }
 
         if (template.description() != null) {
             builder.description(user.getTranslation(template.description(),
-                    "[name]", addon.getDescription().getName(),
-                    "[number]", String.valueOf(count)));
+                    TextVariables.NAME, addon.getDescription().getName(),
+                    TextVariables.NUMBER, String.valueOf(count)));
         } else {
             builder.description(user.getTranslation("panels.placeholder.buttons.addon.description",
-                    "[name]", addon.getDescription().getName(),
-                    "[number]", String.valueOf(count)));
+                    TextVariables.NAME, addon.getDescription().getName(),
+                    TextVariables.NUMBER, String.valueOf(count)));
         }
 
         builder.clickHandler((panel, u, clickType, i) -> {

--- a/src/main/java/world/bentobox/bentobox/panels/customizable/AbstractPanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/customizable/AbstractPanel.java
@@ -12,6 +12,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TemplatedPanel;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
@@ -142,7 +143,7 @@ public abstract class AbstractPanel {
         }
         if (template.description() != null) {
             builder.description(user.getTranslation(template.description(),
-                    "[number]", String.valueOf(nextPage)));
+                    TextVariables.NUMBER, String.valueOf(nextPage)));
         }
 
         builder.clickHandler((panel, u, clickType, i) -> {
@@ -182,7 +183,7 @@ public abstract class AbstractPanel {
         }
         if (template.description() != null) {
             builder.description(user.getTranslation(template.description(),
-                    "[number]", String.valueOf(prevPage)));
+                    TextVariables.NUMBER, String.valueOf(prevPage)));
         }
 
         builder.clickHandler((panel, u, clickType, i) -> {

--- a/src/main/java/world/bentobox/bentobox/panels/customizable/LanguagePanel.java
+++ b/src/main/java/world/bentobox/bentobox/panels/customizable/LanguagePanel.java
@@ -360,125 +360,102 @@ public class LanguagePanel extends AbstractPanel
     {
         if (locale == null)
         {
-            // return as locale is null. Empty button will be created.
             return null;
         }
 
         final String reference = "panels.language.buttons.language.";
-
-        // Get settings for island.
         PanelItemBuilder builder = new PanelItemBuilder();
-
         BentoBoxLocale language = this.plugin.getLocalesManager().getLanguages().get(locale);
+        String displayName = StringUtils.capitalize(locale.getDisplayName(this.user.getLocale()));
 
-        if (template.icon() != null)
-        {
+        // Icon
+        if (template.icon() != null) {
             builder.icon(template.icon().clone());
-        }
-        else
-        {
+        } else {
             builder.icon(Objects.requireNonNullElseGet(language.getBanner(),
                     () -> new ItemStack(Material.WHITE_BANNER, 1)));
         }
 
-        if (template.title() != null)
-        {
+        // Title
+        if (template.title() != null) {
             builder.name(this.user.getTranslation(this.command.getWorld(), template.title(),
-                    TextVariables.NAME, StringUtils.capitalize(locale.getDisplayName(this.user.getLocale()))));
-        }
-        else
-        {
+                    TextVariables.NAME, displayName));
+        } else {
             builder.name(this.user.getTranslation(reference + "name",
-                    TextVariables.NAME, StringUtils.capitalize(locale.getDisplayName(this.user.getLocale()))));
+                    TextVariables.NAME, displayName));
         }
 
-        final StringBuilder authors = new StringBuilder();
-        authors.append(this.user.getTranslation(reference + "authors"));
+        // Description
+        builder.description(buildLocaleDescription(template, reference, language, locale));
 
-        for (String author : language.getAuthors())
-        {
-            authors.append("\n").append(this.user.getTranslation(reference + "author", TextVariables.NAME, author));
-        }
-
-        final StringBuilder selected = new StringBuilder();
-
-        if (this.user.getLocale().equals(locale))
-        {
-            selected.append(this.user.getTranslation(reference + "selected"));
-        }
-
-        String descriptionText;
-
-        if (template.description() != null)
-        {
-            descriptionText = this.user.getTranslationOrNothing(template.description(),
-                    AUTHORS, authors.toString(), SELECTED, selected.toString());
-        }
-        else
-        {
-            descriptionText = this.user.getTranslationOrNothing(reference + "description",
-                    AUTHORS, authors.toString(), SELECTED, selected.toString());
-        }
-
-        descriptionText = descriptionText.replaceAll("(?m)^[ \\t]*\\r?\\n", "").
-                replaceAll("(?<!\\\\)\\|", "\n").replaceAll("\\\\\\|", "|");
-
-        builder.description(descriptionText);
-
-        // Display actions only for non-selected locales.
-        List<ItemTemplateRecord.ActionRecords> actions = template.actions().stream().
-                filter(action -> !this.user.getLocale().equals(locale)
+        // Actions and click handler
+        List<ItemTemplateRecord.ActionRecords> actions = template.actions().stream()
+                .filter(action -> !this.user.getLocale().equals(locale)
                         && (SELECT_ACTION.equalsIgnoreCase(action.actionType())
                                 || COMMANDS_ACTION.equalsIgnoreCase(action.actionType())))
                 .toList();
 
-        // Add ClickHandler
-        builder.clickHandler((panel, user, clickType, i) ->
-        {
-            actions.forEach(action -> {
-                if (clickType == action.clickType() || action.clickType() == ClickType.UNKNOWN)
-                {
-                    if (SELECT_ACTION.equalsIgnoreCase(action.actionType()))
-                    {
-                        this.plugin.getPlayers().setLocale(this.user.getUniqueId(), locale.toLanguageTag());
-                        this.user.sendMessage("panels.language.edited", "[lang]",
-                                WordUtils.capitalize(locale.getDisplayName(this.user.getLocale())));
-
-                        // Rebuild panel
-                        this.build();
-                    }
-                    else if (COMMANDS_ACTION.equalsIgnoreCase(action.actionType()))
-                    {
-                        Util.runCommands(user,
-                                Arrays.stream(action.content()
-                                        .replaceAll(Pattern.quote(TextVariables.LABEL), this.command.getTopLabel())
-                                        .split("\n")).
-                                toList(),
-                                "CHANGE_LOCALE_COMMANDS");
-                    }
-                }
-            });
-
-            // Always return true.
+        builder.clickHandler((panel, user, clickType, i) -> {
+            handleLocaleClick(actions, clickType, locale, user);
             return true;
         });
 
-        // Collect tooltips.
-        List<String> tooltips = actions.stream().
-                filter(action -> action.tooltip() != null)
+        appendTooltips(builder, actions);
+        return builder.build();
+    }
+
+    private String buildLocaleDescription(ItemTemplateRecord template, String reference,
+            BentoBoxLocale language, Locale locale) {
+        StringBuilder authors = new StringBuilder();
+        authors.append(this.user.getTranslation(reference + "authors"));
+        for (String author : language.getAuthors()) {
+            authors.append("\n").append(this.user.getTranslation(reference + "author", TextVariables.NAME, author));
+        }
+
+        String selected = this.user.getLocale().equals(locale)
+                ? this.user.getTranslation(reference + "selected") : "";
+
+        String descKey = template.description() != null ? template.description() : reference + "description";
+        String descriptionText = this.user.getTranslationOrNothing(descKey,
+                AUTHORS, authors.toString(), SELECTED, selected);
+
+        return descriptionText.replaceAll("(?m)^[ \\t]*\\r?\\n", "")
+                .replaceAll("(?<!\\\\)\\|", "\n").replace("\\|", "|");
+    }
+
+    private void handleLocaleClick(List<ItemTemplateRecord.ActionRecords> actions,
+            ClickType clickType, Locale locale, User user) {
+        actions.forEach(action -> {
+            if (clickType != action.clickType() && action.clickType() != ClickType.UNKNOWN) {
+                return;
+            }
+            if (SELECT_ACTION.equalsIgnoreCase(action.actionType())) {
+                this.plugin.getPlayers().setLocale(this.user.getUniqueId(), locale.toLanguageTag());
+                this.user.sendMessage("panels.language.edited", "[lang]",
+                        WordUtils.capitalize(locale.getDisplayName(this.user.getLocale())));
+                this.build();
+            } else if (COMMANDS_ACTION.equalsIgnoreCase(action.actionType())) {
+                Util.runCommands(user,
+                        Arrays.stream(action.content()
+                                .replaceAll(Pattern.quote(TextVariables.LABEL), this.command.getTopLabel())
+                                .split("\n"))
+                        .toList(),
+                        "CHANGE_LOCALE_COMMANDS");
+            }
+        });
+    }
+
+    private void appendTooltips(PanelItemBuilder builder, List<ItemTemplateRecord.ActionRecords> actions) {
+        List<String> tooltips = actions.stream()
+                .filter(action -> action.tooltip() != null)
                 .map(action -> this.user.getTranslation(this.command.getWorld(), action.tooltip()))
                 .filter(text -> !text.isBlank())
                 .collect(Collectors.toCollection(() -> new ArrayList<>(actions.size())));
 
-        // Add tooltips.
-        if (!tooltips.isEmpty())
-        {
-            // Empty line and tooltips.
+        if (!tooltips.isEmpty()) {
             builder.description("");
             builder.description(tooltips);
         }
-
-        return builder.build();
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/DefaultHelpCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/DefaultHelpCommandTest.java
@@ -85,6 +85,7 @@ public class DefaultHelpCommandTest extends CommonTestSetup {
 
         @Override
         public void setup() {
+            // Not needed for test
         }
 
         @Override

--- a/src/test/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommandTest.java
@@ -128,6 +128,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
 
         @Override
         public void setup() {
+            // Not needed for test
         }
 
         @Override

--- a/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
@@ -279,7 +279,7 @@ public class PanelTest extends CommonTestSetup {
     @Test
     @Disabled("New test required for new code")
     public void testSetHead() {
-
+        // Not needed for test
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
@@ -171,13 +171,12 @@ public class PanelListenerManagerTest extends CommonTestSetup {
 
         @Override
         public void setTitle(String title) {
-            
+            // Not needed for test
         }
 
         @Override
         public void setItem(int slot, ItemStack item) {
-            
-
+            // Not needed for test
         }
 
         @Override
@@ -188,8 +187,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
 
         @Override
         public void setCursor(ItemStack item) {
-            
-
+            // Not needed for test
         }
 
         @Override
@@ -217,8 +215,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
 
         @Override
         public void close() {
-            
-
+            // Not needed for test
         }
 
         @Override
@@ -235,8 +232,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
 
         @Override
         public void open() {
-            
-
+            // Not needed for test
         }
 
         @Override

--- a/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
@@ -444,6 +444,7 @@ public class AddonsManagerTest extends CommonTestSetup {
 
         @Override
         public void createWorlds() {
+            // Not needed for test
         }
 
         @Override
@@ -458,14 +459,17 @@ public class AddonsManagerTest extends CommonTestSetup {
 
         @Override
         public void saveWorldSettings() {
+            // Not needed for test
         }
 
         @Override
         public void onEnable() {
+            // Not needed for test
         }
 
         @Override
         public void onDisable() {
+            // Not needed for test
         }
 
     }

--- a/src/test/java/world/bentobox/bentobox/managers/LocalesManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/LocalesManagerTest.java
@@ -326,31 +326,28 @@ public class LocalesManagerTest  extends CommonTestSetup {
 
     private void add(File source, JarOutputStream target) throws IOException
     {
-        BufferedInputStream in = null;
-        try
+        if (source.isDirectory())
         {
-            if (source.isDirectory())
+            String name = source.getPath().replace("\\", "/");
+            if (!name.isEmpty())
             {
-                String name = source.getPath().replace("\\", "/");
-                if (!name.isEmpty())
-                {
-                    if (!name.endsWith("/"))
-                        name += "/";
-                    JarEntry entry = new JarEntry(name);
-                    entry.setTime(source.lastModified());
-                    target.putNextEntry(entry);
-                    target.closeEntry();
-                }
-                for (File nestedFile: source.listFiles())
-                    add(nestedFile, target);
-                return;
+                if (!name.endsWith("/"))
+                    name += "/";
+                JarEntry entry = new JarEntry(name);
+                entry.setTime(source.lastModified());
+                target.putNextEntry(entry);
+                target.closeEntry();
             }
+            for (File nestedFile: source.listFiles())
+                add(nestedFile, target);
+            return;
+        }
 
-            JarEntry entry = new JarEntry(source.getPath().replace("\\", "/"));
-            entry.setTime(source.lastModified());
-            target.putNextEntry(entry);
-            in = new BufferedInputStream(new FileInputStream(source));
-
+        JarEntry entry = new JarEntry(source.getPath().replace("\\", "/"));
+        entry.setTime(source.lastModified());
+        target.putNextEntry(entry);
+        try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(source)))
+        {
             byte[] buffer = new byte[1024];
             while (true)
             {
@@ -359,13 +356,8 @@ public class LocalesManagerTest  extends CommonTestSetup {
                     break;
                 target.write(buffer, 0, count);
             }
-            target.closeEntry();
         }
-        finally
-        {
-            if (in != null)
-                in.close();
-        }
+        target.closeEntry();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Addresses 22 of 29 HIGH severity issues (all CODE_SMELL) reported by SonarCloud in the new code period
- Remaining 7 issues are in untested code (AdminPurgeRegionsCommand complexity, DefaultPasteUtil, YamlDatabaseHandler, FancyNpcsHook) and are deferred to avoid risk

## Changes

### Test code fixes (zero risk)
- Added comments to 12 empty method stubs in test classes (`PanelListenerManagerTest`, `PanelTest`, `DefaultHelpCommandTest`, `DelayedTeleportCommandTest`, `AddonsManagerTest`)
- Converted manual `try/finally` to `try-with-resources` in `LocalesManagerTest`

### Trivial production fixes (minimal risk)
- Replaced `replaceAll()` with `replace()` for literal (non-regex) string replacements in `WebManager` and `LanguagePanel`
- Extracted duplicated string literals into constants using `TextVariables` in `PlaceholderPanel`, `PlaceholderListPanel`, `AbstractPanel`, and `AdminPurgeRegionsCommand`
- Removed unnecessary `? extends` generic wildcards from `NPCHook.getNpcsInArea` and its implementations

### Cognitive complexity refactors (behavior-preserving)
- Extracted helper methods to reduce cognitive complexity in:
  - `HurtingListener.onSplashPotionSplash` — deduplicated potion effect removal
  - `EntityInteractListener.onPlayerInteractEntity` — extracted vehicle and name-tag handling
  - `BlueprintEntity` constructor and `configureEntity` — extracted horse/ageable helpers
  - `IslandsManager.load` — extracted island loading and distance-mismatch check
  - `FlagListener.checkIsland` — extracted bypass-everywhere check
  - `User.sendRawMessage` — extracted click/hover action parsing
  - `BlueprintClipboard.bluePrintBlock` — extracted bedrock, inventory, and ItemsAdder helpers
  - `AdminMaxHomesCommand.canExecute` — split into standing-on-island vs target-player paths
  - `LanguagePanel.createLocaleButton` — extracted description building, click handling, and tooltips

## Test plan
- [x] `./gradlew clean test` passes (all existing tests)
- [x] Verify SonarCloud re-analysis shows reduced issue count

🤖 Generated with [Claude Code](https://claude.com/claude-code)