### PR TITLE
Fix SonarCloud: Replace deprecated EntityDamageByEntityEvent and LingeringPotion in tests

### DIFF
--- a/src/test/java/world/bentobox/bentobox/listeners/flags/settings/PVPListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/settings/PVPListenerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.FishHook;
-import org.bukkit.entity.LingeringPotion;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -43,7 +41,6 @@ import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.LingeringPotionSplashEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
@@ -59,10 +56,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.collect.ImmutableMap;
 
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.Settings;
@@ -213,6 +206,10 @@ public class PVPListenerTest extends CommonTestSetup {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
     }
 
+    private EntityDamageByEntityEvent createDamageEvent(Entity damager, Entity damagee, DamageCause cause) {
+        return new EntityDamageByEntityEvent(damager, damagee, cause, null, 0);
+    }
+
     /**
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
@@ -220,10 +217,7 @@ public class PVPListenerTest extends CommonTestSetup {
     public void testOnEntityDamageNotPlayer() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Creeper.class);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damagee,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
     }
@@ -234,10 +228,7 @@ public class PVPListenerTest extends CommonTestSetup {
     @Test
     public void testOnEntityDamageSelfDamage() {
         Entity damager = mock(Player.class);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damager,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damager, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
     }
@@ -251,10 +242,7 @@ public class PVPListenerTest extends CommonTestSetup {
         when(player2.hasMetadata(eq("NPC"))).thenReturn(true);
         // PVP is not allowed
         when(island.isAllowed(any())).thenReturn(false);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(mockPlayer, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(mockPlayer, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be allowed for NPC
         assertFalse(e.isCancelled());
@@ -271,11 +259,7 @@ public class PVPListenerTest extends CommonTestSetup {
         when(player2.hasMetadata(eq("NPC"))).thenReturn(true);
         // PVP is not allowed
         when(island.isAllowed(any())).thenReturn(false);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(player2, mockPlayer,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(
-                        ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(player2, mockPlayer, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be allowed for NPC
         assertFalse(e.isCancelled());
@@ -296,24 +280,17 @@ public class PVPListenerTest extends CommonTestSetup {
         when(damagee.getWorld()).thenReturn(world);
         when(damager.getLocation()).thenReturn(location);
         when(damagee.getLocation()).thenReturn(location);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damagee,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
 
         // Different attack type
-        e = new EntityDamageByEntityEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK);
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
 
         // Wrong world
-        e = new EntityDamageByEntityEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         wrongWorld();
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
@@ -339,16 +316,11 @@ public class PVPListenerTest extends CommonTestSetup {
         when(iwm.getIvSettings(world)).thenReturn(visitorProtectionList);
         // This player is on their island, i.e., not a visitor
 
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damagee,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
         // Wrong world
-        e = new EntityDamageByEntityEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         wrongWorld();
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
@@ -370,10 +342,7 @@ public class PVPListenerTest extends CommonTestSetup {
         // This player is a visitor
         when(im.userIsOnIsland(any(), any())).thenReturn(false);
 
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damagee,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         assertTrue(e.isCancelled());
     }
@@ -398,10 +367,7 @@ public class PVPListenerTest extends CommonTestSetup {
         // This player is a visitor
         when(im.userIsOnIsland(any(), any())).thenReturn(false);
 
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damagee,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         wrongWorld();
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
@@ -427,10 +393,7 @@ public class PVPListenerTest extends CommonTestSetup {
         // This player is a visitor
         when(im.userIsOnIsland(any(), any())).thenReturn(false);
         // Damage is not entity attack
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damagee,
-                EntityDamageEvent.DamageCause.THORNS, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.THORNS);
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
         // Wrong world
@@ -455,16 +418,11 @@ public class PVPListenerTest extends CommonTestSetup {
         // This player is a visitor
         when(im.userIsOnIsland(any(), any())).thenReturn(false);
 
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(damager, damagee,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
         // Wrong world
-        e = new EntityDamageByEntityEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         wrongWorld();
         new PVPListener().onEntityDamage(e);
         assertFalse(e.isCancelled());
@@ -487,10 +445,7 @@ public class PVPListenerTest extends CommonTestSetup {
     @Test
     public void testOnEntityDamagePVPNotAllowed() {
         // No visitor protection
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(mockPlayer, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(mockPlayer, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be banned
         assertTrue(e.isCancelled());
@@ -503,10 +458,7 @@ public class PVPListenerTest extends CommonTestSetup {
      */
     @Test
     public void testOnEntityDamagePVPNotAllowedInvVisitor() {
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(mockPlayer, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(mockPlayer, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
 
         // Enable visitor protection
         // This player is a visitor and any damage is not allowed
@@ -525,10 +477,7 @@ public class PVPListenerTest extends CommonTestSetup {
     public void testOnEntityDamageOnPVPAllowed() {
         // PVP is allowed
         when(island.isAllowed(any())).thenReturn(true);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(mockPlayer, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(mockPlayer, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be allowed
         assertFalse(e.isCancelled());
@@ -553,10 +502,7 @@ public class PVPListenerTest extends CommonTestSetup {
         when(p.getShooter()).thenReturn(mockPlayer);
         when(p.getLocation()).thenReturn(location);
         when(p.getWorld()).thenReturn(world);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(p, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(p, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be banned
         assertTrue(e.isCancelled());
@@ -582,10 +528,7 @@ public class PVPListenerTest extends CommonTestSetup {
         Projectile p = mock(Projectile.class);
         when(p.getShooter()).thenReturn(mockPlayer);
         when(p.getLocation()).thenReturn(location);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(p, mockPlayer,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(p, mockPlayer, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // Self damage okay
         assertFalse(e.isCancelled());
@@ -601,10 +544,7 @@ public class PVPListenerTest extends CommonTestSetup {
         when(p.getLocation()).thenReturn(location);
         // PVP is allowed
         when(island.isAllowed(any())).thenReturn(true);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(p, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(p, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be allowed
         assertFalse(e.isCancelled());
@@ -630,10 +570,7 @@ public class PVPListenerTest extends CommonTestSetup {
         when(p.getLocation()).thenReturn(location);
         // PVP is allowed
         when(island.isAllowed(any())).thenReturn(true);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(p, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(p, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be allowed
         assertFalse(e.isCancelled());
@@ -651,10 +588,7 @@ public class PVPListenerTest extends CommonTestSetup {
         when(p.getLocation()).thenReturn(location);
         // PVP is allowed
         when(island.isAllowed(any())).thenReturn(true);
-        EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(p, player2,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK, null,
-                new EnumMap<>(ImmutableMap.of(DamageModifier.BASE, 0D)),
-                new EnumMap<DamageModifier, Function<? super Double, Double>>(ImmutableMap.of(DamageModifier.BASE, Functions.constant(-0.0))));
+        EntityDamageByEntityEvent e = createDamageEvent(p, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
         // PVP should be allowed
         assertFalse(e.isCancelled());
@@ -931,7 +865,7 @@ public class PVPListenerTest extends CommonTestSetup {
      */
     @Test
     public void testOnLingeringPotionSplash() {
-        LingeringPotion tp = mock(LingeringPotion.class);
+        ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         when(tp.getWorld()).thenReturn(world);
         when(tp.getLocation()).thenReturn(location);
@@ -950,7 +884,7 @@ public class PVPListenerTest extends CommonTestSetup {
      */
     @Test
     public void testOnLingeringPotionSplashNonHuman() {
-        LingeringPotion tp = mock(LingeringPotion.class);
+        ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(creeper);
         when(tp.getWorld()).thenReturn(world);
         when(tp.getLocation()).thenReturn(location);
@@ -971,7 +905,7 @@ public class PVPListenerTest extends CommonTestSetup {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
         // Throw a potion
-        LingeringPotion tp = mock(LingeringPotion.class);
+        ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         when(tp.getWorld()).thenReturn(world);
         when(tp.getLocation()).thenReturn(location);
@@ -1008,7 +942,7 @@ public class PVPListenerTest extends CommonTestSetup {
         // Allow PVP
         when(island.isAllowed(any())).thenReturn(true);
         // Throw a potion
-        LingeringPotion tp = mock(LingeringPotion.class);
+        ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         when(tp.getWorld()).thenReturn(world);
         when(tp.getLocation()).thenReturn(location);
@@ -1043,7 +977,7 @@ public class PVPListenerTest extends CommonTestSetup {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
         // Throw a potion
-        LingeringPotion tp = mock(LingeringPotion.class);
+        ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         when(tp.getWorld()).thenReturn(world);
         when(tp.getLocation()).thenReturn(location);
@@ -1084,7 +1018,7 @@ public class PVPListenerTest extends CommonTestSetup {
         // Allow PVP
         when(island.isAllowed(any())).thenReturn(true);
         // Throw a potion
-        LingeringPotion tp = mock(LingeringPotion.class);
+        ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         when(tp.getWorld()).thenReturn(world);
         when(tp.getLocation()).thenReturn(location);


### PR DESCRIPTION
## Summary
- Replace all 22 deprecated 6-arg `EntityDamageByEntityEvent` constructors (using `DamageModifier`, Guava `Function`/`ImmutableMap`) with simpler 5-arg constructor via a new `createDamageEvent` helper method in `PVPListenerTest`
- Replace 6 `mock(LingeringPotion.class)` with `mock(ThrownPotion.class)`
- Remove unused Guava imports: `Function`, `Functions`, `ImmutableMap`, `EnumMap`, `DamageModifier`

Other test files (`BreakBlocksListenerTest`, `HurtingListenerTest`, `ItemFrameListenerTest`, `TNTListenerTest`) already use the non-deprecated constructors.

## Risk
**Medium-High** — test rewrite, must maintain coverage.

## Test plan
- [x] `./gradlew clean test` passes
- [ ] SonarCloud re-scan confirms reduction in deprecated API warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)