### PR TITLE
Add automatic update notifications on startup

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
@@ -6,11 +6,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -42,7 +42,7 @@ public class AddonClassLoader extends URLClassLoader {
     /**
      * A cache of classes that have been loaded by this class loader.
      */
-    private final Map<String, Class<?>> classes = new HashMap<>();
+    private final Map<String, Class<?>> classes = new ConcurrentHashMap<>();
     /**
      * The addon instance that was loaded by this class loader.
      */

--- a/src/main/java/world/bentobox/bentobox/api/github/GitHubWebAPI.java
+++ b/src/main/java/world/bentobox/bentobox/api/github/GitHubWebAPI.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -29,15 +30,7 @@ public class GitHubWebAPI {
 
     private final ExecutorService executor = Executors.newCachedThreadPool();
 
-    /**
-     * Fetches the content of a given API endpoint.
-     * 
-     * @param endpoint The API endpoint to fetch.
-     * @return The JSON response as a JsonObject.
-     * @throws IOException If an error occurs during the request.
-     * @throws URISyntaxException if URI syntax is wrong
-     */
-    public synchronized JsonObject fetch(String endpoint) throws IOException, URISyntaxException {
+    private synchronized String fetchRaw(String endpoint) throws IOException, URISyntaxException {
         long currentTime = System.currentTimeMillis();
         long timeSinceLastRequest = currentTime - lastRequestTime;
 
@@ -56,7 +49,7 @@ public class GitHubWebAPI {
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod("GET");
         connection.setRequestProperty("Accept", "application/vnd.github.v3+json");
-        connection.setRequestProperty("User-Agent", "BentoBox"); // Add User-Agent header
+        connection.setRequestProperty("User-Agent", "BentoBox");
 
         int responseCode = connection.getResponseCode();
         if (responseCode == 403) {
@@ -64,9 +57,32 @@ public class GitHubWebAPI {
         }
 
         try (Scanner scanner = new Scanner(connection.getInputStream())) {
-            String response = scanner.useDelimiter("\\A").next();
-            return JsonParser.parseString(response).getAsJsonObject();
+            return scanner.useDelimiter("\\A").next();
         }
+    }
+
+    /**
+     * Fetches the content of a given API endpoint.
+     *
+     * @param endpoint The API endpoint to fetch.
+     * @return The JSON response as a JsonObject.
+     * @throws IOException If an error occurs during the request.
+     * @throws URISyntaxException if URI syntax is wrong
+     */
+    public synchronized JsonObject fetch(String endpoint) throws IOException, URISyntaxException {
+        return JsonParser.parseString(fetchRaw(endpoint)).getAsJsonObject();
+    }
+
+    /**
+     * Fetches the content of a given API endpoint that returns a JSON array.
+     *
+     * @param endpoint The API endpoint to fetch.
+     * @return The JSON response as a JsonArray.
+     * @throws IOException If an error occurs during the request.
+     * @throws URISyntaxException if URI syntax is wrong
+     */
+    public synchronized JsonArray fetchArray(String endpoint) throws IOException, URISyntaxException {
+        return JsonParser.parseString(fetchRaw(endpoint)).getAsJsonArray();
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/github/objects/repositories/GitHubRepository.java
+++ b/src/main/java/world/bentobox/bentobox/api/github/objects/repositories/GitHubRepository.java
@@ -30,7 +30,7 @@ public record GitHubRepository(GitHubWebAPI api, String fullName) {
      * @throws Exception If an error occurs during the request.
      */
     public List<GitHubContributor> getContributors() throws Exception {
-        JsonArray response = api.fetch("repos/" + fullName + "/contributors").getAsJsonArray();
+        JsonArray response = api.fetchArray("repos/" + fullName + "/contributors");
         List<GitHubContributor> contributors = new ArrayList<>();
         response.forEach(element -> {
             JsonObject contributor = element.getAsJsonObject();
@@ -40,5 +40,17 @@ public record GitHubRepository(GitHubWebAPI api, String fullName) {
             ));
         });
         return contributors;
+    }
+
+    /**
+     * Fetches the name of the latest tag for this repository.
+     *
+     * @return the latest tag name (e.g. "3.11.2"), or empty string if none.
+     * @throws Exception if an error occurs during the request.
+     */
+    public String getLatestTagName() throws Exception {
+        JsonArray tags = api.fetchArray("repos/" + fullName + "/tags");
+        if (tags.isEmpty()) return "";
+        return tags.get(0).getAsJsonObject().get("name").getAsString();
     }
 }

--- a/src/main/java/world/bentobox/bentobox/managers/WebManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/WebManager.java
@@ -12,6 +12,8 @@ import javax.xml.bind.DatatypeConverter;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
+import org.bukkit.Bukkit;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
@@ -131,6 +133,10 @@ public class WebManager {
             if (plugin.getSettings().isLogGithubDownloadData()) {
                 plugin.log("Successfully downloaded data from GitHub.");
             }
+
+            if (plugin.getSettings().isCheckBentoBoxUpdates()) {
+                checkForUpdates(gh);
+            }
         });
     }
 
@@ -198,6 +204,54 @@ public class WebManager {
             // Silently fail
         }
         return "";
+    }
+
+    private void checkForUpdates(@NonNull GitHubWebAPI gh) {
+        try {
+            String currentVersion = plugin.getPluginMeta().getVersion();
+            if (currentVersion.contains("LOCAL")) return;
+            String latestTag = new GitHubRepository(gh, "BentoBoxWorld/BentoBox").getLatestTagName();
+            if (!latestTag.isEmpty() && isNewerVersion(currentVersion, latestTag)) {
+                printUpdateBanner(currentVersion, latestTag);
+            }
+        } catch (Exception e) {
+            // Silently fail — same pattern as gatherContributors()
+        }
+    }
+
+    private void printUpdateBanner(String currentVersion, String latestTag) {
+        var cs = Bukkit.getConsoleSender();
+        cs.sendMessage("§6╔══════════════════════════════════════════════╗");
+        cs.sendMessage("§6║  §e★  BentoBox Update Available!  ★           §6║");
+        cs.sendMessage("§6║                                              §6║");
+        cs.sendMessage("§6║  §7Current: §c" + currentVersion);
+        cs.sendMessage("§6║  §7Latest:  §a" + latestTag);
+        cs.sendMessage("§6║                                              §6║");
+        cs.sendMessage("§6║  §7Get it: §bhttps://github.com/BentoBoxWorld/BentoBox/releases");
+        cs.sendMessage("§6╚══════════════════════════════════════════════╝");
+    }
+
+    /**
+     * Returns true if latestTag is strictly newer than currentVersion.
+     * Only the numeric prefix before the first '-' is compared.
+     */
+    static boolean isNewerVersion(String currentVersion, String latestTag) {
+        String current = currentVersion.split("-")[0];
+        String latest = latestTag.replaceFirst("^v", "").split("-")[0];
+        String[] cp = current.split("\\.");
+        String[] lp = latest.split("\\.");
+        int len = Math.max(cp.length, lp.length);
+        for (int i = 0; i < len; i++) {
+            int c = i < cp.length ? parseIntSafe(cp[i]) : 0;
+            int l = i < lp.length ? parseIntSafe(lp[i]) : 0;
+            if (l > c) return true;
+            if (l < c) return false;
+        }
+        return false;
+    }
+
+    private static int parseIntSafe(String s) {
+        try { return Integer.parseInt(s); } catch (NumberFormatException e) { return 0; }
     }
 
     private void gatherContributors(@NonNull GitHubRepository repo) {

--- a/src/test/java/world/bentobox/bentobox/api/github/objects/repositories/GitHubRepositoryTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/github/objects/repositories/GitHubRepositoryTest.java
@@ -1,0 +1,56 @@
+package world.bentobox.bentobox.api.github.objects.repositories;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import world.bentobox.bentobox.api.github.GitHubWebAPI;
+
+class GitHubRepositoryTest {
+
+    private GitHubWebAPI api;
+    private GitHubRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        api = mock(GitHubWebAPI.class);
+        repo = new GitHubRepository(api, "BentoBoxWorld/BentoBox");
+    }
+
+    @Test
+    void testGetLatestTagName_returnsFirstTagName() throws Exception {
+        JsonArray tags = new JsonArray();
+        JsonObject tag1 = new JsonObject();
+        tag1.addProperty("name", "3.12.0");
+        JsonObject tag2 = new JsonObject();
+        tag2.addProperty("name", "3.11.2");
+        tags.add(tag1);
+        tags.add(tag2);
+        when(api.fetchArray("repos/BentoBoxWorld/BentoBox/tags")).thenReturn(tags);
+
+        assertEquals("3.12.0", repo.getLatestTagName());
+    }
+
+    @Test
+    void testGetLatestTagName_emptyArray_returnsEmptyString() throws Exception {
+        when(api.fetchArray("repos/BentoBoxWorld/BentoBox/tags")).thenReturn(new JsonArray());
+
+        assertEquals("", repo.getLatestTagName());
+    }
+
+    @Test
+    void testGetLatestTagName_apiThrows_propagatesException() throws Exception {
+        when(api.fetchArray("repos/BentoBoxWorld/BentoBox/tags")).thenThrow(new IOException("Network error"));
+
+        assertThrows(IOException.class, () -> repo.getLatestTagName());
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/managers/WebManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/WebManagerTest.java
@@ -1,0 +1,49 @@
+package world.bentobox.bentobox.managers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class WebManagerTest {
+
+    @Test
+    void testIsNewerVersion_newerMinor() {
+        assertTrue(WebManager.isNewerVersion("3.11.2", "3.12.0"));
+    }
+
+    @Test
+    void testIsNewerVersion_newerPatch() {
+        assertTrue(WebManager.isNewerVersion("3.11.2", "3.11.3"));
+    }
+
+    @Test
+    void testIsNewerVersion_equalVersions() {
+        assertFalse(WebManager.isNewerVersion("3.11.2", "3.11.2"));
+    }
+
+    @Test
+    void testIsNewerVersion_olderTag() {
+        assertFalse(WebManager.isNewerVersion("3.11.2", "3.11.0"));
+    }
+
+    @Test
+    void testIsNewerVersion_stripsSnapshotSuffix() {
+        assertFalse(WebManager.isNewerVersion("3.11.2-b123-SNAPSHOT", "3.11.2"));
+    }
+
+    @Test
+    void testIsNewerVersion_snapshotOlderThanNewer() {
+        assertTrue(WebManager.isNewerVersion("3.11.2-b123-SNAPSHOT", "3.12.0"));
+    }
+
+    @Test
+    void testIsNewerVersion_majorBump() {
+        assertTrue(WebManager.isNewerVersion("3.11.2", "4.0.0"));
+    }
+
+    @Test
+    void testIsNewerVersion_stripsLeadingV() {
+        assertTrue(WebManager.isNewerVersion("3.11.2", "v3.12.0"));
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix bug**: `GitHubWebAPI.fetchArray()` added (extracts `fetchRaw()` helper); fixes `getContributors()` which previously called `fetch(...).getAsJsonArray()` but `fetch()` already calls `getAsJsonObject()` internally — this would throw on a real response
- **New**: `GitHubRepository.getLatestTagName()` fetches the `/tags` endpoint and returns the first tag name
- **New**: `WebManager` gains `isNewerVersion()`, `checkForUpdates()`, and `printUpdateBanner()`; wired into `requestGitHubData()` gated by the pre-existing `isCheckBentoBoxUpdates()` setting (default: true)

## Behavior

- Runs async ~1s after startup (same timing as existing GitHub data fetch)
- Skips `LOCAL` builds (dev environments)
- Silently fails on network errors — no console noise
- Prints a colored banner to console when a newer tag is available

## Test plan

- [ ] `GitHubRepositoryTest` — 3 tests for `getLatestTagName()` (happy path, empty array, API throws)
- [ ] `WebManagerTest` — 8 tests for `isNewerVersion()` covering minor/patch/major bumps, snapshot stripping, leading `v` stripping
- [ ] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)