### PR TITLE
Fix Sonar code quality issues: S5361, S3776 complexity

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/Addon.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
@@ -306,7 +305,7 @@ public abstract class Addon {
                     }
                     // There are two options, use the path of the resource or not
                     File outFile = new File(destinationFolder,
-                            jarResource.replaceAll("/", Matcher.quoteReplacement(File.separator)));
+                            jarResource.replace("/", File.separator));
 
                     if (noPath) {
                         outFile = new File(destinationFolder, outFile.getName());

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportUserCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportUserCommand.java
@@ -52,7 +52,7 @@ public class AdminTeleportUserCommand extends CompositeCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
-        if (args.isEmpty() || args.size() == 1) {
+        if (args.size() < 2) {
             this.showHelp(this, user);
             return false;
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.UUID;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -153,45 +154,47 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
     }
 
     private void deletePlayerFromWorldFolder(String islandID) {
-        File base = getWorld().getWorldFolder();
-        File playerData = new File(base, "playerdata");
-        // Get the island from the cache
-        getPlugin().getIslands().getIslandById(islandID).ifPresent(island -> island.getMemberSet().forEach(uuid -> {
-            // Check if the player has any islands left
-            List<Island> memberOf = new ArrayList<>(getIslands().getIslands(getWorld(), uuid));
-            deleteableRegions.values().forEach(ids -> memberOf.removeIf(i -> ids.contains(i.getUniqueId())));
-            if (memberOf.isEmpty()) {
-                // Do not remove this player if they are Op
-                OfflinePlayer p = Bukkit.getOfflinePlayer(uuid);
-                if (p.isOp()) {
-                    return;
-                }
-                // Do not remove if player logged in recently
-                Long lastLogin = getPlugin().getPlayers().getLastLoginTimestamp(uuid);
-                if (lastLogin == null) {
-                    lastLogin = Bukkit.getOfflinePlayer(uuid).getLastSeen();
-                }
-                long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days);
-                if (lastLogin >= cutoffMillis) {
-                    return;
-                }
-                // Remove the player from the world folder playerdata because they no longer have any island associated with them
-                if (playerData.exists()) {
-                    File playerFile = new File(playerData, uuid + ".dat");
-                    try {
-                        Files.deleteIfExists(playerFile.toPath());
-                    } catch (IOException ex) {
-                        getPlugin().logError("Failed to delete player data file: " + playerFile.getAbsolutePath());
-                    }
-                    playerFile = new File(playerData, uuid + ".dat_old");
-                    try {
-                        Files.deleteIfExists(playerFile.toPath());
-                    } catch (IOException ex) {
-                        getPlugin().logError("Failed to delete player data backup file: " + playerFile.getAbsolutePath());
-                    }
-                }
-            }
-        }));
+        File playerData = new File(getWorld().getWorldFolder(), "playerdata");
+        getPlugin().getIslands().getIslandById(islandID)
+                .ifPresent(island -> island.getMemberSet()
+                        .forEach(uuid -> maybeDeletePlayerData(uuid, playerData)));
+    }
+
+    private void maybeDeletePlayerData(UUID uuid, File playerData) {
+        List<Island> memberOf = new ArrayList<>(getIslands().getIslands(getWorld(), uuid));
+        deleteableRegions.values().forEach(ids -> memberOf.removeIf(i -> ids.contains(i.getUniqueId())));
+        if (!memberOf.isEmpty()) {
+            return;
+        }
+        if (Bukkit.getOfflinePlayer(uuid).isOp()) {
+            return;
+        }
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days);
+        if (resolveLastLogin(uuid) >= cutoffMillis) {
+            return;
+        }
+        deletePlayerFiles(uuid, playerData);
+    }
+
+    private long resolveLastLogin(UUID uuid) {
+        Long lastLogin = getPlugin().getPlayers().getLastLoginTimestamp(uuid);
+        return lastLogin != null ? lastLogin : Bukkit.getOfflinePlayer(uuid).getLastSeen();
+    }
+
+    private void deletePlayerFiles(UUID uuid, File playerData) {
+        if (!playerData.exists()) {
+            return;
+        }
+        deletePlayerFile(new File(playerData, uuid + ".dat"), "player data file");
+        deletePlayerFile(new File(playerData, uuid + ".dat_old"), "player data backup file");
+    }
+
+    private void deletePlayerFile(File file, String description) {
+        try {
+            Files.deleteIfExists(file.toPath());
+        } catch (IOException ex) {
+            getPlugin().logError("Failed to delete " + description + ": " + file.getAbsolutePath());
+        }
     }
 
     /**
@@ -247,7 +250,7 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
      *         due to any file being newer than the cutoff
      */
     private boolean deleteRegionFiles() {
-        if (days <= 0) { 
+        if (days <= 0) {
             getPlugin().logError("Days is somehow zero or negative!");
             return false;
         }
@@ -255,77 +258,72 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
 
         World world = getWorld();
         File base = world.getWorldFolder();
-        File overworldRegion = new File(base, REGION);
+        File overworldRegion   = new File(base, REGION);
         File overworldEntities = new File(base, ENTITIES);
-        File overworldPoi = new File(base, POI);
+        File overworldPoi      = new File(base, POI);
 
         World netherWorld = getPlugin().getIWM().getNetherWorld(world);
-        File netherBase      = netherWorld != null ? resolveDataFolder(netherWorld) : new File(base, DIM_1);
-        File netherRegion    = new File(netherBase, REGION);
-        File netherEntities  = new File(netherBase, ENTITIES);
-        File netherPoi       = new File(netherBase, POI);
+        File netherBase     = netherWorld != null ? resolveDataFolder(netherWorld) : new File(base, DIM_1);
+        File netherRegion   = new File(netherBase, REGION);
+        File netherEntities = new File(netherBase, ENTITIES);
+        File netherPoi      = new File(netherBase, POI);
 
         World endWorld = getPlugin().getIWM().getEndWorld(world);
-        File endBase         = endWorld != null ? resolveDataFolder(endWorld) : new File(base, "DIM1");
-        File endRegion       = new File(endBase, REGION);
-        File endEntities     = new File(endBase, ENTITIES);
-        File endPoi          = new File(endBase, POI);
+        File endBase     = endWorld != null ? resolveDataFolder(endWorld) : new File(base, "DIM1");
+        File endRegion   = new File(endBase, REGION);
+        File endEntities = new File(endBase, ENTITIES);
+        File endPoi      = new File(endBase, POI);
 
         // Phase 1: verify none of the files have been updated since the cutoff
         for (Pair<Integer, Integer> coords : deleteableRegions.keySet()) {
-            int x = coords.x();
-            int z = coords.z();
-            String name = "r." + x + "." + z + ".mca";
-
-            File owFile = new File(overworldRegion, name);
-            if (owFile.exists() && getRegionTimestamp(owFile) >= cutoffMillis) {
+            String name = "r." + coords.x() + "." + coords.z() + ".mca";
+            if (isAnyDimensionFresh(name, overworldRegion, netherRegion, endRegion, cutoffMillis)) {
                 return false;
-            }
-            if (isNether) {
-                File nf = new File(netherRegion, name);
-                if (nf.exists() && getRegionTimestamp(nf) >= cutoffMillis) {
-                    return false;
-                }
-            }
-            if (isEnd) {
-                File ef = new File(endRegion, name);
-                if (ef.exists() && getRegionTimestamp(ef) >= cutoffMillis) {
-                    return false;
-                }
             }
         }
 
         // Phase 2: perform deletions
         for (Pair<Integer, Integer> coords : deleteableRegions.keySet()) {
-            int x = coords.x();
-            int z = coords.z();
-            String name = "r." + x + "." + z + ".mca";
-
-            boolean allDeleted = true;
-
-            // Overworld
-            allDeleted &= deleteIfExists(new File(overworldRegion, name));
-            allDeleted &= deleteIfExists(new File(overworldEntities, name));
-            allDeleted &= deleteIfExists(new File(overworldPoi, name));
-            // Nether
-            if (isNether) {
-                allDeleted &= deleteIfExists(new File(netherRegion, name));
-                allDeleted &= deleteIfExists(new File(netherEntities, name));
-                allDeleted &= deleteIfExists(new File(netherPoi, name));
-            }
-            // End
-            if (isEnd) {
-                allDeleted &= deleteIfExists(new File(endRegion, name));
-                allDeleted &= deleteIfExists(new File(endEntities, name));
-                allDeleted &= deleteIfExists(new File(endPoi, name));
-            }
-
-            if (!allDeleted) {
+            String name = "r." + coords.x() + "." + coords.z() + ".mca";
+            if (!deleteOneRegion(name, overworldRegion, overworldEntities, overworldPoi,
+                    netherRegion, netherEntities, netherPoi,
+                    endRegion, endEntities, endPoi)) {
                 getPlugin().logError("Could not delete all the region/entity/poi files for some reason");
             }
         }
 
         return true;
+    }
+
+    private boolean isFileFresh(File file, long cutoffMillis) {
+        return file.exists() && getRegionTimestamp(file) >= cutoffMillis;
+    }
+
+    private boolean isAnyDimensionFresh(String name, File overworldRegion, File netherRegion,
+            File endRegion, long cutoffMillis) {
+        if (isFileFresh(new File(overworldRegion, name), cutoffMillis)) return true;
+        if (isNether && isFileFresh(new File(netherRegion, name), cutoffMillis)) return true;
+        return isEnd && isFileFresh(new File(endRegion, name), cutoffMillis);
+    }
+
+    private boolean deleteOneRegion(String name,
+            File owRegion, File owEntities, File owPoi,
+            File netherRegion, File netherEntities, File netherPoi,
+            File endRegion, File endEntities, File endPoi) {
+        boolean ok = deleteIfExists(new File(owRegion, name))
+                   & deleteIfExists(new File(owEntities, name))
+                   & deleteIfExists(new File(owPoi, name));
+        if (isNether) {
+            ok &= deleteIfExists(new File(netherRegion, name));
+            ok &= deleteIfExists(new File(netherEntities, name));
+            ok &= deleteIfExists(new File(netherPoi, name));
+        }
+        if (isEnd) {
+            ok &= deleteIfExists(new File(endRegion, name));
+            ok &= deleteIfExists(new File(endEntities, name));
+            ok &= deleteIfExists(new File(endPoi, name));
+        }
+        return ok;
     }
 
     /**
@@ -486,29 +484,40 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
      *         the age criteria
      */
     private List<Pair<Integer, Integer>> findOldRegions(int days) {
-        List<Pair<Integer, Integer>> regions = new ArrayList<>();
-
-        // Base folders
         World world = this.getWorld();
         File worldDir = world.getWorldFolder();
         File overworldRegion = new File(worldDir, REGION);
 
         World netherWorld = getPlugin().getIWM().getNetherWorld(world);
-        File netherBase = netherWorld != null
-                ? resolveDataFolder(netherWorld)
-                : new File(worldDir, DIM_1);
+        File netherBase = netherWorld != null ? resolveDataFolder(netherWorld) : new File(worldDir, DIM_1);
         File netherRegion = new File(netherBase, REGION);
 
         World endWorld = getPlugin().getIWM().getEndWorld(world);
-        File endBase = endWorld != null
-                ? resolveDataFolder(endWorld)
-                : new File(worldDir, "DIM1");
+        File endBase = endWorld != null ? resolveDataFolder(endWorld) : new File(worldDir, "DIM1");
         File endRegion = new File(endBase, REGION);
 
-        // Compute cutoff timestamp
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days);
 
-        // Log resolved paths for diagnostics
+        logRegionFolderPaths(overworldRegion, netherRegion, endRegion, world);
+
+        // Collect all candidate region names from overworld, nether, and end.
+        // This ensures orphaned nether/end files are caught even if the overworld
+        // file was already deleted by a previous (buggy) purge run.
+        Set<String> candidateNames = collectCandidateNames(overworldRegion, netherRegion, endRegion);
+        getPlugin().log("Purge total candidate region coordinates: " + candidateNames.size());
+
+        List<Pair<Integer, Integer>> regions = new ArrayList<>();
+        for (String name : candidateNames) {
+            Pair<Integer, Integer> coords = parseRegionCoords(name);
+            if (coords == null) continue;
+            if (!isAnyDimensionFresh(name, overworldRegion, netherRegion, endRegion, cutoffMillis)) {
+                regions.add(coords);
+            }
+        }
+        return regions;
+    }
+
+    private void logRegionFolderPaths(File overworldRegion, File netherRegion, File endRegion, World world) {
         getPlugin().log("Purge region folders - Overworld: " + overworldRegion.getAbsolutePath()
                 + EXISTS_PREFIX + overworldRegion.isDirectory() + ")");
         if (isNether) {
@@ -527,79 +536,37 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
                     + getPlugin().getIWM().isEndGenerate(world) + ", isEndIslands="
                     + getPlugin().getIWM().isEndIslands(world) + ")");
         }
+    }
 
-        // Collect all candidate region names from overworld, nether, and end.
-        // This ensures orphaned nether/end files are caught even if the overworld
-        // file was already deleted by a previous (buggy) purge run.
-        Set<String> candidateNames = new HashSet<>();
-
-        File[] owFiles = overworldRegion.listFiles((dir, name) -> name.endsWith(".mca"));
-        if (owFiles != null) {
-            for (File f : owFiles) candidateNames.add(f.getName());
-        }
-        getPlugin().log(PURGE_FOUND + (owFiles != null ? owFiles.length : 0) + " overworld region files");
+    private Set<String> collectCandidateNames(File overworldRegion, File netherRegion, File endRegion) {
+        Set<String> names = new HashSet<>();
+        addFileNames(names, overworldRegion.listFiles((dir, name) -> name.endsWith(".mca")), "overworld");
         if (isNether) {
-            File[] nFiles = netherRegion.listFiles((dir, name) -> name.endsWith(".mca"));
-            if (nFiles != null) {
-                for (File f : nFiles) candidateNames.add(f.getName());
-            }
-            getPlugin().log(PURGE_FOUND + (nFiles != null ? nFiles.length : 0) + " nether region files");
+            addFileNames(names, netherRegion.listFiles((dir, name) -> name.endsWith(".mca")), "nether");
         }
         if (isEnd) {
-            File[] eFiles = endRegion.listFiles((dir, name) -> name.endsWith(".mca"));
-            if (eFiles != null) {
-                for (File f : eFiles) candidateNames.add(f.getName());
-            }
-            getPlugin().log(PURGE_FOUND + (eFiles != null ? eFiles.length : 0) + " end region files");
+            addFileNames(names, endRegion.listFiles((dir, name) -> name.endsWith(".mca")), "end");
         }
+        return names;
+    }
 
-        getPlugin().log("Purge total candidate region coordinates: " + candidateNames.size());
-
-        for (String name : candidateNames) {
-            // Parse region coords from filename "r.<x>.<z>.mca"
-            String coordsPart = name.substring(2, name.length() - 4);
-            String[] parts = coordsPart.split("\\.");
-            if (parts.length != 2) continue;  // malformed
-
-            int rx;
-            int rz;
-            try {
-                rx = Integer.parseInt(parts[0]);
-                rz = Integer.parseInt(parts[1]);
-            } catch (NumberFormatException ex) {
-                continue;
-            }
-
-            boolean include = true;
-
-            // If the overworld file exists and is too recent, skip
-            File owFile = new File(overworldRegion, name);
-            if (owFile.exists() && getRegionTimestamp(owFile) >= cutoffMillis) {
-                include = false;
-            }
-
-            // If nether flag is set, require nether region file (if it exists) to also be older than cutoff
-            if (isNether) {
-                File netherFile = new File(netherRegion, name);
-                if (netherFile.exists() && getRegionTimestamp(netherFile) >= cutoffMillis) {
-                    include = false;
-                }
-            }
-
-            // If end flag is set, require end region file (if it exists) to also be older than cutoff
-            if (isEnd) {
-                File endFile = new File(endRegion, name);
-                if (endFile.exists() && getRegionTimestamp(endFile) >= cutoffMillis) {
-                    include = false;
-                }
-            }
-
-            if (include) {
-                regions.add(new Pair<>(rx, rz));
-            }
+    private void addFileNames(Set<String> names, File[] files, String dimension) {
+        if (files != null) {
+            for (File f : files) names.add(f.getName());
         }
+        getPlugin().log(PURGE_FOUND + (files != null ? files.length : 0) + " " + dimension + " region files");
+    }
 
-        return regions;
+    private Pair<Integer, Integer> parseRegionCoords(String name) {
+        // Parse region coords from filename "r.<x>.<z>.mca"
+        String coordsPart = name.substring(2, name.length() - 4);
+        String[] parts = coordsPart.split("\\.");
+        if (parts.length != 2) return null;
+        try {
+            return new Pair<>(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.event.Listener;
 
@@ -283,11 +282,12 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         }
 
         // Phase 2: perform deletions
+        DimFolders ow     = new DimFolders(overworldRegion, overworldEntities, overworldPoi);
+        DimFolders nether = new DimFolders(netherRegion,    netherEntities,    netherPoi);
+        DimFolders end    = new DimFolders(endRegion,       endEntities,       endPoi);
         for (Pair<Integer, Integer> coords : deleteableRegions.keySet()) {
             String name = "r." + coords.x() + "." + coords.z() + ".mca";
-            if (!deleteOneRegion(name, overworldRegion, overworldEntities, overworldPoi,
-                    netherRegion, netherEntities, netherPoi,
-                    endRegion, endEntities, endPoi)) {
+            if (!deleteOneRegion(name, ow, nether, end)) {
                 getPlugin().logError("Could not delete all the region/entity/poi files for some reason");
             }
         }
@@ -306,22 +306,23 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
         return isEnd && isFileFresh(new File(endRegion, name), cutoffMillis);
     }
 
-    private boolean deleteOneRegion(String name,
-            File owRegion, File owEntities, File owPoi,
-            File netherRegion, File netherEntities, File netherPoi,
-            File endRegion, File endEntities, File endPoi) {
-        boolean ok = deleteIfExists(new File(owRegion, name))
-                   & deleteIfExists(new File(owEntities, name))
-                   & deleteIfExists(new File(owPoi, name));
+    /** Groups the three folder types (region, entities, poi) for one world dimension. */
+    private record DimFolders(File region, File entities, File poi) {}
+
+    private boolean deleteOneRegion(String name, DimFolders overworld, DimFolders nether, DimFolders end) {
+        boolean owRegionOk   = deleteIfExists(new File(overworld.region(),   name));
+        boolean owEntitiesOk = deleteIfExists(new File(overworld.entities(), name));
+        boolean owPoiOk      = deleteIfExists(new File(overworld.poi(),      name));
+        boolean ok = owRegionOk && owEntitiesOk && owPoiOk;
         if (isNether) {
-            ok &= deleteIfExists(new File(netherRegion, name));
-            ok &= deleteIfExists(new File(netherEntities, name));
-            ok &= deleteIfExists(new File(netherPoi, name));
+            ok &= deleteIfExists(new File(nether.region(),   name));
+            ok &= deleteIfExists(new File(nether.entities(), name));
+            ok &= deleteIfExists(new File(nether.poi(),      name));
         }
         if (isEnd) {
-            ok &= deleteIfExists(new File(endRegion, name));
-            ok &= deleteIfExists(new File(endEntities, name));
-            ok &= deleteIfExists(new File(endPoi, name));
+            ok &= deleteIfExists(new File(end.region(),   name));
+            ok &= deleteIfExists(new File(end.entities(), name));
+            ok &= deleteIfExists(new File(end.poi(),      name));
         }
         return ok;
     }

--- a/src/test/java/world/bentobox/bentobox/managers/BlueprintsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/BlueprintsManagerTest.java
@@ -42,7 +42,7 @@ import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
 /**
  * Tests for {@link BlueprintsManager}.
  */
-public class BlueprintsManagerTest extends CommonTestSetup {
+class BlueprintsManagerTest extends CommonTestSetup {
 
     @Mock
     private GameModeAddon addon;
@@ -139,12 +139,12 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testConstructorCreatesManager() {
+    void testConstructorCreatesManager() {
         assertNotNull(manager);
     }
 
     @Test
-    public void testIsBlueprintsLoadedTrueInitially() {
+    void testIsBlueprintsLoadedTrueInitially() {
         assertTrue(manager.isBlueprintsLoaded());
     }
 
@@ -153,14 +153,14 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testGetBlueprintBundlesUnregistered() {
+    void testGetBlueprintBundlesUnregistered() {
         Map<String, BlueprintBundle> result = manager.getBlueprintBundles(addon);
         assertNotNull(result);
         assertTrue(result.isEmpty());
     }
 
     @Test
-    public void testGetBlueprintBundlesWithBundle() {
+    void testGetBlueprintBundlesWithBundle() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BUNDLE_NAME);
         manager.addBlueprintBundle(addon, bb);
@@ -176,12 +176,12 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testGetDefaultBlueprintBundleUnregistered() {
+    void testGetDefaultBlueprintBundleUnregistered() {
         assertNull(manager.getDefaultBlueprintBundle(addon));
     }
 
     @Test
-    public void testGetDefaultBlueprintBundleReturnsDefault() {
+    void testGetDefaultBlueprintBundleReturnsDefault() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BlueprintsManager.DEFAULT_BUNDLE_NAME);
         manager.addBlueprintBundle(addon, bb);
@@ -192,7 +192,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetDefaultBlueprintBundleNoDefaultBundle() {
+    void testGetDefaultBlueprintBundleNoDefaultBundle() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId("custom");
         manager.addBlueprintBundle(addon, bb);
@@ -205,17 +205,17 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testValidateNullName() {
+    void testValidateNullName() {
         assertNull(manager.validate(addon, null));
     }
 
     @Test
-    public void testValidateNameNotFound() {
+    void testValidateNameNotFound() {
         assertNull(manager.validate(addon, "nonexistent"));
     }
 
     @Test
-    public void testValidateNameFound() {
+    void testValidateNameFound() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BUNDLE_NAME);
         manager.addBlueprintBundle(addon, bb);
@@ -228,14 +228,14 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testGetBlueprintsUnregistered() {
+    void testGetBlueprintsUnregistered() {
         Map<String, Blueprint> result = manager.getBlueprints(addon);
         assertNotNull(result);
         assertTrue(result.isEmpty());
     }
 
     @Test
-    public void testAddBlueprintAddsEntry() {
+    void testAddBlueprintAddsEntry() {
         Blueprint bp = new Blueprint();
         bp.setName("island");
         manager.addBlueprint(addon, bp);
@@ -247,7 +247,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddBlueprintReplacesExistingByName() {
+    void testAddBlueprintReplacesExistingByName() {
         Blueprint bp1 = new Blueprint();
         bp1.setName("island");
         Blueprint bp2 = new Blueprint();
@@ -266,7 +266,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testAddBlueprintBundleAddsEntry() {
+    void testAddBlueprintBundleAddsEntry() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId("vip");
         manager.addBlueprintBundle(addon, bb);
@@ -275,7 +275,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddBlueprintBundleReplacesExisting() {
+    void testAddBlueprintBundleReplacesExisting() {
         BlueprintBundle bb1 = new BlueprintBundle();
         bb1.setUniqueId(BUNDLE_NAME);
         bb1.setDisplayName("Old");
@@ -296,7 +296,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testCheckPermBundleNotFound() {
+    void testCheckPermBundleNotFound() {
         User user = mock(User.class);
         assertFalse(manager.checkPerm(addon, user, "nonexistent"));
         verify(user).sendMessage(eq("general.errors.no-permission"),
@@ -304,7 +304,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCheckPermNoPermission() {
+    void testCheckPermNoPermission() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId("vip");
         bb.setRequirePermission(true);
@@ -319,7 +319,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCheckPermAllowed() {
+    void testCheckPermAllowed() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId("vip");
         bb.setRequirePermission(true);
@@ -332,7 +332,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCheckPermDefaultBundleAlwaysAllowed() {
+    void testCheckPermDefaultBundleAlwaysAllowed() {
         // Even with requirePermission=true, the default bundle is always allowed.
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BlueprintsManager.DEFAULT_BUNDLE_NAME);
@@ -344,7 +344,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCheckPermNoPermissionRequired() {
+    void testCheckPermNoPermissionRequired() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId("vip");
         bb.setRequirePermission(false);
@@ -359,7 +359,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testDeleteBlueprintLeavesOtherBlueprints() {
+    void testDeleteBlueprintLeavesOtherBlueprints() {
         Blueprint bp = new Blueprint();
         bp.setName("island");
         manager.addBlueprint(addon, bp);
@@ -370,7 +370,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testDeleteBlueprintRemovesFromListAndFile() throws IOException {
+    void testDeleteBlueprintRemovesFromListAndFile() throws IOException {
         blueprintsFolder.mkdirs();
         Blueprint bp = new Blueprint();
         bp.setName("island");
@@ -387,7 +387,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testDeleteBlueprintCaseInsensitive() {
+    void testDeleteBlueprintCaseInsensitive() {
         Blueprint bp = new Blueprint();
         bp.setName("island");
         manager.addBlueprint(addon, bp);
@@ -402,7 +402,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testDeleteBlueprintBundleRemovesFromMapAndFile() throws IOException {
+    void testDeleteBlueprintBundleRemovesFromMapAndFile() throws IOException {
         blueprintsFolder.mkdirs();
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BUNDLE_NAME);
@@ -419,7 +419,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testDeleteBlueprintBundleAddonNotRegisteredDoesNotThrow() {
+    void testDeleteBlueprintBundleAddonNotRegisteredDoesNotThrow() {
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BUNDLE_NAME);
         assertDoesNotThrow(() -> manager.deleteBlueprintBundle(addon, bb));
@@ -430,20 +430,20 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testLoadBlueprintsNoFolder() {
+    void testLoadBlueprintsNoFolder() {
         manager.loadBlueprints(addon);
         verify(plugin).logError("There is no blueprint folder for addon TestAddon");
     }
 
     @Test
-    public void testLoadBlueprintsEmptyFolder() {
+    void testLoadBlueprintsEmptyFolder() {
         blueprintsFolder.mkdirs();
         manager.loadBlueprints(addon);
         verify(plugin).logError("No blueprints found for TestAddon");
     }
 
     @Test
-    public void testLoadBlueprintsLoadsFile() throws IOException {
+    void testLoadBlueprintsLoadsFile() throws IOException {
         blueprintsFolder.mkdirs();
         // Write the raw JSON, then zip it into "island.blu"
         File jsonFile = new File(blueprintsFolder, "island");
@@ -463,7 +463,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testExtractDefaultBlueprintsFolderAlreadyExists() {
+    void testExtractDefaultBlueprintsFolderAlreadyExists() {
         blueprintsFolder.mkdirs();
         // If the folder exists the method should return immediately without errors.
         manager.extractDefaultBlueprints(addon);
@@ -475,14 +475,14 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testPasteBundleNotRegistered() {
+    void testPasteBundleNotRegistered() {
         boolean result = manager.paste(addon, island, BUNDLE_NAME, null, true);
         assertFalse(result);
         verify(plugin).logError("Tried to paste 'default' but the bundle is not loaded!");
     }
 
     @Test
-    public void testPasteNoBlueprintsForBundle() {
+    void testPasteNoBlueprintsForBundle() {
         // Bundle is registered but no blueprints are loaded.
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BUNDLE_NAME);
@@ -498,7 +498,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testSaveBlueprintCreatesFile() {
+    void testSaveBlueprintCreatesFile() {
         blueprintsFolder.mkdirs();
         Blueprint bp = new Blueprint();
         bp.setName("island");
@@ -515,7 +515,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testSaveBlueprintBundleCreatesFile() throws IOException {
+    void testSaveBlueprintBundleCreatesFile() throws IOException {
         blueprintsFolder.mkdirs();
         BlueprintBundle bb = new BlueprintBundle();
         bb.setUniqueId(BUNDLE_NAME);
@@ -534,7 +534,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     // -----------------------------------------------------------------------
 
     @Test
-    public void testRenameBlueprintSameNameIsNoOp() {
+    void testRenameBlueprintSameNameIsNoOp() {
         Blueprint bp = new Blueprint();
         bp.setName("island");
         manager.addBlueprint(addon, bp);
@@ -547,7 +547,7 @@ public class BlueprintsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testRenameBlueprintNewName() throws IOException {
+    void testRenameBlueprintNewName() throws IOException {
         blueprintsFolder.mkdirs();
         // Create the "old" .blu file so deleteIfExists has something to remove.
         File oldFile = new File(blueprintsFolder,

--- a/src/test/java/world/bentobox/bentobox/managers/BlueprintsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/BlueprintsManagerTest.java
@@ -1,0 +1,571 @@
+package world.bentobox.bentobox.managers;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.bukkit.scheduler.BukkitTask;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.addons.AddonDescription;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.blueprints.Blueprint;
+import world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle;
+
+/**
+ * Tests for {@link BlueprintsManager}.
+ */
+public class BlueprintsManagerTest extends CommonTestSetup {
+
+    @Mock
+    private GameModeAddon addon;
+
+    private BlueprintsManager manager;
+    private File dataFolder;
+    private File blueprintsFolder;
+
+    private static final String BUNDLE_NAME = "default";
+
+    /** A minimal valid blueprint in JSON form (will be zipped into a .blu file). */
+    private static final String BLUEPRINT_JSON = """
+            {
+                "name": "island",
+                "attached": {},
+                "entities": {},
+                "blocks": [
+                    [
+                        [0.0, 0.0, 0.0], {
+                            "blockData": "minecraft:bedrock"
+                        }
+                    ]
+                ],
+                "xSize": 10,
+                "ySize": 10,
+                "zSize": 10,
+                "bedrock": [0.0, 0.0, 0.0]
+            }""";
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        dataFolder = new File("test-bm-" + System.nanoTime());
+        blueprintsFolder = new File(dataFolder, BlueprintsManager.FOLDER_NAME);
+
+        AddonDescription desc = new AddonDescription.Builder("main", "TestAddon", "1.0").build();
+        when(addon.getDescription()).thenReturn(desc);
+        when(addon.getDataFolder()).thenReturn(dataFolder);
+        when(addon.getPermissionPrefix()).thenReturn("testaddon.");
+
+        // Run async tasks synchronously so file-writing tests are deterministic.
+        when(sch.runTaskAsynchronously(any(), any(Runnable.class))).thenAnswer(inv -> {
+            ((Runnable) inv.getArgument(1)).run();
+            return mock(BukkitTask.class);
+        });
+
+        manager = new BlueprintsManager(plugin);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        deleteFolder(dataFolder);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private void deleteFolder(File folder) throws IOException {
+        if (folder != null && folder.exists()) {
+            Files.walk(folder.toPath())
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+    }
+
+    /**
+     * Zips {@code sourceFile} into {@code <parent>/<entryName>.blu}, then
+     * deletes the original file. Mirrors what BlueprintClipboardManager does.
+     */
+    private void zipBlueprint(File sourceFile, String entryName) throws IOException {
+        File zipFile = new File(sourceFile.getParentFile(),
+                entryName + BlueprintsManager.BLUEPRINT_SUFFIX);
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile));
+                FileInputStream fis = new FileInputStream(sourceFile)) {
+            zos.putNextEntry(new ZipEntry(sourceFile.getName()));
+            byte[] buf = new byte[1024];
+            int len;
+            while ((len = fis.read(buf)) >= 0) {
+                zos.write(buf, 0, len);
+            }
+            zos.closeEntry();
+        }
+        Files.delete(sourceFile.toPath());
+    }
+
+    // -----------------------------------------------------------------------
+    // Constructor / isBlueprintsLoaded
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testConstructorCreatesManager() {
+        assertNotNull(manager);
+    }
+
+    @Test
+    public void testIsBlueprintsLoadedTrueInitially() {
+        assertTrue(manager.isBlueprintsLoaded());
+    }
+
+    // -----------------------------------------------------------------------
+    // getBlueprintBundles
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGetBlueprintBundlesUnregistered() {
+        Map<String, BlueprintBundle> result = manager.getBlueprintBundles(addon);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testGetBlueprintBundlesWithBundle() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BUNDLE_NAME);
+        manager.addBlueprintBundle(addon, bb);
+
+        Map<String, BlueprintBundle> result = manager.getBlueprintBundles(addon);
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey(BUNDLE_NAME));
+        assertEquals(bb, result.get(BUNDLE_NAME));
+    }
+
+    // -----------------------------------------------------------------------
+    // getDefaultBlueprintBundle
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGetDefaultBlueprintBundleUnregistered() {
+        assertNull(manager.getDefaultBlueprintBundle(addon));
+    }
+
+    @Test
+    public void testGetDefaultBlueprintBundleReturnsDefault() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BlueprintsManager.DEFAULT_BUNDLE_NAME);
+        manager.addBlueprintBundle(addon, bb);
+
+        BlueprintBundle result = manager.getDefaultBlueprintBundle(addon);
+        assertNotNull(result);
+        assertEquals(BlueprintsManager.DEFAULT_BUNDLE_NAME, result.getUniqueId());
+    }
+
+    @Test
+    public void testGetDefaultBlueprintBundleNoDefaultBundle() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId("custom");
+        manager.addBlueprintBundle(addon, bb);
+
+        assertNull(manager.getDefaultBlueprintBundle(addon));
+    }
+
+    // -----------------------------------------------------------------------
+    // validate
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testValidateNullName() {
+        assertNull(manager.validate(addon, null));
+    }
+
+    @Test
+    public void testValidateNameNotFound() {
+        assertNull(manager.validate(addon, "nonexistent"));
+    }
+
+    @Test
+    public void testValidateNameFound() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BUNDLE_NAME);
+        manager.addBlueprintBundle(addon, bb);
+
+        assertEquals(BUNDLE_NAME, manager.validate(addon, BUNDLE_NAME));
+    }
+
+    // -----------------------------------------------------------------------
+    // addBlueprint / getBlueprints
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGetBlueprintsUnregistered() {
+        Map<String, Blueprint> result = manager.getBlueprints(addon);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testAddBlueprintAddsEntry() {
+        Blueprint bp = new Blueprint();
+        bp.setName("island");
+        manager.addBlueprint(addon, bp);
+
+        Map<String, Blueprint> result = manager.getBlueprints(addon);
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("island"));
+        verify(plugin).log("Added blueprint 'island' for TestAddon");
+    }
+
+    @Test
+    public void testAddBlueprintReplacesExistingByName() {
+        Blueprint bp1 = new Blueprint();
+        bp1.setName("island");
+        Blueprint bp2 = new Blueprint();
+        bp2.setName("island");
+
+        manager.addBlueprint(addon, bp1);
+        manager.addBlueprint(addon, bp2);
+
+        Map<String, Blueprint> result = manager.getBlueprints(addon);
+        assertEquals(1, result.size());
+        assertEquals(bp2, result.get("island"));
+    }
+
+    // -----------------------------------------------------------------------
+    // addBlueprintBundle
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testAddBlueprintBundleAddsEntry() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId("vip");
+        manager.addBlueprintBundle(addon, bb);
+
+        assertTrue(manager.getBlueprintBundles(addon).containsKey("vip"));
+    }
+
+    @Test
+    public void testAddBlueprintBundleReplacesExisting() {
+        BlueprintBundle bb1 = new BlueprintBundle();
+        bb1.setUniqueId(BUNDLE_NAME);
+        bb1.setDisplayName("Old");
+        BlueprintBundle bb2 = new BlueprintBundle();
+        bb2.setUniqueId(BUNDLE_NAME);
+        bb2.setDisplayName("New");
+
+        manager.addBlueprintBundle(addon, bb1);
+        manager.addBlueprintBundle(addon, bb2);
+
+        Map<String, BlueprintBundle> bundles = manager.getBlueprintBundles(addon);
+        assertEquals(1, bundles.size());
+        assertEquals("New", bundles.get(BUNDLE_NAME).getDisplayName());
+    }
+
+    // -----------------------------------------------------------------------
+    // checkPerm
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testCheckPermBundleNotFound() {
+        User user = mock(User.class);
+        assertFalse(manager.checkPerm(addon, user, "nonexistent"));
+        verify(user).sendMessage(eq("general.errors.no-permission"),
+                eq(TextVariables.PERMISSION), anyString());
+    }
+
+    @Test
+    public void testCheckPermNoPermission() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId("vip");
+        bb.setRequirePermission(true);
+        manager.addBlueprintBundle(addon, bb);
+
+        User user = mock(User.class);
+        when(user.hasPermission(anyString())).thenReturn(false);
+
+        assertFalse(manager.checkPerm(addon, user, "vip"));
+        verify(user).sendMessage(eq("general.errors.no-permission"),
+                eq(TextVariables.PERMISSION), anyString());
+    }
+
+    @Test
+    public void testCheckPermAllowed() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId("vip");
+        bb.setRequirePermission(true);
+        manager.addBlueprintBundle(addon, bb);
+
+        User user = mock(User.class);
+        when(user.hasPermission("testaddon.island.create.vip")).thenReturn(true);
+
+        assertTrue(manager.checkPerm(addon, user, "vip"));
+    }
+
+    @Test
+    public void testCheckPermDefaultBundleAlwaysAllowed() {
+        // Even with requirePermission=true, the default bundle is always allowed.
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BlueprintsManager.DEFAULT_BUNDLE_NAME);
+        bb.setRequirePermission(true);
+        manager.addBlueprintBundle(addon, bb);
+
+        User user = mock(User.class);
+        assertTrue(manager.checkPerm(addon, user, BlueprintsManager.DEFAULT_BUNDLE_NAME));
+    }
+
+    @Test
+    public void testCheckPermNoPermissionRequired() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId("vip");
+        bb.setRequirePermission(false);
+        manager.addBlueprintBundle(addon, bb);
+
+        User user = mock(User.class);
+        assertTrue(manager.checkPerm(addon, user, "vip"));
+    }
+
+    // -----------------------------------------------------------------------
+    // deleteBlueprint
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testDeleteBlueprintLeavesOtherBlueprints() {
+        Blueprint bp = new Blueprint();
+        bp.setName("island");
+        manager.addBlueprint(addon, bp);
+
+        manager.deleteBlueprint(addon, "nonexistent");
+
+        assertEquals(1, manager.getBlueprints(addon).size());
+    }
+
+    @Test
+    public void testDeleteBlueprintRemovesFromListAndFile() throws IOException {
+        blueprintsFolder.mkdirs();
+        Blueprint bp = new Blueprint();
+        bp.setName("island");
+        manager.addBlueprint(addon, bp);
+
+        File file = new File(blueprintsFolder, "island" + BlueprintsManager.BLUEPRINT_SUFFIX);
+        Files.writeString(file.toPath(), "dummy");
+        assertTrue(file.exists());
+
+        manager.deleteBlueprint(addon, "island");
+
+        assertTrue(manager.getBlueprints(addon).isEmpty());
+        assertFalse(file.exists());
+    }
+
+    @Test
+    public void testDeleteBlueprintCaseInsensitive() {
+        Blueprint bp = new Blueprint();
+        bp.setName("island");
+        manager.addBlueprint(addon, bp);
+
+        manager.deleteBlueprint(addon, "ISLAND");
+
+        assertTrue(manager.getBlueprints(addon).isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // deleteBlueprintBundle
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testDeleteBlueprintBundleRemovesFromMapAndFile() throws IOException {
+        blueprintsFolder.mkdirs();
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BUNDLE_NAME);
+        manager.addBlueprintBundle(addon, bb);
+
+        File file = new File(blueprintsFolder, BUNDLE_NAME + ".json");
+        Files.writeString(file.toPath(), "{}");
+        assertTrue(file.exists());
+
+        manager.deleteBlueprintBundle(addon, bb);
+
+        assertTrue(manager.getBlueprintBundles(addon).isEmpty());
+        assertFalse(file.exists());
+    }
+
+    @Test
+    public void testDeleteBlueprintBundleAddonNotRegisteredDoesNotThrow() {
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BUNDLE_NAME);
+        assertDoesNotThrow(() -> manager.deleteBlueprintBundle(addon, bb));
+    }
+
+    // -----------------------------------------------------------------------
+    // loadBlueprints
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testLoadBlueprintsNoFolder() {
+        manager.loadBlueprints(addon);
+        verify(plugin).logError("There is no blueprint folder for addon TestAddon");
+    }
+
+    @Test
+    public void testLoadBlueprintsEmptyFolder() {
+        blueprintsFolder.mkdirs();
+        manager.loadBlueprints(addon);
+        verify(plugin).logError("No blueprints found for TestAddon");
+    }
+
+    @Test
+    public void testLoadBlueprintsLoadsFile() throws IOException {
+        blueprintsFolder.mkdirs();
+        // Write the raw JSON, then zip it into "island.blu"
+        File jsonFile = new File(blueprintsFolder, "island");
+        Files.writeString(jsonFile.toPath(), BLUEPRINT_JSON);
+        zipBlueprint(jsonFile, "island");
+
+        manager.loadBlueprints(addon);
+
+        Map<String, Blueprint> blueprints = manager.getBlueprints(addon);
+        assertEquals(1, blueprints.size());
+        assertTrue(blueprints.containsKey("island"));
+        verify(plugin).log("Loaded blueprint 'island' for TestAddon");
+    }
+
+    // -----------------------------------------------------------------------
+    // extractDefaultBlueprints
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testExtractDefaultBlueprintsFolderAlreadyExists() {
+        blueprintsFolder.mkdirs();
+        // If the folder exists the method should return immediately without errors.
+        manager.extractDefaultBlueprints(addon);
+        verify(plugin, never()).logError(anyString());
+    }
+
+    // -----------------------------------------------------------------------
+    // paste
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testPasteBundleNotRegistered() {
+        boolean result = manager.paste(addon, island, BUNDLE_NAME, null, true);
+        assertFalse(result);
+        verify(plugin).logError("Tried to paste 'default' but the bundle is not loaded!");
+    }
+
+    @Test
+    public void testPasteNoBlueprintsForBundle() {
+        // Bundle is registered but no blueprints are loaded.
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BUNDLE_NAME);
+        manager.addBlueprintBundle(addon, bb);
+
+        boolean result = manager.paste(addon, island, BUNDLE_NAME, null, true);
+        assertFalse(result);
+        verify(plugin).logError("No blueprints loaded for bundle 'default'!");
+    }
+
+    // -----------------------------------------------------------------------
+    // saveBlueprint
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSaveBlueprintCreatesFile() {
+        blueprintsFolder.mkdirs();
+        Blueprint bp = new Blueprint();
+        bp.setName("island");
+
+        boolean result = manager.saveBlueprint(addon, bp);
+
+        assertTrue(result);
+        File saved = new File(blueprintsFolder, "island" + BlueprintsManager.BLUEPRINT_SUFFIX);
+        assertTrue(saved.exists());
+    }
+
+    // -----------------------------------------------------------------------
+    // saveBlueprintBundle (async, runs synchronously in test)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSaveBlueprintBundleCreatesFile() throws IOException {
+        blueprintsFolder.mkdirs();
+        BlueprintBundle bb = new BlueprintBundle();
+        bb.setUniqueId(BUNDLE_NAME);
+        bb.setDisplayName("Test Bundle");
+
+        manager.saveBlueprintBundle(addon, bb);
+
+        File savedFile = new File(blueprintsFolder, BUNDLE_NAME + ".json");
+        assertTrue(savedFile.exists());
+        String content = Files.readString(savedFile.toPath());
+        assertTrue(content.contains(BUNDLE_NAME));
+    }
+
+    // -----------------------------------------------------------------------
+    // renameBlueprint
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testRenameBlueprintSameNameIsNoOp() {
+        Blueprint bp = new Blueprint();
+        bp.setName("island");
+        manager.addBlueprint(addon, bp);
+
+        manager.renameBlueprint(addon, bp, "island", "Island Display");
+
+        // Name should be unchanged; method returns early.
+        assertEquals("island", bp.getName());
+        assertTrue(manager.getBlueprints(addon).containsKey("island"));
+    }
+
+    @Test
+    public void testRenameBlueprintNewName() throws IOException {
+        blueprintsFolder.mkdirs();
+        // Create the "old" .blu file so deleteIfExists has something to remove.
+        File oldFile = new File(blueprintsFolder,
+                "island" + BlueprintsManager.BLUEPRINT_SUFFIX);
+        Files.writeString(oldFile.toPath(), "dummy");
+
+        Blueprint bp = new Blueprint();
+        bp.setName("island");
+        manager.addBlueprint(addon, bp);
+
+        manager.renameBlueprint(addon, bp, "newisland", "New Island");
+
+        assertFalse(oldFile.exists());
+        assertEquals("newisland", bp.getName());
+        assertEquals("New Island", bp.getDisplayName());
+
+        Map<String, Blueprint> blueprints = manager.getBlueprints(addon);
+        assertFalse(blueprints.containsKey("island"));
+        assertTrue(blueprints.containsKey("newisland"));
+    }
+}


### PR DESCRIPTION
## Summary

- **Addon.java**: Replace `replaceAll("/", Matcher.quoteReplacement(...))` with `replace("/", File.separator)` (S5361 — prefer `String#replace` over `String#replaceAll` for literal substitution); remove the now-unused `Matcher` import.
- **AdminTeleportUserCommand**: Simplify `args.isEmpty() || args.size() == 1` → `args.size() < 2` to eliminate the `||` operator and bring `canExecute` cognitive complexity down to 15 (S3776).
- **AdminPurgeRegionsCommand**: Extract private helper methods from three over-complex methods to bring each within the 15-point cognitive complexity limit (S3776):
  - `deletePlayerFromWorldFolder` (29 → ~3): `maybeDeletePlayerData`, `resolveLastLogin`, `deletePlayerFiles`, `deletePlayerFile`
  - `deleteRegionFiles` (~24 → ~7): `isFileFresh`, `isAnyDimensionFresh`, `deleteOneRegion`
  - `findOldRegions` (~30 → ~5): `logRegionFolderPaths`, `collectCandidateNames`, `addFileNames`, `parseRegionCoords`

Also includes JUnit tests for `BlueprintsManager` (35 tests).

## Test plan

- [x] `./gradlew compileJava` passes
- [x] `AdminPurgeRegionsCommandTest` passes
- [x] `BlueprintsManagerTest` (35 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)