### PR TITLE
Fix SonarCloud: Disabled tests, parameterized tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,6 +201,7 @@ dependencies {
     // --- Test Dependencies: Only used during testing, not in production ---
     testImplementation(platform("org.junit:junit-bom:$junitVersion"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitVersion")
     testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommandTest.java
@@ -631,7 +631,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    @Disabled("This fails for some reason on the map getting")
+    @Disabled("Reason: IslandGoCommand.getNameIslandMap static mock integration fails during map retrieval")
     public void testExecuteWithMultipleIslandsAfterCanExecute() {
         // Arrange
         args.add("ValidPlayer");

--- a/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEnableEventTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEnableEventTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -96,15 +95,6 @@ public class AddonEnableEventTest extends CommonTestSetup {
     public void testSetNewEvent() {
         aee.setNewEvent(aee);
         assertEquals(aee, aee.getNewEvent().get());
-    }
-
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.events.BentoBoxEvent#setKeyValues(java.util.Map)}.
-     */
-    @Test
-    @Disabled
-    public void testSetKeyValues() {
-        // No fields to set values for in the class
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
@@ -23,7 +23,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -271,15 +270,6 @@ public class PanelTest extends CommonTestSetup {
         assertEquals(Optional.empty(), p.getUser());
         p.setUser(user);
         assertEquals(user, p.getUser().get());
-    }
-
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.panels.Panel#setHead(world.bentobox.bentobox.api.panels.PanelItem)}.
-     */
-    @Test
-    @Disabled("New test required for new code")
-    public void testSetHead() {
-        // Not needed for test
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/BannedCommandsTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/BannedCommandsTest.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -19,6 +20,9 @@ import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import world.bentobox.bentobox.CommonTestSetup;
@@ -44,7 +48,7 @@ public class BannedCommandsTest extends CommonTestSetup {
         when(iwm.getWorldSettings(any())).thenReturn(ws);
         Map<String, Boolean> worldFlags = new HashMap<>();
         when(ws.getWorldFlags()).thenReturn(worldFlags);
-        
+
         // Player
         when(mockPlayer.isOp()).thenReturn(false);
         when(mockPlayer.hasPermission(Mockito.anyString())).thenReturn(false);
@@ -74,38 +78,53 @@ public class BannedCommandsTest extends CommonTestSetup {
     }
 
     /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
+     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}.
+     * Verifies that the command is not cancelled when the player is not in a game world.
      */
     @Test
-    public void testInstantReturn() {
+    public void testInstantReturnNotInWorld() {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
         BannedCommands bvc = new BannedCommands(plugin);
-
-        // Not in world
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
-
         bvc.onVisitorCommand(e);
         assertFalse(e.isCancelled());
+    }
 
-        // In world
-        when(iwm.inWorld(any(World.class))).thenReturn(true);
-        when(iwm.inWorld(any(Location.class))).thenReturn(true);
-        // Op
+    /**
+     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}.
+     * Verifies that the command is not cancelled when the player is an operator.
+     */
+    @Test
+    public void testInstantReturnOp() {
+        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
+        BannedCommands bvc = new BannedCommands(plugin);
         when(mockPlayer.isOp()).thenReturn(true);
         bvc.onVisitorCommand(e);
         assertFalse(e.isCancelled());
+    }
 
-        // Not op
-        when(mockPlayer.isOp()).thenReturn(false);
-        // Has bypass perm
+    /**
+     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}.
+     * Verifies that the command is not cancelled when the player has bypass permission.
+     */
+    @Test
+    public void testInstantReturnBypassPerm() {
+        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
+        BannedCommands bvc = new BannedCommands(plugin);
         when(mockPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
         bvc.onVisitorCommand(e);
         assertFalse(e.isCancelled());
+    }
 
-        // Does not have perm
-        when(mockPlayer.hasPermission(Mockito.anyString())).thenReturn(false);
-        // Not a visitor
+    /**
+     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}.
+     * Verifies that the command is not cancelled when the player is on their own island.
+     */
+    @Test
+    public void testInstantReturnOnOwnIsland() {
+        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
+        BannedCommands bvc = new BannedCommands(plugin);
         when(im.locationIsOnIsland(any(), any())).thenReturn(true);
         bvc.onVisitorCommand(e);
         assertFalse(e.isCancelled());
@@ -123,185 +142,67 @@ public class BannedCommandsTest extends CommonTestSetup {
     }
 
     /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
+     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}.
+     * Verifies that commands matching banned entries are cancelled for visitors.
      */
-    @Test
-    public void testBannedCommands() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
+    @ParameterizedTest
+    @MethodSource("provideCancelledVisitorCommands")
+    public void testVisitorBannedCommandCancelled(String command, List<String> bannedList) {
+        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, command);
         BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("banned_command");
-        banned.add("another_banned_command");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        assertFalse(e.isCancelled());
-        verify(iwm).getVisitorBannedCommands(any());
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithExtra() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah with extra stuff");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("banned_command");
-        banned.add("another_banned_command");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        assertFalse(e.isCancelled());
-        verify(iwm).getVisitorBannedCommands(any());
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedCommand() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/banned_command");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("banned_command");
-        banned.add("another_banned_command");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
+        when(iwm.getVisitorBannedCommands(any())).thenReturn(bannedList);
         bvc.onVisitorCommand(e);
         verify(iwm).getVisitorBannedCommands(any());
         assertTrue(e.isCancelled());
+    }
 
+    static Stream<Arguments> provideCancelledVisitorCommands() {
+        return Stream.of(
+                // Exact match
+                Arguments.of("/banned_command", List.of("banned_command", "another_banned_command")),
+                // Banned command with extra args
+                Arguments.of("/banned_command with extra stuff", List.of("banned_command", "another_banned_command")),
+                // Full match including args
+                Arguments.of("/banned_command with extra stuff", List.of("banned_command with extra stuff", "another_banned_command")),
+                // Another banned command with extra args
+                Arguments.of("/another_banned_command with extra stuff", List.of("banned_command", "another_banned_command")),
+                // Multi-word banned command exact match
+                Arguments.of("/cmi sethome", List.of("cmi sethome"))
+        );
     }
 
     /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
+     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}.
+     * Verifies that commands not matching banned entries are not cancelled for visitors.
      */
-    @Test
-    public void testBannedCommandsWithBannedCommandWithExtra() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/banned_command with extra stuff");
+    @ParameterizedTest
+    @MethodSource("provideNonCancelledVisitorCommands")
+    public void testVisitorBannedCommandNotCancelled(String command, List<String> bannedList) {
+        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, command);
         BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("banned_command");
-        banned.add("another_banned_command");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertTrue(e.isCancelled());
-
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedCommandWithExtraBannedStuff() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/banned_command with extra stuff");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("banned_command with extra stuff");
-        banned.add("another_banned_command");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertTrue(e.isCancelled());
-
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedCommand2() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/spawn");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("cmi sethome");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
+        when(iwm.getVisitorBannedCommands(any())).thenReturn(bannedList);
         bvc.onVisitorCommand(e);
         verify(iwm).getVisitorBannedCommands(any());
         assertFalse(e.isCancelled());
-
     }
 
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedCommand3() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/cmi sethome");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("cmi sethome");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertTrue(e.isCancelled());
-
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedComman4() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/cmi");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("cmi sethome");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertFalse(e.isCancelled());
-
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedCommand5() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/cmi homey");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("cmi sethome");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertFalse(e.isCancelled());
-
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedCommand6() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/spawn");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("cmi sethome");
-        banned.add("spawn sethome now");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertFalse(e.isCancelled());
-
-    }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testBannedCommandsWithBannedCommand7() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/spawn");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("cmi sethome");
-        banned.add("spawn sethome now");
-        banned.add("cmi multi now");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertFalse(e.isCancelled());
-
+    static Stream<Arguments> provideNonCancelledVisitorCommands() {
+        return Stream.of(
+                // Non-matching command
+                Arguments.of("/blah", List.of("banned_command", "another_banned_command")),
+                // Non-matching command with extra args
+                Arguments.of("/blah with extra stuff", List.of("banned_command", "another_banned_command")),
+                // Different command than banned multi-word
+                Arguments.of("/spawn", List.of("cmi sethome")),
+                // Partial match of multi-word banned command (only first word)
+                Arguments.of("/cmi", List.of("cmi sethome")),
+                // Different subcommand than banned
+                Arguments.of("/cmi homey", List.of("cmi sethome")),
+                // Non-matching with multiple banned entries
+                Arguments.of("/spawn", List.of("cmi sethome", "spawn sethome now")),
+                // Non-matching with three banned entries
+                Arguments.of("/spawn", List.of("cmi sethome", "spawn sethome now", "cmi multi now"))
+        );
     }
 
 
@@ -316,24 +217,6 @@ public class BannedCommandsTest extends CommonTestSetup {
         assertFalse(e.isCancelled());
 
     }
-
-    /**
-     * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
-     */
-    @Test
-    public void testAnotherBannedCommandsWithBannedCommandWithExtra() {
-        PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/another_banned_command with extra stuff");
-        BannedCommands bvc = new BannedCommands(plugin);
-        List<String> banned = new ArrayList<>();
-        banned.add("banned_command");
-        banned.add("another_banned_command");
-        when(iwm.getVisitorBannedCommands(any())).thenReturn(banned);
-        bvc.onVisitorCommand(e);
-        verify(iwm).getVisitorBannedCommands(any());
-        assertTrue(e.isCancelled());
-
-    }
-
 
     /**
      * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}

--- a/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -33,6 +34,9 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 
@@ -224,11 +228,14 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
     /**
      * Test method for
      * {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
+     * Verifies that protection range is updated on join when player has a range permission
+     * that differs from the current range. Clamped to island distance (100).
      */
-    @Test
-    public void testOnPlayerJoinRangeChangeTooLargePerm() {
+    @ParameterizedTest
+    @MethodSource("provideRangeChangePermissions")
+    public void testOnPlayerJoinRangeChangePerm(int permRange, int expectedRange) {
         PermissionAttachmentInfo pa = mock(PermissionAttachmentInfo.class);
-        when(pa.getPermission()).thenReturn("acidisland.island.range.1000");
+        when(pa.getPermission()).thenReturn("acidisland.island.range." + permRange);
         when(pa.getValue()).thenReturn(true);
         when(mockPlayer.getEffectivePermissions()).thenReturn(Collections.singleton(pa));
         PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
@@ -236,49 +243,20 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
         // Verify
         checkSpigotMessage("commands.admin.setrange.range-updated");
         // Verify island setting
-        assertEquals(100, island.getProtectionRange());
+        assertEquals(expectedRange, island.getProtectionRange());
         // Verify log
-        verify(plugin).log("Island protection range changed from 50 to 100 for tastybento due to permission.");
+        verify(plugin).log("Island protection range changed from 50 to " + expectedRange + " for tastybento due to permission.");
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
-     */
-    @Test
-    public void testOnPlayerJoinRangeChangeSmallerPerm() {
-        PermissionAttachmentInfo pa = mock(PermissionAttachmentInfo.class);
-        when(pa.getPermission()).thenReturn("acidisland.island.range.10");
-        when(pa.getValue()).thenReturn(true);
-        when(mockPlayer.getEffectivePermissions()).thenReturn(Collections.singleton(pa));
-        PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
-        jll.onPlayerJoin(event);
-        // Verify
-        checkSpigotMessage("commands.admin.setrange.range-updated");
-        // Verify island setting
-        assertEquals(10, island.getProtectionRange());
-        // Verify log
-        verify(plugin).log("Island protection range changed from 50 to 10 for tastybento due to permission.");
-    }
-
-    /**
-     * Test method for
-     * {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
-     */
-    @Test
-    public void testOnPlayerJoinRangeChangeSmallIncreasePerm() {
-        PermissionAttachmentInfo pa = mock(PermissionAttachmentInfo.class);
-        when(pa.getPermission()).thenReturn("acidisland.island.range.55");
-        when(pa.getValue()).thenReturn(true);
-        when(mockPlayer.getEffectivePermissions()).thenReturn(Collections.singleton(pa));
-        PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
-        jll.onPlayerJoin(event);
-        // Verify
-        checkSpigotMessage("commands.admin.setrange.range-updated");
-        // Verify island setting
-        assertEquals(55, island.getProtectionRange());
-        // Verify log
-        verify(plugin).log("Island protection range changed from 50 to 55 for tastybento due to permission.");
+    static Stream<Arguments> provideRangeChangePermissions() {
+        return Stream.of(
+                // Too large perm (1000) is clamped to island distance (100)
+                Arguments.of(1000, 100),
+                // Smaller perm (10) sets range to 10
+                Arguments.of(10, 10),
+                // Small increase perm (55) sets range to 55
+                Arguments.of(55, 55)
+        );
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListenerTest.java
@@ -2,7 +2,6 @@ package world.bentobox.bentobox.listeners.flags.protection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -342,26 +341,6 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
         assertEquals(Event.Result.DENY, e.useInteractedBlock());
         assertEquals(Event.Result.DENY, e.useItemInHand());
         verify(notifier, times(2)).notify(any(), eq("protection.protected"));
-    }
-
-
-
-    /**
-     * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
-     */
-    @Disabled("TODO")
-    @Test
-    public void testOnBlockBreak() {
-        fail("Not yet implemented"); // TODO
-    }
-
-    /**
-     * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onDragonEggTeleport(org.bukkit.event.block.BlockFromToEvent)}.
-     */
-    @Disabled("TODO")
-    @Test
-    public void testOnDragonEggTeleport() {
-        fail("Not yet implemented"); // TODO
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListenerTest.java
@@ -22,7 +22,6 @@ import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerFishEvent.State;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -273,42 +272,6 @@ public class HurtingListenerTest extends CommonTestSetup {
         hl.onFishing(e);
         // Verify
         verify(notifier, never()).notify(user, "protection.protected");
-    }
-
-    /**
-     * Test method for {@link HurtingListener#onPlayerFeedParrots(org.bukkit.event.player.PlayerInteractEntityEvent)}.
-     */
-    @Disabled("Not yet implemented")
-    @Test
-    public void testOnPlayerFeedParrots() {
-        //fail("Not yet implemented"); // TODO
-    }
-
-    /**
-     * Test method for {@link HurtingListener#onSplashPotionSplash(org.bukkit.event.entity.PotionSplashEvent)}.
-     */
-    @Disabled("Not yet implemented")
-    @Test
-    public void testOnSplashPotionSplash() {
-        //fail("Not yet implemented"); // TODO
-    }
-
-    /**
-     * Test method for {@link HurtingListener#onLingeringPotionSplash(org.bukkit.event.entity.LingeringPotionSplashEvent)}.
-     */
-    @Disabled("Not yet implemented")
-    @Test
-    public void testOnLingeringPotionSplash() {
-        //fail("Not yet implemented"); // TODO
-    }
-
-    /**
-     * Test method for {@link HurtingListener#onLingeringPotionDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
-     */
-    @Disabled("Not yet implemented")
-    @Test
-    public void testOnLingeringPotionDamage() {
-        //fail("Not yet implemented"); // TODO
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -360,7 +360,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    @Disabled
+    @Disabled("Reason: Block mocks do not return correct BlockData for isSafeLocation checks")
     public void testIsSafeLocationSafe() {
         assertTrue(im.isSafeLocation(location));
     }
@@ -387,7 +387,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    @Disabled("Weird error")
+    @Disabled("Reason: Block mock types are commented out; test body needs rewrite for water submersion check")
     public void testIsSafeLocationSubmerged() {
  /*        when(ground.getType()).thenReturn(stone);
         when(space1.getType()).thenReturn(water);
@@ -396,7 +396,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    @Disabled()
+    @Disabled("Reason: Material.values() iteration causes mock framework issues with BlockData types")
     public void testCheckIfSafeTrapdoor() {
         for (Material d : Material.values()) {
             if (d.name().contains("DOOR")) {
@@ -413,7 +413,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    @Disabled
+    @Disabled("Reason: Block mocks do not return correct BlockData for portal type checks")
     public void testIsSafeLocationPortals() {
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.AIR);
@@ -477,7 +477,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    @Disabled
+    @Disabled("Reason: Block mocks do not return correct BlockData for trapdoor open/closed state")
     public void testTrapDoor() {
         when(ground.getType()).thenReturn(Material.OAK_TRAPDOOR);
         assertFalse( im.isSafeLocation(location), "Open trapdoor");
@@ -489,7 +489,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    @Disabled
+    @Disabled("Reason: Block mocks do not return correct BlockData for fence/sign/cactus type checks")
     public void testBadBlocks() {
         // Fences
         when(ground.getType()).thenReturn(Material.SPRUCE_FENCE);
@@ -514,7 +514,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    @Disabled
+    @Disabled("Reason: Block mocks do not return correct BlockData for solid block type checks")
     public void testSolidBlocks() {
         when(space1.getType()).thenReturn(Material.STONE);
         assertFalse(im.isSafeLocation(location), "Solid");
@@ -607,7 +607,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getIsland(World, User)}
      */
     @Test
-    @Disabled("Can't get to work yet")
+    @Disabled("Reason: Island cache mock does not integrate with IslandsManager.getIsland(World, User)")
     public void testGetIslandWorldUser()  {
         assertEquals(is, im.getIsland(world, user));
         assertNull(im.getIsland(world, (User) null));
@@ -619,7 +619,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * @throws IOException 
      */
     @Test
-    @Disabled("Can't get this to work")
+    @Disabled("Reason: Database load/mock integration prevents getIsland(World, UUID) from returning expected island")
     public void testGetIsland() throws IOException  {
         //mockedUtil.when(() -> Util.getWorld(staticWorld)).thenReturn(staticWorld);
         im.load();

--- a/src/test/java/world/bentobox/bentobox/managers/RanksManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/RanksManagerTest.java
@@ -14,7 +14,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -139,7 +138,6 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#getRank(int)}.
      */
     @Test
-    @Disabled
     public void testGetRank() {
         assertEquals(RanksManager.BANNED_RANK_REF, rm.getRank(RanksManager.BANNED_RANK));
         assertEquals(RanksManager.VISITOR_RANK_REF, rm.getRank(RanksManager.VISITOR_RANK));


### PR DESCRIPTION
## Summary
- Re-enable `RanksManagerTest.testGetRank()`, remove 7 empty test stubs (S1607)
- Add descriptive `@Disabled` reasons to 9 remaining disabled tests
- Convert `BannedCommandsTest` (12 tests → 2 parameterized) and `JoinLeaveListenerTest` (3 tests → 1 parameterized) using `@ParameterizedTest` (S5976)
- Split `testInstantReturn` into 4 focused tests (S5961)

## Risk
**Low-Medium** — case-by-case decisions on disabled tests.

## Test plan
- [x] `./gradlew clean test` passes
- [x] SonarCloud re-scan confirms reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)