### PR TITLE
fix: reduce BentoBox monster-class coupling from 24 to 20 (S1200)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.generator.ChunkGenerator;
-import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.eclipse.jdt.annotation.NonNull;
@@ -23,29 +22,10 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.user.Notifier;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.bentobox.commands.BentoBoxCommand;
 import world.bentobox.bentobox.database.DatabaseSetup;
-import world.bentobox.bentobox.hooks.FancyNpcsHook;
-import world.bentobox.bentobox.hooks.ItemsAdderHook;
-import world.bentobox.bentobox.hooks.MultipaperHook;
-import world.bentobox.bentobox.hooks.MultiverseCore4Hook;
-import world.bentobox.bentobox.hooks.MultiverseCore5Hook;
-import world.bentobox.bentobox.hooks.MyWorldsHook;
-import world.bentobox.bentobox.hooks.MythicMobsHook;
-import world.bentobox.bentobox.hooks.OraxenHook;
-import world.bentobox.bentobox.hooks.SlimefunHook;
+import world.bentobox.bentobox.hooks.BentoBoxHookRegistrar;
 import world.bentobox.bentobox.hooks.VaultHook;
-import world.bentobox.bentobox.hooks.ZNPCsPlusHook;
-import world.bentobox.bentobox.hooks.placeholders.PlaceholderAPIHook;
-import world.bentobox.bentobox.listeners.BannedCommands;
-import world.bentobox.bentobox.listeners.BlockEndDragon;
-import world.bentobox.bentobox.listeners.DeathListener;
-import world.bentobox.bentobox.listeners.JoinLeaveListener;
-import world.bentobox.bentobox.listeners.PanelListenerManager;
-import world.bentobox.bentobox.listeners.PrimaryIslandListener;
-import world.bentobox.bentobox.listeners.StandardSpawnProtectionListener;
-import world.bentobox.bentobox.listeners.teleports.EntityTeleportListener;
-import world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener;
+import world.bentobox.bentobox.listeners.BentoBoxListenerRegistrar;
 import world.bentobox.bentobox.managers.AddonsManager;
 import world.bentobox.bentobox.managers.BlueprintsManager;
 import world.bentobox.bentobox.managers.CommandsManager;
