### PR TITLE
Replace IslandGrid nested TreeMap with spatial hash

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommand.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -340,17 +339,10 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
                 Bukkit.getScheduler().runTask(getPlugin(), () -> user.sendMessage(NONE_FOUND));
                 return;
             }
-            Map<Integer, TreeMap<Integer, IslandData>> grid = islandGrid.getGrid();
-            if (grid == null) {
-                // There are no islands in this world yet!
-                Bukkit.getScheduler().runTask(getPlugin(), () -> user.sendMessage(NONE_FOUND));
-                return;
-            }
-
             // Find old regions
             List<Pair<Integer, Integer>> oldRegions = this.findOldRegions(days);
             // Get islands that are associated with these regions
-            deleteableRegions = this.mapIslandsToRegions(oldRegions, grid);
+            deleteableRegions = this.mapIslandsToRegions(oldRegions, islandGrid);
             // Remove any region whose island‐set contains at least one island that either isn’t found or fails the deletion check:
             deleteableRegions.values().removeIf(islandIds ->
             islandIds.stream()
@@ -571,59 +563,31 @@ public class AdminPurgeRegionsCommand extends CompositeCommand implements Listen
     }
 
     /**
-     * Maps each old region to the set of island IDs whose island‐squares overlap it.
+     * Maps each old region to the set of island IDs whose island-squares overlap it.
      *
      * <p>Each region covers blocks
-     * [regionX*512 .. regionX*512 + 511] × [regionZ*512 .. regionZ*512 + 511].</p>
+     * [regionX*512 .. regionX*512 + 511] x [regionZ*512 .. regionZ*512 + 511].</p>
      *
-     * <p>Each IslandData provides:
-     * <ul>
-     *   <li>{@code minX}, {@code minZ}: the southwest corner of its square</li>
-     *   <li>{@code range}: half the side‐length of the island square</li>
-     *   <li>{@code id}: the island’s unique identifier</li>
-     * </ul>
-     * The island’s maxX = minX + 2*range, maxZ = minZ + 2*range.</p>
-     *
-     * @param oldRegions the list of region coordinates to process
-     * @param grid       a 2D TreeMap mapping centreX → (centreZ → IslandData)
-     * @return           a map from region coords to the set of overlapping island IDs
+     * @param oldRegions  the list of region coordinates to process
+     * @param islandGrid  the spatial grid to query
+     * @return            a map from region coords to the set of overlapping island IDs
      */
     private Map<Pair<Integer, Integer>, Set<String>> mapIslandsToRegions(
             List<Pair<Integer, Integer>> oldRegions,
-            Map<Integer, TreeMap<Integer, IslandData>> grid
+            IslandGrid islandGrid
             ) {
         final int blocksPerRegion = 512;
         Map<Pair<Integer, Integer>, Set<String>> regionToIslands = new HashMap<>();
 
         for (Pair<Integer, Integer> region : oldRegions) {
-            int rX = region.x();
-            int rZ = region.z();
-
-            int regionMinX = rX * blocksPerRegion;
-            int regionMinZ = rZ * blocksPerRegion;
+            int regionMinX = region.x() * blocksPerRegion;
+            int regionMinZ = region.z() * blocksPerRegion;
             int regionMaxX = regionMinX + blocksPerRegion - 1;
             int regionMaxZ = regionMinZ + blocksPerRegion - 1;
 
             Set<String> ids = new HashSet<>();
-
-            // iterate all islands in the grid
-            for (Map.Entry<Integer, TreeMap<Integer, IslandData>> xEntry : grid.entrySet()) {
-                for (IslandData data : xEntry.getValue().values()) {
-                    int islandMinX = data.minX();
-                    int islandMinZ = data.minZ();
-                    int islandMaxX = islandMinX + 2 * data.range();
-                    int islandMaxZ = islandMinZ + 2 * data.range();
-
-                    // overlap test
-                    boolean overlaps = !(islandMaxX < regionMinX ||
-                            islandMinX > regionMaxX ||
-                            islandMaxZ < regionMinZ ||
-                            islandMinZ > regionMaxZ);
-
-                    if (overlaps) {
-                        ids.add(data.id());
-                    }
-                }
+            for (IslandData data : islandGrid.getIslandsInBounds(regionMinX, regionMinZ, regionMaxX, regionMaxZ)) {
+                ids.add(data.id());
             }
 
             // Always add the region, even if ids is empty

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandGrid.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandGrid.java
@@ -1,17 +1,23 @@
 package world.bentobox.bentobox.managers.island;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.TreeMap;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.database.objects.Island;
 
 /**
- * Handles the island location grid for each world
- * @author tastybento
+ * Handles the island location grid for each world using a cell-based spatial
+ * hash for O(1) average-case point lookups and O(n) bulk loading.
  *
+ * @author tastybento
  */
 public class IslandGrid {
 
@@ -20,11 +26,19 @@ public class IslandGrid {
      */
     public record IslandData(String id, int minX, int minZ, int range) {}
 
-    private final TreeMap<Integer, TreeMap<Integer, IslandData>> grid = new TreeMap<>();
+    /** Side-length of each spatial-hash cell in blocks. */
+    private static final int CELL_SIZE = 256;
+
+    /** Cell coordinate → set of island IDs whose bounding boxes overlap that cell. */
+    private final Map<Long, Set<String>> cellMap = new HashMap<>();
+
+    /** Island ID → its metadata (bounds, range). */
+    private final Map<String, IslandData> islandById = new HashMap<>();
+
     private final IslandCache im;
 
     /**
-     * @param im IslandsManager
+     * @param im IslandCache
      */
     public IslandGrid(IslandCache im) {
         super();
@@ -34,7 +48,7 @@ public class IslandGrid {
     /**
      * Adds island to grid
      * @param island - island to add
-     * @return true if successfully added, false if island already exists, or there is an overlap
+     * @return true if successfully added, false if there is an overlap with a different island
      */
     public boolean addToGrid(Island island) {
         int minX = island.getMinX();
@@ -42,37 +56,41 @@ public class IslandGrid {
         int range = island.getRange();
         IslandData newIsland = new IslandData(island.getUniqueId(), minX, minZ, range);
 
-        // Remove this island if it is already in the grid
-        this.removeFromGrid(island);
+        // If this island is already in the grid, remove it first (handles moves/resizes)
+        IslandData existing = islandById.get(newIsland.id());
+        if (existing != null) {
+            removeCells(existing);
+            islandById.remove(existing.id());
+        }
 
-        // compute bounds for the new island (upper bounds are exclusive)
+        // Compute bounding box (upper bounds exclusive)
         int newMaxX = minX + range * 2;
         int newMaxZ = minZ + range * 2;
 
-        /*
-         * Find any existing islands that could overlap:
-         * - Any existing island with minX <= newMaxX could extend over newMinX, so we must consider
-         *   all entries with key <= newMaxX (use headMap).
-         * - For each candidate X entry, consider Z entries with minZ <= newMaxZ (use headMap).
-         * This avoids missing large islands whose minX is far left of the new island.
-         */
-        for (Entry<Integer, TreeMap<Integer, IslandData>> xEntry : grid.headMap(newMaxX, true).entrySet()) {
-            TreeMap<Integer, IslandData> zMap = xEntry.getValue();
-            for (Entry<Integer, IslandData> zEntry : zMap.headMap(newMaxZ, true).entrySet()) {
-                IslandData existingIsland = zEntry.getValue();
-                if (isOverlapping(newIsland, existingIsland)) {
-                    return false;
+        // Check for overlaps only against islands in the cells this island would occupy
+        List<Long> coveredCells = getCoveredCells(minX, minZ, newMaxX, newMaxZ);
+        for (long cellKey : coveredCells) {
+            Set<String> ids = cellMap.get(cellKey);
+            if (ids != null) {
+                for (String candidateId : ids) {
+                    IslandData candidate = islandById.get(candidateId);
+                    if (candidate != null && isOverlapping(newIsland, candidate)) {
+                        return false;
+                    }
                 }
             }
         }
 
-        // No overlaps found, add the island
-        addNewEntry(minX, minZ, newIsland);
+        // No overlaps — register the island
+        islandById.put(newIsland.id(), newIsland);
+        for (long cellKey : coveredCells) {
+            cellMap.computeIfAbsent(cellKey, k -> new HashSet<>()).add(newIsland.id());
+        }
         return true;
     }
 
     /**
-     * Checks if two islands overlap
+     * Checks if two islands overlap. Touching edges are allowed.
      * @param island1 first island
      * @param island2 second island
      * @return true if islands overlap
@@ -93,26 +111,34 @@ public class IslandGrid {
     }
 
     /**
-     * Helper method to add a new entry to the grid
-     */
-    private void addNewEntry(int minX, int minZ, IslandData islandData) {
-        TreeMap<Integer, IslandData> zEntry = grid.computeIfAbsent(minX, k -> new TreeMap<>());
-        zEntry.put(minZ, islandData);
-    }
-
-    /**
      * Remove island from grid
      * @param island - the island to remove
      * @return true if island existed and was deleted, false if there was nothing to delete
      */
     public boolean removeFromGrid(Island island) {
-        String id = island.getUniqueId();
-        boolean removed = grid.values().stream()
-                .anyMatch(innerMap -> innerMap.values().removeIf(innerValue -> innerValue.id().equals(id)));
+        IslandData data = islandById.remove(island.getUniqueId());
+        if (data == null) {
+            return false;
+        }
+        removeCells(data);
+        return true;
+    }
 
-        grid.values().removeIf(TreeMap::isEmpty);
-
-        return removed;
+    /**
+     * Removes an island's ID from all cells it occupies.
+     */
+    private void removeCells(IslandData data) {
+        int maxX = data.minX() + data.range() * 2;
+        int maxZ = data.minZ() + data.range() * 2;
+        for (long cellKey : getCoveredCells(data.minX(), data.minZ(), maxX, maxZ)) {
+            Set<String> ids = cellMap.get(cellKey);
+            if (ids != null) {
+                ids.remove(data.id());
+                if (ids.isEmpty()) {
+                    cellMap.remove(cellKey);
+                }
+            }
+        }
     }
 
     /**
@@ -151,21 +177,18 @@ public class IslandGrid {
      * @return Unique Island ID string, or null if there is no island here.
      */
     public @Nullable String getIslandStringAt(int x, int z) {
-        // Attempt to find the closest x-coordinate entry that does not exceed 'x'
-        Entry<Integer, TreeMap<Integer, IslandData>> xEntry = grid.floorEntry(x);
-        if (xEntry == null) {
-            return null; // No x-coordinate entry found, return null
+        long cellKey = packCellKey(Math.floorDiv(x, CELL_SIZE), Math.floorDiv(z, CELL_SIZE));
+        Set<String> ids = cellMap.get(cellKey);
+        if (ids == null) {
+            return null;
         }
-
-        // Attempt to find the closest z-coordinate entry that does not exceed 'z' within the found x-coordinate
-        Entry<Integer, IslandData> zEntry = xEntry.getValue().floorEntry(z);
-        if (zEntry == null) {
-            return null; // No z-coordinate entry found, return null
-        }
-        // Check if the specified coordinates are within the island space
-        if (x >= zEntry.getValue().minX() && x < (zEntry.getValue().minX() + zEntry.getValue().range() * 2)
-                && z >= zEntry.getValue().minZ() && z < (zEntry.getValue().minZ() + zEntry.getValue().range() * 2)) {
-            return zEntry.getValue().id();
+        for (String id : ids) {
+            IslandData data = islandById.get(id);
+            if (data != null
+                    && x >= data.minX() && x < data.minX() + data.range() * 2
+                    && z >= data.minZ() && z < data.minZ() + data.range() * 2) {
+                return data.id();
+            }
         }
         return null;
     }
@@ -174,18 +197,93 @@ public class IslandGrid {
      * @return number of islands stored in the grid
      */
     public long getSize() {
-        long count = 0;
-        for (TreeMap<Integer, IslandData> innerMap : grid.values()) {
-            count += innerMap.size();
-        }
-        return count;
+        return islandById.size();
     }
 
     /**
-     * @return the grid
+     * Returns an unmodifiable view of all islands in the grid.
+     * @return all island data entries
      */
-    public TreeMap<Integer, TreeMap<Integer, IslandData>> getGrid() {
-        return grid;
+    public Collection<IslandData> getAllIslands() {
+        return Collections.unmodifiableCollection(islandById.values());
+    }
+
+    /**
+     * Returns all islands whose bounding boxes overlap the given rectangle.
+     * Useful for region-based queries (e.g., purge commands).
+     *
+     * @param minX minimum X of the query rectangle (inclusive)
+     * @param minZ minimum Z of the query rectangle (inclusive)
+     * @param maxX maximum X of the query rectangle (inclusive)
+     * @param maxZ maximum Z of the query rectangle (inclusive)
+     * @return collection of island data entries overlapping the rectangle
+     */
+    public Collection<IslandData> getIslandsInBounds(int minX, int minZ, int maxX, int maxZ) {
+        // Use maxX+1 and maxZ+1 for cell coverage since maxX/maxZ are inclusive
+        List<Long> cells = getCoveredCells(minX, minZ, maxX + 1, maxZ + 1);
+        Set<String> seen = new HashSet<>();
+        List<IslandData> result = new ArrayList<>();
+        for (long cellKey : cells) {
+            collectOverlappingIslands(cellKey, minX, minZ, maxX, maxZ, seen, result);
+        }
+        return result;
+    }
+
+    /**
+     * Collects islands from a single cell that overlap the query rectangle.
+     */
+    private void collectOverlappingIslands(long cellKey, int minX, int minZ, int maxX, int maxZ,
+            Set<String> seen, List<IslandData> result) {
+        Set<String> ids = cellMap.get(cellKey);
+        if (ids == null) {
+            return;
+        }
+        for (String id : ids) {
+            if (!seen.add(id)) {
+                continue;
+            }
+            IslandData data = islandById.get(id);
+            if (data != null && overlapsRect(data, minX, minZ, maxX, maxZ)) {
+                result.add(data);
+            }
+        }
+    }
+
+    /**
+     * Tests whether an island's bounding box overlaps the given inclusive rectangle.
+     */
+    private static boolean overlapsRect(IslandData data, int minX, int minZ, int maxX, int maxZ) {
+        int islandMaxX = data.minX() + 2 * data.range();
+        int islandMaxZ = data.minZ() + 2 * data.range();
+        return islandMaxX > minX && data.minX() <= maxX
+                && islandMaxZ > minZ && data.minZ() <= maxZ;
+    }
+
+    // ---- Internal helpers ----
+
+    /**
+     * Packs two cell coordinates into a single long key.
+     */
+    private static long packCellKey(int cellX, int cellZ) {
+        return ((long) cellX << 32) | (cellZ & 0xFFFFFFFFL);
+    }
+
+    /**
+     * Returns all cell keys that a bounding box [minX, maxX) x [minZ, maxZ) overlaps.
+     */
+    private static List<Long> getCoveredCells(int minX, int minZ, int maxX, int maxZ) {
+        int cellMinX = Math.floorDiv(minX, CELL_SIZE);
+        int cellMinZ = Math.floorDiv(minZ, CELL_SIZE);
+        // maxX/maxZ are exclusive, so subtract 1 before dividing to get the last covered cell
+        int cellMaxX = Math.floorDiv(maxX - 1, CELL_SIZE);
+        int cellMaxZ = Math.floorDiv(maxZ - 1, CELL_SIZE);
+        List<Long> cells = new ArrayList<>();
+        for (int cx = cellMinX; cx <= cellMaxX; cx++) {
+            for (int cz = cellMinZ; cz <= cellMaxZ; cz++) {
+                cells.add(packCellKey(cx, cz));
+            }
+        }
+        return cells;
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -15,10 +16,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -212,13 +213,13 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
     }
 
     /**
-     * When the island grid's internal map is null,
+     * When the island grid is empty (no islands),
      * the command should report none found.
      */
     @Test
-    public void testExecuteNullGrid() {
+    void testExecuteEmptyGrid() {
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(null);
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
 
         assertTrue(aprc.execute(user, "regions", List.of("10")));
@@ -232,7 +233,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
     @Test
     public void testExecuteNoRegionFiles() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(new TreeMap<>());
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
 
         // Create the region directory but leave it empty
@@ -250,7 +251,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
     @Test
     public void testExecuteOldRegionFileNoIslands() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(new TreeMap<>());
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
 
         // Create a small .mca file — getRegionTimestamp() returns 0 for files < 8192 bytes,
@@ -272,7 +273,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
     @Test
     public void testExecuteConfirmDeletesRegions() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(new TreeMap<>());
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
 
         Path regionDir = Files.createDirectories(tempDir.resolve("region"));
@@ -308,7 +309,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
     @Test
     public void testExecuteRecentRegionFileExcluded() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(new TreeMap<>());
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
 
         // Create a valid 8192-byte .mca file with a very recent timestamp so it is excluded.
@@ -356,12 +357,9 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
 
         // Island occupies region r.0.0 (minX=0, minZ=0, range=100)
         IslandGrid.IslandData data = new IslandGrid.IslandData("island-1", 0, 0, 100);
-        TreeMap<Integer, IslandGrid.IslandData> zMap = new TreeMap<>();
-        zMap.put(0, data);
-        TreeMap<Integer, TreeMap<Integer, IslandGrid.IslandData>> gridMap = new TreeMap<>();
-        gridMap.put(0, zMap);
+        Collection<IslandGrid.IslandData> islandList = List.of(data);
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(gridMap);
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(islandList);
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
         when(im.getIslandById("island-1")).thenReturn(Optional.of(island));
 
@@ -393,12 +391,9 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
         when(island.getMemberSet()).thenReturn(ImmutableSet.of(ownerUUID));
 
         IslandGrid.IslandData data = new IslandGrid.IslandData("island-spawn", 0, 0, 100);
-        TreeMap<Integer, IslandGrid.IslandData> zMap = new TreeMap<>();
-        zMap.put(0, data);
-        TreeMap<Integer, TreeMap<Integer, IslandGrid.IslandData>> gridMap = new TreeMap<>();
-        gridMap.put(0, zMap);
+        Collection<IslandGrid.IslandData> islandList = List.of(data);
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(gridMap);
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(islandList);
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
         when(im.getIslandById("island-spawn")).thenReturn(Optional.of(island));
 
@@ -427,12 +422,9 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
         when(island.getMemberSet()).thenReturn(ImmutableSet.of(ownerUUID));
 
         IslandGrid.IslandData data = new IslandGrid.IslandData("island-protected", 0, 0, 100);
-        TreeMap<Integer, IslandGrid.IslandData> zMap = new TreeMap<>();
-        zMap.put(0, data);
-        TreeMap<Integer, TreeMap<Integer, IslandGrid.IslandData>> gridMap = new TreeMap<>();
-        gridMap.put(0, zMap);
+        Collection<IslandGrid.IslandData> islandList = List.of(data);
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(gridMap);
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(islandList);
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
         when(im.getIslandById("island-protected")).thenReturn(Optional.of(island));
 
@@ -461,12 +453,9 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
         when(island.getCenter()).thenReturn(location);
 
         IslandGrid.IslandData data = new IslandGrid.IslandData("island-deletable", 0, 0, 100);
-        TreeMap<Integer, IslandGrid.IslandData> zMap = new TreeMap<>();
-        zMap.put(0, data);
-        TreeMap<Integer, TreeMap<Integer, IslandGrid.IslandData>> gridMap = new TreeMap<>();
-        gridMap.put(0, zMap);
+        Collection<IslandGrid.IslandData> islandList = List.of(data);
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(gridMap);
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(islandList);
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
         when(im.getIslandById("island-deletable")).thenReturn(Optional.of(island));
 
@@ -496,12 +485,9 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
         when(island.getCenter()).thenReturn(location);
 
         IslandGrid.IslandData data = new IslandGrid.IslandData("island-deletable", 0, 0, 100);
-        TreeMap<Integer, IslandGrid.IslandData> zMap = new TreeMap<>();
-        zMap.put(0, data);
-        TreeMap<Integer, TreeMap<Integer, IslandGrid.IslandData>> gridMap = new TreeMap<>();
-        gridMap.put(0, zMap);
+        Collection<IslandGrid.IslandData> islandList = List.of(data);
         IslandGrid grid = mock(IslandGrid.class);
-        when(grid.getGrid()).thenReturn(gridMap);
+        when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(islandList);
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
         when(im.getIslandById("island-deletable")).thenReturn(Optional.of(island));
 

--- a/src/test/java/world/bentobox/bentobox/managers/island/IslandGridTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/island/IslandGridTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,12 +16,13 @@ import org.mockito.Mock;
 
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.island.IslandGrid.IslandData;
 
 /**
  * Grid test
  */
 public class IslandGridTest extends CommonTestSetup {
-    
+
     private IslandGrid ig;
     @Mock
     private IslandCache im;
@@ -81,7 +84,7 @@ public class IslandGridTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#addToGrid(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testAddToGrid() {
+    void testAddToGrid() {
        assertTrue(ig.addToGrid(island));
        assertFalse(ig.addToGrid(overlappingIsland));
        assertTrue(ig.addToGrid(island2));
@@ -91,7 +94,7 @@ public class IslandGridTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#removeFromGrid(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testRemoveFromGrid() {
+    void testRemoveFromGrid() {
         assertTrue(ig.addToGrid(island));
        assertTrue(ig.removeFromGrid(island));
        assertFalse(ig.removeFromGrid(island2));
@@ -101,8 +104,8 @@ public class IslandGridTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#getIslandAt(int, int)}.
      */
     @Test
-    public void testGetIslandAt() {
-        assertNull(ig.getIslandAt(0, 0)); 
+    void testGetIslandAt() {
+        assertNull(ig.getIslandAt(0, 0));
         assertTrue(ig.addToGrid(island));
         assertTrue(ig.addToGrid(island2));
         assertEquals(island, ig.getIslandAt(360, 5700));
@@ -113,7 +116,7 @@ public class IslandGridTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#isIslandAt(int, int)}.
      */
     @Test
-    public void testIsIslandAt() {
+    void testIsIslandAt() {
         assertFalse(ig.isIslandAt(0, 0));
         assertTrue(ig.addToGrid(island2));
         assertTrue(ig.isIslandAt(0, 0));
@@ -126,18 +129,18 @@ public class IslandGridTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#getIslandStringAt(int, int)}.
      */
     @Test
-    public void testGetIslandStringAt() {
+    void testGetIslandStringAt() {
        assertNull(ig.getIslandStringAt(0, 0));
        assertTrue(ig.addToGrid(island2));
        assertEquals("island2", ig.getIslandStringAt(0, 0));
-       
+
     }
 
     /**
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#getSize()}.
      */
     @Test
-    public void testGetSize() {
+    void testGetSize() {
         assertEquals(0, ig.getSize());
         assertTrue(ig.addToGrid(island2));
         assertEquals(1, ig.getSize());
@@ -150,15 +153,18 @@ public class IslandGridTest extends CommonTestSetup {
     }
 
     /**
-     * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#getGrid()}.
+     * Test method for {@link world.bentobox.bentobox.managers.island.IslandGrid#getAllIslands()}.
      */
     @Test
-    public void testGetGrid() {
-        assertNotNull(ig.getGrid());
+    void testGetAllIslands() {
+        assertNotNull(ig.getAllIslands());
+        assertTrue(ig.getAllIslands().isEmpty());
+        ig.addToGrid(island);
+        assertEquals(1, ig.getAllIslands().size());
     }
-    
+
     @Test
-    public void testUpdateIslandCoordinatesKeepsSingleEntry() {
+    void testUpdateIslandCoordinatesKeepsSingleEntry() {
         // original at (100,100) range 20
         when(original.getMinX()).thenReturn(100);
         when(original.getMinZ()).thenReturn(100);
@@ -189,7 +195,7 @@ public class IslandGridTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAdjacentIslandsAllowedWhenEdgesTouch() {
+    void testAdjacentIslandsAllowedWhenEdgesTouch() {
         // island a covers x:[0,20) z:[0,20)
         when(a.getMinX()).thenReturn(0);
         when(a.getMinZ()).thenReturn(0);
@@ -215,7 +221,7 @@ public class IslandGridTest extends CommonTestSetup {
     }
 
     @Test
-    public void testLargeExistingIslandShouldBlockSmallIslandEvenIfMinXOutsideSubMapWindow() {
+    void testLargeExistingIslandShouldBlockSmallIslandEvenIfMinXOutsideSubMapWindow() {
         // big island minX = 0, range = 1000
         when(big.getMinX()).thenReturn(0);
         when(big.getMinZ()).thenReturn(0);
@@ -234,13 +240,12 @@ public class IslandGridTest extends CommonTestSetup {
         assertTrue(ig.addToGrid(big));
 
         // Expected: adding small should be rejected because it lies inside big
-        // If this test fails, it reveals the current subMap window is too small to find big.
         assertFalse(ig.addToGrid(small), "Small island overlaps big island; should have been rejected");
     }
 
     @Test
-    public void testGetIslandStringAtWhenXEntryExistsButNoZEntryApplies() {
-        // island exists at minX=100 minZ=100 range=10 (covers z [110,110))
+    void testGetIslandStringAtWhenXEntryExistsButNoZEntryApplies() {
+        // island exists at minX=100 minZ=100 range=10 (covers z [100,120))
         when(zIsland.getMinX()).thenReturn(100);
         when(zIsland.getMinZ()).thenReturn(100);
         when(zIsland.getRange()).thenReturn(10);
@@ -252,6 +257,204 @@ public class IslandGridTest extends CommonTestSetup {
 
         // Query an x within island x-range but z is below any minZ -> should return null
         assertNull(ig.getIslandStringAt(110, 50));
+    }
+
+    // ---- New tests for spatial hash correctness ----
+
+    /**
+     * Tests that a large island at a low X is found even when a smaller island exists
+     * at a closer X. This was a correctness bug in the old floorEntry-based lookup.
+     */
+    @Test
+    void testLookupCorrectnessWithArbitraryPositions() {
+        // Large island at x=0, covers x:[0, 400)
+        Island largeIsland = createMockIsland("large", 0, 0, 200);
+        when(im.getIslandById("large")).thenReturn(largeIsland);
+
+        // Small island at x=500, different Z to avoid overlap, covers x:[500, 520)
+        Island smallIsland = createMockIsland("small-far", 500, 500, 10);
+        when(im.getIslandById("small-far")).thenReturn(smallIsland);
+
+        assertTrue(ig.addToGrid(largeIsland));
+        assertTrue(ig.addToGrid(smallIsland));
+
+        // Query x=350 — inside large island, past small island's minX position
+        // The old floorEntry approach would have checked smallIsland's X bucket and missed largeIsland
+        assertEquals("large", ig.getIslandStringAt(350, 100));
+        assertEquals("small-far", ig.getIslandStringAt(510, 510));
+    }
+
+    /**
+     * Tests bulk load performance — 10,000 islands should complete quickly.
+     */
+    @Test
+    void testBulkLoadPerformance() {
+        int count = 10_000;
+        int spacing = 200; // each island: range=50, diameter=100, spacing=200 (no overlap)
+        for (int i = 0; i < count; i++) {
+            int x = (i % 100) * spacing;
+            int z = (i / 100) * spacing;
+            String id = "island-" + i;
+            Island mockIsland = createMockIsland(id, x, z, 50);
+            ig.addToGrid(mockIsland);
+        }
+        assertEquals(count, ig.getSize());
+
+        // Verify a few lookups work
+        assertEquals("island-0", ig.getIslandStringAt(25, 25));
+        assertEquals("island-99", ig.getIslandStringAt(99 * spacing + 25, 25));
+    }
+
+    /**
+     * Tests islands in all four quadrants (negative and positive coordinates).
+     */
+    @Test
+    void testNegativeCoordinates() {
+        Island ne = createMockIsland("ne", 100, 100, 50);
+        Island nw = createMockIsland("nw", -200, 100, 50);
+        Island se = createMockIsland("se", 100, -200, 50);
+        Island sw = createMockIsland("sw", -200, -200, 50);
+
+        when(im.getIslandById("ne")).thenReturn(ne);
+        when(im.getIslandById("nw")).thenReturn(nw);
+        when(im.getIslandById("se")).thenReturn(se);
+        when(im.getIslandById("sw")).thenReturn(sw);
+
+        assertTrue(ig.addToGrid(ne));
+        assertTrue(ig.addToGrid(nw));
+        assertTrue(ig.addToGrid(se));
+        assertTrue(ig.addToGrid(sw));
+
+        assertEquals("ne", ig.getIslandStringAt(150, 150));
+        assertEquals("nw", ig.getIslandStringAt(-150, 150));
+        assertEquals("se", ig.getIslandStringAt(150, -150));
+        assertEquals("sw", ig.getIslandStringAt(-150, -150));
+
+        // Outside all islands
+        assertNull(ig.getIslandStringAt(0, 0));
+    }
+
+    /**
+     * Tests mix of small and large range islands.
+     */
+    @Test
+    void testVariableRangeIslands() {
+        // Large island: range=500, covers [0, 1000) x [0, 1000)
+        Island large = createMockIsland("large", 0, 0, 500);
+        when(im.getIslandById("large")).thenReturn(large);
+        assertTrue(ig.addToGrid(large));
+
+        // Small island outside: range=10, at (1500, 1500)
+        Island smallOutside = createMockIsland("small-out", 1500, 1500, 10);
+        when(im.getIslandById("small-out")).thenReturn(smallOutside);
+        assertTrue(ig.addToGrid(smallOutside));
+
+        // Small island overlapping large: should be rejected
+        Island smallInside = createMockIsland("small-in", 500, 500, 10);
+        assertFalse(ig.addToGrid(smallInside));
+
+        assertEquals("large", ig.getIslandStringAt(999, 999));
+        assertNull(ig.getIslandStringAt(1000, 1000)); // just outside large
+        assertEquals("small-out", ig.getIslandStringAt(1510, 1510));
+    }
+
+    /**
+     * Tests that an island straddling a cell boundary is found from both sides.
+     */
+    @Test
+    void testCellBoundaryLookup() {
+        // Place island so it straddles the cell boundary at x=256
+        // minX=200, range=50 -> covers [200, 300) which crosses cell boundary at 256
+        Island crossingIsland = createMockIsland("crossing", 200, 0, 50);
+        when(im.getIslandById("crossing")).thenReturn(crossingIsland);
+        assertTrue(ig.addToGrid(crossingIsland));
+
+        // Query on both sides of the cell boundary
+        assertEquals("crossing", ig.getIslandStringAt(210, 10)); // cell 0
+        assertEquals("crossing", ig.getIslandStringAt(270, 10)); // cell 1
+        assertEquals("crossing", ig.getIslandStringAt(299, 99)); // near edge, cell 1
+        assertNull(ig.getIslandStringAt(300, 10)); // just outside
+    }
+
+    /**
+     * Tests that removal clears island from all cells.
+     */
+    @Test
+    void testRemoveThenRequery() {
+        Island crossingIsland = createMockIsland("crossing", 200, 0, 50);
+        when(im.getIslandById("crossing")).thenReturn(crossingIsland);
+        assertTrue(ig.addToGrid(crossingIsland));
+        assertEquals("crossing", ig.getIslandStringAt(270, 10));
+
+        assertTrue(ig.removeFromGrid(crossingIsland));
+        assertNull(ig.getIslandStringAt(210, 10));
+        assertNull(ig.getIslandStringAt(270, 10));
+        assertEquals(0, ig.getSize());
+    }
+
+    /**
+     * Tests getIslandsInBounds returns correct results.
+     */
+    @Test
+    void testGetIslandsInBounds() {
+        Island i1 = createMockIsland("i1", 0, 0, 50);
+        Island i2 = createMockIsland("i2", 200, 200, 50);
+        Island i3 = createMockIsland("i3", 1000, 1000, 50);
+
+        ig.addToGrid(i1);
+        ig.addToGrid(i2);
+        ig.addToGrid(i3);
+
+        // Query a region that covers i1 and i2 but not i3
+        Collection<IslandData> result = ig.getIslandsInBounds(0, 0, 400, 400);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(d -> d.id().equals("i1")));
+        assertTrue(result.stream().anyMatch(d -> d.id().equals("i2")));
+
+        // Query that covers only i3
+        Collection<IslandData> result2 = ig.getIslandsInBounds(900, 900, 1200, 1200);
+        assertEquals(1, result2.size());
+        assertEquals("i3", result2.iterator().next().id());
+
+        // Query that covers nothing
+        Collection<IslandData> result3 = ig.getIslandsInBounds(5000, 5000, 6000, 6000);
+        assertTrue(result3.isEmpty());
+    }
+
+    /**
+     * Tests many non-overlapping islands packed tightly.
+     */
+    @Test
+    void testDenseCluster() {
+        // 10x10 grid of islands, each range=5 (diameter=10), spaced 10 apart (touching edges)
+        for (int x = 0; x < 10; x++) {
+            for (int z = 0; z < 10; z++) {
+                String id = "dense-" + x + "-" + z;
+                Island di = createMockIsland(id, x * 10, z * 10, 5);
+                when(im.getIslandById(id)).thenReturn(di);
+                assertTrue(ig.addToGrid(di), "Should add " + id);
+            }
+        }
+        assertEquals(100, ig.getSize());
+
+        // Check a few
+        assertEquals("dense-0-0", ig.getIslandStringAt(5, 5));
+        assertEquals("dense-9-9", ig.getIslandStringAt(95, 95));
+        assertEquals("dense-5-3", ig.getIslandStringAt(55, 35));
+
+        // Just outside the cluster
+        assertNull(ig.getIslandStringAt(100, 50));
+    }
+
+    // ---- Helper ----
+
+    private Island createMockIsland(String id, int minX, int minZ, int range) {
+        Island mock = org.mockito.Mockito.mock(Island.class);
+        when(mock.getMinX()).thenReturn(minX);
+        when(mock.getMinZ()).thenReturn(minZ);
+        when(mock.getRange()).thenReturn(range);
+        when(mock.getUniqueId()).thenReturn(id);
+        return mock;
     }
 
 }


### PR DESCRIPTION
## Summary
- Replaces the nested `TreeMap` internals of `IslandGrid` with a cell-based spatial hash (`HashMap`), reducing island loading from O(n²) to O(n) — fixes #2838 where servers with many islands hang at "Loading islands from database.."
- Fixes a correctness bug in `getIslandStringAt()` where the `floorEntry()` approach missed large islands at lower X keys when smaller islands existed at closer X coordinates — critical for Stranger Realms arbitrary island positions
- Replaces `getGrid()` with `getAllIslands()` and `getIslandsInBounds()`, updating `AdminPurgeRegionsCommand` accordingly

## Test plan
- [x] Run `./gradlew clean build` — all existing + 8 new IslandGrid tests should pass
- [ ] Verify island loading time on a server with many islands (the reporter's server would be ideal)
- [x] Verify player movement doesn't cause lag (getIslandStringAt is on the hot path)
- [ ] Test AdminPurgeRegionsCommand still works correctly
- [x] Test with Stranger Realms arbitrary-position islands

relates to #2838 