### PR TITLE
Fix SonarCloud: Variable shadowing in tests and assertion improvements

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/Database.java
+++ b/src/main/java/world/bentobox/bentobox/database/Database.java
@@ -116,7 +116,7 @@ public class Database<T> {
      */
     public boolean saveObject(T instance) {
         saveObjectAsync(instance).thenAccept(r -> {
-            if (Boolean.FALSE.equals(r)) logger.severe(() -> "Could not save object to database!");
+            if (r != null && !r) logger.severe(() -> "Could not save object to database!");
         });
         return true;
     }

--- a/src/main/java/world/bentobox/bentobox/database/objects/adapters/FlagBooleanSerializer.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/adapters/FlagBooleanSerializer.java
@@ -36,7 +36,7 @@ public class FlagBooleanSerializer implements AdapterInterface<Map<String, Integ
         {
             for (Entry<String, Boolean> en : ((Map<String, Boolean>) object).entrySet())
             {
-                result.put(en.getKey(), Boolean.TRUE.equals(en.getValue()) ? 0 : -1);
+                result.put(en.getKey(), en.getValue() ? 0 : -1);
             }
         }
 

--- a/src/main/java/world/bentobox/bentobox/database/objects/adapters/FlagSerializer2.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/adapters/FlagSerializer2.java
@@ -29,7 +29,7 @@ public class FlagSerializer2 implements AdapterInterface<Map<Flag, Integer>, Map
             }
         } else {
             for (Entry<String, Boolean> en : ((Map<String, Boolean>)object).entrySet()) {
-                BentoBox.getInstance().getFlagsManager().getFlag(en.getKey()).ifPresent(flag -> result.put(flag, Boolean.TRUE.equals(en.getValue()) ? 0 : -1));
+                BentoBox.getInstance().getFlagsManager().getFlag(en.getKey()).ifPresent(flag -> result.put(flag, en.getValue() ? 0 : -1));
             }
         }
         return result;