@@ -95,7 +75,7 @@ public class BentoBox extends JavaPlugin implements Listener {
 
     // Notifier
     private Notifier notifier;
-    
+
     // Click limiter
     private ExpiringMap<Pair<UUID, String>, Boolean> lastClick ;
 
@@ -147,7 +127,7 @@ public class BentoBox extends JavaPlugin implements Listener {
         }
         // Saving the config now.
         saveConfig();
-        
+
         // Set up click timeout
         lastClick = new ExpiringMap<>(getSettings().getClickCooldownMs(), TimeUnit.MILLISECONDS);
 
@@ -169,7 +149,7 @@ public class BentoBox extends JavaPlugin implements Listener {
         commandsManager = new CommandsManager();
 
         // Load BentoBox commands
-        new BentoBoxCommand();
+        commandsManager.registerDefaultCommands();
 
         // Start Island Worlds Manager
         islandWorldManager = new IslandWorldManager(this);
@@ -202,19 +182,9 @@ public class BentoBox extends JavaPlugin implements Listener {
     private void completeSetup(long loadTime) {
         final long enableStart = System.currentTimeMillis();
 
-        hooksManager.registerHook(new MultipaperHook());
+        BentoBoxHookRegistrar hookRegistrar = new BentoBoxHookRegistrar(this);
+        hookRegistrar.registerEarlyHooks();
 
-        hooksManager.registerHook(new VaultHook());
-
-        // FancyNpcs
-        hooksManager.registerHook(new FancyNpcsHook());
-        // ZNPCsPlus
-        hooksManager.registerHook(new ZNPCsPlusHook());
-
-        // MythicMobs
-        hooksManager.registerHook(new MythicMobsHook());
-
-        hooksManager.registerHook(new PlaceholderAPIHook());
         // Setup the Placeholders manager
         placeholdersManager = new PlaceholdersManager(this);
 
@@ -245,22 +215,10 @@ public class BentoBox extends JavaPlugin implements Listener {
 
         // Register Multiverse hook - MV loads AFTER BentoBox
         // Make sure all worlds are already registered to Multiverse.
-        if (hasClass("org.mvplugins.multiverse.core.MultiverseCore")) {
-            hooksManager.registerHook(new MultiverseCore5Hook());
-        } else if (hasClass("com.onarandombox.MultiverseCore.MultiverseCore")) {
-            hooksManager.registerHook(new MultiverseCore4Hook());
-        }
-        hooksManager.registerHook(new MyWorldsHook());
+        hookRegistrar.registerWorldHooks();
         islandWorldManager.registerWorldsToMultiverse(true);
 
-        // Register Slimefun
-        hooksManager.registerHook(new SlimefunHook());
-
-        // Register ItemsAdder
-        hooksManager.registerHook(new ItemsAdderHook(this));
-        
-        // Register Oraxen
-        hooksManager.registerHook(new OraxenHook(this));
+        hookRegistrar.registerLateHooks();
 
         // TODO: re-enable after implementation
         // TODO: re-enable after rework
@@ -298,15 +256,6 @@ public class BentoBox extends JavaPlugin implements Listener {
         }
     }
 
-    private boolean hasClass(String className) {
-        try {
-            Class.forName(className);
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-    }
-
     private void fireCriticalError(String message, String error) {
         logError("*****************CRITICAL ERROR!******************");
         logError(message);
@@ -325,30 +274,9 @@ public class BentoBox extends JavaPlugin implements Listener {
      * Registers listeners.
      */
     private void registerListeners() {
-        PluginManager manager = getServer().getPluginManager();
-        // Player join events
-        manager.registerEvents(new JoinLeaveListener(this), this);
-        // Panel listener manager
-        manager.registerEvents(new PanelListenerManager(), this);
-        // Standard Nether/End spawns protection
-        manager.registerEvents(new StandardSpawnProtectionListener(this), this);
-        // Player portals
-        manager.registerEvents(new PlayerTeleportListener(this), this);
-        // Entity portals
-        manager.registerEvents(new EntityTeleportListener(this), this);
-        // End dragon blocking
-        manager.registerEvents(new BlockEndDragon(this), this);
-        // Banned visitor commands
-        manager.registerEvents(new BannedCommands(this), this);
-        // Death counter
-        manager.registerEvents(new DeathListener(this), this);
-        // MV unregister
-        manager.registerEvents(this, this);
-        // Island Delete Manager
-        islandDeletionManager = new IslandDeletionManager(this);
-        manager.registerEvents(islandDeletionManager, this);
-        // Primary Island Listener
-        manager.registerEvents(new PrimaryIslandListener(this), this);
+        BentoBoxListenerRegistrar registrar = new BentoBoxListenerRegistrar(this);
+        registrar.register();
+        islandDeletionManager = registrar.getIslandDeletionManager();
     }
 
     @Override
@@ -652,7 +580,7 @@ public class BentoBox extends JavaPlugin implements Listener {
     public boolean isShutdown() {
         return shutdown;
     }
-    
+
     /**
      * Checks if a user can click a GUI or needs to slow down
      * @param user user

--- a/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
@@ -1,0 +1,67 @@
+package world.bentobox.bentobox.hooks;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.hooks.placeholders.PlaceholderAPIHook;
+import world.bentobox.bentobox.managers.HooksManager;
+
+/**
+ * Registers all built-in BentoBox hooks with the {@link HooksManager}.
+ * Extracted from BentoBox to keep the main class focused on lifecycle coordination.
+ */
+public class BentoBoxHookRegistrar {
+
+    private static final String MV5_CLASS = "org.mvplugins.multiverse.core.MultiverseCore";
+    private static final String MV4_CLASS = "com.onarandombox.MultiverseCore.MultiverseCore";
+
+    private final BentoBox plugin;
+    private final HooksManager hooksManager;
+
+    public BentoBoxHookRegistrar(BentoBox plugin) {
+        this.plugin = plugin;
+        this.hooksManager = plugin.getHooks();
+    }
+
+    /**
+     * Registers hooks that must be available early in the enable sequence,
+     * before addons are enabled and before PlaceholdersManager is created.
+     */
+    public void registerEarlyHooks() {
+        hooksManager.registerHook(new MultipaperHook());
+        hooksManager.registerHook(new VaultHook());
+        hooksManager.registerHook(new FancyNpcsHook());
+        hooksManager.registerHook(new ZNPCsPlusHook());
+        hooksManager.registerHook(new MythicMobsHook());
+        hooksManager.registerHook(new PlaceholderAPIHook());
+    }
+
+    /**
+     * Registers world-manager hooks (Multiverse variants) that load after BentoBox worlds.
+     * Must be called after {@code islandWorldManager.registerWorldsToMultiverse()} is ready.
+     */
+    public void registerWorldHooks() {
+        if (hasClass(MV5_CLASS)) {
+            hooksManager.registerHook(new MultiverseCore5Hook());
+        } else if (hasClass(MV4_CLASS)) {
+            hooksManager.registerHook(new MultiverseCore4Hook());
+        }
+        hooksManager.registerHook(new MyWorldsHook());
+    }
+
+    /**
+     * Registers hooks for plugins that load after BentoBox (Slimefun, ItemsAdder, Oraxen).
+     */
+    public void registerLateHooks() {
+        hooksManager.registerHook(new SlimefunHook());
+        hooksManager.registerHook(new ItemsAdderHook(plugin));
+        hooksManager.registerHook(new OraxenHook(plugin));
+    }
+
+    private boolean hasClass(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/listeners/BentoBoxListenerRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/BentoBoxListenerRegistrar.java
@@ -1,0 +1,49 @@
+package world.bentobox.bentobox.listeners;
+
+import org.bukkit.plugin.PluginManager;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.listeners.teleports.EntityTeleportListener;
+import world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener;
+import world.bentobox.bentobox.managers.IslandDeletionManager;
+
+/**
+ * Registers all BentoBox event listeners with the Bukkit plugin manager.
+ * Extracted from BentoBox to keep the main class focused on lifecycle coordination.
+ */
+public class BentoBoxListenerRegistrar {
+
+    private final BentoBox plugin;
+    private IslandDeletionManager islandDeletionManager;
+
+    public BentoBoxListenerRegistrar(BentoBox plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Registers all listeners. Must be called after worlds and managers are initialised.
+     */
+    public void register() {
+        PluginManager manager = plugin.getServer().getPluginManager();
+        manager.registerEvents(new JoinLeaveListener(plugin), plugin);
+        manager.registerEvents(new PanelListenerManager(), plugin);
+        manager.registerEvents(new StandardSpawnProtectionListener(plugin), plugin);
+        manager.registerEvents(new PlayerTeleportListener(plugin), plugin);
+        manager.registerEvents(new EntityTeleportListener(plugin), plugin);
+        manager.registerEvents(new BlockEndDragon(plugin), plugin);
+        manager.registerEvents(new BannedCommands(plugin), plugin);
+        manager.registerEvents(new DeathListener(plugin), plugin);
+        // Register the plugin itself for any listeners it implements (e.g. MV unregister)
+        manager.registerEvents(plugin, plugin);
+        islandDeletionManager = new IslandDeletionManager(plugin);
+        manager.registerEvents(islandDeletionManager, plugin);
+        manager.registerEvents(new PrimaryIslandListener(plugin), plugin);
+    }
+
+    /**
+     * @return the {@link IslandDeletionManager} created during registration.
+     */
+    public IslandDeletionManager getIslandDeletionManager() {
+        return islandDeletionManager;
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
@@ -14,6 +14,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.commands.BentoBoxCommand;
 
 public class CommandsManager {
 
@@ -89,5 +90,12 @@ public class CommandsManager {
     @NonNull
     public Set<String> listCommands() {
         return commands.keySet();
+    }
+
+    /**
+     * Registers BentoBox's built-in top-level commands.
+     */
+    public void registerDefaultCommands() {
+        new BentoBoxCommand();
     }
 }


### PR DESCRIPTION
## Summary

- Extracts `BentoBoxListenerRegistrar` (`listeners` package) to own all Bukkit event-listener registration and the `IslandDeletionManager` lifecycle.
- Extracts `BentoBoxHookRegistrar` (`hooks` package) to own all hook instantiation (early / world / late phases) and Multiverse class-detection logic.
- Moves `new BentoBoxCommand()` into `CommandsManager.registerDefaultCommands()`, the natural home for "which commands does BentoBox register".

These three changes remove four package-level dependencies from `BentoBox.java` (`org.bukkit.plugin`, `listeners.teleports`, `hooks.placeholders`, `commands`), dropping the Sonar S1200 efferent-coupling count from **24 → 20**.

No behavioural changes; the new classes land in packages already imported by `BentoBox`, so no new dependencies are introduced.

## Test plan

- [x] `./gradlew compileJava` — clean build, no errors
- [x] `./gradlew test` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)