### PR TITLE
Fix force-shown integer value not showing correct number of rows

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/reader/TemplateReader.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/reader/TemplateReader.java
@@ -211,9 +211,11 @@ public class TemplateReader
             {
                 int value = section.getInt(FORCE_SHOWN);
 
-                if (value > 0 && value < 7)
+                // Force all rows from 1 to value (inclusive), so that force-shown: 6
+                // results in a panel with 6 rows, not just forcing the 6th row alone.
+                for (int i = 0; i < value && i < forceShow.length; i++)
                 {
-                    forceShow[value-1] = true;
+                    forceShow[i] = true;
                 }
             }
             else if (section.isList(FORCE_SHOWN))


### PR DESCRIPTION
## Summary

- `force-shown: 6` in a panel YAML was only marking row 6 as forced, not rows 1–6
- `createItemMap` only advances its slot index for forced rows, so unforceed intermediate rows were skipped
- Row 6 ended up at inventory slots 9–17 (2nd row) instead of 45–53 (6th row), producing a 2-row inventory

**Fix:** When `force-shown` is an integer N, force all rows 1 through N (indices 0 to N-1). The list form (`force-shown: [2, 4]`) is unchanged.

Fixes #2471

## Test plan

- [ ] Create a panel with `force-shown: 6` and a background/border — confirm it opens with 6 rows
- [ ] Create a panel with `force-shown: 3` — confirm it opens with 3 rows minimum
- [ ] `force-shown: [2, 4]` still forces only rows 2 and 4 individually (no regression)
- [ ] All existing tests pass (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)