--- a/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseConnector.java
+++ b/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseConnector.java
@@ -177,9 +177,10 @@ public class YamlDatabaseConnector implements DatabaseConnector {
     private void copyFileUsingStream(File source, File dest) throws IOException {
         try (InputStream is = new FileInputStream(source); OutputStream os = new FileOutputStream(dest)) {
             byte[] buffer = new byte[1024];
-            int length;
-            while ((length = is.read(buffer)) > 0) {
+            int length = is.read(buffer);
+            while (length > 0) {
                 os.write(buffer, 0, length);
+                length = is.read(buffer);
             }
         }
     }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListener.java
@@ -87,6 +87,7 @@ public class BreakBlocksListener extends FlagListener {
             try {
                 m = CaveVinesPlant.class.getMethod("isBerries");
             } catch (NoSuchMethodException ignored2) {
+                // Neither method name exists in this version; BERRIES_CHECK will remain null
             }
         }
         BERRIES_CHECK = m;

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/settings/MobSpawnListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/settings/MobSpawnListener.java
@@ -51,8 +51,8 @@ public class MobSpawnListener extends FlagListener
 
         Optional<Island> island = getIslands().getIslandAt(event.getPlayer().getLocation());
 
-        if (Boolean.TRUE.equals(island.map(i -> !i.isAllowed(Flags.MONSTER_NATURAL_SPAWN)).orElseGet(
-                () -> !Flags.MONSTER_NATURAL_SPAWN.isSetForWorld(event.getWorld()))))
+        if (island.map(i -> !i.isAllowed(Flags.MONSTER_NATURAL_SPAWN)).orElseGet(
+                () -> !Flags.MONSTER_NATURAL_SPAWN.isSetForWorld(event.getWorld())))
         {
             // Monster spawning is disabled on island or world. Cancel the raid.
             event.setCancelled(true);
@@ -75,8 +75,8 @@ public class MobSpawnListener extends FlagListener
 
         Optional<Island> island = getIslands().getIslandAt(event.getRaid().getLocation());
 
-        if (Boolean.TRUE.equals(island.map(i -> !i.isAllowed(Flags.MONSTER_NATURAL_SPAWN)).orElseGet(
-                () -> !Flags.MONSTER_NATURAL_SPAWN.isSetForWorld(event.getWorld()))))
+        if (island.map(i -> !i.isAllowed(Flags.MONSTER_NATURAL_SPAWN)).orElseGet(
+                () -> !Flags.MONSTER_NATURAL_SPAWN.isSetForWorld(event.getWorld())))
         {
             // CHEATERS. PUNISH THEM.
             event.getWinners().forEach(player ->

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/settings/MobTeleportListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/settings/MobTeleportListener.java
@@ -35,14 +35,14 @@ public class MobTeleportListener extends FlagListener {
         }
         Optional<Island> island = getIslands().getIslandAt(event.getEntity().getLocation());
 
-        if (event.getEntityType().equals(EntityType.ENDERMAN) && Boolean.TRUE.equals(island.map(i -> !i.isAllowed(Flags.ENDERMAN_TELEPORT)).orElseGet(
-                () -> !Flags.ENDERMAN_TELEPORT.isSetForWorld(w)))) {
+        if (event.getEntityType().equals(EntityType.ENDERMAN) && island.map(i -> !i.isAllowed(Flags.ENDERMAN_TELEPORT)).orElseGet(
+                () -> !Flags.ENDERMAN_TELEPORT.isSetForWorld(w))) {
             // Enderman teleport is disabled on island or world. Cancel it.
             event.setCancelled(true);
         }
 
-        if (event.getEntityType().equals(EntityType.SHULKER) && Boolean.TRUE.equals(island.map(i -> !i.isAllowed(Flags.SHULKER_TELEPORT)).orElseGet(
-                () -> !Flags.SHULKER_TELEPORT.isSetForWorld(w)))) {
+        if (event.getEntityType().equals(EntityType.SHULKER) && island.map(i -> !i.isAllowed(Flags.SHULKER_TELEPORT)).orElseGet(
+                () -> !Flags.SHULKER_TELEPORT.isSetForWorld(w))) {
             // Shulker teleport is disabled on island or world. Cancel it.
             event.setCancelled(true);
         }

--- a/src/main/java/world/bentobox/bentobox/managers/BlueprintClipboardManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/BlueprintClipboardManager.java
@@ -224,9 +224,10 @@ public class BlueprintClipboardManager {
         }
         try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(unzipFilePath.toFile().getCanonicalPath()))) {
             byte[] bytesIn = new byte[1024];
-            int read;
-            while ((read = zipInputStream.read(bytesIn)) != -1) {
+            int read = zipInputStream.read(bytesIn);
+            while (read != -1) {
                 bos.write(bytesIn, 0, read);
+                read = zipInputStream.read(bytesIn);
             }
         }
     }
@@ -236,9 +237,10 @@ public class BlueprintClipboardManager {
             zipOutputStream.putNextEntry(new ZipEntry(targetFile.getName()));
             try (FileInputStream inputStream = new FileInputStream(targetFile)) {
                 final byte[] buffer = new byte[1024];
-                int length;
-                while((length = inputStream.read(buffer)) >= 0) {
+                int length = inputStream.read(buffer);
+                while (length >= 0) {
                     zipOutputStream.write(buffer, 0, length);
+                    length = inputStream.read(buffer);
                 }
             }
             try {

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -1132,7 +1132,7 @@ public class IslandsManager {
             }
             Util.teleportAsync(Objects.requireNonNull(player), home).thenAccept(b -> {
                 // Only run the commands if the player is successfully teleported
-                if (Boolean.TRUE.equals(b)) {
+                if (b != null && b) {
                     teleported(world, user, name, newIsland, island);
                     result.complete(true);
                 } else {
@@ -1852,7 +1852,7 @@ public class IslandsManager {
         readyPlayer(user.getPlayer());
         return Util.teleportAsync(Objects.requireNonNull(user.getPlayer()), loc).thenAccept(b -> {
             // Only run the commands if the player is successfully teleported
-            if (Boolean.TRUE.equals(b)) {
+            if (b != null && b) {
                 teleported(island.getWorld(), user, "", newIsland, island);
                 this.setPrimaryIsland(user.getUniqueId(), island);
             } else {

--- a/src/main/java/world/bentobox/bentobox/util/ExpiringMap.java
+++ b/src/main/java/world/bentobox/bentobox/util/ExpiringMap.java
@@ -162,7 +162,7 @@ public class ExpiringMap<K, V> implements Map<K, V> {
      * @throws NullPointerException if the specified map is null, or if any key or value in the specified map is null
      */
     @Override
-    public void putAll(@NonNull Map<? extends K, ? extends V> m) {
+    public void putAll(Map<? extends K, ? extends V> m) {
         if (m == null) {
             throw new NullPointerException("The specified map cannot be null.");
         }
@@ -238,7 +238,7 @@ public class ExpiringMap<K, V> implements Map<K, V> {
      * @return the current (existing or computed) value associated with the specified key, or {@code null} if the computed value is {@code null}
      * @throws NullPointerException if the specified key or mappingFunction is null
      */
-    public V computeIfAbsent(K key, @NonNull Function<? super K, ? extends V> mappingFunction) {
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
         if (key == null || mappingFunction == null) {
             throw new NullPointerException("Key and mappingFunction cannot be null.");
         }

--- a/src/main/java/world/bentobox/bentobox/util/ExpiringSet.java
+++ b/src/main/java/world/bentobox/bentobox/util/ExpiringSet.java
@@ -206,7 +206,7 @@ public class ExpiringSet<E> implements Set<E>, AutoCloseable {
      * @throws NullPointerException if the specified collection is null
      */
     @Override
-    public boolean containsAll(@NonNull Collection<?> c) {
+    public boolean containsAll(Collection<?> c) {
         if (c == null) {
             throw new NullPointerException("Collection cannot be null.");
         }
@@ -222,7 +222,7 @@ public class ExpiringSet<E> implements Set<E>, AutoCloseable {
      * @throws NullPointerException if the specified collection is null or contains a null element
      */
     @Override
-    public boolean addAll(@NonNull Collection<? extends E> c) {
+    public boolean addAll(Collection<? extends E> c) {
         if (c == null) {
             throw new NullPointerException("The specified collection cannot be null.");
         }
@@ -247,7 +247,7 @@ public class ExpiringSet<E> implements Set<E>, AutoCloseable {
      * @throws NullPointerException if the specified collection is null
      */
     @Override
-    public boolean retainAll(@NonNull Collection<?> c) {
+    public boolean retainAll(Collection<?> c) {
         if (c == null) {
             throw new NullPointerException("Collection cannot be null.");
         }
@@ -264,7 +264,7 @@ public class ExpiringSet<E> implements Set<E>, AutoCloseable {
      * @throws NullPointerException if the specified collection is null
      */
     @Override
-    public boolean removeAll(@NonNull Collection<?> c) {
+    public boolean removeAll(Collection<?> c) {
         if (c == null) {
             throw new NullPointerException("Collection cannot be null.");
         }

--- a/src/main/java/world/bentobox/bentobox/util/UUIDFetcher.java
+++ b/src/main/java/world/bentobox/bentobox/util/UUIDFetcher.java
@@ -40,14 +40,16 @@ public class UUIDFetcher {
             try (BufferedReader bufferedReader = new BufferedReader(
                     new InputStreamReader(connection.getInputStream()))) {
                 StringBuilder response = new StringBuilder();
-                String line;
+                String line = bufferedReader.readLine();
 
-                while ((line = bufferedReader.readLine()) != null)
+                while (line != null) {
                     response.append(line);
+                    line = bufferedReader.readLine();
+                }
 
                 final JsonElement parsed = JsonParser.parseString(response.toString());
 
-                if (parsed == null || !parsed.isJsonObject()) {
+                if (!parsed.isJsonObject()) {
                     return null;
                 }
 

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -274,6 +274,7 @@ public class HeadGetter {
 
             return decodedTexture;
         } catch (Exception ignored) {
+            // Failed to fetch texture from Mojang API; fall through to return null
         }
 
         return null;
@@ -322,6 +323,7 @@ public class HeadGetter {
 
             return new Pair<>(UUID.fromString(userIdString), decodedTexture);
         } catch (Exception ignored) {
+            // Failed to fetch texture from mc-heads.net; fall through to return default
         }
 
         // return random uuid and null, to assign some values for cache.

--- a/src/test/java/world/bentobox/bentobox/SettingsTest.java
+++ b/src/test/java/world/bentobox/bentobox/SettingsTest.java
@@ -23,7 +23,7 @@ public class SettingsTest {
     private Settings s;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         WhiteBox.setInternalState(BentoBox.class, "instance", Mockito.mock(BentoBox.class));
         // Class under test
         s = new Settings();

--- a/src/test/java/world/bentobox/bentobox/api/addons/AddonClassLoaderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/addons/AddonClassLoaderTest.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.api.addons;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
@@ -313,7 +314,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
     public void testGetAddon() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         Addon addon = acl.getAddon();
-        assertEquals(addon, testAddon);
+        assertSame(testAddon, addon);
         acl.close();
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/addons/AddonDescriptionTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/addons/AddonDescriptionTest.java
@@ -24,7 +24,7 @@ public class AddonDescriptionTest {
     private ConfigurationSection configSec;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         configSec = new YamlConfiguration();
         ad = new AddonDescription.Builder("main", "name", "version")
                 .apiVersion("api")

--- a/src/test/java/world/bentobox/bentobox/api/addons/AddonTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/addons/AddonTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -115,7 +116,7 @@ public class AddonTest extends CommonTestSetup {
 
     @Test
     public void testGetPlugin() {
-        assertEquals(plugin, test.getPlugin());
+        assertSame(plugin, test.getPlugin());
     }
 
     @Test
@@ -241,7 +242,7 @@ public class AddonTest extends CommonTestSetup {
     public void testGetIslands() {
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
-        assertEquals(im, test.getIslands());
+        assertSame(im, test.getIslands());
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommandTest.java
@@ -17,7 +17,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 import org.junit.jupiter.api.AfterEach;
@@ -29,7 +28,6 @@ import org.mockito.stubbing.Answer;
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.Addon;
-import world.bentobox.bentobox.api.user.Notifier;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
@@ -42,8 +40,6 @@ import world.bentobox.bentobox.managers.PlaceholdersManager;
 public class DelayedTeleportCommandTest extends CommonTestSetup {
 
     private static final String HELLO = "hello";
-    @Mock
-    private BukkitScheduler sch;
 
     private TestClass dtc;
     @Mock
@@ -62,8 +58,6 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
     private Location from;
     @Mock
     private Location to;
-    @Mock
-    private Notifier notifier;
 
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
@@ -47,7 +47,6 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
     @Mock
     private PlayersManager pm;
     private UUID notUUID;
-    private UUID uuid;
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommandTest.java
@@ -58,9 +58,6 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
 
     private UUID targetUUID;
 
-    @Mock
-    private Island island;
-
     private MockedStatic<RanksManager> mockedRanksManager;
 
     @Override

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
@@ -48,7 +48,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
     @Mock
     private PlayersManager pm;
 
-    private Island island;
+    private Island testIsland;
 
     private AdminInfoCommand iic;
 
@@ -93,13 +93,13 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
                 .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
 
         // Island manager
-        island = new Island(location, uuid, 100);
-        island.setRange(400);
+        testIsland = new Island(location, uuid, 100);
+        testIsland.setRange(400);
         when(location.toVector()).thenReturn(new Vector(1, 2, 3));
         when(plugin.getIslands()).thenReturn(im);
-        Optional<Island> optionalIsland = Optional.of(island);
+        Optional<Island> optionalIsland = Optional.of(testIsland);
         when(im.getIslandAt(any())).thenReturn(optionalIsland);
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(testIsland);
 
         // Players manager
         when(plugin.getPlayers()).thenReturn(pm);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommandTest.java
@@ -59,7 +59,6 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
     @Mock
     private PlayersManager pm;
     private UUID notUUID;
-    private UUID uuid;
     private AdminMaxHomesCommand instance;
     private String label;
     private ArrayList<String> args = new ArrayList<>();

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -48,7 +48,6 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
-    private UUID uuid;
     @Mock
     private User user;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetFlagsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetFlagsCommandTest.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -45,11 +44,10 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
-    private final UUID uuid = UUID.randomUUID();
     @Mock
     private PlayersManager pm;
     @Mock
-    private FlagsManager fm;
+    private FlagsManager testFm;
     @Mock
     private Flag flag;
     @Mock
@@ -79,7 +77,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
         user = User.getInstance(mockPlayer);
 
         // Flags manager
-        when(plugin.getFlagsManager()).thenReturn(fm);
+        when(plugin.getFlagsManager()).thenReturn(testFm);
         when(flag.getType()).thenReturn(Type.PROTECTION);
         when(flag2.getType()).thenReturn(Type.SETTING);
         when(flag3.getType()).thenReturn(Type.WORLD_SETTING);
@@ -91,7 +89,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
         list.add(flag);
         list.add(flag2);
         list.add(flag3);
-        when(fm.getFlags()).thenReturn(list);
+        when(testFm.getFlags()).thenReturn(list);
 
         // Locales & Placeholders
         LocalesManager lm = mock(LocalesManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetHomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetHomeCommandTest.java
@@ -54,7 +54,6 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
     @Mock
     private PlayersManager pm;
     private UUID notUUID;
-    private UUID uuid;
     private AdminResetHomeCommand instance;
     private String label;
     private ArrayList<String> args = new ArrayList<>();

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetspawnCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetspawnCommandTest.java
@@ -34,7 +34,6 @@ import world.bentobox.bentobox.managers.LocalesManager;
 public class AdminSetspawnCommandTest extends CommonTestSetup {
 
     private CompositeCommand ac;
-    private UUID uuid;
     private User user;
  
     @Override

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
@@ -46,7 +46,6 @@ import world.bentobox.bentobox.util.Util;
  */
 public class AdminUnregisterCommandTest extends CommonTestSetup {
 
-    private UUID uuid = UUID.randomUUID();
     @Mock
     private CompositeCommand ac;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCopyCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCopyCommandTest.java
@@ -47,9 +47,6 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
     private User user;
     @Mock
     private BlueprintClipboard clip;
-    private UUID uuid = UUID.randomUUID();
-    @Mock
-    private BlueprintsManager bm;
     private AdminBlueprintCopyCommand abcc;
 
     @Override

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintDeleteCommandTest.java
@@ -44,9 +44,6 @@ public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
     private GameModeAddon addon;
     @Mock
     private User user;
-    private UUID uuid = UUID.randomUUID();
-    @Mock
-    private BlueprintsManager bm;
     private Blueprint bp = new Blueprint();
     private AdminBlueprintDeleteCommand abcc;
     private Map<String, Blueprint> map;

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintLoadCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintLoadCommandTest.java
@@ -19,8 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -28,13 +26,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.blueprints.Blueprint;
-import world.bentobox.bentobox.managers.BlueprintsManager;
 import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.HooksManager;
 import world.bentobox.bentobox.managers.LocalesManager;
@@ -46,16 +42,11 @@ import world.bentobox.bentobox.managers.LocalesManager;
 public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
 
     @Mock
-    BentoBox plugin;
-    @Mock
     private AdminBlueprintCommand ac;
     @Mock
     private GameModeAddon addon;
     @Mock
     private User user;
-    private UUID uuid = UUID.randomUUID();
-    @Mock
-    private BlueprintsManager bm;
     private Blueprint bp = new Blueprint();
     private AdminBlueprintLoadCommand abcc;
     private Map<String, Blueprint> map;

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintSaveCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintSaveCommandTest.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import org.bukkit.util.Vector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -43,8 +41,6 @@ import world.bentobox.bentobox.managers.LocalesManager;
  */
 public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
 
-    @Mock
-    private BentoBox plugin;
     private AdminBlueprintSaveCommand absc;
     @Mock
     private AdminBlueprintCommand ac;
@@ -53,7 +49,6 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
     @Mock
     private User user;
     private BlueprintClipboard clip;
-    private UUID uuid = UUID.randomUUID();
     private File blueprintsFolder;
     private Blueprint bp = new Blueprint();
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
@@ -39,7 +39,6 @@ public class AdminRangeResetCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
-    private UUID uuid;
     @Mock
     private User user;
     private PlayersManager pm;

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
@@ -46,7 +46,6 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
-    private UUID uuid;
     @Mock
     private User user;
     private PlayersManager pm;

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
@@ -47,7 +47,6 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
-    private UUID uuid;
     @Mock
     private User user;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
@@ -40,7 +40,6 @@ public class AdminTeamKickCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
-    private UUID uuid;
     @Mock
     private User user;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
@@ -45,7 +45,6 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
-    private UUID uuid = UUID.randomUUID();
     @Mock
     private User user;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
@@ -54,7 +54,6 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
-    private UUID uuid;
     @Mock
     private User user;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
@@ -54,13 +54,12 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
-    private UUID uuid;
     @Mock
     private User user;
     @Mock
     private PlayersManager pm;
     @Mock
-    private LocalesManager lm;
+    private LocalesManager testLm;
     @Mock
     private Addon addon;
 
@@ -124,8 +123,8 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
 
         // Locales
         Answer<String> answer = invocation -> invocation.getArgument(1, String.class);
-        when(lm.get(any(User.class), anyString())).thenAnswer(answer);
-        when(plugin.getLocalesManager()).thenReturn(lm);
+        when(testLm.get(any(User.class), anyString())).thenAnswer(answer);
+        when(plugin.getLocalesManager()).thenReturn(testLm);
 
         // Placeholders
         PlaceholdersManager placeholdersManager = mock(PlaceholdersManager.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
@@ -42,7 +42,6 @@ import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.flags.Flag;
-import world.bentobox.bentobox.api.user.Notifier;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.managers.CommandsManager;
@@ -67,10 +66,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
     @Mock
     private BukkitTask task;
     private IslandGoCommand igc;
-    @Mock
-    private Notifier notifier;
     private @Nullable WorldSettings ws;
-    private UUID uuid = UUID.randomUUID();
 
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommandTest.java
@@ -41,7 +41,6 @@ public class IslandHomesCommandTest extends CommonTestSetup {
     private CompositeCommand ic;
     @Mock
     private User user;
-    private UUID uuid;
  
 @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandInfoCommandTest.java
@@ -49,7 +49,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
     @Mock
     private PlaceholdersManager phm;
 
-    private Island island;
+    private Island testIsland;
 
     private IslandInfoCommand iic;
 
@@ -85,13 +85,13 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
         when(user.getTranslation(anyString(), anyString(), anyString())).thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
 
         // Island manager
-        island = new Island(location, uuid, 100);
-        island.setRange(400);
+        testIsland = new Island(location, uuid, 100);
+        testIsland.setRange(400);
         when(location.toVector()).thenReturn(new Vector(1,2,3));
         when(plugin.getIslands()).thenReturn(im);
-        Optional<Island> optionalIsland = Optional.of(island);
+        Optional<Island> optionalIsland = Optional.of(testIsland);
         when(im.getIslandAt(any())).thenReturn(optionalIsland);
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(testIsland);
 
         // Players manager
         when(plugin.getPlayers()).thenReturn(pm);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandNearCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandNearCommandTest.java
@@ -54,8 +54,6 @@ public class IslandNearCommandTest extends CommonTestSetup {
     @Mock
     private Player pp;
 
-    private UUID uuid;
-
     private IslandNearCommand inc;
     @Mock
     private Block block;

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
@@ -73,8 +73,6 @@ public class IslandResetCommandTest extends CommonTestSetup {
 
     private IslandResetCommand irc;
 
-    private UUID uuid;
-
     @Override
     @BeforeEach
     public void setUp() throws Exception {

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
@@ -42,7 +42,6 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
     private CompositeCommand ic;
     @Mock
     private User user;
-    private UUID uuid;
     @Mock
     private WorldSettings ws;
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommandTest.java
@@ -46,7 +46,6 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ic;
-    private UUID uuid;
     @Mock
     private User user;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEnableEventTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEnableEventTest.java
@@ -1,8 +1,8 @@
 package world.bentobox.bentobox.api.events.addon;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -78,7 +78,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      */
     @Test
     public void testGetAddon() {
-        assertEquals(addon, aee.getAddon());
+        assertSame(addon, aee.getAddon());
     }
 
     /**
@@ -95,7 +95,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
     @Test
     public void testSetNewEvent() {
         aee.setNewEvent(aee);
-        assertEquals(aee, aee.getNewEvent().get());
+        assertSame(aee, aee.getNewEvent().get());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/events/island/IslandEventTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/events/island/IslandEventTest.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.api.events.island;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -32,7 +33,7 @@ public class IslandEventTest extends CommonTestSetup {
     @Mock
     private IslandDeletion deletedIslandInfo;
     
-    private Island island;
+    private Island testIsland;
 
     @Override
     @BeforeEach
@@ -41,9 +42,9 @@ public class IslandEventTest extends CommonTestSetup {
         Mockito.mockStatic(IslandsManager.class, Mockito.RETURNS_MOCKS);
 
         // Island
-        island = new Island();
+        testIsland = new Island();
         when(location.clone()).thenReturn(location);
-        island.setCenter(location);
+        testIsland.setCenter(location);
     }
 
     @Override
@@ -58,11 +59,11 @@ public class IslandEventTest extends CommonTestSetup {
     @Test
     public void testIslandEvent() {
         for (Reason reason: Reason.values()) {
-            IslandEvent e = new IslandEvent(island, uuid, false, location, reason);
+            IslandEvent e = new IslandEvent(testIsland, uuid, false, location, reason);
             assertEquals(reason, e.getReason());
-            assertEquals(island, e.getIsland());
+            assertSame(testIsland, e.getIsland());
             assertEquals(uuid, e.getPlayerUUID());
-            assertEquals(location, e.getLocation());
+            assertSame(location, e.getLocation());
         }
     }
 
@@ -77,9 +78,9 @@ public class IslandEventTest extends CommonTestSetup {
                     .blueprintBundle(blueprintBundle)
                     .deletedIslandInfo(deletedIslandInfo)
                     .involvedPlayer(uuid)
-                    .island(island)
+                    .island(testIsland)
                     .location(location)
-                    .oldIsland(island)
+                    .oldIsland(testIsland)
                     .protectionRange(120, 100)
                     .reason(reason)
                     .build();

--- a/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
@@ -57,7 +57,7 @@ public class FlagTest extends RanksManagerTestSetup {
     private Listener listener;
     private Map<String, Boolean> worldFlags;
     @Mock
-    private LocalesManager lm;
+    private LocalesManager testLm;
 
     @Override
     @BeforeEach
@@ -82,9 +82,9 @@ public class FlagTest extends RanksManagerTestSetup {
         when(Bukkit.getItemFactory()).thenReturn(itemF);
         
         // Locales manager
-        when(plugin.getLocalesManager()).thenReturn(lm);
+        when(plugin.getLocalesManager()).thenReturn(testLm);
         // Setting US text is successful
-        when(lm.setTranslation(eq(Locale.US), anyString(), anyString())).thenReturn(true);
+        when(testLm.setTranslation(eq(Locale.US), anyString(), anyString())).thenReturn(true);
 
         // Flag
         f = new Flag.Builder("flagID", Material.ACACIA_PLANKS).type(Flag.Type.PROTECTION).listener(listener).build();

--- a/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.api.panels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -193,7 +194,7 @@ public class PanelTest extends CommonTestSetup {
     @Test
     public void testGetListener() {
         Panel p = new Panel(name, items, 10, null, listener);
-        assertEquals(listener, p.getListener().get());
+        assertSame(listener, p.getListener().get());
     }
 
     /**
@@ -202,7 +203,7 @@ public class PanelTest extends CommonTestSetup {
     @Test
     public void testGetUser() {
         Panel p = new Panel(name, items, 10, user, listener);
-        assertEquals(user, p.getUser().get());
+        assertSame(user, p.getUser().get());
 
         p = new Panel(name, items, 10, null, listener);
         assertEquals(Optional.empty(), p.getUser());
@@ -259,7 +260,7 @@ public class PanelTest extends CommonTestSetup {
         Panel p = new Panel(name, items, 10, user, null);
         assertEquals(Optional.empty(), p.getListener());
         p.setListener(listener);
-        assertEquals(listener, p.getListener().get());
+        assertSame(listener, p.getListener().get());
     }
 
     /**
@@ -270,7 +271,7 @@ public class PanelTest extends CommonTestSetup {
         Panel p = new Panel(name, items, 10, null, listener);
         assertEquals(Optional.empty(), p.getUser());
         p.setUser(user);
-        assertEquals(user, p.getUser().get());
+        assertSame(user, p.getUser().get());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilderTest.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.api.panels.builders;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -82,7 +83,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
         PanelItem item = builder.build();
         assertNotNull(item.getItem().getType());
         SkullMeta skullMeta = (SkullMeta) item.getItem().getItemMeta();
-        assertEquals(null, skullMeta.getOwningPlayer());
+        assertNull(skullMeta.getOwningPlayer());
         assertEquals(Material.PLAYER_HEAD, item.getItem().getType());
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/user/NotifierTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/NotifierTest.java
@@ -18,7 +18,7 @@ public class NotifierTest {
     private Notifier n;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         n = new Notifier();
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -66,7 +67,7 @@ public class UserTest extends CommonTestSetup {
     private static final String TEST_TRANSLATION = "mock &a translation &b [test]";
     private static final String TEST_TRANSLATION_WITH_COLOR = "mock §atranslation §b[test]";
     @Mock
-    private LocalesManager lm;
+    private LocalesManager testLm;
 
     private User user;
 
@@ -99,9 +100,9 @@ public class UserTest extends CommonTestSetup {
         user = User.getInstance(mockPlayer);
 
         // Locales
-        when(plugin.getLocalesManager()).thenReturn(lm);
-        when(lm.get(any(), any())).thenReturn(TEST_TRANSLATION);
-        when(lm.get(any())).thenReturn(TEST_TRANSLATION);
+        when(plugin.getLocalesManager()).thenReturn(testLm);
+        when(testLm.get(any(), any())).thenReturn(TEST_TRANSLATION);
+        when(testLm.get(any())).thenReturn(TEST_TRANSLATION);
 
         // Placeholders
         PlaceholdersManager placeholdersManager = mock(PlaceholdersManager.class);
@@ -129,7 +130,7 @@ public class UserTest extends CommonTestSetup {
 
     @Test
     public void testGetInstancePlayer() {
-        assertEquals(mockPlayer, user.getPlayer());
+        assertSame(mockPlayer, user.getPlayer());
     }
 
     @Test
@@ -143,7 +144,7 @@ public class UserTest extends CommonTestSetup {
     @Test
     public void testRemovePlayer() {
         assertNotNull(User.getInstance(uuid));
-        assertEquals(user, User.getInstance(uuid));
+        assertSame(user, User.getInstance(uuid));
         User.removePlayer(mockPlayer);
         // If the player has been removed from the cache, then code will ask server for player
         // Return null and check if instance is null will show that the player is not in the cache
@@ -200,7 +201,7 @@ public class UserTest extends CommonTestSetup {
     @Test
     public void testGetPlayer() {
         User user = User.getInstance(mockPlayer);
-        assertEquals(mockPlayer, user.getPlayer());
+        assertSame(mockPlayer, user.getPlayer());
     }
 
     @Test
@@ -279,7 +280,7 @@ public class UserTest extends CommonTestSetup {
     @Test
     public void testGetTranslationNoTranslationFound() {
         // Test no translation found
-        when(lm.get(any(), any())).thenReturn(null);
+        when(testLm.get(any(), any())).thenReturn(null);
         assertEquals("a.reference", user.getTranslation("a.reference"));
 
     }
@@ -287,8 +288,8 @@ public class UserTest extends CommonTestSetup {
     @Test
     public void testGetTranslationOrNothing() {
         // Return the original string to pretend that a translation could not be found
-        when(lm.get(any(), any())).thenReturn("fake.reference");
-        when(lm.get(any())).thenReturn("fake.reference");
+        when(testLm.get(any(), any())).thenReturn("fake.reference");
+        when(testLm.get(any())).thenReturn("fake.reference");
 
         User user = User.getInstance(mockPlayer);
         assertEquals("", user.getTranslationOrNothing("fake.reference"));
@@ -310,7 +311,7 @@ public class UserTest extends CommonTestSetup {
         user.setAddon(addon);
         Optional<GameModeAddon> optionalAddon = Optional.of(addon);
         when(iwm .getAddon(any())).thenReturn(optionalAddon);
-        when(lm.get(any(), eq("name.a.reference"))).thenReturn("mockmockmock");
+        when(testLm.get(any(), eq("name.a.reference"))).thenReturn("mockmockmock");
         user.sendMessage("a.reference");
         verify(mockPlayer, never()).sendMessage(eq(TEST_TRANSLATION));
         checkSpigotMessage("mockmockmock");
@@ -319,7 +320,7 @@ public class UserTest extends CommonTestSetup {
     @Test
     public void testSendMessageBlankTranslation() {
         // Nothing - blank translation
-        when(lm.get(any(), any())).thenReturn("");
+        when(testLm.get(any(), any())).thenReturn("");
         user.sendMessage("a.reference");
         checkSpigotMessage("a.reference", 0);
     }
@@ -332,7 +333,7 @@ public class UserTest extends CommonTestSetup {
         for (@SuppressWarnings("deprecation") ChatColor cc : ChatColor.values()) {
             allColors.append(cc);
         }
-        when(lm.get(any(), any())).thenReturn(allColors.toString());
+        when(testLm.get(any(), any())).thenReturn(allColors.toString());
         user.sendMessage("a.reference");
         verify(mockPlayer, never()).sendMessage(anyString());
     }
@@ -340,7 +341,7 @@ public class UserTest extends CommonTestSetup {
     @SuppressWarnings("deprecation")
     @Test
     public void testSendMessageColorsAndSpaces() {
-        when(lm.get(any(), any())).thenReturn(ChatColor.COLOR_CHAR + "6 Hello there");
+        when(testLm.get(any(), any())).thenReturn(ChatColor.COLOR_CHAR + "6 Hello there");
         user.sendMessage("a.reference");
         checkSpigotMessage(ChatColor.COLOR_CHAR + "6Hello there");
     }
@@ -369,7 +370,7 @@ public class UserTest extends CommonTestSetup {
         when(plugin.getNotifier()).thenReturn(notifier);
         @SuppressWarnings("deprecation")
         String translation = ChatColor.RED + "" + ChatColor.BOLD + "test translation";
-        when(lm.get(any(), any())).thenReturn(translation);
+        when(testLm.get(any(), any())).thenReturn(translation);
 
         // Set notify
         when(notifier.notify(any(), eq(translation))).thenReturn(true);
@@ -400,7 +401,7 @@ public class UserTest extends CommonTestSetup {
         World world = mock(World.class);
         when(mockPlayer.getWorld()).thenReturn(world);
         User user = User.getInstance(mockPlayer);
-        assertEquals(world, user.getWorld());
+        assertSame(world, user.getWorld());
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/blueprints/BlueprintClipboardTest.java
+++ b/src/test/java/world/bentobox/bentobox/blueprints/BlueprintClipboardTest.java
@@ -24,7 +24,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.managers.HooksManager;
@@ -41,8 +40,6 @@ public class BlueprintClipboardTest extends CommonTestSetup {
     private @NonNull Blueprint blueprint;
     @Mock
     private @NonNull User user;
-    @Mock
-    private BentoBox plugin;
 
     /**
      * @throws java.lang.Exception

--- a/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
@@ -27,7 +27,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerQuitEvent.QuitReason;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
@@ -70,11 +69,9 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
     private Inventory chest;
     @Mock
     private Settings settings;
-    @Mock
-    private PlayerInventory inv;
     private Set<String> set;
 
-    private @Nullable Island island;
+    private @Nullable Island testIsland;
     @Mock
     private GameModeAddon gameMode;
 
@@ -129,13 +126,13 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         when(plugin.getSettings()).thenReturn(settings);
 
         // Island
-        island = new Island(location, uuid, 50);
-        island.setWorld(world);
+        testIsland = new Island(location, uuid, 50);
+        testIsland.setWorld(world);
 
-        when(im.getIsland(any(), any(User.class))).thenReturn(island);
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
-        when(im.getIslands()).thenReturn(Collections.singletonList(island));
-        when(im.getIslands(any(UUID.class))).thenReturn(Collections.singletonList(island));
+        when(im.getIsland(any(), any(User.class))).thenReturn(testIsland);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(testIsland);
+        when(im.getIslands()).thenReturn(Collections.singletonList(testIsland));
+        when(im.getIslands(any(UUID.class))).thenReturn(Collections.singletonList(testIsland));
         Map<UUID, Integer> memberMap = new HashMap<>();
 
         memberMap.put(uuid, RanksManager.OWNER_RANK);
@@ -146,7 +143,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         when(coopPlayer.getWorld()).thenReturn(world);
         User.getInstance(coopPlayer);
         memberMap.put(uuid2, RanksManager.COOP_RANK);
-        island.setMembers(memberMap);
+        testIsland.setMembers(memberMap);
 
 
         // Bukkit - online players
@@ -236,7 +233,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         // Verify
         checkSpigotMessage("commands.admin.setrange.range-updated");
         // Verify island setting
-        assertEquals(100, island.getProtectionRange());
+        assertEquals(100, testIsland.getProtectionRange());
         // Verify log
         verify(plugin).log("Island protection range changed from 50 to 100 for tastybento due to permission.");
     }
@@ -256,7 +253,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         // Verify
         checkSpigotMessage("commands.admin.setrange.range-updated");
         // Verify island setting
-        assertEquals(10, island.getProtectionRange());
+        assertEquals(10, testIsland.getProtectionRange());
         // Verify log
         verify(plugin).log("Island protection range changed from 50 to 10 for tastybento due to permission.");
     }
@@ -276,7 +273,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         // Verify
         checkSpigotMessage("commands.admin.setrange.range-updated");
         // Verify island setting
-        assertEquals(55, island.getProtectionRange());
+        assertEquals(55, testIsland.getProtectionRange());
         // Verify log
         verify(plugin).log("Island protection range changed from 50 to 55 for tastybento due to permission.");
     }
@@ -297,7 +294,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         verify(mockPlayer, never()).sendMessage(eq("commands.admin.setrange.range-updated"));
         // Verify that the island protection range is not changed if it is already at
         // that value
-        assertEquals(50, island.getProtectionRange());
+        assertEquals(50, testIsland.getProtectionRange());
         // Verify log
         verify(plugin, never()).log("Island protection range changed from 50 to 10 for tastybento due to permission.");
     }
@@ -353,7 +350,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         jll.onPlayerQuit(event);
         checkSpigotMessage("commands.island.team.uncoop.all-members-logged-off");
         // Team is now only 1 big
-        assertEquals(1, island.getMembers().size());
+        assertEquals(1, testIsland.getMembers().size());
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.listeners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -390,7 +391,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
     @Test
     public void testGetOpenPanels() {
         PanelListenerManager.getOpenPanels().put(uuid, panel);
-        assertEquals(panel, PanelListenerManager.getOpenPanels().get(uuid));
+        assertSame(panel, PanelListenerManager.getOpenPanels().get(uuid));
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListenerTest.java
@@ -236,7 +236,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
         when(block.getLocation()).thenReturn(location);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_AIR, item, block, BlockFace.EAST);
         bbl.onPlayerInteract(e);
-        assertEquals(e.useInteractedBlock(), Result.ALLOW);
+        assertEquals(Result.ALLOW, e.useInteractedBlock());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
@@ -56,8 +56,6 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     @Mock
     private Location inside;
     @Mock
-    private Notifier notifier;
-    @Mock
     private Location inside2;
 
     @Override

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/settings/PVPListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/settings/PVPListenerTest.java
@@ -92,8 +92,6 @@ public class PVPListenerTest extends CommonTestSetup {
     private Zombie zombie;
     @Mock
     private Creeper creeper;
-    @Mock
-    private Notifier notifier;
 
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CoarseDirtTillingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CoarseDirtTillingListenerTest.java
@@ -54,8 +54,6 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
     private CoarseDirtTillingListener ctl;
     @Mock
     private Block clickedBlock;
-    @Mock
-    private Notifier notifier;
 
 
     @Override

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListenerTest.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.listeners.flags.worldsettings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -215,7 +216,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
         // Respawn
         PlayerRespawnEvent ev = new PlayerRespawnEvent(mockPlayer, location, false, false, false, RespawnReason.DEATH);
         l.onPlayerRespawn(ev);
-        assertEquals(location, ev.getRespawnLocation());
+        assertSame(location, ev.getRespawnLocation());
     }
 
     /**
@@ -238,7 +239,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
         // Respawn
         PlayerRespawnEvent ev = new PlayerRespawnEvent(mockPlayer, location, false, false, false, RespawnReason.DEATH);
         l.onPlayerRespawn(ev);
-        assertEquals(location, ev.getRespawnLocation());
+        assertSame(location, ev.getRespawnLocation());
     }
 
     /**
@@ -261,6 +262,6 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
         // Respawn
         PlayerRespawnEvent ev = new PlayerRespawnEvent(mockPlayer, location, false, false, false, RespawnReason.DEATH);
         l.onPlayerRespawn(ev);
-        assertEquals(location, ev.getRespawnLocation());
+        assertSame(location, ev.getRespawnLocation());
     }
 }

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ObsidianScoopingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ObsidianScoopingListenerTest.java
@@ -31,7 +31,6 @@ import org.mockito.Mockito;
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.bentobox.managers.LocalesManager;
 
 public class ObsidianScoopingListenerTest extends CommonTestSetup {
 
@@ -40,8 +39,6 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     private ItemStack item;
     @Mock
     private Block clickedBlock;
-    @Mock
-    private LocalesManager lm;
     private Material inHand;
     private Material block;
 

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/TreesGrowingOutsideRangeListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/TreesGrowingOutsideRangeListenerTest.java
@@ -47,8 +47,6 @@ public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
 
     /* Islands */
     @Mock
-    private Island island;
-    @Mock
     private Island anotherIsland;
 
     @Mock

--- a/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -50,8 +51,6 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     private PlayerTeleportListener ptl;
     @Mock
     private Block block;
-    @Mock
-    private BukkitScheduler sch;
 
     /**
      * @throws java.lang.Exception
@@ -492,7 +491,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.onPlayerExitPortal(event);
 
         // Verify that no changes occurred to the event
-        assertEquals(location, event.getRespawnLocation());
+        assertSame(location, event.getRespawnLocation());
     }
 
     @Test
@@ -511,7 +510,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.onPlayerExitPortal(event);
 
         // Verify that no changes occurred to the event
-        assertEquals(location, event.getRespawnLocation());
+        assertSame(location, event.getRespawnLocation());
     }
 
     @Test
@@ -527,7 +526,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.onPlayerExitPortal(event);
 
         // Verify that the respawn location remains unchanged
-        assertEquals(location, event.getRespawnLocation());
+        assertSame(location, event.getRespawnLocation());
     }
 
     @Test
@@ -543,7 +542,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.onPlayerExitPortal(event);
 
         // Verify that the respawn location was updated to the island spawn point
-        assertEquals(location, event.getRespawnLocation());
+        assertSame(location, event.getRespawnLocation());
     }
 
     @Test
@@ -560,7 +559,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.onPlayerExitPortal(event);
 
         // Verify that the respawn location was updated to the island's protection center
-        assertEquals(location, event.getRespawnLocation());
+        assertSame(location, event.getRespawnLocation());
     }
 
     @Test
@@ -576,7 +575,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.onPlayerExitPortal(event);
 
         // Verify that the respawn location was updated to the world spawn location
-        assertEquals(location, event.getRespawnLocation());
+        assertSame(location, event.getRespawnLocation());
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/managers/IslandWorldManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandWorldManagerTest.java
@@ -41,10 +41,10 @@ import world.bentobox.bentobox.api.flags.Flag;
  */
 public class IslandWorldManagerTest extends CommonTestSetup {
 
-    private IslandWorldManager iwm;
+    private IslandWorldManager testIwm;
 
     @Mock
-    private World world;
+    private World testWorld;
 
     @Mock
     private WorldSettings ws;
@@ -63,12 +63,12 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        iwm = new IslandWorldManager(plugin);
+        testIwm = new IslandWorldManager(plugin);
         // World
-        when(world.getName()).thenReturn("test-world");
-        when(world.getEnvironment()).thenReturn(World.Environment.NORMAL);
-        when(world.getMaxHeight()).thenReturn(256);
-        when(location.getWorld()).thenReturn(world);
+        when(testWorld.getName()).thenReturn("test-world");
+        when(testWorld.getEnvironment()).thenReturn(World.Environment.NORMAL);
+        when(testWorld.getMaxHeight()).thenReturn(256);
+        when(location.getWorld()).thenReturn(testWorld);
 
         // Scheduler
         BukkitScheduler sch = mock(BukkitScheduler.class);
@@ -82,10 +82,10 @@ public class IslandWorldManagerTest extends CommonTestSetup {
         // Gamemode
         when(ws.getFriendlyName()).thenReturn("friendly");
         when(gm.getWorldSettings()).thenReturn(ws);
-        when(gm.getOverWorld()).thenReturn(world);
+        when(gm.getOverWorld()).thenReturn(testWorld);
         when(gm.getNetherWorld()).thenReturn(netherWorld);
         when(gm.getEndWorld()).thenReturn(endWorld);
-        iwm.addGameMode(gm);
+        testIwm.addGameMode(gm);
     }
 
     @AfterEach
@@ -98,7 +98,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testRegisterWorldsToMultiverse() {
-        iwm.registerWorldsToMultiverse(true);
+        testIwm.registerWorldsToMultiverse(true);
     }
 
     /**
@@ -106,7 +106,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testInWorldLocation() {
-        assertTrue(iwm.inWorld(location));
+        assertTrue(testIwm.inWorld(location));
     }
 
     /**
@@ -114,7 +114,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testInWorldLocationNull() {
-        assertFalse(iwm.inWorld((Location)null));
+        assertFalse(testIwm.inWorld((Location)null));
     }
 
     /**
@@ -122,7 +122,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testInWorldWorld() {
-        assertTrue(iwm.inWorld(world));
+        assertTrue(testIwm.inWorld(testWorld));
     }
 
     /**
@@ -130,7 +130,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testInWorldWorldNull() {
-        assertFalse(iwm.inWorld((World)null));
+        assertFalse(testIwm.inWorld((World)null));
     }
 
     /**
@@ -138,7 +138,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetWorlds() {
-        assertTrue(iwm.getWorlds().contains(world));
+        assertTrue(testIwm.getWorlds().contains(testWorld));
     }
 
     /**
@@ -146,7 +146,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetOverWorlds() {
-        assertTrue(iwm.getOverWorlds().contains(world));
+        assertTrue(testIwm.getOverWorlds().contains(testWorld));
     }
 
     /**
@@ -154,7 +154,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetOverWorldNames() {
-        Map<String, String> map = iwm.getOverWorldNames();
+        Map<String, String> map = testIwm.getOverWorldNames();
         map.forEach((k,v) -> {
             assertEquals("test-world", k);
             assertEquals("friendly", v);
@@ -166,8 +166,8 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsKnownFriendlyWorldName() {
-        assertTrue(iwm.isKnownFriendlyWorldName("friendly"));
-        assertFalse(iwm.isKnownFriendlyWorldName("not-friendly"));
+        assertTrue(testIwm.isKnownFriendlyWorldName("friendly"));
+        assertFalse(testIwm.isKnownFriendlyWorldName("not-friendly"));
     }
 
     /**
@@ -181,9 +181,9 @@ public class IslandWorldManagerTest extends CommonTestSetup {
         WorldSettings ws = mock(WorldSettings.class);
         when(ws.getFriendlyName()).thenReturn("friendly2");
         when(gm.getWorldSettings()).thenReturn(ws);
-        when(gm.getOverWorld()).thenReturn(world);
+        when(gm.getOverWorld()).thenReturn(testWorld);
 
-        iwm.addGameMode(gm);
+        testIwm.addGameMode(gm);
     }
 
     /**
@@ -191,7 +191,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetWorldSettings() {
-        assertEquals(ws, iwm.getWorldSettings(world));
+        assertEquals(ws, testIwm.getWorldSettings(testWorld));
     }
 
     /**
@@ -199,8 +199,8 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetOverWorld() {
-        assertEquals(world, iwm.getOverWorld("friendly"));
-        assertNull(iwm.getOverWorld("not-friendly"));
+        assertEquals(testWorld, testIwm.getOverWorld("friendly"));
+        assertNull(testIwm.getOverWorld("not-friendly"));
     }
 
     /**
@@ -208,7 +208,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandDistance() {
-        assertEquals(0, iwm.getIslandDistance(world));
+        assertEquals(0, testIwm.getIslandDistance(testWorld));
     }
 
     /**
@@ -216,7 +216,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandHeight() {
-        assertEquals(0, iwm.getIslandHeight(world));
+        assertEquals(0, testIwm.getIslandHeight(testWorld));
     }
 
     /**
@@ -225,7 +225,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     @Test
     public void testGetIslandHeightOverMax() {
         when(ws.getIslandHeight()).thenReturn(500);
-        assertEquals(255, iwm.getIslandHeight(world));
+        assertEquals(255, testIwm.getIslandHeight(testWorld));
     }
 
     /**
@@ -234,7 +234,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     @Test
     public void testGetIslandHeightSubZero() {
         when(ws.getIslandHeight()).thenReturn(-50);
-        assertEquals(0, iwm.getIslandHeight(world));
+        assertEquals(0, testIwm.getIslandHeight(testWorld));
     }
 
     /**
@@ -242,7 +242,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandProtectionRange() {
-        assertEquals(0, iwm.getIslandProtectionRange(world));
+        assertEquals(0, testIwm.getIslandProtectionRange(testWorld));
     }
 
     /**
@@ -250,7 +250,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandStartX() {
-        assertEquals(0, iwm.getIslandStartX(world));
+        assertEquals(0, testIwm.getIslandStartX(testWorld));
     }
 
     /**
@@ -258,7 +258,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandStartZ() {
-        assertEquals(0, iwm.getIslandStartZ(world));
+        assertEquals(0, testIwm.getIslandStartZ(testWorld));
     }
 
     /**
@@ -266,7 +266,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandXOffset() {
-        assertEquals(0, iwm.getIslandXOffset(world));
+        assertEquals(0, testIwm.getIslandXOffset(testWorld));
     }
 
     /**
@@ -274,7 +274,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandZOffset() {
-        assertEquals(0, iwm.getIslandZOffset(world));
+        assertEquals(0, testIwm.getIslandZOffset(testWorld));
     }
 
     /**
@@ -282,7 +282,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetMaxIslands() {
-        assertEquals(0, iwm.getMaxIslands(world));
+        assertEquals(0, testIwm.getMaxIslands(testWorld));
     }
 
     /**
@@ -290,7 +290,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetNetherSpawnRadius() {
-        assertEquals(0, iwm.getNetherSpawnRadius(world));
+        assertEquals(0, testIwm.getNetherSpawnRadius(testWorld));
     }
 
     /**
@@ -298,7 +298,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetSeaHeight() {
-        assertEquals(0, iwm.getSeaHeight(world));
+        assertEquals(0, testIwm.getSeaHeight(testWorld));
     }
 
     /**
@@ -307,7 +307,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     @Test
     public void testGetWorldName() {
         when(ws.getWorldName()).thenReturn("test-world");
-        assertEquals("test-world", iwm.getWorldName(world));
+        assertEquals("test-world", testIwm.getWorldName(testWorld));
     }
 
     /**
@@ -315,7 +315,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsEndGenerate() {
-        assertFalse(iwm.isEndGenerate(world));
+        assertFalse(testIwm.isEndGenerate(testWorld));
     }
 
     /**
@@ -323,7 +323,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsEndIslands() {
-        assertFalse(iwm.isEndIslands(world));
+        assertFalse(testIwm.isEndIslands(testWorld));
     }
 
     /**
@@ -331,7 +331,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsNetherGenerate() {
-        assertFalse(iwm.isNetherGenerate(world));
+        assertFalse(testIwm.isNetherGenerate(testWorld));
     }
 
     /**
@@ -339,7 +339,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsNetherIslands() {
-        assertFalse(iwm.isNetherIslands(world));
+        assertFalse(testIwm.isNetherIslands(testWorld));
     }
 
     /**
@@ -347,7 +347,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsNether() {
-        assertFalse(iwm.isNether(world));
+        assertFalse(testIwm.isNether(testWorld));
     }
 
     /**
@@ -355,7 +355,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsIslandNether() {
-        assertFalse(iwm.isIslandNether(world));
+        assertFalse(testIwm.isIslandNether(testWorld));
     }
 
     /**
@@ -363,7 +363,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsEnd() {
-        assertFalse(iwm.isEnd(world));
+        assertFalse(testIwm.isEnd(testWorld));
     }
 
     /**
@@ -371,7 +371,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsIslandEnd() {
-        assertFalse(iwm.isIslandEnd(world));
+        assertFalse(testIwm.isIslandEnd(testWorld));
     }
 
     /**
@@ -379,7 +379,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetNetherWorld() {
-        assertEquals(netherWorld, iwm.getNetherWorld(world));
+        assertEquals(netherWorld, testIwm.getNetherWorld(testWorld));
     }
 
     /**
@@ -387,7 +387,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetNetherWorldNull() {
-        assertNull(iwm.getNetherWorld(null));
+        assertNull(testIwm.getNetherWorld(null));
     }
 
     /**
@@ -395,7 +395,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetEndWorld() {
-        assertEquals(endWorld, iwm.getEndWorld(world));
+        assertEquals(endWorld, testIwm.getEndWorld(testWorld));
     }
 
     /**
@@ -403,7 +403,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetEndWorldNull() {
-        assertNull(iwm.getEndWorld(null));
+        assertNull(testIwm.getEndWorld(null));
     }
 
     /**
@@ -411,7 +411,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsDragonSpawn() {
-        assertTrue(iwm.isDragonSpawn(endWorld));
+        assertTrue(testIwm.isDragonSpawn(endWorld));
     }
 
     /**
@@ -419,7 +419,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsDragonSpawnNull() {
-        assertTrue(iwm.isDragonSpawn(null));
+        assertTrue(testIwm.isDragonSpawn(null));
     }
 
     /**
@@ -434,9 +434,9 @@ public class IslandWorldManagerTest extends CommonTestSetup {
         when(ws.getFriendlyName()).thenReturn("fri2");
         when(gm2.getWorldSettings()).thenReturn(ws);
         when(gm2.getOverWorld()).thenReturn(mock(World.class));
-        iwm.addGameMode(gm2);
+        testIwm.addGameMode(gm2);
         // String can be in any order
-        String result = iwm.getFriendlyNames();
+        String result = testIwm.getFriendlyNames();
         assertTrue(result.contains("fri2"));
         assertTrue(result.contains("friendly"));
         assertTrue(result.contains(", "));
@@ -447,8 +447,8 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandWorld() {
-        assertEquals(world, iwm.getIslandWorld("friendly"));
-        assertNull(iwm.getIslandWorld("not-friendly"));
+        assertEquals(testWorld, testIwm.getIslandWorld("friendly"));
+        assertNull(testIwm.getIslandWorld("not-friendly"));
     }
 
     /**
@@ -456,7 +456,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetMaxTeamSize() {
-        assertEquals(0, iwm.getMaxTeamSize(world));
+        assertEquals(0, testIwm.getMaxTeamSize(testWorld));
     }
 
     /**
@@ -464,7 +464,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetMaxHomes() {
-        assertEquals(0, iwm.getMaxHomes(world));
+        assertEquals(0, testIwm.getMaxHomes(testWorld));
     }
 
     /**
@@ -472,7 +472,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetFriendlyName() {
-        assertEquals("friendly", iwm.getFriendlyName(world));
+        assertEquals("friendly", testIwm.getFriendlyName(testWorld));
     }
 
     /**
@@ -481,7 +481,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     @Test
     public void testGetPermissionPrefix() {
         when(ws.getPermissionPrefix()).thenReturn("bsky");
-        assertEquals("bsky.", iwm.getPermissionPrefix(world));
+        assertEquals("bsky.", testIwm.getPermissionPrefix(testWorld));
     }
 
     /**
@@ -491,7 +491,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetIvSettings() {
         List<String> list = Collections.singletonList("blah");
         when(ws.getIvSettings()).thenReturn(list);
-        assertEquals(list, iwm.getIvSettings(world));
+        assertEquals(list, testIwm.getIvSettings(testWorld));
     }
 
     /**
@@ -508,7 +508,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     @Test
     public void testGetDefaultGameMode() {
         when(ws.getDefaultGameMode()).thenReturn(GameMode.ADVENTURE);
-        assertEquals(GameMode.ADVENTURE, iwm.getDefaultGameMode(world));
+        assertEquals(GameMode.ADVENTURE, testIwm.getDefaultGameMode(testWorld));
     }
 
     /**
@@ -518,7 +518,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetRemoveMobsWhitelist() {
         Set<EntityType> set = new HashSet<>();
         when(ws.getRemoveMobsWhitelist()).thenReturn(set);
-        assertEquals(set, iwm.getRemoveMobsWhitelist(world));
+        assertEquals(set, testIwm.getRemoveMobsWhitelist(testWorld));
     }
 
     /**
@@ -526,7 +526,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsOnJoinResetMoney() {
-        assertFalse(iwm.isOnJoinResetMoney(world));
+        assertFalse(testIwm.isOnJoinResetMoney(testWorld));
     }
 
     /**
@@ -534,7 +534,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsOnJoinResetInventory() {
-        assertFalse(iwm.isOnJoinResetInventory(world));
+        assertFalse(testIwm.isOnJoinResetInventory(testWorld));
     }
 
     /**
@@ -542,7 +542,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsOnJoinResetEnderChest() {
-        assertFalse(iwm.isOnJoinResetEnderChest(world));
+        assertFalse(testIwm.isOnJoinResetEnderChest(testWorld));
     }
 
     /**
@@ -550,7 +550,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsOnLeaveResetMoney() {
-        assertFalse(iwm.isOnLeaveResetMoney(world));
+        assertFalse(testIwm.isOnLeaveResetMoney(testWorld));
     }
 
     /**
@@ -558,7 +558,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsOnLeaveResetInventory() {
-        assertFalse(iwm.isOnLeaveResetInventory(world));
+        assertFalse(testIwm.isOnLeaveResetInventory(testWorld));
     }
 
     /**
@@ -566,7 +566,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsOnLeaveResetEnderChest() {
-        assertFalse(iwm.isOnLeaveResetEnderChest(world));
+        assertFalse(testIwm.isOnLeaveResetEnderChest(testWorld));
     }
 
     /**
@@ -576,7 +576,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetDataFolder() {
         File dataFolder = mock(File.class);
         when(gm.getDataFolder()).thenReturn(dataFolder);
-        assertEquals(dataFolder, iwm.getDataFolder(world));
+        assertEquals(dataFolder, testIwm.getDataFolder(testWorld));
     }
 
     /**
@@ -584,7 +584,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetAddon() {
-        assertEquals(gm, iwm.getAddon(world).get());
+        assertEquals(gm, testIwm.getAddon(testWorld).get());
     }
 
     /**
@@ -592,7 +592,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetAddonNull() {
-        assertEquals(Optional.empty(), iwm.getAddon(null));
+        assertEquals(Optional.empty(), testIwm.getAddon(null));
     }
 
     /**
@@ -603,7 +603,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetDefaultIslandFlags() {
         Map<Flag, Integer> flags = new HashMap<>();
         when(ws.getDefaultIslandFlags()).thenReturn(flags);
-        assertEquals(flags, iwm.getDefaultIslandFlags(world));
+        assertEquals(flags, testIwm.getDefaultIslandFlags(testWorld));
     }
 
     /**
@@ -613,7 +613,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetVisibleSettings() {
         List<String> list = new ArrayList<>();
         when(ws.getHiddenFlags()).thenReturn(list);
-        assertEquals(list, iwm.getHiddenFlags(world));
+        assertEquals(list, testIwm.getHiddenFlags(testWorld));
     }
 
     /**
@@ -624,7 +624,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetDefaultIslandSettings() {
         Map<Flag, Integer> flags = new HashMap<>();
         when(ws.getDefaultIslandFlags()).thenReturn(flags);
-        assertEquals(flags,iwm.getDefaultIslandSettings(world));
+        assertEquals(flags,testIwm.getDefaultIslandSettings(testWorld));
     }
 
     /**
@@ -632,7 +632,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsUseOwnGenerator() {
-        assertFalse(iwm.isUseOwnGenerator(world));
+        assertFalse(testIwm.isUseOwnGenerator(testWorld));
     }
 
     /**
@@ -642,7 +642,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetVisitorBannedCommands() {
         List<String> list = new ArrayList<>();
         when(ws.getVisitorBannedCommands()).thenReturn(list);
-        assertEquals(list, iwm.getVisitorBannedCommands(world));
+        assertEquals(list, testIwm.getVisitorBannedCommands(testWorld));
     }
 
     /**
@@ -650,7 +650,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsWaterNotSafe() {
-        assertFalse(iwm.isWaterNotSafe(world));
+        assertFalse(testIwm.isWaterNotSafe(testWorld));
     }
 
     /**
@@ -660,7 +660,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
     public void testGetGeoLimitSettings() {
         List<String> list = new ArrayList<>();
         when(ws.getGeoLimitSettings()).thenReturn(list);
-        assertEquals(list, iwm.getGeoLimitSettings(world));
+        assertEquals(list, testIwm.getGeoLimitSettings(testWorld));
     }
 
     /**
@@ -668,7 +668,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetResetLimit() {
-        assertEquals(0,iwm.getResetLimit(world));
+        assertEquals(0,testIwm.getResetLimit(testWorld));
     }
 
     /**
@@ -676,7 +676,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetResetEpoch() {
-        assertEquals(0,iwm.getResetEpoch(world));
+        assertEquals(0,testIwm.getResetEpoch(testWorld));
     }
 
     /**
@@ -684,7 +684,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testSetResetEpoch() {
-        iwm.setResetEpoch(world);
+        testIwm.setResetEpoch(testWorld);
         Mockito.verify(ws).setResetEpoch(Mockito.anyLong());
     }
 
@@ -693,7 +693,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsTeamJoinDeathReset() {
-        assertFalse(iwm.isTeamJoinDeathReset(world));
+        assertFalse(testIwm.isTeamJoinDeathReset(testWorld));
     }
 
     /**
@@ -701,7 +701,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetDeathsMax() {
-        assertEquals(0, iwm.getDeathsMax(world));
+        assertEquals(0, testIwm.getDeathsMax(testWorld));
     }
 
     /**
@@ -709,7 +709,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetBanLimit() {
-        assertEquals(0, iwm.getBanLimit(world));
+        assertEquals(0, testIwm.getBanLimit(testWorld));
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -88,7 +88,6 @@ public class IslandsManagerTest extends CommonTestSetup {
     private @Nullable UUID owner = UUID.randomUUID();
     private Island is;
 
-    private UUID uuid;
     @Mock
     private User user;
     @Mock
@@ -101,8 +100,6 @@ public class IslandsManagerTest extends CommonTestSetup {
     private Block ground;
     @Mock
     private Block space2;
-    @Mock
-    private IslandWorldManager iwm;
     @Mock
     private IslandDeletionManager deletionManager;
     @Mock
@@ -133,7 +130,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     private Material wallSign;
 
     // Class under test
-    IslandsManager im;
+    IslandsManager islandsManager;
 
     private Settings settings;
 
@@ -343,9 +340,9 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(world.getUID()).thenReturn(uuid);
 
         // Class under test
-        im = new IslandsManager(plugin);
+        islandsManager = new IslandsManager(plugin);
         // Set cache
-        // im.setIslandCache(islandCache);
+        // islandsManager.setIslandCache(islandCache);
     }
 
     @Override
@@ -362,7 +359,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     @Disabled
     public void testIsSafeLocationSafe() {
-        assertTrue(im.isSafeLocation(location));
+        assertTrue(islandsManager.isSafeLocation(location));
     }
 
     /**
@@ -371,7 +368,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testIsSafeLocationNullWorld() {
         when(location.getWorld()).thenReturn(null);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
     }
 
     /**
@@ -380,7 +377,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testIsSafeLocationNonSolidGround() {
         when(ground.getType()).thenReturn(Material.WATER);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
     }
 
     /**
@@ -392,7 +389,7 @@ public class IslandsManagerTest extends CommonTestSetup {
  /*        when(ground.getType()).thenReturn(stone);
         when(space1.getType()).thenReturn(water);
         when(space2.getType()).thenReturn(water);*/
-        assertTrue(im.isSafeLocation(location)); // Since poseidon this is ok
+        assertTrue(islandsManager.isSafeLocation(location)); // Since poseidon this is ok
     }
 
     @Test
@@ -402,7 +399,7 @@ public class IslandsManagerTest extends CommonTestSetup {
             if (d.name().contains("DOOR")) {
                 for (Material s : Material.values()) {
                     if (s.name().contains("_SIGN") && !s.isLegacy()) {
-                        assertFalse( im.checkIfSafe(world, d, s, Material.AIR), "Fail " + d.name() + " " + s.name());
+                        assertFalse( islandsManager.checkIfSafe(world, d, s, Material.AIR), "Fail " + d.name() + " " + s.name());
                     }
                 }
             }
@@ -418,39 +415,39 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.NETHER_PORTAL);
-        assertTrue(im.isSafeLocation(location));
+        assertTrue(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.END_PORTAL);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.NETHER_PORTAL);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertTrue(im.isSafeLocation(location));
+        assertTrue(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.END_PORTAL);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.NETHER_PORTAL);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.END_PORTAL);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.END_GATEWAY);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.END_GATEWAY);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.END_GATEWAY);
-        assertFalse(im.isSafeLocation(location));
+        assertFalse(islandsManager.isSafeLocation(location));
 
     }
 
@@ -462,15 +459,15 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(ground.getType()).thenReturn(Material.LAVA);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertFalse( im.isSafeLocation(location), "In lava");
+        assertFalse( islandsManager.isSafeLocation(location), "In lava");
         when(ground.getType()).thenReturn(Material.AIR);
         when(space1.getType()).thenReturn(Material.LAVA);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertFalse( im.isSafeLocation(location), "In lava");
+        assertFalse( islandsManager.isSafeLocation(location), "In lava");
         when(ground.getType()).thenReturn(Material.AIR);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.LAVA);
-        assertFalse( im.isSafeLocation(location), "In lava");
+        assertFalse( islandsManager.isSafeLocation(location), "In lava");
     }
 
     /**
@@ -480,9 +477,9 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Disabled
     public void testTrapDoor() {
         when(ground.getType()).thenReturn(Material.OAK_TRAPDOOR);
-        assertFalse( im.isSafeLocation(location), "Open trapdoor");
+        assertFalse( islandsManager.isSafeLocation(location), "Open trapdoor");
         when(ground.getType()).thenReturn(Material.IRON_TRAPDOOR);
-        assertFalse(im.isSafeLocation(location), "Open iron trapdoor");
+        assertFalse(islandsManager.isSafeLocation(location), "Open iron trapdoor");
     }
 
     /**
@@ -493,19 +490,19 @@ public class IslandsManagerTest extends CommonTestSetup {
     public void testBadBlocks() {
         // Fences
         when(ground.getType()).thenReturn(Material.SPRUCE_FENCE);
-        assertFalse( im.isSafeLocation(location), "Fence :" + Material.SPRUCE_FENCE.toString());
+        assertFalse( islandsManager.isSafeLocation(location), "Fence :" + Material.SPRUCE_FENCE.toString());
         // Signs
         sign = Material.BIRCH_SIGN;
         when(ground.getType()).thenReturn(sign);
-        assertFalse(im.isSafeLocation(location), "Sign");
+        assertFalse(islandsManager.isSafeLocation(location), "Sign");
         wallSign = Material.ACACIA_WALL_SIGN;
         when(ground.getType()).thenReturn(wallSign);
-        assertFalse(im.isSafeLocation(location), "Sign");
+        assertFalse(islandsManager.isSafeLocation(location), "Sign");
         // Bad Blocks
         Material[] badMats = {Material.CACTUS, Material.OAK_BOAT};
         Arrays.asList(badMats).forEach(m -> {
             when(ground.getType()).thenReturn(m);
-            assertFalse(im.isSafeLocation(location), "Bad mat :" + m.toString());
+            assertFalse(islandsManager.isSafeLocation(location), "Bad mat :" + m.toString());
         });
 
     }
@@ -517,27 +514,27 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Disabled
     public void testSolidBlocks() {
         when(space1.getType()).thenReturn(Material.STONE);
-        assertFalse(im.isSafeLocation(location), "Solid");
+        assertFalse(islandsManager.isSafeLocation(location), "Solid");
 
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.STONE);
-        assertFalse(im.isSafeLocation(location), "Solid");
+        assertFalse(islandsManager.isSafeLocation(location), "Solid");
 
         when(space1.getType()).thenReturn(wallSign);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertTrue(im.isSafeLocation(location), "Wall sign 1");
+        assertTrue(islandsManager.isSafeLocation(location), "Wall sign 1");
 
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(wallSign);
-        assertTrue(im.isSafeLocation(location), "Wall sign 2");
+        assertTrue(islandsManager.isSafeLocation(location), "Wall sign 2");
 
         when(space1.getType()).thenReturn(sign);
         when(space2.getType()).thenReturn(Material.AIR);
-        assertTrue(im.isSafeLocation(location), "Wall sign 1");
+        assertTrue(islandsManager.isSafeLocation(location), "Wall sign 1");
 
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(sign);
-        assertTrue(im.isSafeLocation(location), "Wall sign 2");
+        assertTrue(islandsManager.isSafeLocation(location), "Wall sign 2");
     }
 
     /**
@@ -546,7 +543,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testCreateIslandLocation() {
-        Island island = im.createIsland(location);
+        Island island = islandsManager.createIsland(location);
         assertNotNull(island);
         assertEquals(island.getCenter().getWorld(), location.getWorld());
     }
@@ -558,7 +555,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testCreateIslandLocationUUID() {
         UUID owner = UUID.randomUUID();
-        Island island = im.createIsland(location, owner);
+        Island island = islandsManager.createIsland(location, owner);
         assertNotNull(island);
         assertEquals(island.getCenter().getWorld(), location.getWorld());
         assertEquals(owner, island.getOwner());
@@ -571,8 +568,8 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testDeleteIslandIslandBooleanNoBlockRemoval() {
         UUID owner = UUID.randomUUID();
-        Island island = im.createIsland(location, owner);
-        im.deleteIsland(island, false, owner);
+        Island island = islandsManager.createIsland(location, owner);
+        islandsManager.deleteIsland(island, false, owner);
         assertNull(island.getOwner());
         verify(pim).callEvent(any(IslandDeleteEvent.class));
     }
@@ -585,8 +582,8 @@ public class IslandsManagerTest extends CommonTestSetup {
     public void testDeleteIslandIslandBooleanRemoveBlocks() {
         verify(pim, never()).callEvent(any());
         UUID owner = UUID.randomUUID();
-        Island island = im.createIsland(location, owner);
-        im.deleteIsland(island, true, owner);
+        Island island = islandsManager.createIsland(location, owner);
+        islandsManager.deleteIsland(island, true, owner);
         assertNull(island.getOwner());
         verify(pim).callEvent(any(IslandDeleteEvent.class));
     }
@@ -597,9 +594,9 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetCount() {
-        assertEquals(0, im.getIslandCount());
-        im.createIsland(location, UUID.randomUUID());
-        assertEquals(1, im.getIslandCount());
+        assertEquals(0, islandsManager.getIslandCount());
+        islandsManager.createIsland(location, UUID.randomUUID());
+        assertEquals(1, islandsManager.getIslandCount());
     }
 
     /**
@@ -609,8 +606,8 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     @Disabled("Can't get to work yet")
     public void testGetIslandWorldUser()  {
-        assertEquals(is, im.getIsland(world, user));
-        assertNull(im.getIsland(world, (User) null));
+        assertEquals(is, islandsManager.getIsland(world, user));
+        assertNull(islandsManager.getIsland(world, (User) null));
     }
 
     /**
@@ -622,9 +619,9 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Disabled("Can't get this to work")
     public void testGetIsland() throws IOException  {
         //mockedUtil.when(() -> Util.getWorld(staticWorld)).thenReturn(staticWorld);
-        im.load();
-        assertEquals(is, im.getIsland(staticWorld, owner));
-        assertNull(im.getIsland(staticWorld, UUID.randomUUID()));
+        islandsManager.load();
+        assertEquals(is, islandsManager.getIsland(staticWorld, owner));
+        assertNull(islandsManager.getIsland(staticWorld, UUID.randomUUID()));
     }
 
     /**
@@ -632,20 +629,20 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getIslandAt(org.bukkit.Location)}.
      */
     @Test
-    public void testGetIslandAtLocation() throws Exception {
-        im.setIslandCache(islandCache);
+    public void testGetIslandAtLocation() {
+        islandsManager.setIslandCache(islandCache);
         // In world, correct island
-        assertEquals(optionalIsland, im.getIslandAt(location));
+        assertEquals(optionalIsland, islandsManager.getIslandAt(location));
 
         // in world, wrong island
         when(islandCache.getIslandAt(any(Location.class))).thenReturn(null);
-        assertEquals(Optional.empty(), im.getIslandAt(new Location(world, 100000, 120, -100000)));
+        assertEquals(Optional.empty(), islandsManager.getIslandAt(new Location(world, 100000, 120, -100000)));
 
         // not in world
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
-        assertEquals(Optional.empty(), im.getIslandAt(new Location(world, 100000, 120, -100000)));
-        assertEquals(Optional.empty(), im.getIslandAt(location));
+        assertEquals(Optional.empty(), islandsManager.getIslandAt(new Location(world, 100000, 120, -100000)));
+        assertEquals(Optional.empty(), islandsManager.getIslandAt(location));
     }
 
     /**
@@ -660,14 +657,14 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetIslandLocation()  {
-        im.createIsland(location, uuid);
-        assertEquals(world, im.getIslandLocation(world, uuid).getWorld());
-        Location l = im.getIslandLocation(world, uuid);
+        islandsManager.createIsland(location, uuid);
+        assertEquals(world, islandsManager.getIslandLocation(world, uuid).getWorld());
+        Location l = islandsManager.getIslandLocation(world, uuid);
         assertEquals(location.getWorld(), l.getWorld());
         assertEquals(location.getBlockX(), l.getBlockX());
         assertEquals(location.getBlockY(), l.getBlockY());
         assertEquals(location.getBlockZ(), l.getBlockZ());
-        assertNull(im.getIslandLocation(world, UUID.randomUUID()));
+        assertNull(islandsManager.getIslandLocation(world, UUID.randomUUID()));
     }
 
     /**
@@ -676,8 +673,8 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetLast() {
-        im.setLast(location);
-        assertEquals(location, im.getLast(world));
+        islandsManager.setLast(location);
+        assertEquals(location, islandsManager.getLast(world));
     }
 
     /**
@@ -693,8 +690,8 @@ public class IslandsManagerTest extends CommonTestSetup {
         members.add(UUID.randomUUID());
         /*
          * when(islandCache.getMembers(any(), any(),
-         * Mockito.anyInt())).thenReturn(members); im.setIslandCache(islandCache);
-         * assertEquals(members, im.getMembers(world, UUID.randomUUID()));
+         * Mockito.anyInt())).thenReturn(members); islandsManager.setIslandCache(islandCache);
+         * assertEquals(members, islandsManager.getMembers(world, UUID.randomUUID()));
          */
     }
 
@@ -711,25 +708,25 @@ public class IslandsManagerTest extends CommonTestSetup {
 
         // In world
 
-        im.setIslandCache(islandCache);
+        islandsManager.setIslandCache(islandCache);
 
         Optional<Island> optionalIsland = Optional.ofNullable(is);
         // In world, correct island
         when(is.onIsland(any())).thenReturn(true);
-        assertEquals(optionalIsland, im.getProtectedIslandAt(location));
+        assertEquals(optionalIsland, islandsManager.getProtectedIslandAt(location));
 
         // Not in protected space
         when(is.onIsland(any())).thenReturn(false);
-        assertEquals(Optional.empty(), im.getProtectedIslandAt(location));
+        assertEquals(Optional.empty(), islandsManager.getProtectedIslandAt(location));
 
-        im.setSpawn(is);
+        islandsManager.setSpawn(is);
         // In world, correct island
         when(is.onIsland(any())).thenReturn(true);
-        assertEquals(optionalIsland, im.getProtectedIslandAt(location));
+        assertEquals(optionalIsland, islandsManager.getProtectedIslandAt(location));
 
         // Not in protected space
         when(is.onIsland(any())).thenReturn(false);
-        assertEquals(Optional.empty(), im.getProtectedIslandAt(location));
+        assertEquals(Optional.empty(), islandsManager.getProtectedIslandAt(location));
     }
 
     /**
@@ -738,15 +735,15 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testGetSpawnPoint() {
-        assertNull(im.getSpawnPoint(world));
+        assertNull(islandsManager.getSpawnPoint(world));
         // Create a spawn island for this world
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         // Make a spawn position on the island
         when(island.getSpawnPoint(any())).thenReturn(location);
         // Set the spawn island
-        im.setSpawn(island);
-        assertEquals(location, im.getSpawnPoint(world));
+        islandsManager.setSpawn(island);
+        assertEquals(location, islandsManager.getSpawnPoint(world));
     }
 
     /**
@@ -755,12 +752,12 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testIsAtSpawn() {
-        assertFalse(im.isAtSpawn(location));
+        assertFalse(islandsManager.isAtSpawn(location));
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         when(island.onIsland(any())).thenReturn(true);
-        im.setSpawn(island);
-        assertTrue(im.isAtSpawn(location));
+        islandsManager.setSpawn(island);
+        assertTrue(islandsManager.isAtSpawn(location));
     }
 
     /**
@@ -774,19 +771,19 @@ public class IslandsManagerTest extends CommonTestSetup {
      * when(islandCache.getIslandAt(any())).thenReturn(is);
      * 
      * 
-     * im.setIslandCache(islandCache);
+     * islandsManager.setIslandCache(islandCache);
      * 
-     * assertFalse(im.isOwner(world, null));
+     * assertFalse(islandsManager.isOwner(world, null));
      * 
      * when(islandCache.hasIsland(any(), any())).thenReturn(false);
-     * assertFalse(im.isOwner(world, UUID.randomUUID()));
+     * assertFalse(islandsManager.isOwner(world, UUID.randomUUID()));
      * 
      * when(islandCache.hasIsland(any(), any())).thenReturn(true);
      * when(islandCache.get(any(), any(UUID.class))).thenReturn(is); UUID owner =
      * UUID.randomUUID(); when(is.getOwner()).thenReturn(owner); UUID notOwner =
      * UUID.randomUUID(); while (owner.equals(notOwner)) { notOwner =
-     * UUID.randomUUID(); } assertFalse(im.isOwner(world, notOwner));
-     * assertTrue(im.isOwner(world, owner)); }
+     * UUID.randomUUID(); } assertFalse(islandsManager.isOwner(world, notOwner));
+     * assertTrue(islandsManager.isOwner(world, owner)); }
      */
     /**
      * Test method for
@@ -802,7 +799,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testLoad() throws IOException {
         try {
-            im.load();
+            islandsManager.load();
         } catch (IOException e) {
             assertEquals("Island distance mismatch!\n" + "World 'world' distance 25 != island range 100!\n"
                     + "Island ID in database is null.\n"
@@ -815,7 +812,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testLoadNoDistanceCheck() throws IOException  {
         settings.setOverrideSafetyCheck(true);
-        im.load();
+        islandsManager.load();
         // No exception should be thrown
     }
 
@@ -840,23 +837,23 @@ public class IslandsManagerTest extends CommonTestSetup {
 
         when(player.getUniqueId()).thenReturn(uuid);
 
-        im.setIslandCache(islandCache);
+        islandsManager.setIslandCache(islandCache);
 
-        assertFalse(im.locationIsOnIsland(null, null));
+        assertFalse(islandsManager.locationIsOnIsland(null, null));
 
-        assertTrue(im.locationIsOnIsland(player, location));
+        assertTrue(islandsManager.locationIsOnIsland(player, location));
 
         // No members
         Builder<UUID> mem = new ImmutableSet.Builder<>();
         when(is.getMemberSet()).thenReturn(mem.build());
         when(is.inTeam(uuid)).thenReturn(false);
-        assertFalse(im.locationIsOnIsland(player, location));
+        assertFalse(islandsManager.locationIsOnIsland(player, location));
 
         // Not on island
         when(is.getMemberSet()).thenReturn(members.build());
         when(is.inTeam(uuid)).thenReturn(true);
         when(is.onIsland(any())).thenReturn(false);
-        assertFalse(im.locationIsOnIsland(player, location));
+        assertFalse(islandsManager.locationIsOnIsland(player, location));
     }
 
     /**
@@ -864,22 +861,22 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testUserIsOnIsland() {
-        im.setIslandCache(islandCache);
+        islandsManager.setIslandCache(islandCache);
 
         // ----- CHECK INVALID ARGUMENTS -----
 
         // Null user
-        assertFalse(im.userIsOnIsland(world, null));
+        assertFalse(islandsManager.userIsOnIsland(world, null));
 
         // Null world
-        assertFalse(im.userIsOnIsland(null, user));
+        assertFalse(islandsManager.userIsOnIsland(null, user));
 
         // Both null user and null world
-        assertFalse(im.userIsOnIsland(null, null));
+        assertFalse(islandsManager.userIsOnIsland(null, null));
 
         // User is not a player
         when(user.isPlayer()).thenReturn(false);
-        assertFalse(im.userIsOnIsland(world, user));
+        assertFalse(islandsManager.userIsOnIsland(world, user));
 
         // ----- CHECK MEMBERSHIP -----
         // We assume there that the User is in the good World.
@@ -893,11 +890,11 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(island.getMembers()).thenReturn(members);
 
         // -- The user is not part of the island --
-        assertFalse(im.userIsOnIsland(world, user));
+        assertFalse(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is the owner of the island --
         members.put(user.getUniqueId(), RanksManager.OWNER_RANK);
-        assertTrue(im.userIsOnIsland(world, user));
+        assertTrue(islandsManager.userIsOnIsland(world, user));
 
         // Add some members to see if it still works
         members.put(UUID.randomUUID(), RanksManager.MEMBER_RANK);
@@ -907,7 +904,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         members.put(UUID.randomUUID(), RanksManager.MEMBER_RANK);
         members.put(UUID.randomUUID(), RanksManager.MEMBER_RANK);
         members.put(UUID.randomUUID(), RanksManager.MEMBER_RANK);
-        assertTrue(im.userIsOnIsland(world, user));
+        assertTrue(islandsManager.userIsOnIsland(world, user));
 
         // Add some other ranks to see if it still works
         members.put(UUID.randomUUID(), RanksManager.BANNED_RANK);
@@ -915,42 +912,42 @@ public class IslandsManagerTest extends CommonTestSetup {
         members.put(UUID.randomUUID(), RanksManager.COOP_RANK);
         members.put(UUID.randomUUID(), RanksManager.TRUSTED_RANK);
         members.put(UUID.randomUUID(), RanksManager.BANNED_RANK);
-        assertTrue(im.userIsOnIsland(world, user));
+        assertTrue(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is a sub-owner on the island --
         members.put(user.getUniqueId(), RanksManager.SUB_OWNER_RANK);
-        assertTrue(im.userIsOnIsland(world, user));
+        assertTrue(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is a member on the island --
         members.put(user.getUniqueId(), RanksManager.MEMBER_RANK);
-        assertTrue(im.userIsOnIsland(world, user));
+        assertTrue(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is a trusted on the island --
         members.put(user.getUniqueId(), RanksManager.TRUSTED_RANK);
-        assertTrue(im.userIsOnIsland(world, user));
+        assertTrue(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is a coop on the island --
         members.put(user.getUniqueId(), RanksManager.COOP_RANK);
-        assertTrue(im.userIsOnIsland(world, user));
+        assertTrue(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is a visitor on the island --
         members.remove(user.getUniqueId());
-        assertFalse(im.userIsOnIsland(world, user));
+        assertFalse(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is explicitly a visitor on the island --
         members.put(user.getUniqueId(), RanksManager.VISITOR_RANK);
-        assertFalse(im.userIsOnIsland(world, user));
+        assertFalse(islandsManager.userIsOnIsland(world, user));
 
         // -- The user is banned from the island --
         members.put(user.getUniqueId(), RanksManager.BANNED_RANK);
-        assertFalse(im.userIsOnIsland(world, user));
+        assertFalse(islandsManager.userIsOnIsland(world, user));
 
         // ----- CHECK WORLD -----
         // Assertions above succeeded, so let's check that again with the User being a
         // MEMBER and being in the wrong world.
         when(user.getLocation().getWorld()).thenReturn(mock(World.class));
         members.put(user.getUniqueId(), RanksManager.MEMBER_RANK);
-        assertFalse(im.userIsOnIsland(world, user));
+        assertFalse(islandsManager.userIsOnIsland(world, user));
     }
 
     /**
@@ -960,7 +957,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testRemovePlayer() {
 
-        im.removePlayer(world, uuid);
+        islandsManager.removePlayer(world, uuid);
     }
 
     /**
@@ -971,7 +968,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     public void testRemovePlayersFromIsland() {
 
         Island is = mock(Island.class);
-        im.removePlayersFromIsland(is);
+        islandsManager.removePlayersFromIsland(is);
     }
 
     /**
@@ -1031,7 +1028,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         collection.add(is);
         when(islandCache.getCachedIslands()).thenReturn(collection);
 
-        im.setIslandCache(islandCache);
+        islandsManager.setIslandCache(islandCache);
         Map<UUID, Integer> members = new HashMap<>();
         when(is.getMembers()).thenReturn(members);
         // -- The user is the owner of the island --
@@ -1052,7 +1049,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         members.put(UUID.randomUUID(), RanksManager.TRUSTED_RANK);
         members.put(UUID.randomUUID(), RanksManager.TRUSTED_RANK);
 
-        im.shutdown();
+        islandsManager.shutdown();
 
         assertEquals(10, members.size());
         verify(islandCache).clear();
@@ -1071,7 +1068,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         collection.add(is);
         when(islandCache.getCachedIslands()).thenReturn(collection);
 
-        im.setIslandCache(islandCache);
+        islandsManager.setIslandCache(islandCache);
         Map<UUID, Integer> members = new HashMap<>();
         when(is.getMembers()).thenReturn(members);
         // -- The user is the owner of the island --
@@ -1095,9 +1092,9 @@ public class IslandsManagerTest extends CommonTestSetup {
         UUID coopUUID = UUID.randomUUID();
         members.put(coopUUID, RanksManager.COOP_RANK);
         // Clear a random user
-        im.clearRankSync(RanksManager.COOP_RANK, UUID.randomUUID());
+        islandsManager.clearRankSync(RanksManager.COOP_RANK, UUID.randomUUID());
         assertEquals(14, members.size());
-        im.clearRankSync(RanksManager.COOP_RANK, coopUUID);
+        islandsManager.clearRankSync(RanksManager.COOP_RANK, coopUUID);
         assertEquals(13, members.size());
     }
 
@@ -1107,7 +1104,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     @Test
     public void testClearAreaWrongWorld() {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
-        im.clearArea(location);
+        islandsManager.clearArea(location);
         // No entities should be cleared
         verify(zombie, never()).remove();
         verify(player, never()).remove();
@@ -1126,7 +1123,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     public void testClearArea() {
-        im.clearArea(location);
+        islandsManager.clearArea(location);
         // Only the correct entities should be cleared
         verify(zombie).remove();
         verify(player, never()).remove();
@@ -1148,8 +1145,8 @@ public class IslandsManagerTest extends CommonTestSetup {
         String uuid = UUID.randomUUID().toString();
         when(islandCache.getIslandById(anyString())).thenReturn(island);
         // Test
-        im.setIslandCache(islandCache);
-        assertEquals(island, im.getIslandById(uuid).get());
+        islandsManager.setIslandCache(islandCache);
+        assertEquals(island, islandsManager.getIslandById(uuid).get());
     }
 
     /**
@@ -1176,7 +1173,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Island distance
         when(iwm.getIslandDistance(eq(world))).thenReturn(100);
         // Test
-        assertFalse(im.fixIslandCenter(island));
+        assertFalse(islandsManager.fixIslandCenter(island));
     }
 
     /**
@@ -1204,7 +1201,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(iwm.getIslandDistance(eq(world))).thenReturn(100);
         // Test
         ArgumentCaptor<Location> captor = ArgumentCaptor.forClass(Location.class);
-        assertTrue(im.fixIslandCenter(island));
+        assertTrue(islandsManager.fixIslandCenter(island));
         // Verify location
         verify(island).setCenter(captor.capture());
         assertEquals(world, captor.getValue().getWorld());
@@ -1239,7 +1236,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(iwm.getIslandDistance(eq(world))).thenReturn(100);
         // Test
         ArgumentCaptor<Location> captor = ArgumentCaptor.forClass(Location.class);
-        assertTrue(im.fixIslandCenter(island));
+        assertTrue(islandsManager.fixIslandCenter(island));
         // Verify location
         verify(island).setCenter(captor.capture());
         assertEquals(world, captor.getValue().getWorld());
@@ -1273,7 +1270,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Island distance
         when(iwm.getIslandDistance(eq(world))).thenReturn(100);
         // Test
-        assertFalse(im.fixIslandCenter(island));
+        assertFalse(islandsManager.fixIslandCenter(island));
     }
 
     /**
@@ -1300,7 +1297,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Island distance
         when(iwm.getIslandDistance(eq(world))).thenReturn(100);
         // Test
-        assertFalse(im.fixIslandCenter(island));
+        assertFalse(islandsManager.fixIslandCenter(island));
     }
 
     /**
@@ -1328,7 +1325,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(iwm.getIslandDistance(eq(world))).thenReturn(100);
         // Test
         ArgumentCaptor<Location> captor = ArgumentCaptor.forClass(Location.class);
-        assertTrue(im.fixIslandCenter(island));
+        assertTrue(islandsManager.fixIslandCenter(island));
         // Verify location
         verify(island).setCenter(captor.capture());
         assertEquals(world, captor.getValue().getWorld());
@@ -1347,13 +1344,13 @@ public class IslandsManagerTest extends CommonTestSetup {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(null);
         // Test
-        assertFalse(im.fixIslandCenter(island));
+        assertFalse(islandsManager.fixIslandCenter(island));
         when(island.getWorld()).thenReturn(world);
         when(island.getCenter()).thenReturn(null);
-        assertFalse(im.fixIslandCenter(island));
+        assertFalse(islandsManager.fixIslandCenter(island));
         when(island.getCenter()).thenReturn(location);
         when(iwm.inWorld(eq(world))).thenReturn(false);
-        assertFalse(im.fixIslandCenter(island));
+        assertFalse(islandsManager.fixIslandCenter(island));
     }
 
     /**
@@ -1365,7 +1362,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(null);
         // Test
-        assertEquals(0, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        assertEquals(0, islandsManager.getMaxMembers(island, RanksManager.MEMBER_RANK));
         verify(island).setMaxMembers(eq(null));
     }
 
@@ -1384,7 +1381,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Offline owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(null);
         // Test
-        assertEquals(4, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        assertEquals(4, islandsManager.getMaxMembers(island, RanksManager.MEMBER_RANK));
         verify(island, never()).setMaxMembers(eq(RanksManager.MEMBER_RANK), eq(null)); // No change
     }
 
@@ -1403,7 +1400,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        assertEquals(4, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        assertEquals(4, islandsManager.getMaxMembers(island, RanksManager.MEMBER_RANK));
         verify(island, never()).setMaxMembers(RanksManager.MEMBER_RANK, null);
     }
 
@@ -1424,9 +1421,9 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        assertEquals(2, im.getMaxMembers(island, RanksManager.COOP_RANK));
+        assertEquals(2, islandsManager.getMaxMembers(island, RanksManager.COOP_RANK));
         verify(island, never()).setMaxMembers(RanksManager.COOP_RANK, null); // No change
-        assertEquals(3, im.getMaxMembers(island, RanksManager.TRUSTED_RANK));
+        assertEquals(3, islandsManager.getMaxMembers(island, RanksManager.TRUSTED_RANK));
         verify(island, never()).setMaxMembers(RanksManager.TRUSTED_RANK, null);
     }
 
@@ -1444,7 +1441,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        assertEquals(10, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        assertEquals(10, islandsManager.getMaxMembers(island, RanksManager.MEMBER_RANK));
         verify(island).setMaxMembers(RanksManager.MEMBER_RANK, 10);
     }
 
@@ -1462,7 +1459,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        assertEquals(10, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        assertEquals(10, islandsManager.getMaxMembers(island, RanksManager.MEMBER_RANK));
         verify(island).setMaxMembers(RanksManager.MEMBER_RANK, 10);
     }
 
@@ -1487,7 +1484,7 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        assertEquals(8, im.getMaxMembers(island, RanksManager.MEMBER_RANK));
+        assertEquals(8, islandsManager.getMaxMembers(island, RanksManager.MEMBER_RANK));
         verify(island).setMaxMembers(RanksManager.MEMBER_RANK, 8);
     }
 
@@ -1499,7 +1496,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     public void testsetMaxMembers() {
         Island island = mock(Island.class);
         // Test
-        im.setMaxMembers(island, RanksManager.MEMBER_RANK, 40);
+        islandsManager.setMaxMembers(island, RanksManager.MEMBER_RANK, 40);
         verify(island).setMaxMembers(RanksManager.MEMBER_RANK, 40);
     }
 
@@ -1524,8 +1521,8 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        assertEquals(8, im.getMaxHomes(island));
+        IslandsManager localIM = new IslandsManager(plugin);
+        assertEquals(8, localIM.getMaxHomes(island));
         verify(island).setMaxHomes(eq(8));
     }
 
@@ -1550,8 +1547,8 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        assertEquals(4, im.getMaxHomes(island));
+        IslandsManager localIM = new IslandsManager(plugin);
+        assertEquals(4, localIM.getMaxHomes(island));
         verify(island, never()).setMaxHomes(null);
     }
 
@@ -1576,8 +1573,8 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        assertEquals(20, im.getMaxHomes(island));
+        IslandsManager localIM = new IslandsManager(plugin);
+        assertEquals(20, localIM.getMaxHomes(island));
         verify(island, never()).setMaxHomes(20);
     }
 
@@ -1602,8 +1599,8 @@ public class IslandsManagerTest extends CommonTestSetup {
         // Online owner
         mockedBukkit.when(() -> Bukkit.getPlayer(any(UUID.class))).thenReturn(player);
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        assertEquals(8, im.getMaxHomes(island));
+        IslandsManager localIM = new IslandsManager(plugin);
+        assertEquals(8, localIM.getMaxHomes(island));
         verify(island).setMaxHomes(8);
     }
 
@@ -1615,8 +1612,8 @@ public class IslandsManagerTest extends CommonTestSetup {
     public void testsetMaxHomes() {
         Island island = mock(Island.class);
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        im.setMaxHomes(island, 40);
+        IslandsManager localIM = new IslandsManager(plugin);
+        localIM.setMaxHomes(island, 40);
         verify(island).setMaxHomes(eq(40));
     }
 
@@ -1642,12 +1639,12 @@ public class IslandsManagerTest extends CommonTestSetup {
         mockedUtil.when(() -> Util.teleportAsync(eq(player), eq(homeLoc))).thenReturn(future);
         
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        CompletableFuture<Void> result = im.homeTeleportAsync(island, user);
-        
+        IslandsManager localIM = new IslandsManager(plugin);
+        CompletableFuture<Void> result = localIM.homeTeleportAsync(island, user);
+
         // Wait for async completion
         result.get();
-        
+
         // Verify
         assertNotNull(result);
         verify(user).sendMessage("commands.island.go.teleport");
@@ -1677,18 +1674,18 @@ public class IslandsManagerTest extends CommonTestSetup {
         mockedUtil.when(() -> Util.teleportAsync(eq(player), eq(homeLoc))).thenReturn(future);
         
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        CompletableFuture<Void> result = im.homeTeleportAsync(island, user, false);
-        
+        IslandsManager localIM = new IslandsManager(plugin);
+        CompletableFuture<Void> result = localIM.homeTeleportAsync(island, user, false);
+
         // Wait for async completion
         result.get();
-        
+
         // Verify
         assertNotNull(result);
         verify(user).sendMessage("commands.island.go.teleport");
         verify(island).getHome("");
         // User should be removed from goingHome after successful teleport
-        assertFalse(im.isGoingHome(user));
+        assertFalse(localIM.isGoingHome(user));
     }
 
     /**
@@ -1705,27 +1702,27 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(island.getWorld()).thenReturn(world);
         when(user.getPlayer()).thenReturn(player);
         when(user.getUniqueId()).thenReturn(uuid);
-        
+
         // Mock player methods called by readyPlayer
         when(player.isInsideVehicle()).thenReturn(false);
-        
+
         // Mock teleportAsync to return successful future
         CompletableFuture<Boolean> future = CompletableFuture.completedFuture(true);
         mockedUtil.when(() -> Util.teleportAsync(eq(player), eq(homeLoc))).thenReturn(future);
-        
+
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        CompletableFuture<Void> result = im.homeTeleportAsync(island, user, true);
-        
+        IslandsManager localIM = new IslandsManager(plugin);
+        CompletableFuture<Void> result = localIM.homeTeleportAsync(island, user, true);
+
         // Wait for async completion
         result.get();
-        
+
         // Verify
         assertNotNull(result);
         verify(user).sendMessage("commands.island.go.teleport");
         verify(island).getHome("");
         // User should be removed from goingHome after successful teleport
-        assertFalse(im.isGoingHome(user));
+        assertFalse(localIM.isGoingHome(user));
     }
 
     /**
@@ -1742,23 +1739,23 @@ public class IslandsManagerTest extends CommonTestSetup {
         when(island.getWorld()).thenReturn(world);
         when(user.getPlayer()).thenReturn(player);
         when(user.getUniqueId()).thenReturn(uuid);
-        
+
         // Mock player methods called by readyPlayer
         when(player.isInsideVehicle()).thenReturn(false);
-        
+
         // Mock teleportAsync to return failed future
         CompletableFuture<Boolean> future = CompletableFuture.completedFuture(false);
         mockedUtil.when(() -> Util.teleportAsync(eq(player), eq(homeLoc))).thenReturn(future);
-        
+
         // Test
-        IslandsManager im = new IslandsManager(plugin);
-        CompletableFuture<Void> result = im.homeTeleportAsync(island, user, false);
-        
+        IslandsManager localIM = new IslandsManager(plugin);
+        CompletableFuture<Void> result = localIM.homeTeleportAsync(island, user, false);
+
         // Wait for async completion
         result.get();
-        
+
         // Verify user was removed from goingHome after failed teleport
-        assertFalse(im.isGoingHome(user));
+        assertFalse(localIM.isGoingHome(user));
         verify(user).sendMessage("commands.island.go.teleport");
         verify(island).getHome("");
     }

--- a/src/test/java/world/bentobox/bentobox/panels/settings/SettingsTabTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/settings/SettingsTabTest.java
@@ -2,6 +2,8 @@ package world.bentobox.bentobox.panels.settings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -109,21 +111,21 @@ public class SettingsTabTest extends CommonTestSetup {
     @Test
     public void testGetUser() {
         testSettingsTabWorldUserTypeMode();
-        assertEquals(user, tab.getUser());
+        assertSame(user, tab.getUser());
     }
 
     @Test
     public void testGetWorld() {
         testSettingsTabWorldUserTypeMode();
-        assertEquals(world, tab.getWorld());
+        assertSame(world, tab.getWorld());
     }
 
     @Test
     public void testGetIsland() {
         testSettingsTabWorldUserTypeMode();
-        assertEquals(null, tab.getIsland());
+        assertNull(tab.getIsland());
         tab.setParentPanel(parent);
-        assertEquals(island, tab.getIsland());
+        assertSame(island, tab.getIsland());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fix ~80 variable shadowing issues in ~45 test classes (S1117). Removed duplicate field declarations when same as `CommonTestSetup` parent, renamed to distinct names when different.
- Improve ~52 assertions: remove Boolean boxing (S5411), `assertEquals` → `assertSame` (S5785), swap reversed args (S3415), add comments to empty blocks (S108), extract assignments from sub-expressions (S3010), remove always-true/false conditions (S2589)

## Risk
**Low-Medium** — verified each shadowed field's setUp() doesn't assign different values than the parent.

## Test plan
- [x] `./gradlew clean test` passes
- [ ] SonarCloud re-scan confirms reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)