### PR TITLE
chore: Remove unnecessary public modifiers from JUnit 5 test classes

### DIFF
--- a/src/test/java/world/bentobox/bentobox/SettingsTest.java
+++ b/src/test/java/world/bentobox/bentobox/SettingsTest.java
@@ -18,12 +18,12 @@ import world.bentobox.bentobox.database.DatabaseSetup.DatabaseType;
  *
  */
 
-public class SettingsTest {
+class SettingsTest {
 
     private Settings s;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         WhiteBox.setInternalState(BentoBox.class, "instance", Mockito.mock(BentoBox.class));
         // Class under test
         s = new Settings();
@@ -34,7 +34,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getDefaultLanguage()}.
      */
     @Test
-    public void testGetDefaultLanguage() {
+    void testGetDefaultLanguage() {
         assertEquals("en-US", s.getDefaultLanguage());
     }
 
@@ -43,7 +43,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDefaultLanguage(java.lang.String)}.
      */
     @Test
-    public void testSetDefaultLanguage() {
+    void testSetDefaultLanguage() {
         s.setDefaultLanguage("test");
         assertEquals("test", s.getDefaultLanguage());
     }
@@ -52,7 +52,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#isUseEconomy()}.
      */
     @Test
-    public void testIsUseEconomy() {
+    void testIsUseEconomy() {
         assertTrue(s.isUseEconomy());
 
     }
@@ -62,7 +62,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setUseEconomy(boolean)}.
      */
     @Test
-    public void testSetUseEconomy() {
+    void testSetUseEconomy() {
         s.setUseEconomy(false);
         assertFalse(s.isUseEconomy());
     }
@@ -71,7 +71,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getDatabaseType()}.
      */
     @Test
-    public void testGetDatabaseType() {
+    void testGetDatabaseType() {
         assertEquals(DatabaseType.JSON, s.getDatabaseType());
     }
 
@@ -80,7 +80,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabaseType(world.bentobox.bentobox.database.DatabaseSetup.DatabaseType)}.
      */
     @Test
-    public void testSetDatabaseType() {
+    void testSetDatabaseType() {
         s.setDatabaseType(DatabaseType.JSON2MONGODB);
         assertEquals(DatabaseType.JSON2MONGODB, s.getDatabaseType());
     }
@@ -89,7 +89,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getDatabaseHost()}.
      */
     @Test
-    public void testGetDatabaseHost() {
+    void testGetDatabaseHost() {
         assertEquals("localhost", s.getDatabaseHost());
     }
 
@@ -98,7 +98,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabaseHost(java.lang.String)}.
      */
     @Test
-    public void testSetDatabaseHost() {
+    void testSetDatabaseHost() {
         s.setDatabaseHost("remotehost");
         assertEquals("remotehost", s.getDatabaseHost());
     }
@@ -107,7 +107,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getDatabasePort()}.
      */
     @Test
-    public void testGetDatabasePort() {
+    void testGetDatabasePort() {
         assertEquals(3306, s.getDatabasePort());
     }
 
@@ -115,7 +115,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#isUseSSL()}.
      */
     @Test
-    public void testIsUseSSL() {
+    void testIsUseSSL() {
         assertFalse(s.isUseSSL());
     }
 
@@ -123,7 +123,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#setUseSSL(boolean)}.
      */
     @Test
-    public void testSetUseSSL() {
+    void testSetUseSSL() {
         s.setUseSSL(false);
         assertFalse(s.isUseSSL());
         s.setUseSSL(true);
@@ -135,7 +135,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabasePort(int)}.
      */
     @Test
-    public void testSetDatabasePort() {
+    void testSetDatabasePort() {
         s.setDatabasePort(1234);
         assertEquals(1234, s.getDatabasePort());
     }
@@ -144,7 +144,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getDatabaseName()}.
      */
     @Test
-    public void testGetDatabaseName() {
+    void testGetDatabaseName() {
         assertEquals("bentobox", s.getDatabaseName());
     }
 
@@ -153,7 +153,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabaseName(java.lang.String)}.
      */
     @Test
-    public void testSetDatabaseName() {
+    void testSetDatabaseName() {
         s.setDatabaseName("fredthedoggy");
         assertEquals("fredthedoggy", s.getDatabaseName());
     }
@@ -163,7 +163,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getDatabaseUsername()}.
      */
     @Test
-    public void testGetDatabaseUsername() {
+    void testGetDatabaseUsername() {
         assertEquals("username", s.getDatabaseUsername());
     }
 
@@ -172,7 +172,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabaseUsername(java.lang.String)}.
      */
     @Test
-    public void testSetDatabaseUsername() {
+    void testSetDatabaseUsername() {
         s.setDatabaseUsername("BONNe");
         assertEquals("BONNe", s.getDatabaseUsername());
     }
@@ -182,7 +182,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getDatabasePassword()}.
      */
     @Test
-    public void testGetDatabasePassword() {
+    void testGetDatabasePassword() {
         assertEquals("password", s.getDatabasePassword());
     }
 
@@ -191,7 +191,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabasePassword(java.lang.String)}.
      */
     @Test
-    public void testSetDatabasePassword() {
+    void testSetDatabasePassword() {
         s.setDatabasePassword("afero");
         assertEquals("afero", s.getDatabasePassword());
     }
@@ -201,7 +201,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getDatabaseBackupPeriod()}.
      */
     @Test
-    public void testGetDatabaseBackupPeriod() {
+    void testGetDatabaseBackupPeriod() {
         assertEquals(5, s.getDatabaseBackupPeriod());
     }
 
@@ -210,7 +210,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabaseBackupPeriod(int)}.
      */
     @Test
-    public void testSetDatabaseBackupPeriod() {
+    void testSetDatabaseBackupPeriod() {
         s.setDatabaseBackupPeriod(10);
         assertEquals(10, s.getDatabaseBackupPeriod());
     }
@@ -219,7 +219,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getFakePlayers()}.
      */
     @Test
-    public void testGetFakePlayers() {
+    void testGetFakePlayers() {
         assertTrue(s.getFakePlayers().isEmpty());
     }
 
@@ -228,7 +228,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setFakePlayers(java.util.Set)}.
      */
     @Test
-    public void testSetFakePlayers() {
+    void testSetFakePlayers() {
         s.setFakePlayers(Collections.singleton("npc"));
         assertTrue(s.getFakePlayers().contains("npc"));
     }
@@ -238,7 +238,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isClosePanelOnClickOutside()}.
      */
     @Test
-    public void testIsClosePanelOnClickOutside() {
+    void testIsClosePanelOnClickOutside() {
         assertTrue(s.isClosePanelOnClickOutside());
     }
 
@@ -247,7 +247,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setClosePanelOnClickOutside(boolean)}.
      */
     @Test
-    public void testSetClosePanelOnClickOutside() {
+    void testSetClosePanelOnClickOutside() {
         assertTrue(s.isClosePanelOnClickOutside());
         s.setClosePanelOnClickOutside(false);
         assertFalse(s.isClosePanelOnClickOutside());
@@ -257,7 +257,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getInviteCooldown()}.
      */
     @Test
-    public void testGetInviteCooldown() {
+    void testGetInviteCooldown() {
         assertEquals(60, s.getInviteCooldown());
     }
 
@@ -266,7 +266,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setInviteCooldown(int)}.
      */
     @Test
-    public void testSetInviteCooldown() {
+    void testSetInviteCooldown() {
         s.setInviteCooldown(99);
         assertEquals(99, s.getInviteCooldown());
     }
@@ -275,7 +275,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getCoopCooldown()}.
      */
     @Test
-    public void testGetCoopCooldown() {
+    void testGetCoopCooldown() {
         assertEquals(5, s.getCoopCooldown());
     }
 
@@ -284,7 +284,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setCoopCooldown(int)}.
      */
     @Test
-    public void testSetCoopCooldown() {
+    void testSetCoopCooldown() {
         s.setCoopCooldown(15);
         assertEquals(15, s.getCoopCooldown());
     }
@@ -293,7 +293,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getTrustCooldown()}.
      */
     @Test
-    public void testGetTrustCooldown() {
+    void testGetTrustCooldown() {
         assertEquals(5, s.getTrustCooldown());
     }
 
@@ -302,7 +302,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setTrustCooldown(int)}.
      */
     @Test
-    public void testSetTrustCooldown() {
+    void testSetTrustCooldown() {
         s.setTrustCooldown(15);
         assertEquals(15, s.getTrustCooldown());
     }
@@ -311,7 +311,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getBanCooldown()}.
      */
     @Test
-    public void testGetBanCooldown() {
+    void testGetBanCooldown() {
         assertEquals(10, s.getBanCooldown());
     }
 
@@ -319,7 +319,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#setBanCooldown(int)}.
      */
     @Test
-    public void testSetBanCooldown() {
+    void testSetBanCooldown() {
         s.setBanCooldown(99);
         assertEquals(99, s.getBanCooldown());
     }
@@ -328,7 +328,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getResetCooldown()}.
      */
     @Test
-    public void testGetResetCooldown() {
+    void testGetResetCooldown() {
         assertEquals(300, s.getResetCooldown());
     }
 
@@ -337,7 +337,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setResetCooldown(int)}.
      */
     @Test
-    public void testSetResetCooldown() {
+    void testSetResetCooldown() {
         s.setResetCooldown(3);
         assertEquals(3, s.getResetCooldown());
     }
@@ -347,7 +347,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getConfirmationTime()}.
      */
     @Test
-    public void testGetConfirmationTime() {
+    void testGetConfirmationTime() {
         assertEquals(10, s.getConfirmationTime());
     }
 
@@ -356,7 +356,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setConfirmationTime(int)}.
      */
     @Test
-    public void testSetConfirmationTime() {
+    void testSetConfirmationTime() {
         s.setConfirmationTime(100);
         assertEquals(100, s.getConfirmationTime());
     }
@@ -366,7 +366,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isKickConfirmation()}.
      */
     @Test
-    public void testIsKickConfirmation() {
+    void testIsKickConfirmation() {
         assertTrue(s.isKickConfirmation());
     }
 
@@ -375,7 +375,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setKickConfirmation(boolean)}.
      */
     @Test
-    public void testSetKickConfirmation() {
+    void testSetKickConfirmation() {
         assertTrue(s.isKickConfirmation());
         s.setKickConfirmation(false);
         assertFalse(s.isKickConfirmation());
@@ -386,7 +386,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isLeaveConfirmation()}.
      */
     @Test
-    public void testIsLeaveConfirmation() {
+    void testIsLeaveConfirmation() {
         assertTrue(s.isLeaveConfirmation());
     }
 
@@ -395,7 +395,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setLeaveConfirmation(boolean)}.
      */
     @Test
-    public void testSetLeaveConfirmation() {
+    void testSetLeaveConfirmation() {
         assertTrue(s.isLeaveConfirmation());
         s.setLeaveConfirmation(false);
         assertFalse(s.isLeaveConfirmation());
@@ -407,7 +407,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isResetConfirmation()}.
      */
     @Test
-    public void testIsResetConfirmation() {
+    void testIsResetConfirmation() {
         assertTrue(s.isResetConfirmation());
     }
 
@@ -416,7 +416,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setResetConfirmation(boolean)}.
      */
     @Test
-    public void testSetResetConfirmation() {
+    void testSetResetConfirmation() {
         assertTrue(s.isResetConfirmation());
         s.setResetConfirmation(false);
         assertFalse(s.isResetConfirmation());
@@ -427,7 +427,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getNameMinLength()}.
      */
     @Test
-    public void testGetNameMinLength() {
+    void testGetNameMinLength() {
         assertEquals(4, s.getNameMinLength());
     }
 
@@ -436,7 +436,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setNameMinLength(int)}.
      */
     @Test
-    public void testSetNameMinLength() {
+    void testSetNameMinLength() {
         assertEquals(4, s.getNameMinLength());
         s.setNameMinLength(2);
         assertEquals(2, s.getNameMinLength());
@@ -446,7 +446,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getNameMaxLength()}.
      */
     @Test
-    public void testGetNameMaxLength() {
+    void testGetNameMaxLength() {
         assertEquals(20, s.getNameMaxLength());
     }
 
@@ -455,7 +455,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setNameMaxLength(int)}.
      */
     @Test
-    public void testSetNameMaxLength() {
+    void testSetNameMaxLength() {
         assertEquals(20, s.getNameMaxLength());
         s.setNameMaxLength(2);
         assertEquals(2, s.getNameMaxLength());
@@ -466,7 +466,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#isNameUniqueness()}.
      */
     @Test
-    public void testIsNameUniqueness() {
+    void testIsNameUniqueness() {
         assertFalse(s.isNameUniqueness());
     }
 
@@ -475,7 +475,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setNameUniqueness(boolean)}.
      */
     @Test
-    public void testSetNameUniqueness() {
+    void testSetNameUniqueness() {
         assertFalse(s.isNameUniqueness());
         s.setNameUniqueness(true);
         assertTrue(s.isNameUniqueness());
@@ -485,7 +485,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#setPasteSpeed(int)}.
      */
     @Test
-    public void testSetPasteSpeed() {
+    void testSetPasteSpeed() {
         assertEquals(64, s.getPasteSpeed());
         s.setPasteSpeed(100);
         assertEquals(100, s.getPasteSpeed());
@@ -495,7 +495,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getPasteSpeed()}.
      */
     @Test
-    public void testGetPasteSpeed() {
+    void testGetPasteSpeed() {
         assertEquals(64, s.getPasteSpeed());
     }
 
@@ -503,7 +503,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getDeleteSpeed()}.
      */
     @Test
-    public void testGetDeleteSpeed() {
+    void testGetDeleteSpeed() {
         assertEquals(1, s.getDeleteSpeed());
     }
 
@@ -511,7 +511,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#setDeleteSpeed(int)}.
      */
     @Test
-    public void testSetDeleteSpeed() {
+    void testSetDeleteSpeed() {
         assertEquals(1, s.getDeleteSpeed());
         s.setDeleteSpeed(4);
         assertEquals(4, s.getDeleteSpeed());
@@ -522,7 +522,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isLogCleanSuperFlatChunks()}.
      */
     @Test
-    public void testIsLogCleanSuperFlatChunks() {
+    void testIsLogCleanSuperFlatChunks() {
         assertTrue(s.isLogCleanSuperFlatChunks());
     }
 
@@ -531,7 +531,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setLogCleanSuperFlatChunks(boolean)}.
      */
     @Test
-    public void testSetLogCleanSuperFlatChunks() {
+    void testSetLogCleanSuperFlatChunks() {
         assertTrue(s.isLogCleanSuperFlatChunks());
         s.setLogCleanSuperFlatChunks(false);
         assertFalse(s.isLogCleanSuperFlatChunks());
@@ -542,7 +542,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isResetCooldownOnCreate()}.
      */
     @Test
-    public void testIsResetCooldownOnCreate() {
+    void testIsResetCooldownOnCreate() {
         assertTrue(s.isResetCooldownOnCreate());
     }
 
@@ -551,7 +551,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setResetCooldownOnCreate(boolean)}.
      */
     @Test
-    public void testSetResetCooldownOnCreate() {
+    void testSetResetCooldownOnCreate() {
         assertTrue(s.isResetCooldownOnCreate());
         s.setResetCooldownOnCreate(false);
         assertFalse(s.isResetCooldownOnCreate());
@@ -562,7 +562,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isGithubDownloadData()}.
      */
     @Test
-    public void testIsGithubDownloadData() {
+    void testIsGithubDownloadData() {
         assertTrue(s.isGithubDownloadData());
     }
 
@@ -571,7 +571,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setGithubDownloadData(boolean)}.
      */
     @Test
-    public void testSetGithubDownloadData() {
+    void testSetGithubDownloadData() {
         assertTrue(s.isGithubDownloadData());
         s.setGithubDownloadData(false);
         assertFalse(s.isGithubDownloadData());
@@ -582,7 +582,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getGithubConnectionInterval()}.
      */
     @Test
-    public void testGetGithubConnectionInterval() {
+    void testGetGithubConnectionInterval() {
         assertEquals(120, s.getGithubConnectionInterval());
     }
 
@@ -591,7 +591,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setGithubConnectionInterval(int)}.
      */
     @Test
-    public void testSetGithubConnectionInterval() {
+    void testSetGithubConnectionInterval() {
         assertEquals(120, s.getGithubConnectionInterval());
         s.setGithubConnectionInterval(20);
         assertEquals(20, s.getGithubConnectionInterval());
@@ -602,7 +602,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isCheckBentoBoxUpdates()}.
      */
     @Test
-    public void testIsCheckBentoBoxUpdates() {
+    void testIsCheckBentoBoxUpdates() {
         assertTrue(s.isCheckBentoBoxUpdates());
     }
 
@@ -611,7 +611,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setCheckBentoBoxUpdates(boolean)}.
      */
     @Test
-    public void testSetCheckBentoBoxUpdates() {
+    void testSetCheckBentoBoxUpdates() {
         assertTrue(s.isCheckBentoBoxUpdates());
         s.setCheckBentoBoxUpdates(false);
         assertFalse(s.isCheckBentoBoxUpdates());
@@ -622,7 +622,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isCheckAddonsUpdates()}.
      */
     @Test
-    public void testIsCheckAddonsUpdates() {
+    void testIsCheckAddonsUpdates() {
         assertTrue(s.isCheckAddonsUpdates());
     }
 
@@ -631,7 +631,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setCheckAddonsUpdates(boolean)}.
      */
     @Test
-    public void testSetCheckAddonsUpdates() {
+    void testSetCheckAddonsUpdates() {
         assertTrue(s.isCheckAddonsUpdates());
         s.setCheckAddonsUpdates(false);
         assertFalse(s.isCheckAddonsUpdates());
@@ -642,7 +642,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isLogGithubDownloadData()}.
      */
     @Test
-    public void testIsLogGithubDownloadData() {
+    void testIsLogGithubDownloadData() {
         assertTrue(s.isLogGithubDownloadData());
     }
 
@@ -651,7 +651,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setLogGithubDownloadData(boolean)}.
      */
     @Test
-    public void testSetLogGithubDownloadData() {
+    void testSetLogGithubDownloadData() {
         assertTrue(s.isLogGithubDownloadData());
         s.setLogGithubDownloadData(false);
         assertFalse(s.isLogGithubDownloadData());
@@ -661,7 +661,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getDelayTime()}.
      */
     @Test
-    public void testGetDelayTime() {
+    void testGetDelayTime() {
         assertEquals(0, s.getDelayTime());
     }
 
@@ -669,7 +669,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#setDelayTime(int)}.
      */
     @Test
-    public void testSetDelayTime() {
+    void testSetDelayTime() {
         assertEquals(0, s.getDelayTime());
         s.setDelayTime(10);
         assertEquals(10, s.getDelayTime());
@@ -679,7 +679,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getClearRadius()}.
      */
     @Test
-    public void testGetClearRadius() {
+    void testGetClearRadius() {
         assertEquals(5, s.getClearRadius());
 
     }
@@ -688,7 +688,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#setClearRadius(int)}.
      */
     @Test
-    public void testSetClearRadius() {
+    void testSetClearRadius() {
         assertEquals(5, s.getClearRadius());
         s.setClearRadius(20);
         assertEquals(20, s.getClearRadius());
@@ -699,7 +699,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isInviteConfirmation()}.
      */
     @Test
-    public void testIsInviteConfirmation() {
+    void testIsInviteConfirmation() {
         assertFalse(s.isInviteConfirmation());
     }
 
@@ -708,7 +708,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setInviteConfirmation(boolean)}.
      */
     @Test
-    public void testSetInviteConfirmation() {
+    void testSetInviteConfirmation() {
         assertFalse(s.isInviteConfirmation());
         s.setInviteConfirmation(true);
         assertTrue(s.isInviteConfirmation());
@@ -718,7 +718,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.bentobox.Settings#getDatabasePrefix()}.
      */
     @Test
-    public void testGetDatabasePrefix() {
+    void testGetDatabasePrefix() {
         assertEquals("", s.getDatabasePrefix());
     }
 
@@ -727,7 +727,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setDatabasePrefix(java.lang.String)}.
      */
     @Test
-    public void testSetDatabasePrefix() {
+    void testSetDatabasePrefix() {
         assertEquals("", s.getDatabasePrefix());
         s.setDatabasePrefix("Prefix");
         assertEquals("Prefix", s.getDatabasePrefix());
@@ -738,7 +738,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#isKeepPreviousIslandOnReset()}.
      */
     @Test
-    public void testIsKeepPreviousIslandOnReset() {
+    void testIsKeepPreviousIslandOnReset() {
         assertFalse(s.isKeepPreviousIslandOnReset());
     }
 
@@ -747,7 +747,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setKeepPreviousIslandOnReset(boolean)}.
      */
     @Test
-    public void testSetKeepPreviousIslandOnReset() {
+    void testSetKeepPreviousIslandOnReset() {
         assertFalse(s.isKeepPreviousIslandOnReset());
         s.setKeepPreviousIslandOnReset(true);
         assertTrue(s.isKeepPreviousIslandOnReset());
@@ -758,7 +758,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getMongodbConnectionUri()}.
      */
     @Test
-    public void testGetMongodbConnectionUri() {
+    void testGetMongodbConnectionUri() {
         assertEquals("", s.getMongodbConnectionUri());
     }
 
@@ -767,7 +767,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setMongodbConnectionUri(java.lang.String)}.
      */
     @Test
-    public void testSetMongodbConnectionUri() {
+    void testSetMongodbConnectionUri() {
         assertEquals("", s.getMongodbConnectionUri());
         s.setMongodbConnectionUri("xyz");
         assertEquals("xyz", s.getMongodbConnectionUri());
@@ -778,7 +778,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getPanelFillerMaterial()}.
      */
     @Test
-    public void testGetPanelFillerMaterial() {
+    void testGetPanelFillerMaterial() {
         assertEquals(Material.LIGHT_BLUE_STAINED_GLASS_PANE, s.getPanelFillerMaterial());
     }
 
@@ -787,7 +787,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setPanelFillerMaterial(org.bukkit.Material)}.
      */
     @Test
-    public void testSetPanelFillerMaterial() {
+    void testSetPanelFillerMaterial() {
         assertEquals(Material.LIGHT_BLUE_STAINED_GLASS_PANE, s.getPanelFillerMaterial());
         s.setPanelFillerMaterial(Material.ACACIA_BOAT);
         assertEquals(Material.ACACIA_BOAT, s.getPanelFillerMaterial());
@@ -798,7 +798,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#getPlayerHeadCacheTime()}.
      */
     @Test
-    public void testGetPlayerHeadCacheTime() {
+    void testGetPlayerHeadCacheTime() {
         assertEquals(60L, s.getPlayerHeadCacheTime());
     }
 
@@ -807,7 +807,7 @@ public class SettingsTest {
      * {@link world.bentobox.bentobox.Settings#setPlayerHeadCacheTime(long)}.
      */
     @Test
-    public void testSetPlayerHeadCacheTime() {
+    void testSetPlayerHeadCacheTime() {
         assertEquals(60L, s.getPlayerHeadCacheTime());
         s.setPlayerHeadCacheTime(0L);
         assertEquals(0L, s.getPlayerHeadCacheTime());

--- a/src/test/java/world/bentobox/bentobox/TestBentoBox.java
+++ b/src/test/java/world/bentobox/bentobox/TestBentoBox.java
@@ -53,7 +53,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
-public class TestBentoBox extends CommonTestSetup {
+class TestBentoBox extends CommonTestSetup {
     private static final UUID MEMBER_UUID = UUID.randomUUID();
     private static final UUID VISITOR_UUID = UUID.randomUUID();
     @Mock
@@ -117,7 +117,7 @@ public class TestBentoBox extends CommonTestSetup {
     }
 
     @Test
-    public void testIslandEvent() {
+    void testIslandEvent() {
         // Test island events
         IslandBaseEvent event = TeamEvent.builder()
                 //.island(getIslands().getIsland(playerUUID))
@@ -128,7 +128,7 @@ public class TestBentoBox extends CommonTestSetup {
     }
 
     @Test
-    public void testCommandAPI() {
+    void testCommandAPI() {
         // Test command
         User user = User.getInstance(uuid);
         CompositeCommand testCommand = new TestCommand();
@@ -309,7 +309,7 @@ public class TestBentoBox extends CommonTestSetup {
 
     // Protection tests
     @Test
-    public void testProtection() {
+    void testProtection() {
         User owner = User.getInstance(uuid);
         Island island = new Island();
         island.setOwner(uuid);
@@ -407,7 +407,7 @@ public class TestBentoBox extends CommonTestSetup {
     }
 
     @Test
-    public void testEventProtection() {
+    void testEventProtection() {
         // Test events
 
         TestFlagListener fl = new TestFlagListener(plugin);
@@ -427,7 +427,7 @@ public class TestBentoBox extends CommonTestSetup {
     }
 
     @Test
-    public void testDefaultFlags() {
+    void testDefaultFlags() {
         // Check all the default flags
         FlagsManager fm = new FlagsManager(plugin);
         Collection<Flag> defaultFlags = Flags.values();
@@ -441,7 +441,7 @@ public class TestBentoBox extends CommonTestSetup {
     }
 
     @Test
-    public void testCustomFlags() {
+    void testCustomFlags() {
         // Custom
         TestFlagListener fl = new TestFlagListener(plugin);
         Flag customFlag = new Flag.Builder("CUSTOM_FLAG", Material.DIAMOND).listener(fl).build();

--- a/src/test/java/world/bentobox/bentobox/WhiteBox.java
+++ b/src/test/java/world/bentobox/bentobox/WhiteBox.java
@@ -1,6 +1,6 @@
 package world.bentobox.bentobox;
 
-public class WhiteBox {
+class WhiteBox {
     /**
      * Sets the value of a private static field using Java Reflection.
      * @param targetClass The class containing the static field.

--- a/src/test/java/world/bentobox/bentobox/api/addons/AddonClassLoaderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/addons/AddonClassLoaderTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.managers.AddonsManager;
  * @author tastybento
  *
  */
-public class AddonClassLoaderTest extends CommonTestSetup {
+class AddonClassLoaderTest extends CommonTestSetup {
 
     private enum mandatoryTags {
         MAIN,
@@ -170,7 +170,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * @throws Exception 
      */
     @AfterEach
-    public void TearDown() throws Exception {
+    void TearDown() throws Exception {
         super.tearDown();
         Files.deleteIfExists(jarFile.toPath());
         if (dataFolder.exists()) {
@@ -194,7 +194,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#AddonClassLoader(world.bentobox.bentobox.managers.AddonsManager, org.bukkit.configuration.file.YamlConfiguration, java.io.File, java.lang.ClassLoader)}.
      */
     @Test
-    public void testAddonClassLoader() throws MalformedURLException {
+    void testAddonClassLoader() throws MalformedURLException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
     }
 
@@ -202,7 +202,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#asDescription(org.bukkit.configuration.file.YamlConfiguration)}.
      */
     @Test
-    public void testAsDescription() throws InvalidAddonDescriptionException {
+    void testAsDescription() throws InvalidAddonDescriptionException {
         YamlConfiguration yml = this.getYaml(List.of());
         @NonNull
         AddonDescription desc = AddonClassLoader.asDescription(yml);
@@ -225,7 +225,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#asDescription(org.bukkit.configuration.file.YamlConfiguration)}.
      */
     @Test
-    public void testAsDescriptionNoName() {
+    void testAsDescriptionNoName() {
         YamlConfiguration yml = this.getYaml(List.of(mandatoryTags.NAME));
         try {
             AddonClassLoader.asDescription(yml);
@@ -238,7 +238,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#asDescription(org.bukkit.configuration.file.YamlConfiguration)}.
      */
     @Test
-    public void testAsDescriptionNoAuthors() {
+    void testAsDescriptionNoAuthors() {
         YamlConfiguration yml = this.getYaml(List.of(mandatoryTags.AUTHORS));
         try {
             AddonClassLoader.asDescription(yml);
@@ -251,7 +251,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#asDescription(org.bukkit.configuration.file.YamlConfiguration)}.
      */
     @Test
-    public void testAsDescriptionNoVersion() {
+    void testAsDescriptionNoVersion() {
         YamlConfiguration yml = this.getYaml(List.of(mandatoryTags.VERSION));
         try {
             AddonClassLoader.asDescription(yml);
@@ -264,7 +264,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#asDescription(org.bukkit.configuration.file.YamlConfiguration)}.
      */
     @Test
-    public void testAsDescriptionNoMain() {
+    void testAsDescriptionNoMain() {
         YamlConfiguration yml = this.getYaml(List.of(mandatoryTags.MAIN));
         try {
             AddonClassLoader.asDescription(yml);
@@ -277,7 +277,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#asDescription(org.bukkit.configuration.file.YamlConfiguration)}.
      */
     @Test
-    public void testAsDescriptionUnknownIconMaterial() {
+    void testAsDescriptionUnknownIconMaterial() {
         YamlConfiguration yml = this.getYaml(List.of(mandatoryTags.ICON));
         try {
             AddonClassLoader.asDescription(yml);
@@ -290,7 +290,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#findClass(java.lang.String)}.
      */
     @Test
-    public void testFindClassString() throws IOException {
+    void testFindClassString() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         assertNull(acl.findClass(""));
         assertNull(acl.findClass("world.bentobox.bentobox"));
@@ -301,7 +301,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#findClass(java.lang.String, boolean)}.
      */
     @Test
-    public void testFindClassStringBoolean() throws IOException {
+    void testFindClassStringBoolean() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         assertNull(acl.findClass("", false));
         assertNull(acl.findClass("world.bentobox.bentobox", false));
@@ -312,7 +312,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#getAddon()}.
      */
     @Test
-    public void testGetAddon() throws IOException {
+    void testGetAddon() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         Addon addon = acl.getAddon();
         assertSame(testAddon, addon);
@@ -323,7 +323,7 @@ public class AddonClassLoaderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonClassLoader#getClasses()}.
      */
     @Test
-    public void testGetClasses() throws IOException {
+    void testGetClasses() throws IOException {
         acl = new AddonClassLoader(testAddon, am, jarFile);
         Set<String> set = acl.getClasses();
         assertTrue(set.isEmpty());

--- a/src/test/java/world/bentobox/bentobox/api/addons/AddonDescriptionTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/addons/AddonDescriptionTest.java
@@ -18,13 +18,13 @@ import org.junit.jupiter.api.Test;
  *
  */
 
-public class AddonDescriptionTest {
+class AddonDescriptionTest {
 
     private @NonNull AddonDescription ad;
     private ConfigurationSection configSec;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         configSec = new YamlConfiguration();
         ad = new AddonDescription.Builder("main", "name", "version")
                 .apiVersion("api")
@@ -43,7 +43,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getName()}.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("name", ad.getName());
     }
 
@@ -51,7 +51,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getMain()}.
      */
     @Test
-    public void testGetMain() {
+    void testGetMain() {
         assertEquals("main", ad.getMain());
     }
 
@@ -59,7 +59,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getVersion()}.
      */
     @Test
-    public void testGetVersion() {
+    void testGetVersion() {
         assertEquals("version", ad.getVersion());
     }
 
@@ -67,7 +67,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getDescription()}.
      */
     @Test
-    public void testGetDescription() {
+    void testGetDescription() {
         assertEquals("description", ad.getDescription());
     }
 
@@ -75,7 +75,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getAuthors()}.
      */
     @Test
-    public void testGetAuthors() {
+    void testGetAuthors() {
         assertEquals("tastybento", ad.getAuthors().getFirst());
     }
 
@@ -83,7 +83,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getDependencies()}.
      */
     @Test
-    public void testGetDependencies() {
+    void testGetDependencies() {
         assertEquals("dep1", ad.getDependencies().getFirst());
     }
 
@@ -91,7 +91,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getSoftDependencies()}.
      */
     @Test
-    public void testGetSoftDependencies() {
+    void testGetSoftDependencies() {
         assertEquals("sdep1", ad.getSoftDependencies().getFirst());
     }
 
@@ -99,7 +99,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#isMetrics()}.
      */
     @Test
-    public void testIsMetrics() {
+    void testIsMetrics() {
         assertTrue(ad.isMetrics());
     }
 
@@ -107,7 +107,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getRepository()}.
      */
     @Test
-    public void testGetRepository() {
+    void testGetRepository() {
         assertEquals("repo", ad.getRepository());
     }
 
@@ -115,7 +115,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getIcon()}.
      */
     @Test
-    public void testGetIcon() {
+    void testGetIcon() {
         assertEquals(Material.ACACIA_BOAT, ad.getIcon());
     }
 
@@ -123,7 +123,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getApiVersion()}.
      */
     @Test
-    public void testGetApiVersion() {
+    void testGetApiVersion() {
         assertEquals("api", ad.getApiVersion());
     }
 
@@ -131,7 +131,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#getPermissions()}.
      */
     @Test
-    public void testGetPermissions() {
+    void testGetPermissions() {
         assertEquals(configSec, ad.getPermissions());
     }
 
@@ -139,7 +139,7 @@ public class AddonDescriptionTest {
      * Test method for {@link world.bentobox.bentobox.api.addons.AddonDescription#toString()}.
      */
     @Test
-    public void testToString() {
+    void testToString() {
         assertEquals("AddonDescription [name=name, version=version]", ad.toString());
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/addons/AddonTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/addons/AddonTest.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.managers.AddonsManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 
-public class AddonTest extends CommonTestSetup {
+class AddonTest extends CommonTestSetup {
 
     public static int BUFFER_SIZE = 10240;
 
@@ -90,7 +90,7 @@ public class AddonTest extends CommonTestSetup {
     }
 
     @AfterEach
-    public void TearDown() throws Exception {
+    void TearDown() throws Exception {
         super.tearDown();
         Files.deleteIfExists(jarFile.toPath());
         if (dataFolder.exists()) {
@@ -110,29 +110,29 @@ public class AddonTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddon() {
+    void testAddon() {
         assertNotNull(test);
         assertFalse(test.isEnabled());
     }
 
     @Test
-    public void testGetPlugin() {
+    void testGetPlugin() {
         assertSame(plugin, test.getPlugin());
     }
 
     @Test
-    public void testGetConfig() {
+    void testGetConfig() {
         // No config file
         assertNull(test.getConfig());
     }
 
     @Test
-    public void testGetDataFolder() {
+    void testGetDataFolder() {
         assertEquals(dataFolder, test.getDataFolder());
     }
 
     @Test
-    public void testGetDescription() {
+    void testGetDescription() {
         AddonDescription d = new AddonDescription.Builder("main", "name", "1.0").build();
         assertNull(test.getDescription());
         test.setDescription(d);
@@ -140,27 +140,27 @@ public class AddonTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetFile() {
+    void testGetFile() {
         assertEquals(jarFile, test.getFile());
     }
 
     @Test
-    public void testGetLogger() {
+    void testGetLogger() {
         assertEquals(plugin.getLogger(), test.getLogger());
     }
 
     @Test
-    public void testGetServer() {
+    void testGetServer() {
         assertEquals(server, test.getServer());
     }
 
     @Test
-    public void testIsEnabled() {
+    void testIsEnabled() {
         assertFalse(test.isEnabled());
     }
 
     @Test
-    public void testRegisterListener() {
+    void testRegisterListener() {
         class TestListener implements Listener {}
         TestListener listener = new TestListener();
         test.registerListener(listener);
@@ -168,7 +168,7 @@ public class AddonTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSaveDefaultConfig() {
+    void testSaveDefaultConfig() {
         test.saveDefaultConfig();
         File testConfig = new File(dataFolder, "config.yml");
         assertTrue(testConfig.exists());
@@ -194,38 +194,38 @@ public class AddonTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetResource() {
+    void testGetResource() {
         assertNull(test.getResource("nothing"));
     }
 
     @Test
-    public void testGetResourceSomething() {
+    void testGetResourceSomething() {
         assertNotNull(test.getResource("addon.yml"));
     }
 
     @Test
-    public void testSetAddonFile() {
+    void testSetAddonFile() {
         File af = new File("af");
         test.setFile(af);
         assertEquals(af, test.getFile());
     }
 
     @Test
-    public void testSetDataFolder() {
+    void testSetDataFolder() {
         File df = new File("df");
         test.setDataFolder(df);
         assertEquals(df, test.getDataFolder());
     }
 
     @Test
-    public void testSetDescription() {
+    void testSetDescription() {
         AddonDescription desc = new AddonDescription.Builder("main", "name", "2.0").build();
         test.setDescription(desc);
         assertEquals(desc, test.getDescription());
     }
 
     @Test
-    public void testSetEnabled() {
+    void testSetEnabled() {
         test.setState(Addon.State.DISABLED);
         assertFalse(test.isEnabled());
         test.setState(Addon.State.ENABLED);
@@ -233,21 +233,21 @@ public class AddonTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetPlayers() {
+    void testGetPlayers() {
         PlayersManager pm = mock(PlayersManager.class);
         when(plugin.getPlayers()).thenReturn(pm);
         assertEquals(pm, test.getPlayers());
     }
 
     @Test
-    public void testGetIslands() {
+    void testGetIslands() {
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
         assertSame(im, test.getIslands());
     }
 
     @Test
-    public void testGetAddonByName() {
+    void testGetAddonByName() {
         AddonsManager am = new AddonsManager(plugin);
         when(plugin.getAddonsManager()).thenReturn(am);
         assertEquals(Optional.empty(),test.getAddonByName("addon"));

--- a/src/test/java/world/bentobox/bentobox/api/commands/DefaultHelpCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/DefaultHelpCommandTest.java
@@ -27,7 +27,7 @@ import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.IslandWorldManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 
-public class DefaultHelpCommandTest extends CommonTestSetup {
+class DefaultHelpCommandTest extends CommonTestSetup {
 
     private User user;
 
@@ -105,7 +105,7 @@ public class DefaultHelpCommandTest extends CommonTestSetup {
      * Test for {@link DefaultHelpCommand}
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         CompositeCommand cc = mock(CompositeCommand.class);
         DefaultHelpCommand dhc = new DefaultHelpCommand(cc);
         assertNotNull(dhc);
@@ -119,7 +119,7 @@ public class DefaultHelpCommandTest extends CommonTestSetup {
      * Test for {@link DefaultHelpCommand#execute(User, String, List)}
      */
     @Test
-    public void testExecuteUserListOfString() {
+    void testExecuteUserListOfString() {
         CompositeCommand parent = mock(CompositeCommand.class);
         when(parent.getLabel()).thenReturn("island");
         when(parent.getUsage()).thenReturn("island");
@@ -143,7 +143,7 @@ public class DefaultHelpCommandTest extends CommonTestSetup {
      * Test for {@link DefaultHelpCommand#execute(User, String, List)}
      */
     @Test
-    public void testExecuteSecondLevelHelp() {
+    void testExecuteSecondLevelHelp() {
         CompositeCommand parent = mock(CompositeCommand.class);
         when(parent.getLabel()).thenReturn("island");
         when(parent.getUsage()).thenReturn("island");
@@ -165,7 +165,7 @@ public class DefaultHelpCommandTest extends CommonTestSetup {
      * Test for {@link DefaultHelpCommand#execute(User, String, List)}
      */
     @Test
-    public void testExecuteDirectHelpHelp() {
+    void testExecuteDirectHelpHelp() {
         CompositeCommand parent = mock(CompositeCommand.class);
         when(parent.getLabel()).thenReturn("island");
         when(parent.getUsage()).thenReturn("island");

--- a/src/test/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommandTest.java
@@ -37,7 +37,7 @@ import world.bentobox.bentobox.managers.PlaceholdersManager;
  * @author tastybento
  *
  */
-public class DelayedTeleportCommandTest extends CommonTestSetup {
+class DelayedTeleportCommandTest extends CommonTestSetup {
 
     private static final String HELLO = "hello";
 
@@ -142,7 +142,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#onPlayerMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnPlayerMoveNoCooldown() {
+    void testOnPlayerMoveNoCooldown() {
         PlayerMoveEvent e = new PlayerMoveEvent(player, from, to);
         dtc.onPlayerMove(e);
         verify(notifier, never()).notify(any(), anyString());
@@ -152,7 +152,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#onPlayerMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnPlayerMoveCommandCancelled() {
+    void testOnPlayerMoveCommandCancelled() {
         testDelayCommandUserStringRunnableStandStill();
         PlayerMoveEvent e = new PlayerMoveEvent(player, from, to);
         dtc.onPlayerMove(e);
@@ -163,7 +163,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#onPlayerMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnPlayerMoveHeadMove() {
+    void testOnPlayerMoveHeadMove() {
         testDelayCommandUserStringRunnableStandStill();
         PlayerMoveEvent e = new PlayerMoveEvent(player, from, from);
         dtc.onPlayerMove(e);
@@ -174,7 +174,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#onPlayerMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnPlayerTeleport() {
+    void testOnPlayerTeleport() {
         testDelayCommandUserStringRunnableStandStill();
         PlayerTeleportEvent e = new PlayerTeleportEvent(player, from, to);
         dtc.onPlayerTeleport(e);
@@ -185,7 +185,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#DelayedTeleportCommand(world.bentobox.bentobox.api.addons.Addon, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testDelayedTeleportCommandAddonStringStringArray() {
+    void testDelayedTeleportCommandAddonStringStringArray() {
         verify(pim).registerEvents(dtc, plugin);
     }
 
@@ -193,7 +193,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#delayCommand(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.Runnable)}.
      */
     @Test
-    public void testDelayCommandUserStringRunnableZeroDelay() {
+    void testDelayCommandUserStringRunnableZeroDelay() {
         when(settings.getDelayTime()).thenReturn(0);
         dtc.delayCommand(user, HELLO, command);
         verify(sch).runTask(plugin, command);
@@ -203,7 +203,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#delayCommand(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.Runnable)}.
      */
     @Test
-    public void testDelayCommandUserStringRunnableOp() {
+    void testDelayCommandUserStringRunnableOp() {
         when(user.isOp()).thenReturn(true);
         dtc.delayCommand(user, HELLO, command);
         verify(sch).runTask(plugin, command);
@@ -213,7 +213,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#delayCommand(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.Runnable)}.
      */
     @Test
-    public void testDelayCommandUserStringRunnablePermBypassCooldowns() {
+    void testDelayCommandUserStringRunnablePermBypassCooldowns() {
         when(user.hasPermission("nullmod.bypasscooldowns")).thenReturn(true);
         dtc.delayCommand(user, HELLO, command);
         verify(sch).runTask(plugin, command);
@@ -223,7 +223,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#delayCommand(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.Runnable)}.
      */
     @Test
-    public void testDelayCommandUserStringRunnablePermBypassDelay() {
+    void testDelayCommandUserStringRunnablePermBypassDelay() {
         when(user.hasPermission("nullmod.bypassdelays")).thenReturn(true);
         dtc.delayCommand(user, HELLO, command);
         verify(sch).runTask(plugin, command);
@@ -233,7 +233,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#delayCommand(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.Runnable)}.
      */
     @Test
-    public void testDelayCommandUserStringRunnableStandStill() {
+    void testDelayCommandUserStringRunnableStandStill() {
         dtc.delayCommand(user, HELLO, command);
         verify(sch, never()).runTask(plugin, command);
         verify(user).sendRawMessage(HELLO);
@@ -246,7 +246,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#delayCommand(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.Runnable)}.
      */
     @Test
-    public void testDelayCommandUserStringRunnableStandStillDuplicate() {
+    void testDelayCommandUserStringRunnableStandStillDuplicate() {
         dtc.delayCommand(user, HELLO, command);
         dtc.delayCommand(user, HELLO, command);
         verify(user).sendMessage("commands.delay.previous-command-cancelled");
@@ -257,7 +257,7 @@ public class DelayedTeleportCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.DelayedTeleportCommand#delayCommand(world.bentobox.bentobox.api.user.User, java.lang.Runnable)}.
      */
     @Test
-    public void testDelayCommandUserRunnable() {
+    void testDelayCommandUserRunnable() {
         dtc.delayCommand(user, command);
         verify(sch, never()).runTask(plugin, command);
         verify(user, never()).sendRawMessage(anyString());

--- a/src/test/java/world/bentobox/bentobox/api/commands/HiddenCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/HiddenCommandTest.java
@@ -29,7 +29,7 @@ import world.bentobox.bentobox.managers.CommandsManager;
  * @author tastybento
  *
  */
-public class HiddenCommandTest extends CommonTestSetup {
+class HiddenCommandTest extends CommonTestSetup {
 
     @Mock
     private User user;
@@ -56,7 +56,7 @@ public class HiddenCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.CompositeCommand#tabComplete(org.bukkit.command.CommandSender, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testTabCompleteCommandSenderStringStringArrayVisible() {
+    void testTabCompleteCommandSenderStringStringArrayVisible() {
         TopLevelCommand tlc = new TopLevelCommand();
         CommandSender sender = mock(CommandSender.class);
         String[] args = {"v"};
@@ -69,7 +69,7 @@ public class HiddenCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.CompositeCommand#tabComplete(org.bukkit.command.CommandSender, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testTabCompleteCommandSenderStringStringArrayHidden() {
+    void testTabCompleteCommandSenderStringStringArrayHidden() {
         TopLevelCommand tlc = new TopLevelCommand();
         CommandSender sender = mock(CommandSender.class);
         String[] args = {"h"};
@@ -83,7 +83,7 @@ public class HiddenCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.CompositeCommand#tabComplete(Player, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testTabCompletePlayerStringStringArrayHidden() {
+    void testTabCompletePlayerStringStringArrayHidden() {
         TopLevelCommand tlc = new TopLevelCommand();
         Player sender = mock(Player.class);
         String[] args = {"h"};
@@ -97,7 +97,7 @@ public class HiddenCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.CompositeCommand#tabComplete(org.bukkit.command.CommandSender, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testTabCompleteCommandSenderStringStringArrayInvisible() {
+    void testTabCompleteCommandSenderStringStringArrayInvisible() {
         TopLevelCommand tlc = new TopLevelCommand();
         Player sender = mock(Player.class);
         String[] args = {"i"};
@@ -109,7 +109,7 @@ public class HiddenCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.CompositeCommand#showHelp(world.bentobox.bentobox.api.commands.CompositeCommand, world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testShowHelp() {
+    void testShowHelp() {
         // Only the visible command should show in help
         TopLevelCommand tlc = new TopLevelCommand();
         tlc.showHelp(tlc, user);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminDeleteCommandTest extends CommonTestSetup {
+class AdminDeleteCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -122,7 +122,7 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
      * {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
-    public void testExecuteNoTarget() {
+    void testExecuteNoTarget() {
         AdminDeleteCommand itl = new AdminDeleteCommand(ac);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
         // Show help
@@ -133,7 +133,7 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
      * {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         AdminDeleteCommand itl = new AdminDeleteCommand(ac);
         String[] name = { "tastybento" };
         when(pm.getUUID(any())).thenReturn(null);
@@ -146,7 +146,7 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
      * {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
-    public void testExecutePlayerNoIsland() {
+    void testExecutePlayerNoIsland() {
         AdminDeleteCommand itl = new AdminDeleteCommand(ac);
         when(pm.getUUID(any())).thenReturn(notUUID);
         when(im.hasIsland(world, notUUID)).thenReturn(false);
@@ -159,7 +159,7 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
-    public void testExecuteOwner() {
+    void testExecuteOwner() {
         when(im.hasIsland(world, notUUID)).thenReturn(true);
         when(im.inTeam(world, notUUID)).thenReturn(true);
         when(island.getOwner()).thenReturn(notUUID);
@@ -174,7 +174,7 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
-    public void testcanExecuteSuccessUUID() {
+    void testcanExecuteSuccessUUID() {
         when(im.hasIsland(world, uuid)).thenReturn(true);
         when(island.hasTeam()).thenReturn(false);
         when(im.inTeam(any(), any())).thenReturn(false);
@@ -195,7 +195,7 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)
      */
     @Test
-    public void testExecuteFailUUID() {
+    void testExecuteFailUUID() {
         when(im.inTeam(any(), any())).thenReturn(false);
         Island is = mock(Island.class);
         Location loc = mock(Location.class);
@@ -214,7 +214,7 @@ public class AdminDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link AdminDeleteCommand#execute(User, String, java.util.List)
      */
     @Test
-    public void testCanExecuteSuccess() {
+    void testCanExecuteSuccess() {
         when(island.hasTeam()).thenReturn(false);
         when(im.inTeam(any(), any())).thenReturn(false);
         Island is = mock(Island.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminGetrankCommandTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminGetrankCommandTest extends CommonTestSetup {
+class AdminGetrankCommandTest extends CommonTestSetup {
 
     private static final String[] NAMES = {"adam", "ben", "cara", "dave", "ed", "frank", "freddy", "george", "harry", "ian", "joe"};
 
@@ -108,7 +108,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#AdminGetrankCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testAdminGetrankCommand() {
+    void testAdminGetrankCommand() {
         assertEquals("getrank", c.getLabel());
     }
 
@@ -116,7 +116,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("admin.getrank", c.getPermission());
         assertFalse(c.isOnlyPlayer());
         assertEquals("commands.admin.getrank.parameters", c.getParameters());
@@ -128,7 +128,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoArgs() {
+    void testCanExecuteNoArgs() {
         assertFalse(c.canExecute(user, "", Collections.emptyList()));
         verify(user).getTranslation("commands.help.console");
     }
@@ -137,7 +137,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         assertFalse(c.canExecute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player",
                 "[name]",
@@ -148,7 +148,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteKnownPlayerNoIsland() {
+    void testCanExecuteKnownPlayerNoIsland() {
         when(pm.getUUID(any())).thenReturn(targetUUID);
         assertFalse(c.canExecute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
@@ -158,7 +158,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteKnownPlayerHasIslandSuccess() {
+    void testCanExecuteKnownPlayerHasIslandSuccess() {
         when(pm.getUUID(any())).thenReturn(targetUUID);
         when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
         when(user.getTranslation(anyString())).thenReturn("member");
@@ -171,7 +171,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         // Set the target
         testCanExecuteKnownPlayerHasIslandSuccess();
         when(island.getRank(any(User.class))).thenReturn(RanksManager.SUB_OWNER_RANK);
@@ -190,7 +190,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringNoChars() {
+    void testTabCompleteUserStringListOfStringNoChars() {
         Optional<List<String>> result = c.tabComplete(user, "", Collections.emptyList());
         assertFalse(result.isPresent());
     }
@@ -199,7 +199,7 @@ public class AdminGetrankCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminGetrankCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringWithChars() {
+    void testTabCompleteUserStringListOfStringWithChars() {
         Optional<List<String>> result = c.tabComplete(user, "", Collections.singletonList("g"));
         assertTrue(result.isPresent());
         result.ifPresent(list -> assertEquals(1, list.size()));

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminInfoCommandTest extends RanksManagerTestSetup {
+class AdminInfoCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -112,7 +112,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("mod.info", iic.getPermission());
         assertFalse(iic.isOnlyPlayer());
         assertEquals("commands.admin.info.parameters", iic.getParameters());
@@ -123,7 +123,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringTooManyArgs() {
+    void testExecuteUserStringListOfStringTooManyArgs() {
         assertFalse(iic.execute(user, "", Arrays.asList("hdhh", "hdhdhd")));
         verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
     }
@@ -132,7 +132,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoArgsConsole() {
+    void testExecuteUserStringListOfStringNoArgsConsole() {
         CommandSender console = mock(CommandSender.class);
         when(console.spigot()).thenReturn(spigot);
         User sender = User.getInstance(console);
@@ -144,7 +144,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoArgsNoIsland() {
+    void testExecuteUserStringListOfStringNoArgsNoIsland() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         assertTrue(iic.execute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.admin.info.no-island");
@@ -154,7 +154,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoArgsSuccess() {
+    void testExecuteUserStringListOfStringNoArgsSuccess() {
         assertTrue(iic.execute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.admin.info.title");
         verify(user).sendMessage(eq("commands.admin.info.island-uuid"), eq("[uuid]"), any());
@@ -176,7 +176,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringArgsSuccess() {
+    void testExecuteUserStringListOfStringArgsSuccess() {
         assertTrue(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("commands.admin.info.title");
         verify(user).sendMessage(eq("commands.admin.info.island-uuid"), eq("[uuid]"), any());
@@ -199,7 +199,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringArgsNoIsland() {
+    void testExecuteUserStringListOfStringArgsNoIsland() {
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
@@ -209,7 +209,7 @@ public class AdminInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringArgsUnknownPlayer() {
+    void testExecuteUserStringListOfStringArgsUnknownPlayer() {
         mockedUtil.when(() -> Util.getUUID(any())).thenReturn(null);
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminMaxHomesCommandTest.java
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.util.Util;
 /**
  * @author tastybento
  */
-public class AdminMaxHomesCommandTest extends CommonTestSetup {
+class AdminMaxHomesCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -143,7 +143,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsIsEmpty() {
+    void testArgsIsEmpty() {
         // Arrange: args is already empty
 
         // Act
@@ -159,7 +159,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSize1_UserNotPlayer() {
+    void testArgsSize1_UserNotPlayer() {
         // Arrange
         args.add("5");
         when(user.isPlayer()).thenReturn(false);
@@ -176,7 +176,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSize1_WrongWorld() {
+    void testArgsSize1_WrongWorld() {
         // Arrange
         args.add("5");
         when(user.isPlayer()).thenReturn(true);
@@ -197,7 +197,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSize1_InvalidMaxHomes() {
+    void testArgsSize1_InvalidMaxHomes() {
         // Arrange
         args.add("notanumber");
         when(user.isPlayer()).thenReturn(true);
@@ -217,7 +217,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSize1_UserNotOnIsland() {
+    void testArgsSize1_UserNotOnIsland() {
         // Arrange
         args.add("5");
         when(user.isPlayer()).thenReturn(true);
@@ -242,7 +242,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSize1_Success() {
+    void testArgsSize1_Success() {
         // Arrange
         args.add("5");
         when(user.isPlayer()).thenReturn(true);
@@ -267,7 +267,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSizeGreaterThan1_InvalidPlayer() {
+    void testArgsSizeGreaterThan1_InvalidPlayer() {
         // Arrange
         args.add("UnknownPlayer");
         args.add("5");
@@ -286,7 +286,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSizeGreaterThan1_InvalidMaxHomes() {
+    void testArgsSizeGreaterThan1_InvalidMaxHomes() {
         // Arrange
         args.add("ValidPlayer");
         args.add("notanumber");
@@ -306,7 +306,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSizeGreaterThan1_TargetPlayerHasNoIslands() {
+    void testArgsSizeGreaterThan1_TargetPlayerHasNoIslands() {
         // Arrange
         args.add("ValidPlayer");
         args.add("5");
@@ -332,7 +332,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSizeGreaterThan2_UnknownIsland() {
+    void testArgsSizeGreaterThan2_UnknownIsland() {
         // Arrange
         args.add("ValidPlayer");
         args.add("5");
@@ -362,7 +362,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSizeGreaterThan1_Success() {
+    void testArgsSizeGreaterThan1_Success() {
         // Arrange
         args.add("ValidPlayer");
         args.add("5");
@@ -390,7 +390,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("mod.maxhomes", instance.getPermission());
         assertFalse(instance.isOnlyPlayer());
         assertEquals("commands.admin.maxhomes.parameters", instance.getParameters());
@@ -402,7 +402,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabComplete_ArgsSize2_ReturnsPlayerNames() {
+    void testTabComplete_ArgsSize2_ReturnsPlayerNames() {
         // Arrange
         args.add("someArg"); // args.size() == 1
         args.add(""); // args.size() == 2
@@ -423,7 +423,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabComplete_ArgsSizeGreaterThan3_ReturnsIslandNames() {
+    void testTabComplete_ArgsSizeGreaterThan3_ReturnsIslandNames() {
         // Arrange
         args.add("someArg");
         args.add("anotherArg");
@@ -456,7 +456,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabComplete_Otherwise_ReturnsListOfOne() {
+    void testTabComplete_Otherwise_ReturnsListOfOne() {
         // Arrange
         args.add(""); // args.size() == 1
 
@@ -472,7 +472,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabComplete_ArgsSize3_ReturnsListOfOne() {
+    void testTabComplete_ArgsSize3_ReturnsListOfOne() {
         // Arrange
         args.add("someArg");
         args.add("anotherArg");
@@ -490,7 +490,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteWithEmptyIslands_ShouldReturnFalse() {
+    void testExecuteWithEmptyIslands_ShouldReturnFalse() {
         // Arrange
         instance.maxHomes = 5; // Set maxHomes to a valid number
         instance.islands = new HashMap<>(); // Empty islands map
@@ -506,7 +506,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteWithMaxHomesLessThanOne_ShouldReturnFalse() {
+    void testExecuteWithMaxHomesLessThanOne_ShouldReturnFalse() {
         // Arrange
         instance.maxHomes = 0; // Invalid maxHomes
         Island island = mock(Island.class);
@@ -526,7 +526,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessful_SingleIsland() {
+    void testExecuteSuccessful_SingleIsland() {
         // Arrange
         instance.maxHomes = 5;
         Island island = mock(Island.class);
@@ -549,7 +549,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessful_MultipleIslands() {
+    void testExecuteSuccessful_MultipleIslands() {
         // Arrange
         instance.maxHomes = 3;
         Island island1 = mock(Island.class);
@@ -577,7 +577,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteAfterSuccessfulCanExecute() {
+    void testExecuteAfterSuccessfulCanExecute() {
         // Arrange
         args.add("5");
         when(user.isPlayer()).thenReturn(true);
@@ -607,7 +607,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteWithInvalidMaxHomesAfterCanExecute() {
+    void testExecuteWithInvalidMaxHomesAfterCanExecute() {
         // Arrange
         args.add("-1");
         when(user.isPlayer()).thenReturn(true);
@@ -629,7 +629,7 @@ public class AdminMaxHomesCommandTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: IslandGoCommand.getNameIslandMap static mock integration fails during map retrieval")
-    public void testExecuteWithMultipleIslandsAfterCanExecute() {
+    void testExecuteWithMultipleIslandsAfterCanExecute() {
         // Arrange
         args.add("ValidPlayer");
         args.add("4");

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -44,7 +44,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminRegisterCommandTest extends CommonTestSetup {
+class AdminRegisterCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -139,7 +139,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testCanExecuteNoTarget() {
+    void testCanExecuteNoTarget() {
         assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
     }
@@ -149,7 +149,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testCanExecuteWrongWorld() {
+    void testCanExecuteWrongWorld() {
         when(user.getWorld()).thenReturn(mock(World.class));
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).sendMessage("general.errors.wrong-world");
@@ -160,7 +160,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento2")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "tastybento2");
@@ -171,7 +171,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testCanExecuteNoIsland() {
+    void testCanExecuteNoIsland() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).getTranslation("commands.admin.register.no-island-here");
@@ -182,7 +182,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testCanExecuteAlreadyOwnedIsland() {
+    void testCanExecuteAlreadyOwnedIsland() {
         when(im.inTeam(any(), any())).thenReturn(false);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(pm.getUUID(any())).thenReturn(notUUID);
@@ -204,7 +204,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testCanExecuteInDeletionIsland() {
+    void testCanExecuteInDeletionIsland() {
         when(idm.inDeletion(any())).thenReturn(true);
         when(im.inTeam(any(), any())).thenReturn(false);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
@@ -225,7 +225,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
      */
     @Test
-    public void testCanExecuteSuccess() {
+    void testCanExecuteSuccess() {
         when(location.toVector()).thenReturn(new Vector(123,123,432));
         when(island.getCenter()).thenReturn(location);
         when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
@@ -241,7 +241,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminRegisterCommand#register(User, String)}.
      */
     @Test
-    public void testRegister() {
+    void testRegister() {
         testCanExecuteSuccess();
         when(island.isSpawn()).thenReturn(true);
         itl.register(user, "tastybento");
@@ -256,7 +256,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminRegisterCommand#reserve(User, String)}.
      */
     @Test
-    public void testReserveCannotMakeIsland() {
+    void testReserveCannotMakeIsland() {
         when(im.createIsland(any(), eq(uuid))).thenReturn(null);
         testCanExecuteNoIsland();
         itl.reserve(user, "tastybento");
@@ -268,7 +268,7 @@ public class AdminRegisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminRegisterCommand#reserve(User, String)}.
      */
     @Test
-    public void testReserveCanMakeIsland() {
+    void testReserveCanMakeIsland() {
         testCanExecuteNoIsland();
         itl.reserve(user, "tastybento");
         verify(im).createIsland(any(), eq(uuid));

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetFlagsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetFlagsCommandTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class AdminResetFlagsCommandTest extends CommonTestSetup {
+class AdminResetFlagsCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -125,7 +125,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#AdminResetFlagsCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testAdminResetFlagsCommand() {
+    void testAdminResetFlagsCommand() {
         assertEquals("resetflags", arf.getLabel());
     }
 
@@ -133,7 +133,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertFalse(arf.isOnlyPlayer());
         assertEquals("bskyblock.admin.resetflags", arf.getPermission());
         assertEquals("commands.admin.resetflags.parameters", arf.getParameters());
@@ -144,7 +144,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringTwoArgs() {
+    void testExecuteUserStringListOfStringTwoArgs() {
         List<String> args = Arrays.asList("sdfsd", "werwerw");
         assertFalse(arf.execute(user, "", args));
         checkSpigotMessage("commands.help.header");
@@ -154,7 +154,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringOneArgNotFlag() {
+    void testExecuteUserStringListOfStringOneArgNotFlag() {
         assertFalse(arf.execute(user, "", Collections.singletonList("FLAG3")));
         checkSpigotMessage("commands.help.header");
     }
@@ -163,7 +163,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringOneArgFlag2() {
+    void testExecuteUserStringListOfStringOneArgFlag2() {
         assertTrue(arf.execute(user, "", Collections.singletonList("FLAG2")));
     }
 
@@ -171,7 +171,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringOneArgFlag1() {
+    void testExecuteUserStringListOfStringOneArgFlag1() {
         assertTrue(arf.execute(user, "", Collections.singletonList("FLAG1")));
     }
 
@@ -179,7 +179,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         assertTrue(arf.execute(user, "", Collections.emptyList()));
     }
 
@@ -187,7 +187,7 @@ public class AdminResetFlagsCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminResetFlagsCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         Optional<List<String>> list = arf.tabComplete(user, "", Collections.emptyList());
         assertTrue(list.isPresent());
         assertEquals(2, list.get().size());

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetHomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminResetHomeCommandTest.java
@@ -45,7 +45,7 @@ import world.bentobox.bentobox.util.Util;
 /**
  * @author tastybento
  */
-public class AdminResetHomeCommandTest extends CommonTestSetup {
+class AdminResetHomeCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -138,7 +138,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsIsEmpty() {
+    void testArgsIsEmpty() {
         // Arrange: args is already empty
 
         // Act
@@ -154,7 +154,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSizeGreaterThan1_InvalidPlayer() {
+    void testArgsSizeGreaterThan1_InvalidPlayer() {
         // Arrange
         args.add("UnknownPlayer");
 
@@ -172,7 +172,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testArgsSizeGreaterThan2_UnknownIsland() {
+    void testArgsSizeGreaterThan2_UnknownIsland() {
         // Arrange
         args.add("ValidPlayer");
         args.add("UnknownIsland");
@@ -204,7 +204,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("mod.resethome", instance.getPermission());
         assertFalse(instance.isOnlyPlayer());
         assertEquals("commands.admin.resethome.parameters", instance.getParameters());
@@ -216,7 +216,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabComplete_ArgsSize2_ReturnsPlayerNames() {
+    void testTabComplete_ArgsSize2_ReturnsPlayerNames() {
         // Arrange
         args.add("someArg"); // args.size() == 1
         args.add(""); // args.size() == 2
@@ -237,7 +237,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabComplete_ArgsSizeGreaterThan2_ReturnsIslandNames() {
+    void testTabComplete_ArgsSizeGreaterThan2_ReturnsIslandNames() {
         // Arrange
         args.add("someArg");
         args.add("anotherArg");
@@ -270,7 +270,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteWithEmptyIslands_ShouldReturnFalse() {
+    void testExecuteWithEmptyIslands_ShouldReturnFalse() {
         // Arrange
         instance.islands = new HashMap<>(); // Empty islands map
 
@@ -286,7 +286,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessful_SingleIsland() {
+    void testExecuteSuccessful_SingleIsland() {
 
         Map<String, IslandInfo> islandsMap = new HashMap<>();
         islandsMap.put("TestIsland", new IslandInfo(island, false));
@@ -305,7 +305,7 @@ public class AdminResetHomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminMaxHomesCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessful_MultipleIslands() {
+    void testExecuteSuccessful_MultipleIslands() {
         // Arrange
         Island island1 = mock(Island.class);
         Island island2 = mock(Island.class);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
@@ -33,7 +33,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminSetrankCommandTest extends RanksManagerTestSetup {
+class AdminSetrankCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -79,7 +79,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#AdminSetrankCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testAdminSetrankCommand() {
+    void testAdminSetrankCommand() {
         assertEquals("setrank", c.getLabel());
     }
 
@@ -88,7 +88,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("admin.setrank", c.getPermission());
         assertFalse(c.isOnlyPlayer());
         assertEquals("commands.admin.setrank.parameters", c.getParameters());
@@ -101,7 +101,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoArgs() {
+    void testCanExecuteNoArgs() {
         assertFalse(c.canExecute(user, "", Collections.emptyList()));
         verify(user).getTranslation("commands.help.console");
     }
@@ -111,7 +111,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOneArg() {
+    void testCanExecuteOneArg() {
         assertFalse(c.canExecute(user, "", Collections.singletonList("test")));
         verify(user).getTranslation("commands.help.console");
     }
@@ -121,7 +121,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "member")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
     }
@@ -130,7 +130,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteKnownPlayerNoIsland() {
+    void testCanExecuteKnownPlayerNoIsland() {
         when(pm.getUUID(any())).thenReturn(targetUUID);
         assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "ranks.member")));
         verify(user).sendMessage("general.errors.player-has-no-island");
@@ -140,7 +140,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteKnownPlayerHasIslandUnknownRank() {
+    void testCanExecuteKnownPlayerHasIslandUnknownRank() {
         when(pm.getUUID(any())).thenReturn(targetUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "xxx")));
@@ -151,7 +151,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteKnownPlayerHasIslandTooLowRank() {
+    void testCanExecuteKnownPlayerHasIslandTooLowRank() {
         when(pm.getUUID(any())).thenReturn(targetUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "ranks.visitor")));
@@ -162,7 +162,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteKnownPlayerHasIslandSuccess() {
+    void testCanExecuteKnownPlayerHasIslandSuccess() {
         when(pm.getUUID(any())).thenReturn(targetUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         assertTrue(c.canExecute(user, "", Arrays.asList("tastybento", "ranks.member")));
@@ -173,7 +173,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         // Set the target
         testCanExecuteKnownPlayerHasIslandSuccess();
         Island island = mock(Island.class);
@@ -189,7 +189,7 @@ public class AdminSetrankCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         Optional<List<String>> result = c.tabComplete(user, "", Arrays.asList("setrank", ""));
         assertTrue(result.isPresent());
         result.ifPresent(list -> {

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetspawnCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetspawnCommandTest.java
@@ -31,7 +31,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
  * @author tastybento
  *
  */
-public class AdminSetspawnCommandTest extends CommonTestSetup {
+class AdminSetspawnCommandTest extends CommonTestSetup {
 
     private CompositeCommand ac;
     private User user;
@@ -88,7 +88,7 @@ public class AdminSetspawnCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetspawnCommand#AdminSetspawnCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testAdminSetspawnCommand() {
+    void testAdminSetspawnCommand() {
         AdminSetspawnCommand c = new AdminSetspawnCommand(ac);
         assertEquals("setspawn", c.getLabel());
     }
@@ -98,7 +98,7 @@ public class AdminSetspawnCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetspawnCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         AdminSetspawnCommand c = new AdminSetspawnCommand(ac);
         assertEquals("bskyblock.admin.setspawn", c.getPermission());
         assertTrue(c.isOnlyPlayer());
@@ -110,7 +110,7 @@ public class AdminSetspawnCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetspawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         Island island = mock(Island.class);
         Optional<Island> oi = Optional.of(island);
         when(im.getIslandAt(any(Location.class))).thenReturn(oi);
@@ -123,7 +123,7 @@ public class AdminSetspawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetspawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIsland() {
+    void testExecuteUserStringListOfStringNoIsland() {
         when(im.getIslandAt(any(Location.class))).thenReturn(Optional.empty());
         AdminSetspawnCommand c = new AdminSetspawnCommand(ac);
         assertFalse(c.execute(user, "setspawn", Collections.emptyList()));
@@ -135,7 +135,7 @@ public class AdminSetspawnCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.AdminSetspawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringAlreadySpawn() {
+    void testExecuteUserStringListOfStringAlreadySpawn() {
         Island island = mock(Island.class);
         when(island.isSpawn()).thenReturn(true);
         Optional<Island> oi = Optional.of(island);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSettingsCommandTest.java
@@ -45,7 +45,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminSettingsCommandTest extends RanksManagerTestSetup {
+class AdminSettingsCommandTest extends RanksManagerTestSetup {
 
     private AdminSettingsCommand asc;
     @Mock
@@ -143,7 +143,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertFalse(asc.isOnlyPlayer());
         assertEquals("admin.settings", asc.getPermission());
         assertEquals("commands.admin.settings.parameters", asc.getParameters());
@@ -154,7 +154,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteEmpty() {
+    void testCanExecuteEmpty() {
         assertTrue(asc.canExecute(user, "", Collections.emptyList()));
     }
 
@@ -162,7 +162,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOneArgUnknownPlayer() {
+    void testCanExecuteOneArgUnknownPlayer() {
         mockedUtil.when(() -> Util.getUUID(anyString())).thenReturn(null);
         assertFalse(asc.canExecute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "tastybento");
@@ -172,7 +172,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOneArgKnownPlayerNoIsland() {
+    void testCanExecuteOneArgKnownPlayerNoIsland() {
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         assertFalse(asc.canExecute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
@@ -182,7 +182,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOneArgKnownPlayerIslandNotOwner() {
+    void testCanExecuteOneArgKnownPlayerIslandNotOwner() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         assertFalse(asc.canExecute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
@@ -192,7 +192,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOneArgKnownPlayer() {
+    void testCanExecuteOneArgKnownPlayer() {
         assertTrue(asc.canExecute(user, "", Collections.singletonList("tastybento")));
         verify(user, never()).sendMessage(anyString());
     }
@@ -201,7 +201,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOneArgSpawnNoSpawn() {
+    void testCanExecuteOneArgSpawnNoSpawn() {
         mockedUtil.when(() -> Util.getUUID(anyString())).thenReturn(null);
         assertFalse(asc.canExecute(user, "", Collections.singletonList("spawn-island")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "spawn-island");
@@ -211,7 +211,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOneArgSpawnSpawn() {
+    void testCanExecuteOneArgSpawnSpawn() {
         when(im.getSpawn(any())).thenReturn(Optional.of(island));
         assertTrue(asc.canExecute(user, "", Collections.singletonList("spawn-island")));
         verify(user, never()).sendMessage(anyString());
@@ -221,7 +221,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoArgsConsole() {
+    void testExecuteUserStringListOfStringNoArgsConsole() {
         when(user.isPlayer()).thenReturn(false);
         assertFalse(asc.execute(user, "", Collections.emptyList()));
         verify(user).sendMessage("general.errors.use-in-game");
@@ -231,7 +231,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringArgs() {
+    void testExecuteUserStringListOfStringArgs() {
         assertTrue(asc.execute(user, "", Arrays.asList("blah", "blah")));
         verify(user).sendMessage("general.success");
     }
@@ -240,7 +240,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringTwoArgs() {
+    void testTabCompleteUserStringListOfStringTwoArgs() {
         Optional<List<String>> r = asc.tabComplete(user, "", Arrays.asList("b", "WORLD_TNT"));
         assertFalse(r.isEmpty());
         assertEquals("WORLD_TNT_DAMAGE", r.get().getFirst());
@@ -250,7 +250,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringThreeArgs() {
+    void testTabCompleteUserStringListOfStringThreeArgs() {
         Optional<List<String>> r = asc.tabComplete(user, "", Arrays.asList("b", "WORLD_TNT", "BEACO"));
         assertFalse(r.isEmpty());
         assertEquals("BEACON", r.get().getFirst());
@@ -260,7 +260,7 @@ public class AdminSettingsCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSettingsCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringFourArgs() {
+    void testTabCompleteUserStringListOfStringFourArgs() {
         Optional<List<String>> r = asc.tabComplete(user, "", Arrays.asList("b", "b", "PVP_OVERWORLD", "t"));
         assertFalse(r.isEmpty());
         // TODO - finish this.

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSwitchCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSwitchCommandTest.java
@@ -30,7 +30,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminSwitchCommandTest extends CommonTestSetup {
+class AdminSwitchCommandTest extends CommonTestSetup {
 
     private AdminSwitchCommand asc;
     @Mock
@@ -83,7 +83,7 @@ public class AdminSwitchCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSwitchCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("mod.switch", asc.getPermission());
         assertTrue(asc.isOnlyPlayer());
         assertEquals("commands.admin.switch.parameters", asc.getParameters());
@@ -94,7 +94,7 @@ public class AdminSwitchCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSwitchCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecute() {
+    void testCanExecute() {
         assertFalse(asc.canExecute(user, "", Collections.singletonList("hello")));
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, null);
         assertTrue(asc.canExecute(user, "", Collections.emptyList()));
@@ -104,7 +104,7 @@ public class AdminSwitchCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSwitchCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoMetaData() {
+    void testExecuteUserStringListOfStringNoMetaData() {
         when(user.getMetaData("AdminCommandSwitch")).thenReturn(Optional.empty());
         asc.execute(user, "", Collections.emptyList());
         verify(user).getMetaData("AdminCommandSwitch");
@@ -116,7 +116,7 @@ public class AdminSwitchCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSwitchCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringMetaFalse() {
+    void testExecuteUserStringListOfStringMetaFalse() {
         MetaDataValue md = new MetaDataValue(false);
         when(user.getMetaData("AdminCommandSwitch")).thenReturn(Optional.of(md));
         asc.execute(user, "", Collections.emptyList());
@@ -129,7 +129,7 @@ public class AdminSwitchCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSwitchCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringMetaTrue() {
+    void testExecuteUserStringListOfStringMetaTrue() {
         MetaDataValue md = new MetaDataValue(true);
         when(user.getMetaData("AdminCommandSwitch")).thenReturn(Optional.of(md));
         asc.execute(user, "", Collections.emptyList());

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportCommandTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.util.Util;
 
-public class AdminTeleportCommandTest extends CommonTestSetup {
+class AdminTeleportCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -164,7 +164,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
      * Test all the various commands
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         AdminTeleportCommand c = new AdminTeleportCommand(ac, "tp");
         assertEquals("tp", c.getLabel());
         c = new AdminTeleportCommand(ac, "tpnether");
@@ -177,21 +177,21 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
      * Test no args
      */
     @Test
-    public void testExecuteUserStringListOfStringEmptyArgs() {
+    void testExecuteUserStringListOfStringEmptyArgs() {
         AdminTeleportCommand atc = new AdminTeleportCommand(ac, "tp");
         assertFalse(atc.canExecute(user, "tp", new ArrayList<>()));
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
     }
 
     @Test
-    public void testExecuteUserStringListOfStringUnknownTarget() {
+    void testExecuteUserStringListOfStringUnknownTarget() {
         AdminTeleportCommand atc = new AdminTeleportCommand(ac, "tp");
         assertFalse(atc.canExecute(user, "tp", List.of("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "tastybento");
     }
 
     @Test
-    public void testExecuteUserStringListOfStringKnownTargetNoIsland() {
+    void testExecuteUserStringListOfStringKnownTargetNoIsland() {
         when(pm.getUUID("tastybento")).thenReturn(notUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         AdminTeleportCommand atc = new AdminTeleportCommand(ac,"tp");
@@ -203,7 +203,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
      * Test for {@link AdminTeleportCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteUserStringListOfStringKnownTargetHasIsland() {
+    void testExecuteUserStringListOfStringKnownTargetHasIsland() {
         when(pm.getUUID("tastybento")).thenReturn(notUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         AdminTeleportCommand atc = new AdminTeleportCommand(ac,"tp");
@@ -216,7 +216,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
      * Test for {@link AdminTeleportCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteUserStringListOfStringKnownTargetHasIslandSpawnPoint() {
+    void testExecuteUserStringListOfStringKnownTargetHasIslandSpawnPoint() {
         when(island.getSpawnPoint(any())).thenReturn(spawnPoint);
         when(pm.getUUID("tastybento")).thenReturn(notUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
@@ -227,7 +227,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testExecuteUserStringListOfStringKnownTargetIsTeamMember() {
+    void testExecuteUserStringListOfStringKnownTargetIsTeamMember() {
         when(pm.getUUID("tastybento")).thenReturn(notUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(true);
@@ -240,7 +240,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testExecuteUserStringListOfStringKnownTargetHasIslandNether() {
+    void testExecuteUserStringListOfStringKnownTargetHasIslandNether() {
         when(pm.getUUID("tastybento")).thenReturn(notUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         AdminTeleportCommand atc = new AdminTeleportCommand(ac,"tpnether");
@@ -252,7 +252,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testExecuteUserStringListOfStringKnownTargetHasIslandEnd() {
+    void testExecuteUserStringListOfStringKnownTargetHasIslandEnd() {
         when(pm.getUUID("tastybento")).thenReturn(notUUID);
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         AdminTeleportCommand atc = new AdminTeleportCommand(ac,"tpend");
@@ -264,7 +264,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPermissionsNoRootPermission() {
+    void testPermissionsNoRootPermission() {
         when(mockPlayer.hasPermission("admin.tp")).thenReturn(true);
         when(mockPlayer.hasPermission("admin")).thenReturn(false);
         when(pm.getUUID("tastybento")).thenReturn(notUUID);
@@ -279,7 +279,7 @@ public class AdminTeleportCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPermissionsHasRootPermission() {
+    void testPermissionsHasRootPermission() {
         when(mockPlayer.hasPermission("admin.tp")).thenReturn(true);
         when(mockPlayer.hasPermission("admin")).thenReturn(true);
         when(pm.getUUID("tastybento")).thenReturn(notUUID);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportUserCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminTeleportUserCommandTest.java
@@ -47,7 +47,7 @@ import world.bentobox.bentobox.util.Util;
 /**
  * Tests for {@link AdminTeleportUserCommand}.
  */
-public class AdminTeleportUserCommandTest extends CommonTestSetup {
+class AdminTeleportUserCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -168,7 +168,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testSetupMetadata() {
+    void testSetupMetadata() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertEquals("tpuser", cmd.getLabel());
         assertEquals("admin.tpuser", cmd.getPermission());
@@ -177,7 +177,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSetupAllLabels() {
+    void testSetupAllLabels() {
         assertEquals("tpuser",      new AdminTeleportUserCommand(ac, "tpuser").getLabel());
         assertEquals("tpusernether", new AdminTeleportUserCommand(ac, "tpusernether").getLabel());
         assertEquals("tpuserend",    new AdminTeleportUserCommand(ac, "tpuserend").getLabel());
@@ -188,14 +188,14 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testCanExecuteNoArgs() {
+    void testCanExecuteNoArgs() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertFalse(cmd.canExecute(user, "tpuser", List.of()));
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
     }
 
     @Test
-    public void testCanExecuteOneArgShowsHelp() {
+    void testCanExecuteOneArgShowsHelp() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertFalse(cmd.canExecute(user, "tpuser", List.of("teleportee")));
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
@@ -206,7 +206,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testCanExecuteUnknownTeleportee() {
+    void testCanExecuteUnknownTeleportee() {
         // pm.getUUID returns null for unknown names (default Mockito behaviour)
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertFalse(cmd.canExecute(user, "tpuser", List.of("unknown", "target")));
@@ -214,7 +214,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteTeleporteeOffline() {
+    void testCanExecuteTeleporteeOffline() {
         when(mockPlayer.isOnline()).thenReturn(false);
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertFalse(cmd.canExecute(user, "tpuser", List.of("teleportee", "target")));
@@ -227,7 +227,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
      * This test documents that behaviour.
      */
     @Test
-    public void testCanExecuteUnknownTarget() {
+    void testCanExecuteUnknownTarget() {
         // "bad-target" is not registered → pm.getUUID returns null
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertFalse(cmd.canExecute(user, "tpuser", List.of("teleportee", "bad-target")));
@@ -240,7 +240,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testCanExecuteTargetHasNoIslandOrTeam() {
+    void testCanExecuteTargetHasNoIslandOrTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
@@ -249,7 +249,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteTargetInTeamWithNoOwnIsland() {
+    void testCanExecuteTargetInTeamWithNoOwnIsland() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(true);
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
@@ -257,7 +257,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteGetSpotReturnsNullIsland() {
+    void testCanExecuteGetSpotReturnsNullIsland() {
         // getIsland returns null → getSpot returns null → no-safe-location
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
@@ -266,7 +266,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteGetSpotUsesSpawnPointWhenAvailable() {
+    void testCanExecuteGetSpotUsesSpawnPointWhenAvailable() {
         when(island.getSpawnPoint(Environment.NORMAL)).thenReturn(spawnPoint);
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertTrue(cmd.canExecute(user, "tpuser", List.of("teleportee", "target")));
@@ -277,7 +277,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testCanExecuteTwoArgsOverworld() {
+    void testCanExecuteTwoArgsOverworld() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertTrue(cmd.canExecute(user, "tpuser", List.of("teleportee", "target")));
         verify(iwm, never()).getNetherWorld(any());
@@ -285,7 +285,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteTwoArgsNether() {
+    void testCanExecuteTwoArgsNether() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpusernether");
         assertTrue(cmd.canExecute(user, "tpusernether", List.of("teleportee", "target")));
         verify(iwm).getNetherWorld(world);
@@ -293,7 +293,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteTwoArgsEnd() {
+    void testCanExecuteTwoArgsEnd() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuserend");
         assertTrue(cmd.canExecute(user, "tpuserend", List.of("teleportee", "target")));
         verify(iwm, never()).getNetherWorld(world);
@@ -301,7 +301,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteNetherWorldNull() {
+    void testCanExecuteNetherWorldNull() {
         when(iwm.getNetherWorld(any())).thenReturn(null);
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpusernether");
         assertFalse(cmd.canExecute(user, "tpusernether", List.of("teleportee", "target")));
@@ -309,7 +309,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteEndWorldNull() {
+    void testCanExecuteEndWorldNull() {
         when(iwm.getEndWorld(any())).thenReturn(null);
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuserend");
         assertFalse(cmd.canExecute(user, "tpuserend", List.of("teleportee", "target")));
@@ -321,7 +321,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testCanExecuteUnknownIslandName() {
+    void testCanExecuteUnknownIslandName() {
         try (MockedStatic<IslandGoCommand> mockedGo = Mockito.mockStatic(IslandGoCommand.class)) {
             mockedGo.when(() -> IslandGoCommand.getNameIslandMap(any(User.class), any(World.class)))
                     .thenReturn(Map.of("existing-home", new IslandInfo(island, false)));
@@ -334,7 +334,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteKnownIslandNameSingleEntry() {
+    void testCanExecuteKnownIslandNameSingleEntry() {
         // names.size() == 1 → warpSpot is not updated, just returns true
         try (MockedStatic<IslandGoCommand> mockedGo = Mockito.mockStatic(IslandGoCommand.class)) {
             mockedGo.when(() -> IslandGoCommand.getNameIslandMap(any(User.class), any(World.class)))
@@ -345,7 +345,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteKnownIslandNameMultipleEntriesNoSpawnPoint() {
+    void testCanExecuteKnownIslandNameMultipleEntriesNoSpawnPoint() {
         Island island2 = mock(Island.class);
         when(island2.getProtectionCenter()).thenReturn(location);
         try (MockedStatic<IslandGoCommand> mockedGo = Mockito.mockStatic(IslandGoCommand.class)) {
@@ -361,7 +361,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteKnownIslandNameMultipleEntriesWithSpawnPoint() {
+    void testCanExecuteKnownIslandNameMultipleEntriesWithSpawnPoint() {
         Island island2 = mock(Island.class);
         when(island.getSpawnPoint(Environment.NORMAL)).thenReturn(spawnPoint);
         try (MockedStatic<IslandGoCommand> mockedGo = Mockito.mockStatic(IslandGoCommand.class)) {
@@ -377,7 +377,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCanExecuteMultiWordIslandName() {
+    void testCanExecuteMultiWordIslandName() {
         try (MockedStatic<IslandGoCommand> mockedGo = Mockito.mockStatic(IslandGoCommand.class)) {
             mockedGo.when(() -> IslandGoCommand.getNameIslandMap(any(User.class), any(World.class)))
                     .thenReturn(Map.of("my cool island", new IslandInfo(island, true)));
@@ -392,7 +392,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testExecuteTwoArgsUsesNoSafeLocationFailureMessage() {
+    void testExecuteTwoArgsUsesNoSafeLocationFailureMessage() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertTrue(cmd.canExecute(user, "tpuser", List.of("teleportee", "target")));
         assertTrue(cmd.execute(user, "tpuser", List.of("teleportee", "target")));
@@ -401,7 +401,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testExecuteThreeArgsUsesManualLocationFailureMessage() {
+    void testExecuteThreeArgsUsesManualLocationFailureMessage() {
         try (MockedStatic<IslandGoCommand> mockedGo = Mockito.mockStatic(IslandGoCommand.class)) {
             mockedGo.when(() -> IslandGoCommand.getNameIslandMap(any(User.class), any(World.class)))
                     .thenReturn(Map.of("myhome", new IslandInfo(island, false)));
@@ -418,20 +418,20 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     // -------------------------------------------------------------------------
 
     @Test
-    public void testTabCompleteEmptyArgs() {
+    void testTabCompleteEmptyArgs() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertTrue(cmd.tabComplete(user, "tpuser", List.of()).isEmpty());
     }
 
     @Test
-    public void testTabCompleteOneArg() {
+    void testTabCompleteOneArg() {
         // size == 1 → no matching branch → empty
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertTrue(cmd.tabComplete(user, "tpuser", List.of("t")).isEmpty());
     }
 
     @Test
-    public void testTabCompleteTwoArgs() {
+    void testTabCompleteTwoArgs() {
         mockedUtil.when(() -> Util.getOnlinePlayerList(any())).thenReturn(List.of("alice", "bob"));
         mockedUtil.when(() -> Util.tabLimit(any(), anyString())).thenCallRealMethod();
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
@@ -441,7 +441,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTabCompleteThreeArgs() {
+    void testTabCompleteThreeArgs() {
         mockedUtil.when(() -> Util.getOnlinePlayerList(any())).thenReturn(List.of("alice"));
         mockedUtil.when(() -> Util.tabLimit(any(), anyString())).thenCallRealMethod();
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
@@ -450,7 +450,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTabCompleteFourArgsUnresolvableIndex2() {
+    void testTabCompleteFourArgsUnresolvableIndex2() {
         // args.get(2) = "badname" → Util.getUUID → null → empty
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         Optional<List<String>> result = cmd.tabComplete(user, "tpuser", List.of("teleportee", "target", "badname", ""));
@@ -458,7 +458,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTabCompleteFourArgsKnownUUIDAtIndex2() {
+    void testTabCompleteFourArgsKnownUUIDAtIndex2() {
         // args.get(2) can be a UUID string (edge case in the source that uses index 2 for target)
         try (MockedStatic<IslandGoCommand> mockedGo = Mockito.mockStatic(IslandGoCommand.class)) {
             mockedGo.when(() -> IslandGoCommand.getNameIslandMap(any(User.class), any(World.class)))
@@ -475,7 +475,7 @@ public class AdminTeleportUserCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTabCompleteFiveOrMoreArgs() {
+    void testTabCompleteFiveOrMoreArgs() {
         AdminTeleportUserCommand cmd = new AdminTeleportUserCommand(ac, "tpuser");
         assertTrue(cmd.tabComplete(user, "tpuser", List.of("a", "b", "c", "d", "e")).isEmpty());
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUnregisterCommandTest.java
@@ -44,7 +44,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminUnregisterCommandTest extends CommonTestSetup {
+class AdminUnregisterCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -141,7 +141,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoTarget() {
+    void testCanExecuteNoTarget() {
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
         // Show help
     }
@@ -151,7 +151,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         String[] name = { "tastybento" };
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), Arrays.asList(name)));
@@ -163,7 +163,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecutePlayerFailNoIsland() {
+    void testCanExecutePlayerFailNoIsland() {
         // No island
         when(im.getOwnedIslands(world, uuid)).thenReturn(Set.of());
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
@@ -175,7 +175,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecutePlayerFailMoreIsland() {
+    void testCanExecutePlayerFailMoreIsland() {
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
         verify(user).sendMessage("commands.admin.unregister.errors.specify-island-location");
@@ -186,7 +186,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecutePlayerFailWrongIsland() {
+    void testCanExecutePlayerFailWrongIsland() {
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "1,2,4")));
         verify(user).sendMessage("commands.admin.unregister.errors.unknown-island-location");
     }
@@ -196,7 +196,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteDiffernetPlayerFailWrongIsland() {
+    void testCanExecuteDiffernetPlayerFailWrongIsland() {
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("BoxManager", "1,2,4")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "BoxManager");
     }
@@ -206,7 +206,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecutePlayerSuccessMultiIsland() {
+    void testCanExecutePlayerSuccessMultiIsland() {
         assertTrue(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "1,2,3")));
         assertTrue(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "4,5,6")));
     }
@@ -215,7 +215,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSuccessOneIsland() {
+    void testCanExecuteSuccessOneIsland() {
         when(im.getOwnedIslands(world, uuid)).thenReturn(Set.of(island));
         itl.canExecute(user, itl.getLabel(), List.of("tastybento"));
         assertTrue(itl.execute(user, itl.getLabel(), List.of("tastybento")));
@@ -227,7 +227,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminUnregisterCommand#unregisterIsland(User)}
      */
     @Test
-    public void testUnregisterIsland() {
+    void testUnregisterIsland() {
         this.testCanExecuteSuccessOneIsland();
         itl.unregisterIsland(user);
         verify(user).sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, "1,2,3",
@@ -241,7 +241,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * Test method for {@link AdminUnregisterCommand#unregisterIsland(User)}
      */
     @Test
-    public void testUnregisterIslandMulti() {
+    void testUnregisterIslandMulti() {
         this.testCanExecutePlayerSuccessMultiIsland();
         itl.unregisterIsland(user);
         verify(user).sendMessage("commands.admin.unregister.unregistered-island", TextVariables.XYZ, "4,5,6",
@@ -253,7 +253,7 @@ public class AdminUnregisterCommandTest extends CommonTestSetup {
      * {@link AdminUnregisterCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteHelp() {
+    void testCanExecuteHelp() {
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "help")));
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCopyCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCopyCommandTest.java
@@ -37,7 +37,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
  * @author tastybento
  *
  */
-public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
+class AdminBlueprintCopyCommandTest extends CommonTestSetup {
 
     @Mock
     private AdminBlueprintCommand ac;
@@ -105,7 +105,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#AdminBlueprintCopyCommand(world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCommand)}.
      */
     @Test
-    public void testAdminBlueprintCopyCommand() {
+    void testAdminBlueprintCopyCommand() {
         assertNotNull(abcc);
     }
 
@@ -113,7 +113,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         abcc.setup();
         assertEquals("commands.admin.blueprint.copy.description", abcc.getDescription());
         assertEquals("commands.admin.blueprint.copy.parameters", abcc.getParameters());
@@ -124,7 +124,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringHelp() {
+    void testExecuteUserStringListOfStringHelp() {
         assertFalse(abcc.execute(user, "", List.of("1", "2", "3")));
         verify(user).sendMessage("commands.help.header", "[label]", "translation");
     }
@@ -133,7 +133,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringSuccess() {
+    void testExecuteUserStringListOfStringSuccess() {
         assertTrue(abcc.execute(user, "", List.of("air", "biome")));
         verify(clip).copy(user, true, true, false);
     }
@@ -142,7 +142,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringSuccessCaps() {
+    void testExecuteUserStringListOfStringSuccessCaps() {
         assertTrue(abcc.execute(user, "", List.of("AIR", "BIOME")));
         verify(clip).copy(user, true, true, false);
     }
@@ -151,7 +151,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringJunk() {
+    void testExecuteUserStringListOfStringJunk() {
         assertTrue(abcc.execute(user, "", List.of("junk", "junk")));
         verify(clip).copy(user, false, false, false);
     }
@@ -160,7 +160,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNothing() {
+    void testExecuteUserStringListOfStringNothing() {
         assertTrue(abcc.execute(user, "", Collections.emptyList()));
         verify(clip).copy(user, false, false, false);
     }
@@ -169,7 +169,7 @@ public class AdminBlueprintCopyCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCopyCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         Optional<List<String>> o = abcc.tabComplete(user, "", List.of(""));
         assertTrue(o.isPresent());
         assertEquals("air", o.get().getFirst());

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintDeleteCommandTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
  * @author tastybento
  *
  */
-public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
+class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
 
     @Mock
     private AdminBlueprintCommand ac;
@@ -99,7 +99,7 @@ public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintDeleteCommand#AdminBlueprintDeleteCommand(world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCommand)}.
      */
     @Test
-    public void testAdminBlueprintDeleteCommand() {
+    void testAdminBlueprintDeleteCommand() {
         assertNotNull(abcc);
     }
 
@@ -107,7 +107,7 @@ public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintDeleteCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         abcc.setup();
         assertEquals("commands.admin.blueprint.delete.description", abcc.getDescription());
         assertEquals("commands.admin.blueprint.delete.parameters", abcc.getParameters());
@@ -118,7 +118,7 @@ public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintDeleteCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringHelp() {
+    void testExecuteUserStringListOfStringHelp() {
         assertFalse(abcc.execute(user, "", List.of("1", "2", "3")));
         verify(user).sendMessage("commands.help.header", "[label]", "translation");
     }
@@ -127,7 +127,7 @@ public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintDeleteCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoBp() {
+    void testExecuteUserStringListOfStringNoBp() {
         assertFalse(abcc.execute(user, "", List.of(" iSlAnd  ")));
         verify(user).sendMessage("commands.admin.blueprint.delete.no-blueprint", TextVariables.NAME, "_island__");
     }
@@ -136,7 +136,7 @@ public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintDeleteCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringSuccessCaps() {
+    void testExecuteUserStringListOfStringSuccessCaps() {
         assertTrue(abcc.execute(user, "", List.of("KEY")));
         verify(user).getTranslation("commands.admin.blueprint.delete.confirmation");
     }
@@ -145,7 +145,7 @@ public class AdminBlueprintDeleteCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintDeleteCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         Optional<List<String>> o = abcc.tabComplete(user, "", List.of(""));
         assertTrue(o.isPresent());
         assertEquals("key", o.get().getFirst());

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintLoadCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintLoadCommandTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
  * @author tastybento
  *
  */
-public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
+class AdminBlueprintLoadCommandTest extends CommonTestSetup {
 
     @Mock
     private AdminBlueprintCommand ac;
@@ -123,7 +123,7 @@ public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintLoadCommand#AdminBlueprintLoadCommand(world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCommand)}.
      */
     @Test
-    public void testAdminBlueprintLoadCommand() {
+    void testAdminBlueprintLoadCommand() {
         assertNotNull(abcc);
     }
 
@@ -131,7 +131,7 @@ public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintLoadCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         abcc.setup();
         assertEquals("commands.admin.blueprint.load.description", abcc.getDescription());
         assertEquals("commands.admin.blueprint.load.parameters", abcc.getParameters());
@@ -142,7 +142,7 @@ public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintLoadCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringHelp() {
+    void testExecuteUserStringListOfStringHelp() {
         assertFalse(abcc.execute(user, "", List.of("1", "2", "3")));
         verify(user).sendMessage("commands.help.header", "[label]", "translation");
     }
@@ -151,7 +151,7 @@ public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintLoadCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoLoad() {
+    void testExecuteUserStringListOfStringNoLoad() {
         assertFalse(abcc.execute(user, "", List.of(" iSlAnd  ")));
         verify(user).sendMessage("commands.admin.blueprint.could-not-load");
     }
@@ -161,7 +161,7 @@ public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
      */
     @Disabled("Paper Biome issue")
     @Test
-    public void testExecuteUserStringListOfStringSuccessCaps() {
+    void testExecuteUserStringListOfStringSuccessCaps() {
         assertTrue(abcc.execute(user, "", List.of("island")));
         verify(user).sendMessage("general.success");
     }
@@ -170,7 +170,7 @@ public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintLoadCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         Optional<List<String>> o = abcc.tabComplete(user, "", List.of(""));
         assertTrue(o.isPresent());
         assertEquals("island", o.get().getFirst());
@@ -180,7 +180,7 @@ public class AdminBlueprintLoadCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintLoadCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringIsland() {
+    void testTabCompleteUserStringListOfStringIsland() {
         Optional<List<String>> o = abcc.tabComplete(user, "", List.of("e"));
         assertTrue(o.isPresent());
         assertTrue(o.get().isEmpty());

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintSaveCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintSaveCommandTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
  * @author tastybento
  *
  */
-public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
+class AdminBlueprintSaveCommandTest extends CommonTestSetup {
 
     private AdminBlueprintSaveCommand absc;
     @Mock
@@ -111,7 +111,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#AdminBlueprintSaveCommand(world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCommand)}.
      */
     @Test
-    public void testAdminBlueprintSaveCommand() {
+    void testAdminBlueprintSaveCommand() {
         assertNotNull(absc);
     }
 
@@ -119,7 +119,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         absc.setup();
         assertEquals("commands.admin.blueprint.save.description", absc.getDescription());
         assertEquals("commands.admin.blueprint.save.parameters", absc.getParameters());
@@ -129,7 +129,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteShowHelp() {
+    void testCanExecuteShowHelp() {
         assertFalse(absc.canExecute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.help.header", "[label]", "translation");
     }
@@ -138,7 +138,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoClipboard() {
+    void testCanExecuteNoClipboard() {
         when(ac.getClipboards()).thenReturn(new HashMap<>());
         assertFalse(absc.canExecute(user, "", List.of("")));
         verify(user).sendMessage("commands.admin.blueprint.copy-first");
@@ -148,7 +148,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoBedrock() {
+    void testCanExecuteNoBedrock() {
         Blueprint bp = new Blueprint();
         clip.setBlueprint(bp);
         assertFalse(absc.canExecute(user, "", List.of("")));
@@ -159,7 +159,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecute() {
+    void testCanExecute() {
 
         bp.setBedrock(new Vector(1,2,3));
         clip.setBlueprint(bp);
@@ -172,7 +172,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         testCanExecute();
         assertTrue(absc.execute(user, "", List.of("island")));
         verify(ac).hideClipboard(user);
@@ -183,7 +183,7 @@ public class AdminBlueprintSaveCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintSaveCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringFileExists() {
+    void testExecuteUserStringListOfStringFileExists() {
         testCanExecute();
         assertTrue(absc.execute(user, "", List.of("island")));
         assertFalse(absc.execute(user, "", List.of("island")));

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintsListCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintsListCommandTest.java
@@ -32,7 +32,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
  * @author tastybento
  *
  */
-public class AdminBlueprintsListCommandTest extends CommonTestSetup {
+class AdminBlueprintsListCommandTest extends CommonTestSetup {
 
     @Mock
     private AdminBlueprintCommand ac;
@@ -96,7 +96,7 @@ public class AdminBlueprintsListCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintListCommand#AdminBlueprintListCommand(world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCommand)}.
      */
     @Test
-    public void testAdminBlueprintListCommand() {
+    void testAdminBlueprintListCommand() {
         assertEquals("list", list.getLabel());
     }
 
@@ -104,7 +104,7 @@ public class AdminBlueprintsListCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintListCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("commands.admin.blueprint.list.description", list.getDescription());
     }
 
@@ -112,7 +112,7 @@ public class AdminBlueprintsListCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintListCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecute() {
+    void testCanExecute() {
         assertTrue(list.canExecute(user, "", Collections.emptyList()));
         assertFalse(list.canExecute(user, "", Collections.singletonList("extraneous")));
     }
@@ -121,7 +121,7 @@ public class AdminBlueprintsListCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintListCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoBlueprintsFolder() {
+    void testExecuteUserStringListOfStringNoBlueprintsFolder() {
         assertFalse(list.execute(user, "", Collections.emptyList()));
         Mockito.verify(user).sendMessage("commands.admin.blueprint.list.no-blueprints");
     }
@@ -130,7 +130,7 @@ public class AdminBlueprintsListCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintListCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoBlueprintsFilesEmptyFolder() {
+    void testExecuteUserStringListOfStringNoBlueprintsFilesEmptyFolder() {
         File blueprintFolder = new File(dataFolder, "blueprints");
         blueprintFolder.mkdirs();
         assertFalse(list.execute(user, "", Collections.emptyList()));
@@ -141,7 +141,7 @@ public class AdminBlueprintsListCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintListCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoBlueprintsFiles() throws IOException {
+    void testExecuteUserStringListOfStringNoBlueprintsFiles() throws IOException {
         File blueprintFolder = new File(dataFolder, "blueprints");
         blueprintFolder.mkdirs();
         new File(blueprintFolder, "random.txt").createNewFile();
@@ -153,7 +153,7 @@ public class AdminBlueprintsListCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintListCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringWithBlueprintsFiles() throws IOException {
+    void testExecuteUserStringListOfStringWithBlueprintsFiles() throws IOException {
         File blueprintFolder = new File(dataFolder, BlueprintsManager.FOLDER_NAME);
         blueprintFolder.mkdirs();
         new File(blueprintFolder, "island" + BlueprintsManager.BLUEPRINT_SUFFIX).createNewFile();

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeCommandTest.java
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class AdminPurgeCommandTest extends CommonTestSetup {
+class AdminPurgeCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -119,7 +119,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#AdminPurgeCommand(CompositeCommand)}.
      */
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         verify(addon).registerListener(apc);
     }
 
@@ -127,7 +127,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("admin.purge", apc.getPermission());
         assertFalse(apc.isOnlyPlayer());
         assertEquals("commands.admin.purge.parameters", apc.getParameters());
@@ -140,7 +140,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringEmptyArgs() {
+    void testCanExecuteUserStringListOfStringEmptyArgs() {
         assertFalse(apc.canExecute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.help.header",
                 "[label]",
@@ -151,7 +151,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringWithArg() {
+    void testCanExecuteUserStringListOfStringWithArg() {
         assertTrue(apc.canExecute(user, "", Collections.singletonList("23")));
     }
 
@@ -159,7 +159,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNotNumber() {
+    void testExecuteUserStringListOfStringNotNumber() {
         assertFalse(apc.execute(user, "", Collections.singletonList("abc")));
         verify(user).sendMessage("commands.admin.purge.number-error");
     }
@@ -168,7 +168,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringZero() {
+    void testExecuteUserStringListOfStringZero() {
         assertFalse(apc.execute(user, "", Collections.singletonList("0")));
         verify(user).sendMessage("commands.admin.purge.days-one-or-more");
     }
@@ -177,7 +177,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIslands() {
+    void testExecuteUserStringListOfStringNoIslands() {
         assertTrue(apc.execute(user, "", Collections.singletonList("10")));
         verify(user).sendMessage("commands.admin.purge.purgable-islands", "[number]", "0");
     }
@@ -186,7 +186,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIslandsPurgeProtected() {
+    void testExecuteUserStringListOfStringNoIslandsPurgeProtected() {
         when(island.isPurgeProtected()).thenReturn(true);
         when(im.getIslands()).thenReturn(Collections.singleton(island));
         assertTrue(apc.execute(user, "", Collections.singletonList("10")));
@@ -197,7 +197,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIslandsWrongWorld() {
+    void testExecuteUserStringListOfStringNoIslandsWrongWorld() {
         when(island.isPurgeProtected()).thenReturn(false);
         when(island.getWorld()).thenReturn(mock(World.class));
         when(im.getIslands()).thenReturn(Collections.singleton(island));
@@ -209,7 +209,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIslandsUnowned() {
+    void testExecuteUserStringListOfStringNoIslandsUnowned() {
         when(island.isPurgeProtected()).thenReturn(false);
         when(island.getWorld()).thenReturn(world);
         when(island.getOwner()).thenReturn(null);
@@ -224,7 +224,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Makes sure that no spawn islands are deleted
      */
     @Test
-    public void testExecuteUserStringListOfStringOnlyIslandSpawn() {
+    void testExecuteUserStringListOfStringOnlyIslandSpawn() {
         when(island.isPurgeProtected()).thenReturn(false);
         when(island.getWorld()).thenReturn(world);
         when(island.isSpawn()).thenReturn(true);
@@ -238,7 +238,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      */
     @SuppressWarnings("deprecation")
     @Test
-    public void testExecuteUserStringListOfStringNoIslandsTeamIsland() {
+    void testExecuteUserStringListOfStringNoIslandsTeamIsland() {
         when(island.isPurgeProtected()).thenReturn(false);
         when(island.getWorld()).thenReturn(world);
         when(island.getOwner()).thenReturn(UUID.randomUUID());
@@ -258,7 +258,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIslandsRecentLogin() {
+    void testExecuteUserStringListOfStringNoIslandsRecentLogin() {
         when(island.isPurgeProtected()).thenReturn(false);
         when(island.getWorld()).thenReturn(world);
         when(island.getOwner()).thenReturn(UUID.randomUUID());
@@ -275,7 +275,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringIslandsFound() {
+    void testExecuteUserStringListOfStringIslandsFound() {
         when(island.isPurgeProtected()).thenReturn(false);
         when(island.getWorld()).thenReturn(world);
         when(island.getOwner()).thenReturn(UUID.randomUUID());
@@ -295,7 +295,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#removeIslands()}.
      */
     @Test
-    public void testRemoveIslands() {
+    void testRemoveIslands() {
         @NonNull
         Optional<Island> opIsland = Optional.of(island);
         when(im.getIslandById(any())).thenReturn(opIsland);
@@ -310,7 +310,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#onIslandDeleted(world.bentobox.bentobox.api.events.island.IslandEvent.IslandDeletedEvent)}.
      */
     @Test
-    public void testOnIslandDeletedNotInPurge() {
+    void testOnIslandDeletedNotInPurge() {
         IslandDeletedEvent e = mock(IslandDeletedEvent.class);
         apc.onIslandDeleted(e);
         verify(user, Mockito.never()).sendMessage(any());
@@ -321,7 +321,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#onIslandDeleted(world.bentobox.bentobox.api.events.island.IslandEvent.IslandDeletedEvent)}.
      */
     @Test
-    public void testOnIslandDeletedPurgeCompleted() {
+    void testOnIslandDeletedPurgeCompleted() {
         testRemoveIslands();
         IslandDeletedEvent e = mock(IslandDeletedEvent.class);
         apc.onIslandDeleted(e);
@@ -333,7 +333,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#isInPurge()}.
      */
     @Test
-    public void testIsInPurge() {
+    void testIsInPurge() {
         assertFalse(apc.isInPurge());
         testRemoveIslands();
         assertTrue(apc.isInPurge());
@@ -343,7 +343,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#stop()}.
      */
     @Test
-    public void testStop() {
+    void testStop() {
         testRemoveIslands();
         assertTrue(apc.isInPurge());
         apc.stop();
@@ -354,7 +354,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.purge.AdminPurgeCommand#setUser(world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testSetUser() {
+    void testSetUser() {
         apc.setUser(user);
         apc.removeIslands();
         verify(user, Mockito.times(1)).sendMessage(any());
@@ -367,7 +367,7 @@ public class AdminPurgeCommandTest extends CommonTestSetup {
      * @throws InterruptedException 
      */
     @Test
-    public void testGetOldIslands() throws InterruptedException, ExecutionException, TimeoutException {
+    void testGetOldIslands() throws InterruptedException, ExecutionException, TimeoutException {
         assertTrue(apc.execute(user, "", Collections.singletonList("10"))); // 10 days ago
         // First, ensure that the result is empty
         CompletableFuture<Set<String>> result = apc.getOldIslands(10);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeRegionsCommandTest.java
@@ -48,7 +48,7 @@ import world.bentobox.bentobox.managers.island.IslandGrid;
 /**
  * Tests for {@link AdminPurgeRegionsCommand}.
  */
-public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
+class AdminPurgeRegionsCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -139,7 +139,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * AdminPurgeCommand.setup() creates one instance, and setUp() creates a second — so two calls.
      */
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         verify(addon, times(2)).registerListener(any(AdminPurgeRegionsCommand.class));
     }
 
@@ -147,7 +147,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * Verify command metadata set in setup().
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("admin.purge.regions", aprc.getPermission());
         assertFalse(aprc.isOnlyPlayer());
         assertEquals("commands.admin.purge.regions.parameters", aprc.getParameters());
@@ -158,7 +158,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * canExecute with no args should show help and return false.
      */
     @Test
-    public void testCanExecuteEmptyArgs() {
+    void testCanExecuteEmptyArgs() {
         assertFalse(aprc.canExecute(user, "regions", Collections.emptyList()));
         verify(user).sendMessage(eq("commands.help.header"), any(), any());
     }
@@ -167,7 +167,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * canExecute with a valid argument should return true.
      */
     @Test
-    public void testCanExecuteWithArgs() {
+    void testCanExecuteWithArgs() {
         assertTrue(aprc.canExecute(user, "regions", List.of("10")));
         verify(user, never()).sendMessage("commands.admin.purge.purge-in-progress", TextVariables.LABEL, "bsb");
     }
@@ -176,7 +176,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * A non-numeric argument should produce an error message and return false.
      */
     @Test
-    public void testExecuteNotANumber() {
+    void testExecuteNotANumber() {
         assertFalse(aprc.execute(user, "regions", List.of("notanumber")));
         verify(user).sendMessage("commands.admin.purge.days-one-or-more");
     }
@@ -185,7 +185,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * Zero days is invalid — must be one or more.
      */
     @Test
-    public void testExecuteZeroDays() {
+    void testExecuteZeroDays() {
         assertFalse(aprc.execute(user, "regions", List.of("0")));
         verify(user).sendMessage("commands.admin.purge.days-one-or-more");
     }
@@ -194,7 +194,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * Negative days is invalid.
      */
     @Test
-    public void testExecuteNegativeDays() {
+    void testExecuteNegativeDays() {
         assertFalse(aprc.execute(user, "regions", List.of("-3")));
         verify(user).sendMessage("commands.admin.purge.days-one-or-more");
     }
@@ -204,7 +204,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * the command should report none found.
      */
     @Test
-    public void testExecuteNullIslandGrid() {
+    void testExecuteNullIslandGrid() {
         when(islandCache.getIslandGrid(world)).thenReturn(null);
 
         assertTrue(aprc.execute(user, "regions", List.of("10")));
@@ -231,7 +231,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * When there are no .mca files in the region folder, none-found should be sent.
      */
     @Test
-    public void testExecuteNoRegionFiles() throws IOException {
+    void testExecuteNoRegionFiles() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
         when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
@@ -249,7 +249,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * the command should propose deletion and ask for confirmation.
      */
     @Test
-    public void testExecuteOldRegionFileNoIslands() throws IOException {
+    void testExecuteOldRegionFileNoIslands() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
         when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
@@ -271,7 +271,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * the region files and send the success message.
      */
     @Test
-    public void testExecuteConfirmDeletesRegions() throws IOException {
+    void testExecuteConfirmDeletesRegions() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
         when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
@@ -296,7 +296,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * which is not a valid number).
      */
     @Test
-    public void testExecuteConfirmWithoutPriorScan() {
+    void testExecuteConfirmWithoutPriorScan() {
         assertFalse(aprc.execute(user, "regions", List.of("confirm")));
         verify(user).sendMessage("commands.admin.purge.days-one-or-more");
         verify(user, never()).sendMessage("general.success");
@@ -307,7 +307,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * The command should report none found.
      */
     @Test
-    public void testExecuteRecentRegionFileExcluded() throws IOException {
+    void testExecuteRecentRegionFileExcluded() throws IOException {
         IslandGrid grid = mock(IslandGrid.class);
         when(grid.getIslandsInBounds(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(Collections.emptyList());
         when(islandCache.getIslandGrid(world)).thenReturn(grid);
@@ -339,7 +339,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * An island whose member logged in recently must be excluded from purge candidates.
      */
     @Test
-    public void testExecuteIslandWithRecentLoginIsExcluded() throws IOException {
+    void testExecuteIslandWithRecentLoginIsExcluded() throws IOException {
         UUID ownerUUID = UUID.randomUUID();
         when(island.getUniqueId()).thenReturn("island-1");
         when(island.getOwner()).thenReturn(ownerUUID);
@@ -372,7 +372,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * Spawn islands must never be purged.
      */
     @Test
-    public void testExecuteSpawnIslandNotPurged() throws IOException {
+    void testExecuteSpawnIslandNotPurged() throws IOException {
         UUID ownerUUID = UUID.randomUUID();
         when(island.getUniqueId()).thenReturn("island-spawn");
         when(island.getOwner()).thenReturn(ownerUUID);
@@ -403,7 +403,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * Purge-protected islands must never be purged.
      */
     @Test
-    public void testExecutePurgeProtectedIslandNotPurged() throws IOException {
+    void testExecutePurgeProtectedIslandNotPurged() throws IOException {
         UUID ownerUUID = UUID.randomUUID();
         when(island.getUniqueId()).thenReturn("island-protected");
         when(island.getOwner()).thenReturn(ownerUUID);
@@ -433,7 +433,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * An island marked as deletable should always be eligible regardless of other flags.
      */
     @Test
-    public void testExecuteDeletableIslandIncluded() throws IOException {
+    void testExecuteDeletableIslandIncluded() throws IOException {
         UUID ownerUUID = UUID.randomUUID();
         when(island.getUniqueId()).thenReturn("island-deletable");
         when(island.getOwner()).thenReturn(ownerUUID);
@@ -465,7 +465,7 @@ public class AdminPurgeRegionsCommandTest extends CommonTestSetup {
      * when they have no remaining islands and haven't logged in recently.
      */
     @Test
-    public void testExecuteConfirmDeletesPlayerData() throws IOException {
+    void testExecuteConfirmDeletesPlayerData() throws IOException {
         UUID ownerUUID = UUID.randomUUID();
         when(island.getUniqueId()).thenReturn("island-deletable");
         when(island.getOwner()).thenReturn(ownerUUID);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeUnownedCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/purge/AdminPurgeUnownedCommandTest.java
@@ -24,7 +24,7 @@ import world.bentobox.bentobox.managers.CommandsManager;
  * @author Poslovitch
  *
  */
-public class AdminPurgeUnownedCommandTest extends CommonTestSetup {
+class AdminPurgeUnownedCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -78,7 +78,7 @@ public class AdminPurgeUnownedCommandTest extends CommonTestSetup {
      * Makes sure no spawn islands are purged whatsoever
      */
     @Test
-    public void testNoPurgeIfIslandIsSpawn() {
+    void testNoPurgeIfIslandIsSpawn() {
         when(island.isSpawn()).thenReturn(true);
         when(im.getIslands()).thenReturn(Collections.singleton(island));
         assertTrue(apuc.execute(user, "", Collections.emptyList()));
@@ -86,7 +86,7 @@ public class AdminPurgeUnownedCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testNoPurgeIfIslandIsOwned() {
+    void testNoPurgeIfIslandIsOwned() {
         when(im.getIslands()).thenReturn(Collections.singleton(island));
         assertTrue(apuc.execute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.admin.purge.unowned.unowned-islands", "[number]", "0");
@@ -94,7 +94,7 @@ public class AdminPurgeUnownedCommandTest extends CommonTestSetup {
 
     @Disabled("unable to mock CompositeCommand#askConfirmation()")
     @Test
-    public void testPurgeIfIslandIsUnowned() {
+    void testPurgeIfIslandIsUnowned() {
         when(island.isOwned()).thenReturn(false);
         when(island.isUnowned()).thenReturn(true);
         when(im.getIslands()).thenReturn(Collections.singleton(island));
@@ -103,7 +103,7 @@ public class AdminPurgeUnownedCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testNoPurgeIfIslandIsPurgeProtected() {
+    void testNoPurgeIfIslandIsPurgeProtected() {
         when(island.isPurgeProtected()).thenReturn(true);
         when(im.getIslands()).thenReturn(Collections.singleton(island));
         assertTrue(apuc.execute(user, "", Collections.emptyList()));

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommandTest.java
@@ -27,7 +27,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.util.Util;
 
-public class AdminRangeCommandTest extends CommonTestSetup {
+class AdminRangeCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -93,7 +93,7 @@ public class AdminRangeCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testExecuteConsoleNoArgs() {
+    void testExecuteConsoleNoArgs() {
         AdminRangeCommand arc = new AdminRangeCommand(ac);
         CommandSender sender = mock(CommandSender.class);
         when(sender.spigot()).thenReturn(spigot);
@@ -104,7 +104,7 @@ public class AdminRangeCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testExecutePlayerNoArgs() {
+    void testExecutePlayerNoArgs() {
         AdminRangeCommand arc = new AdminRangeCommand(ac);
         arc.execute(user, "", new ArrayList<>());
         // Show help"

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeDisplayCommandTest.java
@@ -31,7 +31,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminRangeDisplayCommandTest extends CommonTestSetup {
+class AdminRangeDisplayCommandTest extends CommonTestSetup {
 
     private CompositeCommand ac;
     private User user;
@@ -102,7 +102,7 @@ public class AdminRangeDisplayCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeDisplayCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayerDisplayArgs() {
+    void testExecutePlayerDisplayArgs() {
         AdminRangeDisplayCommand ardc = new AdminRangeDisplayCommand(ac);
         ardc.execute(user, "display", new ArrayList<>());
         // Show display
@@ -119,7 +119,7 @@ public class AdminRangeDisplayCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeDisplayCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayeShowArgs() {
+    void testExecutePlayeShowArgs() {
         AdminRangeDisplayCommand ardc = new AdminRangeDisplayCommand(ac);
         ardc.execute(user, "show", new ArrayList<>());
         // Show display
@@ -137,7 +137,7 @@ public class AdminRangeDisplayCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeDisplayCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayeHideArgs() {
+    void testExecutePlayeHideArgs() {
         AdminRangeDisplayCommand ardc = new AdminRangeDisplayCommand(ac);
         ardc.execute(user, "hide", new ArrayList<>());
         verify(user).sendMessage("commands.admin.range.display.already-off");

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeResetCommandTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminRangeResetCommandTest extends CommonTestSetup {
+class AdminRangeResetCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -107,7 +107,7 @@ public class AdminRangeResetCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeResetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteConsoleNoArgs() {
+    void testExecuteConsoleNoArgs() {
         AdminRangeResetCommand arc = new AdminRangeResetCommand(ac);
         CommandSender sender = mock(CommandSender.class);
         when(sender.spigot()).thenReturn(spigot);
@@ -122,7 +122,7 @@ public class AdminRangeResetCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeResetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayerNoArgs() {
+    void testExecutePlayerNoArgs() {
         AdminRangeResetCommand arc = new AdminRangeResetCommand(ac);
         arc.execute(user, "", new ArrayList<>());
         // Show help
@@ -134,7 +134,7 @@ public class AdminRangeResetCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeResetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         AdminRangeResetCommand arc = new AdminRangeResetCommand(ac);
         String[] name = { "tastybento" };
         arc.execute(user, "", Arrays.asList(name));
@@ -145,7 +145,7 @@ public class AdminRangeResetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeResetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteKnownPlayerNotOwnerNoTeam() {
+    void testExecuteKnownPlayerNotOwnerNoTeam() {
         when(pm.getUUID(Mockito.anyString())).thenReturn(uuid);
         when(im.hasIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(false);
         when(im.inTeam(Mockito.any(), Mockito.any(UUID.class))).thenReturn(false);
@@ -157,7 +157,7 @@ public class AdminRangeResetCommandTest extends CommonTestSetup {
     }
 
     @Test
-    public void testExecuteKnownPlayerNotOwnerButInTeam() {
+    void testExecuteKnownPlayerNotOwnerButInTeam() {
         when(pm.getUUID(Mockito.anyString())).thenReturn(uuid);
         when(im.hasIsland(Mockito.any(), Mockito.any(UUID.class))).thenReturn(false);
         when(im.inTeam(Mockito.any(), Mockito.any(UUID.class))).thenReturn(true);
@@ -172,7 +172,7 @@ public class AdminRangeResetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeResetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteKnownPlayer() {
+    void testExecuteKnownPlayer() {
         when(pm.getUUID(Mockito.anyString())).thenReturn(uuid);
         AdminRangeResetCommand arc = new AdminRangeResetCommand(ac);
         List<String> args = new ArrayList<>();

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeSetCommandTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminRangeSetCommandTest extends CommonTestSetup {
+class AdminRangeSetCommandTest extends CommonTestSetup {
 
     @Mock
     private CommandsManager cm;
@@ -112,7 +112,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteConsoleNoArgs() {
+    void testExecuteConsoleNoArgs() {
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         CommandSender sender = mock(CommandSender.class);
         when(sender.spigot()).thenReturn(spigot);
@@ -127,7 +127,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayerNoArgs() {
+    void testExecutePlayerNoArgs() {
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         assertFalse(arc.canExecute(user, "", List.of()));
         // Show help
@@ -139,7 +139,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         String[] args = { "tastybento", "100" };
         assertFalse(arc.canExecute(user, "", Arrays.asList(args)));
@@ -150,7 +150,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteKnownPlayerNotOwnerNoTeam() {
+    void testExecuteKnownPlayerNotOwnerNoTeam() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         when(im.getOwnedIslands(any(), any(UUID.class))).thenReturn(Set.of());
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
@@ -166,7 +166,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteKnownPlayerNotOwnerButInTeam() {
+    void testExecuteKnownPlayerNotOwnerButInTeam() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         when(im.getOwnedIslands(any(), any(UUID.class))).thenReturn(Set.of());
         when(im.inTeam(any(), any(UUID.class))).thenReturn(true);
@@ -182,7 +182,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteTooHigh() {
+    void testExecuteTooHigh() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();
@@ -197,7 +197,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNotANumber() {
+    void testExecuteNotANumber() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();
@@ -211,7 +211,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test()
-    public void testExecuteDoubleNumber() {
+    void testExecuteDoubleNumber() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();
@@ -225,7 +225,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteZero() {
+    void testExecuteZero() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();
@@ -240,7 +240,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNegNumber() {
+    void testExecuteNegNumber() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();
@@ -254,7 +254,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSame() {
+    void testExecuteSame() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();
@@ -269,7 +269,7 @@ public class AdminRangeSetCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.range.AdminRangeSetCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecute() {
+    void testExecute() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         AdminRangeSetCommand arc = new AdminRangeSetCommand(ac);
         List<String> args = new ArrayList<>();

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminTeamAddCommandTest extends CommonTestSetup {
+class AdminTeamAddCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -110,7 +110,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteWrongArgs() {
+    void testExecuteWrongArgs() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         List<String> args = new ArrayList<>();
         assertFalse(itl.execute(user, itl.getLabel(), args));
@@ -128,7 +128,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         String[] name = { "tastybento", "poslovich" };
 
@@ -149,7 +149,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteTargetTargetInTeam() {
+    void testExecuteTargetTargetInTeam() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         String[] name = { "tastybento", "poslovich" };
 
@@ -166,7 +166,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteAddNoIsland() {
+    void testExecuteAddNoIsland() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         String[] name = { "tastybento", "poslovich" };
 
@@ -185,7 +185,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteAddNotOwner() {
+    void testExecuteAddNotOwner() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         String[] name = { "tastybento", "poslovich" };
 
@@ -208,7 +208,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteAddTargetHasIsland() {
+    void testExecuteAddTargetHasIsland() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         String[] name = { "tastybento", "poslovich" };
 
@@ -231,7 +231,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteAddTargetHasIslandNoTeam() {
+    void testExecuteAddTargetHasIslandNoTeam() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         String[] name = { "tastybento", "poslovich" };
 
@@ -255,7 +255,7 @@ public class AdminTeamAddCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamAddCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteSuccess() {
+    void testExecuteSuccess() {
         AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
         String[] name = { "tastybento", "poslovich" };
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandCommandTest.java
@@ -43,7 +43,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminTeamDisbandCommandTest extends CommonTestSetup {
+class AdminTeamDisbandCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -139,7 +139,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamDisbandCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testExecuteNoTarget() {
+    void testExecuteNoTarget() {
         assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
     }
 
@@ -147,7 +147,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamDisbandCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         String[] name = { "tastybento" };
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), Arrays.asList(name)));
@@ -158,7 +158,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamDisbandCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testExecutePlayerNotInTeam() {
+    void testExecutePlayerNotInTeam() {
         when(Util.getUUID("tastybento")).thenReturn(notUUID);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
@@ -168,7 +168,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamDisbandCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testExecuteDisbandNoIsland() {
+    void testExecuteDisbandNoIsland() {
         when(im.inTeam(any(), any())).thenReturn(true);
         when(Util.getUUID("tastybento")).thenReturn(uuid);
         when(im.getOwnedIslands(any(), eq(uuid))).thenReturn(Set.of());
@@ -180,7 +180,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testCanExecuteSuccess() {
+    void testCanExecuteSuccess() {
         when(im.inTeam(any(), any())).thenReturn(true);
         when(Util.getUUID("tastybento")).thenReturn(uuid);
         when(pm.getName(uuid)).thenReturn("tastybento");
@@ -195,7 +195,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteSuccess() {
+    void testExecuteSuccess() {
         this.testCanExecuteSuccess();
         assertTrue(itl.execute(user, itl.getLabel(), List.of("tastybento")));
         verify(im, never()).removePlayer(island, uuid);
@@ -210,7 +210,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand#tabComplete(User, String, List)}
      */
     @Test
-    public void testTabCompleteNoArgs() {
+    void testTabCompleteNoArgs() {
         AdminTeamDisbandCommand itl = new AdminTeamDisbandCommand(ac);
         Optional<List<String>> list = itl.tabComplete(user, "", List.of(""));
         assertTrue(list.isEmpty());
@@ -220,7 +220,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand#tabComplete(User, String, List)}
      */
     @Test
-    public void testTabCompleteOneArg() {
+    void testTabCompleteOneArg() {
         when(Util.getUUID("tastybento")).thenReturn(uuid);
         when(pm.getName(uuid)).thenReturn("tastybento");
 
@@ -233,7 +233,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand#tabComplete(User, String, List)}
      */
     @Test
-    public void testTabCompleteTwoArgs() {
+    void testTabCompleteTwoArgs() {
         when(Util.getUUID("tastybento")).thenReturn(uuid);
         when(pm.getName(uuid)).thenReturn("tastybento");
 
@@ -246,7 +246,7 @@ public class AdminTeamDisbandCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand#tabComplete(User, String, List)}
      */
     @Test
-    public void testTabCompleteThreeArgs() {
+    void testTabCompleteThreeArgs() {
         when(Util.getUUID("tastybento")).thenReturn(uuid);
         when(pm.getName(uuid)).thenReturn("tastybento");
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamKickCommandTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminTeamKickCommandTest extends CommonTestSetup {
+class AdminTeamKickCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -108,7 +108,7 @@ public class AdminTeamKickCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamKickCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testCanExecuteNoTarget() {
+    void testCanExecuteNoTarget() {
         AdminTeamKickCommand itl = new AdminTeamKickCommand(ac);
         assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
@@ -118,7 +118,7 @@ public class AdminTeamKickCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamKickCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         AdminTeamKickCommand itl = new AdminTeamKickCommand(ac);
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -129,7 +129,7 @@ public class AdminTeamKickCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamKickCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testCanExecutePlayerNotInTeam() {
+    void testCanExecutePlayerNotInTeam() {
         AdminTeamKickCommand itl = new AdminTeamKickCommand(ac);
         when(pm.getUUID(any())).thenReturn(notUUID);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -140,7 +140,7 @@ public class AdminTeamKickCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamKickCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecute() {
+    void testExecute() {
         when(im.inTeam(any(), any())).thenReturn(true);
         String name = "tastybento";
         when(pm.getUUID(any())).thenReturn(uuid);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
@@ -41,7 +41,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class AdminTeamSetownerCommandTest extends CommonTestSetup {
+class AdminTeamSetownerCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ac;
@@ -128,7 +128,7 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamSetownerCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testExecuteNoTarget() {
+    void testExecuteNoTarget() {
         assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "commands.help.console");
@@ -138,7 +138,7 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamSetownerCommand#setup()}
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("commands.admin.team.setowner.description", itl.getDescription());
         assertEquals("commands.admin.team.setowner.parameters", itl.getParameters());
         assertTrue(itl.isOnlyPlayer());
@@ -149,7 +149,7 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamSetownerCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
     }
@@ -158,7 +158,7 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamSetownerCommand#canExecute(User, String, List)}.
      */
     @Test
-    public void testExecuteMakeOwnerAlreadyOwner() {
+    void testExecuteMakeOwnerAlreadyOwner() {
         when(im.getIslandAt(any())).thenReturn(Optional.of(island));
         when(island.getOwner()).thenReturn(uuid);
         when(Util.getUUID("tastybento")).thenReturn(uuid);
@@ -170,7 +170,7 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamSetownerCommand#execute(User, String, List)}.
      */
     @Test
-    public void testExecuteSuccess() {
+    void testExecuteSuccess() {
         when(im.getIslandAt(any())).thenReturn(Optional.of(island));
         when(island.getOwner()).thenReturn(notUUID);
         when(Util.getUUID("tastybento")).thenReturn(uuid);
@@ -186,7 +186,7 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamSetownerCommand#changeOwner(User)}
      */
     @Test
-    public void testChangeOwner() {
+    void testChangeOwner() {
         when(im.getIslandAt(any())).thenReturn(Optional.of(island));
         when(island.getOwner()).thenReturn(notUUID);
         when(Util.getUUID("tastybento")).thenReturn(uuid);
@@ -201,7 +201,7 @@ public class AdminTeamSetownerCommandTest extends CommonTestSetup {
      * Test method for {@link AdminTeamSetownerCommand#changeOwner(User)}
      */
     @Test
-    public void testChangeOwnerNoOwner() {
+    void testChangeOwnerNoOwner() {
         when(im.getIslandAt(any())).thenReturn(Optional.of(island));
         when(island.getOwner()).thenReturn(null);
         when(Util.getUUID("tastybento")).thenReturn(uuid);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/DefaultPlayerCommandTest.java
@@ -29,7 +29,7 @@ import world.bentobox.bentobox.managers.CommandsManager;
  * @author tastybento
  *
  */
-public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
+class DefaultPlayerCommandTest extends RanksManagerTestSetup {
 
     @Mock
     GameModeAddon addon;
@@ -88,7 +88,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#DefaultPlayerCommand(world.bentobox.bentobox.api.addons.GameModeAddon)}.
      */
     @Test
-    public void testDefaultPlayerCommand() {
+    void testDefaultPlayerCommand() {
         assertNotNull(dpc);
     }
 
@@ -97,7 +97,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("commands.island.help.description", dpc.getDescription());
         assertTrue(dpc.isOnlyPlayer());
         assertEquals("island", dpc.getPermission());
@@ -110,7 +110,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringUnknownCommand() {
+    void testExecuteUserStringListOfStringUnknownCommand() {
         assertFalse(dpc.execute(user, "label", List.of("unknown")));
         verify(user).sendMessage("general.errors.unknown-command", TextVariables.LABEL, "island");
     }
@@ -120,7 +120,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNullUser() {
+    void testExecuteUserStringListOfStringNullUser() {
         assertFalse(dpc.execute(null, "label", List.of()));
     }
 
@@ -129,7 +129,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEmptyArgsHasIsland() {
+    void testExecuteUserStringListOfStringEmptyArgsHasIsland() {
         assertFalse(dpc.execute(user, "label", List.of()));
         verify(user).sendMessage("general.errors.use-in-game");
     }
@@ -138,7 +138,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEmptyArgsHasNoIsland() {
+    void testExecuteUserStringListOfStringEmptyArgsHasNoIsland() {
         when(im.getIsland(any(World.class), any(UUID.class))).thenReturn(null);
         assertFalse(dpc.execute(user, "label", List.of()));
         verify(user).sendMessage("general.errors.use-in-game");
@@ -148,7 +148,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEmptyArgsHasIslandUnknownCommand() {
+    void testExecuteUserStringListOfStringEmptyArgsHasIslandUnknownCommand() {
         when(ws.getDefaultPlayerAction()).thenReturn("goxxx");
 
         assertFalse(dpc.execute(user, "label", List.of()));
@@ -159,7 +159,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEmptyArgsHasNoIslandUnknownCommand() {
+    void testExecuteUserStringListOfStringEmptyArgsHasNoIslandUnknownCommand() {
 
         when(ws.getDefaultNewPlayerAction()).thenReturn("createxxx");
 
@@ -172,7 +172,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEmptyArgsHasIslandUnknownCommandSlash() {
+    void testExecuteUserStringListOfStringEmptyArgsHasIslandUnknownCommandSlash() {
         when(ws.getDefaultPlayerAction()).thenReturn("/goxxx");
 
         assertFalse(dpc.execute(user, "label", List.of()));
@@ -183,7 +183,7 @@ public class DefaultPlayerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEmptyArgsHasNoIslandUnknownCommandSlash() {
+    void testExecuteUserStringListOfStringEmptyArgsHasNoIslandUnknownCommandSlash() {
 
         when(ws.getDefaultNewPlayerAction()).thenReturn("/createxxx");
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanCommandTest.java
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandBanCommandTest extends RanksManagerTestSetup {
+class IslandBanCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -162,12 +162,12 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     // Ban online user
 
     @Test
-    public void testNoArgs() {
+    void testNoArgs() {
         assertFalse(ibc.canExecute(user, ibc.getLabel(), new ArrayList<>()));
     }
 
     @Test
-    public void testNoIsland() {
+    void testNoIsland() {
         when(im.hasIsland(any(), eq(uuid))).thenReturn(false);
         when(im.inTeam(any(), eq(uuid))).thenReturn(false);
         assertFalse(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
@@ -175,7 +175,7 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTooLowRank() {
+    void testTooLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
@@ -183,21 +183,21 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testUnknownUser() {
+    void testUnknownUser() {
         when(pm.getUUID(Mockito.anyString())).thenReturn(null);
         assertFalse(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "bill");
     }
 
     @Test
-    public void testBanSelf() {
+    void testBanSelf() {
         when(pm.getUUID(anyString())).thenReturn(uuid);
         assertFalse(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
         verify(user).sendMessage("commands.island.ban.cannot-ban-yourself");
     }
 
     @Test
-    public void testBanTeamMate() {
+    void testBanTeamMate() {
         UUID teamMate = UUID.randomUUID();
         when(pm.getUUID(anyString())).thenReturn(teamMate);
         when(island.getMemberSet()).thenReturn(ImmutableSet.of(uuid, teamMate));
@@ -207,7 +207,7 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testBanAlreadyBanned() {
+    void testBanAlreadyBanned() {
         UUID bannedUser = UUID.randomUUID();
         when(pm.getUUID(anyString())).thenReturn(bannedUser);
         when(island.isBanned(bannedUser)).thenReturn(true);
@@ -216,14 +216,14 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testBanOp() {
+    void testBanOp() {
         when(mockPlayer.isOp()).thenReturn(true);
         assertFalse(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
         verify(user).sendMessage("commands.island.ban.cannot-ban");
     }
 
     @Test
-    public void testBanOnlineNoBanPermission() {
+    void testBanOnlineNoBanPermission() {
         when(mockPlayer.hasPermission(anyString())).thenReturn(true);
         User.getInstance(mockPlayer);
 
@@ -232,7 +232,7 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testBanOfflineUserSuccess() {
+    void testBanOfflineUserSuccess() {
         when(mockPlayer.isOnline()).thenReturn(false);
         assertTrue(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
 
@@ -245,7 +245,7 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testBanOnlineUserSuccess() {
+    void testBanOnlineUserSuccess() {
         assertTrue(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
 
         // Allow adding to ban list
@@ -258,7 +258,7 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testCancelledBan() {
+    void testCancelledBan() {
         assertTrue(ibc.canExecute(user, ibc.getLabel(), Collections.singletonList("bill")));
 
         // Disallow adding to ban list - event cancelled
@@ -271,7 +271,7 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteNoIsland() {
+    void testTabCompleteNoIsland() {
         // No island
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         // Set up the user
@@ -297,7 +297,7 @@ public class IslandBanCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabComplete() {
+    void testTabComplete() {
 
         String[] names = { "adam", "ben", "cara", "dave", "ed", "frank", "freddy", "george", "harry", "ian", "joe" };
         Map<UUID, String> online = new HashMap<>();

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanlistCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandBanlistCommandTest.java
@@ -37,7 +37,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandBanlistCommandTest extends RanksManagerTestSetup {
+class IslandBanlistCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -101,7 +101,7 @@ public class IslandBanlistCommandTest extends RanksManagerTestSetup {
      * {@link IslandBanlistCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testWithArgs() {
+    void testWithArgs() {
         IslandBanlistCommand iubc = new IslandBanlistCommand(ic);
         assertFalse(iubc.canExecute(user, iubc.getLabel(), Collections.singletonList("bill")));
         // Verify show help
@@ -112,7 +112,7 @@ public class IslandBanlistCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandBanlistCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testNoIsland() {
+    void testNoIsland() {
         // not in team
         when(im.inTeam(any(), eq(uuid))).thenReturn(false);
         IslandBanlistCommand iubc = new IslandBanlistCommand(ic);
@@ -124,7 +124,7 @@ public class IslandBanlistCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandBanlistCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testTooLowRank() {
+    void testTooLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandBanlistCommand iubc = new IslandBanlistCommand(ic);
@@ -137,7 +137,7 @@ public class IslandBanlistCommandTest extends RanksManagerTestSetup {
      * {@link IslandBanlistCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testBanlistNooneBanned() {
+    void testBanlistNooneBanned() {
         IslandBanlistCommand iubc = new IslandBanlistCommand(ic);
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         iubc.canExecute(user, iubc.getLabel(), Collections.emptyList());
@@ -150,7 +150,7 @@ public class IslandBanlistCommandTest extends RanksManagerTestSetup {
      * {@link IslandBanlistCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testBanlistBanned() {
+    void testBanlistBanned() {
         IslandBanlistCommand iubc = new IslandBanlistCommand(ic);
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         // Make a ban list
@@ -176,7 +176,7 @@ public class IslandBanlistCommandTest extends RanksManagerTestSetup {
      * {@link IslandBanlistCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testBanlistMaxBanNoLimit() {
+    void testBanlistMaxBanNoLimit() {
         testBanlistBanned();
         verify(user, never()).sendMessage(eq("commands.island.banlist.you-can-ban"), anyString(), anyString());
     }
@@ -185,7 +185,7 @@ public class IslandBanlistCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandBanlistCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testBanlistMaxBanLimit() {
+    void testBanlistMaxBanLimit() {
         when(user.getPermissionValue(anyString(), anyInt())).thenReturn(15);
         testBanlistBanned();
         verify(user).sendMessage("commands.island.banlist.you-can-ban", TextVariables.NUMBER, "4");

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandCreateCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandCreateCommandTest.java
@@ -51,7 +51,7 @@ import world.bentobox.bentobox.panels.customizable.IslandCreationPanel;
  * @author tastybento
  *
  */
-public class IslandCreateCommandTest extends CommonTestSetup {
+class IslandCreateCommandTest extends CommonTestSetup {
 
     @Mock
     private User user;
@@ -159,7 +159,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#IslandCreateCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandCreateCommand() {
+    void testIslandCreateCommand() {
         assertEquals("create", cc.getLabel());
         assertEquals("new", cc.getAliases().getFirst());
     }
@@ -169,7 +169,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertTrue(cc.isOnlyPlayer());
         assertEquals("commands.island.create.parameters", cc.getParameters());
         assertEquals("commands.island.create.description", cc.getDescription());
@@ -180,7 +180,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringHasIsland() {
+    void testCanExecuteUserStringListOfStringHasIsland() {
         // Currently user has two islands
         when(im.getNumberOfConcurrentIslands(user.getUniqueId(), world)).thenReturn(2);
         // Player has an island
@@ -192,7 +192,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringZeroAllowed() {
+    void testCanExecuteUserStringListOfStringZeroAllowed() {
         when(ws.getConcurrentIslands()).thenReturn(0); // No islands allowed
         assertFalse(cc.canExecute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.island.create.you-cannot-make");
@@ -203,7 +203,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringHasPerm() {
+    void testCanExecuteUserStringListOfStringHasPerm() {
         // Currently user has two islands
         when(im.getNumberOfConcurrentIslands(user.getUniqueId(), world)).thenReturn(19);
         // Perm
@@ -217,7 +217,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringHasIslandReserved() {
+    void testCanExecuteUserStringListOfStringHasIslandReserved() {
         @Nullable
         Island island = mock(Island.class);
         when(im.getIsland(any(), any(User.class))).thenReturn(island);
@@ -231,7 +231,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringTooManyIslands() {
+    void testCanExecuteUserStringListOfStringTooManyIslands() {
         when(im.getPrimaryIsland(any(), any(UUID.class))).thenReturn(null);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         when(iwm.getMaxIslands(any())).thenReturn(100);
@@ -245,7 +245,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringSuccess() throws Exception {
+    void testExecuteUserStringListOfStringSuccess() throws Exception {
         // Bundle exists
         when(bpm.validate(any(), any())).thenReturn("custom");
         // Has permission
@@ -264,7 +264,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringThrowException() throws Exception {
+    void testExecuteUserStringListOfStringThrowException() throws Exception {
         // Bundle exists
         when(bpm.validate(any(), any())).thenReturn("custom");
         // Has permission
@@ -281,7 +281,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringBundleNoPermission() {
+    void testExecuteUserStringListOfStringBundleNoPermission() {
         // Bundle exists
         when(bpm.validate(any(), any())).thenReturn("custom");
         // No permission
@@ -295,7 +295,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringUnknownBundle() {
+    void testExecuteUserStringListOfStringUnknownBundle() {
         assertFalse(cc.execute(user, "", List.of("custom")));
         verify(user).sendMessage("commands.island.create.unknown-blueprint");
         verify(user, never()).sendMessage("commands.island.create.creating-island");
@@ -306,7 +306,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoBundleNoPanel() {
+    void testExecuteUserStringListOfStringNoBundleNoPanel() {
         // Creates default bundle
         assertTrue(cc.execute(user, "", Collections.emptyList()));
         // do not show panel, just make the island
@@ -317,7 +317,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringKnownBundle() throws Exception {
+    void testExecuteUserStringListOfStringKnownBundle() throws Exception {
         // Has permission
         when(bpm.checkPerm(any(), any(), any())).thenReturn(true);
         when(bpm.validate(any(), any())).thenReturn("custom");
@@ -335,7 +335,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringCooldown() {
+    void testExecuteUserStringListOfStringCooldown() {
         assertTrue(cc.execute(user, "", Collections.emptyList()));
         verify(ic, never()).getSubCommand("reset");
     }
@@ -344,7 +344,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoCooldown() {
+    void testExecuteUserStringListOfStringNoCooldown() {
         when(settings.isResetCooldownOnCreate()).thenReturn(true);
         assertTrue(cc.execute(user, "", Collections.emptyList()));
     }
@@ -354,7 +354,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandCreateCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringShowPanel() {
+    void testExecuteUserStringListOfStringShowPanel() {
         Map<String, BlueprintBundle> map = Map.of("bundle1", new BlueprintBundle(), "bundle2", new BlueprintBundle(),
                 "bundle3", new BlueprintBundle());
         when(bpm.getBlueprintBundles(any())).thenReturn(map);
@@ -367,7 +367,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for cost check - cannot afford
      */
     @Test
-    public void testMakeIslandWithCostCannotAfford() {
+    void testMakeIslandWithCostCannotAfford() {
         // Multiple bundles
         BlueprintBundle bb = new BlueprintBundle();
         bb.setCost(100.0);
@@ -394,7 +394,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for cost check - can afford
      */
     @Test
-    public void testMakeIslandWithCostCanAfford() {
+    void testMakeIslandWithCostCanAfford() {
         // Multiple bundles
         BlueprintBundle bb = new BlueprintBundle();
         bb.setCost(100.0);
@@ -421,7 +421,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for cost check - single bundle ignores cost
      */
     @Test
-    public void testMakeIslandCostIgnoredSingleBundle() {
+    void testMakeIslandCostIgnoredSingleBundle() {
         // Single bundle with cost
         BlueprintBundle bb = new BlueprintBundle();
         bb.setCost(100.0);
@@ -442,7 +442,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for cost check - economy disabled ignores cost
      */
     @Test
-    public void testMakeIslandCostIgnoredNoEconomy() {
+    void testMakeIslandCostIgnoredNoEconomy() {
         // Multiple bundles
         BlueprintBundle bb = new BlueprintBundle();
         bb.setCost(100.0);
@@ -463,7 +463,7 @@ public class IslandCreateCommandTest extends CommonTestSetup {
      * Test method for cost check - no vault ignores cost
      */
     @Test
-    public void testMakeIslandCostIgnoredNoVault() {
+    void testMakeIslandCostIgnoredNoVault() {
         // Multiple bundles
         BlueprintBundle bb = new BlueprintBundle();
         bb.setCost(100.0);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommandTest.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
+class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -121,7 +121,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#IslandDeletehomeCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandDeletehomeCommand() {
+    void testIslandDeletehomeCommand() {
         assertEquals("deletehome", idh.getLabel());
 
     }
@@ -130,7 +130,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertTrue(idh.isOnlyPlayer());
         assertEquals("commands.island.deletehome.parameters", idh.getParameters());
         assertEquals("commands.island.deletehome.description", idh.getDescription());
@@ -142,7 +142,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteHelp() {
+    void testCanExecuteHelp() {
         idh.canExecute(user, "label", List.of());
         verify(user).sendMessage("commands.help.header","[label]","BSkyBlock");
     }
@@ -151,7 +151,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoIsland() {
+    void testCanExecuteNoIsland() {
         when(im.getIsland(any(), eq(user))).thenReturn(null);
         assertFalse(idh.canExecute(user, "label", List.of("something")));
         verify(user).sendMessage("general.errors.no-island");
@@ -161,7 +161,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteLowRank() {
+    void testCanExecuteLowRank() {
         when(island.getRank(user)).thenReturn(RanksManager.COOP_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(idh.canExecute(user, "label", List.of("something")));
@@ -172,7 +172,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUnknownHome() {
+    void testExecuteUnknownHome() {
         when(island.getHomes()).thenReturn(Map.of("home", location));
 
         when(im.isHomeLocation(eq(island), anyString())).thenReturn(false);
@@ -188,7 +188,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         when(island.getHomes()).thenReturn(Map.of("home", location));
         when(im.isHomeLocation(eq(island), anyString())).thenReturn(true);
         assertTrue(idh.execute(user, "label", List.of("home")));
@@ -199,7 +199,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         when(island.getHomes()).thenReturn(Map.of("home", location));
         Optional<List<String>> list = idh.tabComplete(user, "label", List.of("hom"));
         assertTrue(list.isPresent());
@@ -210,7 +210,7 @@ public class IslandDeletehomeCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandDeletehomeCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringNothing() {
+    void testTabCompleteUserStringListOfStringNothing() {
         when(island.getHomes()).thenReturn(Map.of("home", location));
         Optional<List<String>> list = idh.tabComplete(user, "label", List.of("f"));
         assertTrue(list.isPresent());

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommandTest.java
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandExpelCommandTest extends RanksManagerTestSetup {
+class IslandExpelCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -146,7 +146,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#IslandExpelCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandExpelCommand() {
+    void testIslandExpelCommand() {
         assertEquals("expel", iec.getLabel());
     }
 
@@ -155,7 +155,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertTrue(iec.isOnlyPlayer());
         assertEquals("bskyblock.island.expel", iec.getPermission());
         assertEquals("commands.island.expel.parameters", iec.getParameters());
@@ -168,7 +168,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoArgs() {
+    void testCanExecuteNoArgs() {
         assertFalse(iec.canExecute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
     }
@@ -178,7 +178,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteTooManyArgs() {
+    void testCanExecuteTooManyArgs() {
         assertFalse(iec.canExecute(user, "", Arrays.asList("Hello", "there")));
         verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
     }
@@ -188,7 +188,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoTeamNoIsland() {
+    void testCanExecuteNoTeamNoIsland() {
 
         assertFalse(iec.canExecute(user, "", Collections.singletonList("tasty")));
         verify(user).sendMessage("general.errors.no-island");
@@ -198,7 +198,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownTargetUserInTeam() {
+    void testCanExecuteUnknownTargetUserInTeam() {
         when(im.inTeam(any(), any())).thenReturn(true);
         assertFalse(iec.canExecute(user, "", Collections.singletonList("tasty")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "tasty");
@@ -208,7 +208,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownTargetUserHasIsland() {
+    void testCanExecuteUnknownTargetUserHasIsland() {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         assertFalse(iec.canExecute(user, "", Collections.singletonList("tasty")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "tasty");
@@ -218,7 +218,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteLowRank() {
+    void testCanExecuteLowRank() {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         when(island.getRank(any(User.class))).thenReturn(RanksManager.VISITOR_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
@@ -230,7 +230,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSelf() {
+    void testCanExecuteSelf() {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         when(pm.getUUID(anyString())).thenReturn(uuid);
         assertFalse(iec.canExecute(user, "", Collections.singletonList("tasty")));
@@ -241,7 +241,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteTeamMember() {
+    void testCanExecuteTeamMember() {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         UUID target = UUID.randomUUID();
         when(pm.getUUID(anyString())).thenReturn(target);
@@ -255,7 +255,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOfflinePlayer() {
+    void testCanExecuteOfflinePlayer() {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         UUID target = UUID.randomUUID();
         when(pm.getUUID(anyString())).thenReturn(target);
@@ -267,7 +267,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteInvisiblePlayer() {
+    void testCanExecuteInvisiblePlayer() {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         Player t = setUpTarget();
         when(mockPlayer.canSee(t)).thenReturn(false);
@@ -279,7 +279,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNotOnIsland() {
+    void testCanExecuteNotOnIsland() {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         setUpTarget();
         assertFalse(iec.canExecute(user, "", Collections.singletonList("tasty")));
@@ -290,7 +290,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOp() {
+    void testCanExecuteOp() {
         when(im.locationIsOnIsland(any(), any())).thenReturn(true);
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         Player t = setUpTarget();
@@ -303,7 +303,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteBypassPerm() {
+    void testCanExecuteBypassPerm() {
         when(im.locationIsOnIsland(any(), any())).thenReturn(true);
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         Player t = setUpTarget();
@@ -317,7 +317,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecute() {
+    void testCanExecute() {
         when(im.locationIsOnIsland(any(), any())).thenReturn(true);
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         setUpTarget();
@@ -350,7 +350,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringHasIsland() {
+    void testExecuteUserStringListOfStringHasIsland() {
         testCanExecute();
         assertTrue(iec.execute(user, "", Collections.singletonList("tasty")));
         verify(user).sendMessage("commands.island.expel.success", TextVariables.NAME, "target",
@@ -363,7 +363,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIslandSendToSpawn() {
+    void testExecuteUserStringListOfStringNoIslandSendToSpawn() {
         Optional<Island> optionalIsland = Optional.of(island);
         when(im.getSpawn(any())).thenReturn(optionalIsland);
         testCanExecute();
@@ -379,7 +379,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringCreateIsland() {
+    void testExecuteUserStringListOfStringCreateIsland() {
         GameModeAddon gma = mock(GameModeAddon.class);
         CompositeCommand pc = mock(CompositeCommand.class);
         Optional<CompositeCommand> optionalPlayerCommand = Optional.of(pc);
@@ -401,7 +401,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringCreateIslandFailCommand() {
+    void testExecuteUserStringListOfStringCreateIslandFailCommand() {
         GameModeAddon gma = mock(GameModeAddon.class);
         CompositeCommand pc = mock(CompositeCommand.class);
         Optional<CompositeCommand> optionalPlayerCommand = Optional.empty();
@@ -421,7 +421,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#tabComplete(User, String, java.util.List)}
      */
     @Test
-    public void testTabCompleteUserStringListNoIsland() {
+    void testTabCompleteUserStringListNoIsland() {
         when(im.getIsland(any(), any(User.class))).thenReturn(null);
         assertFalse(iec.tabComplete(user, "", Collections.emptyList()).isPresent());
     }
@@ -431,7 +431,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#tabComplete(User, String, java.util.List)}
      */
     @Test
-    public void testTabCompleteUserStringListNoPlayersOnIsland() {
+    void testTabCompleteUserStringListNoPlayersOnIsland() {
         assertTrue(iec.tabComplete(user, "", Collections.emptyList()).get().isEmpty());
     }
 
@@ -440,7 +440,7 @@ public class IslandExpelCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandExpelCommand#tabComplete(User, String, java.util.List)}
      */
     @Test
-    public void testTabCompleteUserStringListPlayersOnIsland() {
+    void testTabCompleteUserStringListPlayersOnIsland() {
         List<Player> list = new ArrayList<>();
         Player p1 = mock(Player.class);
         when(p1.getName()).thenReturn("normal");

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
@@ -57,7 +57,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class IslandGoCommandTest extends CommonTestSetup {
+class IslandGoCommandTest extends CommonTestSetup {
     @Mock
     private CompositeCommand ic;
     private User user;
@@ -164,7 +164,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteMidTeleport() {
+    void testExecuteMidTeleport() {
         when(im.isGoingHome(user)).thenReturn(true);
         assertFalse(igc.canExecute(user, igc.getLabel(), Collections.emptyList()));
         checkSpigotMessage("commands.island.go.in-progress");
@@ -174,7 +174,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsNoIsland() {
+    void testExecuteNoArgsNoIsland() {
         when(im.getIslands(world, uuid)).thenReturn(List.of());
         assertFalse(igc.canExecute(user, igc.getLabel(), Collections.emptyList()));
         checkSpigotMessage("general.errors.no-island");
@@ -184,7 +184,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgs() {
+    void testExecuteNoArgs() {
         assertTrue(igc.canExecute(user, igc.getLabel(), Collections.emptyList()));
     }
 
@@ -192,7 +192,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsReservedIsland() {
+    void testExecuteNoArgsReservedIsland() {
         when(ic.call(any(), any(), any())).thenReturn(true);
         when(island.isReserved()).thenReturn(true);
         assertFalse(igc.canExecute(user, igc.getLabel(), Collections.emptyList()));
@@ -203,7 +203,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsReservedIslandNoCreateCommand() {
+    void testExecuteNoArgsReservedIslandNoCreateCommand() {
         when(ic.getSubCommand("create")).thenReturn(Optional.empty());
 
         when(ic.call(any(), any(), any())).thenReturn(true);
@@ -216,7 +216,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsNoTeleportWhenFalling() {
+    void testExecuteNoArgsNoTeleportWhenFalling() {
         Flags.PREVENT_TELEPORT_WHEN_FALLING.setSetting(world, true);
         when(mockPlayer.getFallDistance()).thenReturn(10F);
         assertFalse(igc.canExecute(user, igc.getLabel(), Collections.emptyList()));
@@ -227,7 +227,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsNoTeleportWhenFallingNotFalling() {
+    void testExecuteNoArgsNoTeleportWhenFallingNotFalling() {
         Flags.PREVENT_TELEPORT_WHEN_FALLING.setSetting(world, true);
         when(mockPlayer.getFallDistance()).thenReturn(0F);
         assertTrue(igc.canExecute(user, igc.getLabel(), Collections.emptyList()));
@@ -237,7 +237,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#execute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsMultipleHomes() {
+    void testExecuteNoArgsMultipleHomes() {
 
         assertTrue(igc.execute(user, igc.getLabel(), Collections.emptyList()));
     }
@@ -246,7 +246,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#execute(User, String, List)}
      */
     @Test
-    public void testExecuteArgs1MultipleHomes() {
+    void testExecuteArgs1MultipleHomes() {
         assertFalse(igc.execute(user, igc.getLabel(), Collections.singletonList("1")));
         checkSpigotMessage("commands.island.go.unknown-home");
         checkSpigotMessage("commands.island.sethome.homes-are");
@@ -257,7 +257,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#execute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsDelay() {
+    void testExecuteNoArgsDelay() {
         when(s.getDelayTime()).thenReturn(10);
 
         assertTrue(igc.execute(user, igc.getLabel(), Collections.emptyList()));
@@ -268,7 +268,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#execute(User, String, List)}
      */
     @Test
-    public void testExecuteNoArgsDelayTwice() {
+    void testExecuteNoArgsDelayTwice() {
         when(s.getDelayTime()).thenReturn(10);
         when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
         assertTrue(igc.execute(user, igc.getLabel(), Collections.emptyList()));
@@ -283,7 +283,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#onPlayerMove(PlayerMoveEvent)}
      */
     @Test
-    public void testOnPlayerMoveHeadMoveNothing() {
+    void testOnPlayerMoveHeadMoveNothing() {
         Location l = mock(Location.class);
         Vector vector = mock(Vector.class);
         when(l.toVector()).thenReturn(vector);
@@ -297,7 +297,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#onPlayerMove(PlayerMoveEvent)}
      */
     @Test
-    public void testOnPlayerMoveHeadMoveTeleportPending() {
+    void testOnPlayerMoveHeadMoveTeleportPending() {
         Location l = mock(Location.class);
         Vector vector = mock(Vector.class);
         when(l.toVector()).thenReturn(vector);
@@ -312,7 +312,7 @@ public class IslandGoCommandTest extends CommonTestSetup {
      * Test method for {@link IslandGoCommand#onPlayerMove(PlayerMoveEvent)}
      */
     @Test
-    public void testOnPlayerMovePlayerMoveTeleportPending() {
+    void testOnPlayerMovePlayerMoveTeleportPending() {
         Location l = mock(Location.class);
         Vector vector = mock(Vector.class);
         when(l.toVector()).thenReturn(vector);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandHomesCommandTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class IslandHomesCommandTest extends CommonTestSetup {
+class IslandHomesCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -112,7 +112,7 @@ public class IslandHomesCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandHomesCommand#IslandHomesCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandHomesCommand() {
+    void testIslandHomesCommand() {
         IslandHomesCommand cmd = new IslandHomesCommand(ic);
         assertEquals("homes", cmd.getName());
     }
@@ -122,7 +122,7 @@ public class IslandHomesCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandHomesCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         IslandHomesCommand isc = new IslandHomesCommand(ic);
         assertEquals("bskyblock.island.homes", isc.getPermission());
         assertTrue(isc.isOnlyPlayer());
@@ -134,7 +134,7 @@ public class IslandHomesCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoIsland() {
+    void testCanExecuteNoIsland() {
         // Player doesn't have an island
         IslandHomesCommand isc = new IslandHomesCommand(ic);
         assertFalse(isc.canExecute(user, "island", Collections.emptyList()));
@@ -145,7 +145,7 @@ public class IslandHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandHomesCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecute() {
+    void testCanExecute() {
         when(im.getIslands(world, user)).thenReturn(List.of(island));
         IslandHomesCommand isc = new IslandHomesCommand(ic);
         assertTrue(isc.canExecute(user, "island", Collections.emptyList()));
@@ -156,7 +156,7 @@ public class IslandHomesCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandHomesCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         IslandHomesCommand isc = new IslandHomesCommand(ic);
         assertTrue(isc.execute(user, "island", Collections.emptyList()));
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandInfoCommandTest.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class IslandInfoCommandTest extends RanksManagerTestSetup {
+class IslandInfoCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -112,7 +112,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("island.info", iic.getPermission());
         assertFalse(iic.isOnlyPlayer());
         assertEquals("commands.island.info.parameters", iic.getParameters());
@@ -123,7 +123,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringTooManyArgs() {
+    void testExecuteUserStringListOfStringTooManyArgs() {
         assertFalse(iic.execute(user, "", Arrays.asList("hdhh", "hdhdhd")));
         verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
     }
@@ -132,7 +132,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoArgsConsole() {
+    void testExecuteUserStringListOfStringNoArgsConsole() {
         CommandSender console = mock(CommandSender.class);
         User sender = User.getInstance(console);
         when(console.spigot()).thenReturn(spigot);
@@ -144,7 +144,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoArgsNoIsland() {
+    void testExecuteUserStringListOfStringNoArgsNoIsland() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         assertFalse(iic.execute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.admin.info.no-island");
@@ -154,7 +154,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoArgsSuccess() {
+    void testExecuteUserStringListOfStringNoArgsSuccess() {
         assertTrue(iic.execute(user, "", Collections.emptyList()));
         verify(user).sendMessage("commands.admin.info.title");
         verify(user).sendMessage(eq("commands.admin.info.owner"), eq("[owner]"), eq(null), eq("[uuid]"), anyString());
@@ -171,7 +171,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringArgsSuccess() {
+    void testExecuteUserStringListOfStringArgsSuccess() {
         assertTrue(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("commands.admin.info.title");
         verify(user).sendMessage(eq("commands.admin.info.owner"), eq("[owner]"), eq(null), eq("[uuid]"), anyString());
@@ -188,7 +188,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringArgsNoIsland() {
+    void testExecuteUserStringListOfStringArgsNoIsland() {
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
@@ -198,7 +198,7 @@ public class IslandInfoCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringArgsUnknownPlayer() {
+    void testExecuteUserStringListOfStringArgsUnknownPlayer() {
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandNearCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandNearCommandTest.java
@@ -41,7 +41,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class IslandNearCommandTest extends CommonTestSetup {
+class IslandNearCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -136,7 +136,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("island.near", inc.getPermission());
         assertTrue(inc.isOnlyPlayer());
         assertEquals("commands.island.near.parameters", inc.getParameters());
@@ -149,7 +149,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteWithArgsShowHelp() {
+    void testCanExecuteWithArgsShowHelp() {
         assertFalse(inc.canExecute(user, "near", Collections.singletonList("fghjk")));
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
     }
@@ -158,7 +158,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteHasTeam() {
+    void testCanExecuteHasTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any())).thenReturn(true);
         assertTrue(inc.canExecute(user, "near", Collections.emptyList()));
@@ -168,7 +168,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteHasIslandAndTeam() {
+    void testCanExecuteHasIslandAndTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         when(im.inTeam(any(), any())).thenReturn(true);
         assertTrue(inc.canExecute(user, "near", Collections.emptyList()));
@@ -178,7 +178,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteHasIslandNoTeam() {
+    void testCanExecuteHasIslandNoTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         when(im.inTeam(any(), any())).thenReturn(false);
         assertTrue(inc.canExecute(user, "near", Collections.emptyList()));
@@ -188,7 +188,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoIslandNoTeam() {
+    void testCanExecuteNoIslandNoTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any())).thenReturn(false);
         assertFalse(inc.canExecute(user, "near", Collections.emptyList()));
@@ -199,7 +199,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringAllFourPoints() {
+    void testExecuteUserStringListOfStringAllFourPoints() {
         assertTrue(inc.execute(user, "near", Collections.emptyList()));
         verify(user).sendMessage("commands.island.near.the-following-islands");
         verify(user).sendMessage("commands.island.near.syntax", "[direction]", "commands.island.near.north",
@@ -216,7 +216,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringUnowned() {
+    void testExecuteUserStringListOfStringUnowned() {
         when(island.getName()).thenReturn("");
         when(island.isUnowned()).thenReturn(true);
         assertTrue(inc.execute(user, "near", Collections.emptyList()));
@@ -231,7 +231,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoName() {
+    void testExecuteUserStringListOfStringNoName() {
         when(island.getName()).thenReturn("");
         assertTrue(inc.execute(user, "near", Collections.emptyList()));
         verify(user).sendMessage("commands.island.near.the-following-islands");
@@ -253,7 +253,7 @@ public class IslandNearCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandNearCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIslands() {
+    void testExecuteUserStringListOfStringNoIslands() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         assertTrue(inc.execute(user, "near", Collections.emptyList()));
         verify(user).sendMessage("commands.island.near.the-following-islands");

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
@@ -57,7 +57,7 @@ import world.bentobox.bentobox.managers.island.NewIsland;
  * @author tastybento
  *
  */
-public class IslandResetCommandTest extends CommonTestSetup {
+class IslandResetCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -182,7 +182,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * {@link IslandResetCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testNoIsland() {
+    void testNoIsland() {
         // Test the reset command
         // Does not have island
         assertFalse(irc.canExecute(user, irc.getLabel(), Collections.emptyList()));
@@ -193,7 +193,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for {@link IslandResetCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testNoResetsLeft() {
+    void testNoResetsLeft() {
         // Now has island, but is not the owner
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         // Now has no team
@@ -212,7 +212,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for {@link IslandResetCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testNoConfirmationRequired() throws Exception {
+    void testNoConfirmationRequired() throws Exception {
         // Now has island, but is not the owner
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         // Set so no confirmation required
@@ -245,7 +245,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for {@link IslandResetCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testUnlimitedResets() throws Exception {
+    void testUnlimitedResets() throws Exception {
         // Now has island, but is not the owner
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         // Now has no team
@@ -279,7 +279,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * {@link IslandResetCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testNoPaste() throws Exception {
+    void testNoPaste() throws Exception {
         irc = new IslandResetCommand(ic, true);
         // Now has island, but is not the owner
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
@@ -312,7 +312,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for {@link IslandResetCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testConfirmationRequired() throws Exception {
+    void testConfirmationRequired() throws Exception {
         // Now has island, but is not the owner
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         // Now has no team
@@ -353,7 +353,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for {@link IslandResetCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testNoConfirmationRequiredUnknownBlueprint() throws IOException {
+    void testNoConfirmationRequiredUnknownBlueprint() throws IOException {
         // No such bundle
         when(bpm.validate(any(), any())).thenReturn(null);
         // Reset command, no confirmation required
@@ -367,7 +367,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for {@link IslandResetCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testNoConfirmationRequiredBlueprintNoPerm() throws IOException {
+    void testNoConfirmationRequiredBlueprintNoPerm() throws IOException {
         // Bundle exists
         when(bpm.validate(any(), any())).thenReturn("custom");
         // No permission
@@ -380,7 +380,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for {@link IslandResetCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testNoConfirmationRequiredCustomSchemHasPermission() throws Exception {
+    void testNoConfirmationRequiredCustomSchemHasPermission() throws Exception {
         // Now has island, but is not the owner
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         // Now has no team
@@ -421,7 +421,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for reset with cost - cannot afford
      */
     @Test
-    public void testResetIslandWithCostCannotAfford() {
+    void testResetIslandWithCostCannotAfford() {
         // Enable reset charging
         when(s.isChargeForBlueprintOnReset()).thenReturn(true);
         // Multiple bundles
@@ -450,7 +450,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for reset with cost - can afford
      */
     @Test
-    public void testResetIslandWithCostCanAfford() throws Exception {
+    void testResetIslandWithCostCanAfford() throws Exception {
         // Enable reset charging
         when(s.isChargeForBlueprintOnReset()).thenReturn(true);
         // Now has island
@@ -494,7 +494,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for reset cost - disabled by config (default)
      */
     @Test
-    public void testResetIslandCostDisabledByConfig() throws Exception {
+    void testResetIslandCostDisabledByConfig() throws Exception {
         // Reset charging disabled (default)
         when(s.isChargeForBlueprintOnReset()).thenReturn(false);
         // Now has island
@@ -533,7 +533,7 @@ public class IslandResetCommandTest extends CommonTestSetup {
      * Test method for reset cost - no vault ignores cost
      */
     @Test
-    public void testResetIslandCostIgnoredNoVault() throws Exception {
+    void testResetIslandCostIgnoredNoVault() throws Exception {
         // Enable reset charging
         when(s.isChargeForBlueprintOnReset()).thenReturn(true);
         // Now has island

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommandTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class IslandSethomeCommandTest extends CommonTestSetup {
+class IslandSethomeCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -115,7 +115,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#IslandSethomeCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandSethomeCommand() {
+    void testIslandSethomeCommand() {
         IslandSethomeCommand cmd = new IslandSethomeCommand(ic);
         assertEquals("sethome", cmd.getName());
     }
@@ -125,7 +125,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         IslandSethomeCommand isc = new IslandSethomeCommand(ic);
         assertEquals("bskyblock.island.sethome", isc.getPermission());
         assertTrue(isc.isOnlyPlayer());
@@ -136,7 +136,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoIsland() {
+    void testCanExecuteNoIsland() {
         // Player doesn't have an island
         when(im.getIsland(world, user)).thenReturn(null);
 
@@ -149,7 +149,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNotOnIsland() {
+    void testCanExecuteNotOnIsland() {
         when(island.onIsland(any())).thenReturn(false);
         IslandSethomeCommand isc = new IslandSethomeCommand(ic);
         assertFalse(isc.canExecute(user, "island", Collections.emptyList()));
@@ -162,7 +162,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteTooManyHomes() {
+    void testCanExecuteTooManyHomes() {
         when(im.getMaxHomes(island)).thenReturn(9);
         when(im.getNumberOfHomesIfAdded(eq(island), anyString())).thenReturn(11);
         IslandSethomeCommand isc = new IslandSethomeCommand(ic);
@@ -176,7 +176,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecute() {
+    void testCanExecute() {
         IslandSethomeCommand isc = new IslandSethomeCommand(ic);
         assertTrue(isc.canExecute(user, "island", Collections.emptyList()));
         verify(user, never()).sendMessage("general.errors.no-island");
@@ -188,7 +188,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         IslandSethomeCommand isc = new IslandSethomeCommand(ic);
         assertTrue(isc.canExecute(user, "island", Collections.emptyList()));
         assertTrue(isc.execute(user, "island", Collections.emptyList()));
@@ -199,7 +199,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringHomeSuccess() {
+    void testExecuteUserStringListOfStringHomeSuccess() {
         when(island.getMaxHomes()).thenReturn(5);
         IslandSethomeCommand isc = new IslandSethomeCommand(ic);
         assertTrue(isc.canExecute(user, "island", Collections.singletonList("home")));
@@ -211,7 +211,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringMultiHomeTooMany() {
+    void testExecuteUserStringListOfStringMultiHomeTooMany() {
         when(im.getMaxHomes(island)).thenReturn(3);
         when(im.getNumberOfHomesIfAdded(eq(island), anyString())).thenReturn(5);
         IslandSethomeCommand isc = new IslandSethomeCommand(ic);
@@ -223,7 +223,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNether() {
+    void testExecuteUserStringListOfStringNether() {
         when(iwm.isNether(any())).thenReturn(true);
         WorldSettings ws = mock(WorldSettings.class);
         when(ws.isAllowSetHomeInNether()).thenReturn(true);
@@ -239,7 +239,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNetherNotAllowed() {
+    void testExecuteUserStringListOfStringNetherNotAllowed() {
         when(iwm.isNether(any())).thenReturn(true);
         WorldSettings ws = mock(WorldSettings.class);
         when(ws.isAllowSetHomeInNether()).thenReturn(false);
@@ -254,7 +254,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNetherConfirmation() {
+    void testExecuteUserStringListOfStringNetherConfirmation() {
         when(iwm.isNether(any())).thenReturn(true);
         WorldSettings ws = mock(WorldSettings.class);
         when(ws.isAllowSetHomeInNether()).thenReturn(true);
@@ -270,7 +270,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEnd() {
+    void testExecuteUserStringListOfStringEnd() {
         when(iwm.isEnd(any())).thenReturn(true);
         WorldSettings ws = mock(WorldSettings.class);
         when(ws.isAllowSetHomeInTheEnd()).thenReturn(true);
@@ -286,7 +286,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEndNotAllowed() {
+    void testExecuteUserStringListOfStringEndNotAllowed() {
         when(iwm.isEnd(any())).thenReturn(true);
         WorldSettings ws = mock(WorldSettings.class);
         when(ws.isAllowSetHomeInTheEnd()).thenReturn(false);
@@ -301,7 +301,7 @@ public class IslandSethomeCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSethomeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringEndConfirmation() {
+    void testExecuteUserStringListOfStringEndConfirmation() {
         when(iwm.isEnd(any())).thenReturn(true);
         WorldSettings ws = mock(WorldSettings.class);
         when(ws.isAllowSetHomeInTheEnd()).thenReturn(true);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommandTest.java
@@ -42,7 +42,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandSetnameCommandTest extends CommonTestSetup {
+class IslandSetnameCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -120,7 +120,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#IslandSetnameCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandSetnameCommand() {
+    void testIslandSetnameCommand() {
         assertEquals("setname", isc.getLabel());
 
     }
@@ -129,7 +129,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertTrue(isc.isOnlyPlayer());
         assertEquals("commands.island.setname.parameters", isc.getParameters());
         assertEquals("commands.island.setname.description", isc.getDescription());
@@ -141,7 +141,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testIslandSetnameCommandNoArgs() {
+    void testIslandSetnameCommandNoArgs() {
         assertFalse(isc.canExecute(user, isc.getLabel(), new ArrayList<>()));
         verify(user).sendMessage("commands.help.header", "[label]", "BSkyBlock");
     }
@@ -150,7 +150,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testIslandSetnameCommandNoIsland() {
+    void testIslandSetnameCommandNoIsland() {
         when(im.getIsland(world, user)).thenReturn(null);
         assertFalse(isc.canExecute(user, isc.getLabel(), List.of("name")));
         verify(user).sendMessage("general.errors.no-island");
@@ -160,7 +160,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTooLowRank() {
+    void testTooLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(isc.canExecute(user, isc.getLabel(), List.of("name")));
@@ -171,7 +171,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testIslandSetnameCommandNameTooShort() {
+    void testIslandSetnameCommandNameTooShort() {
         assertFalse(isc.canExecute(user, isc.getLabel(), List.of("x")));
         verify(user).sendMessage("commands.island.setname.name-too-short", TextVariables.NUMBER, "4");
     }
@@ -180,7 +180,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testIslandSetnameCommandNameOnlyColors() {
+    void testIslandSetnameCommandNameOnlyColors() {
         assertFalse(isc.canExecute(user, isc.getLabel(), List.of("§b§c§d§e")));
         verify(user).sendMessage("commands.island.setname.name-too-short", TextVariables.NUMBER, "4");
     }
@@ -189,7 +189,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testIslandSetnameCommandNameTooLong() {
+    void testIslandSetnameCommandNameTooLong() {
         assertFalse(isc.canExecute(user, isc.getLabel(), List.of("This is a very long name that is not allowed and will have to be prevented")));
         verify(user).sendMessage("commands.island.setname.name-too-long", TextVariables.NUMBER, "20");
     }
@@ -198,7 +198,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testIslandSetnameCommandAllOK() {
+    void testIslandSetnameCommandAllOK() {
         assertTrue(isc.canExecute(user, isc.getLabel(), List.of("name-okay")));
         verify(user, never()).sendMessage(anyString());
     }
@@ -208,7 +208,7 @@ public class IslandSetnameCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSetnameCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         when(user.hasPermission(anyString())).thenReturn(true);
         assertTrue(isc.execute(user, isc.getLabel(), List.of("name-okay")));
         verify(island).setName("name-okay");

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSpawnCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSpawnCommandTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.managers.PlaceholdersManager;
  * @author tastybento
  *
  */
-public class IslandSpawnCommandTest extends CommonTestSetup {
+class IslandSpawnCommandTest extends CommonTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -126,7 +126,7 @@ public class IslandSpawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSpawnCommand#IslandSpawnCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandSpawnCommand() {
+    void testIslandSpawnCommand() {
         assertEquals("spawn", isc.getLabel());
     }
 
@@ -134,7 +134,7 @@ public class IslandSpawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSpawnCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("permission.island.spawn", isc.getPermission());
         assertTrue(isc.isOnlyPlayer());
         assertEquals("commands.island.spawn.description", isc.getDescription());
@@ -144,7 +144,7 @@ public class IslandSpawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSpawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         assertTrue(isc.execute(user, "spawn", Collections.emptyList()));
     }
 
@@ -152,7 +152,7 @@ public class IslandSpawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSpawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringInWorldNoTeleportFalling() {
+    void testExecuteUserStringListOfStringInWorldNoTeleportFalling() {
         when(mockPlayer.getFallDistance()).thenReturn(10F);
         map.put("PREVENT_TELEPORT_WHEN_FALLING", true);
         when(iwm.inWorld(any(World.class))).thenReturn(true);
@@ -164,7 +164,7 @@ public class IslandSpawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSpawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringInWorldTeleportOkFalling() {
+    void testExecuteUserStringListOfStringInWorldTeleportOkFalling() {
         when(mockPlayer.getFallDistance()).thenReturn(10F);
         map.put("PREVENT_TELEPORT_WHEN_FALLING", false);
         when(iwm.inWorld(any(World.class))).thenReturn(true);
@@ -176,7 +176,7 @@ public class IslandSpawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSpawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringWrongWorldTeleportOkFalling() {
+    void testExecuteUserStringListOfStringWrongWorldTeleportOkFalling() {
         when(mockPlayer.getFallDistance()).thenReturn(10F);
         map.put("PREVENT_TELEPORT_WHEN_FALLING", true);
         when(iwm.inWorld(any(World.class))).thenReturn(false);
@@ -188,7 +188,7 @@ public class IslandSpawnCommandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.IslandSpawnCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringInWorldTeleportNotFalling() {
+    void testExecuteUserStringListOfStringInWorldTeleportNotFalling() {
         when(mockPlayer.getFallDistance()).thenReturn(0F);
         map.put("PREVENT_TELEPORT_WHEN_FALLING", true);
         when(iwm.inWorld(any(World.class))).thenReturn(true);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandUnbanCommandTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandUnbanCommandTest extends RanksManagerTestSetup {
+class IslandUnbanCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -115,7 +115,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
     // Unban user
 
     @Test
-    public void testNoArgs() {
+    void testNoArgs() {
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         assertFalse(iubc.canExecute(user, iubc.getLabel(), new ArrayList<>()));
     }
@@ -124,7 +124,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testNoIsland() {
+    void testNoIsland() {
         when(im.inTeam(any(), eq(uuid))).thenReturn(false);
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         assertFalse(iubc.canExecute(user, iubc.getLabel(), Collections.singletonList("bill")));
@@ -135,7 +135,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testTooLowRank() {
+    void testTooLowRank() {
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
@@ -148,7 +148,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testUnknownUser() {
+    void testUnknownUser() {
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
 
@@ -161,7 +161,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testBanSelf() {
+    void testBanSelf() {
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
 
@@ -174,7 +174,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#canExecute(User, String, List)}
      */
     @Test
-    public void testBanNotBanned() {
+    void testBanNotBanned() {
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
 
@@ -189,7 +189,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#execute(User, String, List)}
      */
     @Test
-    public void testUnbanUser() {
+    void testUnbanUser() {
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);
         when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
 
@@ -220,7 +220,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#tabComplete(User, String, List)}
      */
     @Test
-    public void testTabComplete() {
+    void testTabComplete() {
         Set<UUID> banned = new HashSet<>();
         // Add ten people to the banned list
         for (int i = 0; i < 10; i++) {
@@ -241,7 +241,7 @@ public class IslandUnbanCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandUnbanCommand#tabComplete(User, String, List)}
      */
     @Test
-    public void testTabCompleteNoIsland() {
+    void testTabCompleteNoIsland() {
         // No island
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         IslandUnbanCommand iubc = new IslandUnbanCommand(ic);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCommandTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamCommandTest extends RanksManagerTestSetup {
+class IslandTeamCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -105,7 +105,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#IslandTeamCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testIslandTeamCommand() {
+    void testIslandTeamCommand() {
         assertEquals("team", tc.getLabel());
     }
 
@@ -114,7 +114,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("bskyblock.island.team", tc.getPermission());
         assertTrue(tc.isOnlyPlayer());
         assertEquals("commands.island.team.description", tc.getDescription());
@@ -125,7 +125,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringNoIsland() {
+    void testCanExecuteUserStringListOfStringNoIsland() {
         when(im.getPrimaryIsland(world, uuid)).thenReturn(null);
         assertFalse(tc.canExecute(user, "team", Collections.emptyList()));
         verify(user).sendMessage("general.errors.no-island");
@@ -135,7 +135,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringIslandIsFull() {
+    void testCanExecuteUserStringListOfStringIslandIsFull() {
         // Max members
         when(im.getMaxMembers(island, RanksManager.MEMBER_RANK)).thenReturn(0);
         assertTrue(tc.canExecute(user, "team", Collections.emptyList()));
@@ -150,7 +150,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * @throws IllegalAccessException 
      */
     @Test
-    public void testAddInvite() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+    void testAddInvite() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         tc.addInvite(Type.TEAM, uuid, invitee, island);
         verify(invitesHandler, atLeast(1)).saveObject(any());
     }
@@ -160,7 +160,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#isInvited(java.util.UUID)}.
      */
     @Test
-    public void testIsInvited() {
+    void testIsInvited() {
         assertFalse(tc.isInvited(invitee));
     }
 
@@ -169,7 +169,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#getInviter(java.util.UUID)}.
      */
     @Test
-    public void testGetInviter() {
+    void testGetInviter() {
         assertNull(tc.getInviter(invitee));
     }
 
@@ -178,7 +178,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#getInviter(java.util.UUID)}.
      */
     @Test
-    public void testGetInviterNoInvite() {
+    void testGetInviterNoInvite() {
         assertNull(tc.getInviter(invitee));
     }
 
@@ -187,7 +187,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#getInvite(java.util.UUID)}.
      */
     @Test
-    public void testGetInvite() {
+    void testGetInvite() {
         assertNull(tc.getInvite(invitee));
     }
 
@@ -196,7 +196,7 @@ public class IslandTeamCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand#removeInvite(java.util.UUID)}.
      */
     @Test
-    public void testRemoveInvite() {
+    void testRemoveInvite() {
         assertNull(tc.getInvite(invitee));
         tc.addInvite(Type.TEAM, uuid, invitee, island);
         tc.removeInvite(invitee);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamCoopCommandTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
+class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private IslandTeamCommand ic;
@@ -122,7 +122,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoisland() {
+    void testCanExecuteNoisland() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
@@ -134,7 +134,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteLowRank() {
+    void testCanExecuteLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
@@ -147,7 +147,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoTarget() {
+    void testCanExecuteNoTarget() {
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
         assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
@@ -158,7 +158,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -170,7 +170,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSamePlayer() {
+    void testCanExecuteSamePlayer() {
         MockedStatic<User> userMock = Mockito.mockStatic(User.class);
         userMock.when(() -> User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -185,7 +185,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecutePlayerHasRank() {
+    void testCanExecutePlayerHasRank() {
         MockedStatic<User> userMock = Mockito.mockStatic(User.class);
         userMock.when(() -> User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -201,7 +201,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteCannotCoopSelf() {
+    void testCanExecuteCannotCoopSelf() {
         when(pm.getUUID(any())).thenReturn(uuid);
         IslandTeamCoopCommand itl = new IslandTeamCoopCommand(ic);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -213,7 +213,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteCannotAlreadyHasRank() {
+    void testCanExecuteCannotAlreadyHasRank() {
         UUID other = UUID.randomUUID();
         when(pm.getUUID(any())).thenReturn(other);
         when(island.getMemberSet(anyInt())).thenReturn(ImmutableSet.of(other));
@@ -227,7 +227,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSuccess() {
+    void testCanExecuteSuccess() {
         UUID other = UUID.randomUUID();
         when(pm.getUUID(any())).thenReturn(other);
         when(island.getMemberSet(anyInt())).thenReturn(ImmutableSet.of());
@@ -239,7 +239,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNullIsland() {
+    void testExecuteNullIsland() {
         // Can execute
         when(pm.getUUID(any())).thenReturn(notUUID);
         when(island.getMemberSet(anyInt())).thenReturn(ImmutableSet.of());
@@ -256,7 +256,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteTooManyCoops() {
+    void testExecuteTooManyCoops() {
         Player p = mock(Player.class);
         when(p.getUniqueId()).thenReturn(notUUID);
         // Can execute
@@ -275,7 +275,7 @@ public class IslandTeamCoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamCoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccess() {
+    void testExecuteSuccess() {
         Player p = mock(Player.class);
         when(p.getUniqueId()).thenReturn(notUUID);
         when(p.getName()).thenReturn("target");

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommandTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
+class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private IslandTeamCommand itc;
@@ -131,7 +131,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#IslandTeamInviteAcceptCommand(world.bentobox.bentobox.api.commands.island.team.IslandTeamCommand)}.
      */
     @Test
-    public void testIslandTeamInviteAcceptCommand() {
+    void testIslandTeamInviteAcceptCommand() {
         assertEquals("accept", c.getLabel());
     }
 
@@ -140,7 +140,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         // TODO: test permission inheritance?
         assertTrue(c.isOnlyPlayer());
         assertEquals("commands.island.team.invite.accept.description", c.getDescription());
@@ -151,7 +151,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoInvite() {
+    void testCanExecuteNoInvite() {
         assertFalse(c.canExecute(user, "accept", Collections.emptyList()));
         verify(user).sendMessage("commands.island.team.invite.errors.none-invited-you");
     }
@@ -160,7 +160,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteInTeam() {
+    void testCanExecuteInTeam() {
         when(itc.isInvited(any())).thenReturn(true);
         assertFalse(c.canExecute(user, "accept", Collections.emptyList()));
         verify(user).sendMessage("commands.island.team.invite.errors.you-already-are-in-team");
@@ -170,7 +170,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteInvalidInvite() {
+    void testCanExecuteInvalidInvite() {
         when(itc.isInvited(any())).thenReturn(true);
         when(im.inTeam(any(), any())).thenReturn(false);
         when(island.getRank(any(UUID.class))).thenReturn(RanksManager.VISITOR_RANK);
@@ -183,7 +183,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSubOwnerRankInvite() {
+    void testCanExecuteSubOwnerRankInvite() {
         when(itc.isInvited(any())).thenReturn(true);
         when(im.inTeam(any(), any())).thenReturn(false);
         when(island.getRank(any(UUID.class))).thenReturn(RanksManager.SUB_OWNER_RANK);
@@ -198,7 +198,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteInvalidInviteNull() {
+    void testCanExecuteInvalidInviteNull() {
         when(itc.getInviter(any())).thenReturn(null);
         when(itc.isInvited(any())).thenReturn(true);
         assertFalse(c.canExecute(user, "accept", Collections.emptyList()));
@@ -210,7 +210,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOkay() {
+    void testCanExecuteOkay() {
         when(itc.isInvited(any())).thenReturn(true);
         when(itc.getInviter(any())).thenReturn(notUUID);
         when(itc.getInvite(any())).thenReturn(invite);
@@ -225,7 +225,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOkayTrust() {
+    void testCanExecuteOkayTrust() {
         when(itc.isInvited(any())).thenReturn(true);
         when(itc.getInviter(any())).thenReturn(notUUID);
         when(itc.getInvite(any())).thenReturn(invite);
@@ -242,7 +242,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOkayCoop() {
+    void testCanExecuteOkayCoop() {
         when(itc.isInvited(any())).thenReturn(true);
         when(itc.getInviter(any())).thenReturn(notUUID);
         when(itc.getInvite(any())).thenReturn(invite);
@@ -259,7 +259,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteEventBlocked() {
+    void testCanExecuteEventBlocked() {
         when(itc.isInvited(any())).thenReturn(true);
         when(itc.getInviter(any())).thenReturn(notUUID);
         when(itc.getInvite(any())).thenReturn(invite);
@@ -285,7 +285,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         // Team
         assertTrue(c.execute(user, "accept", Collections.emptyList()));
         verify(user).getTranslation("commands.island.team.invite.accept.confirmation");
@@ -295,7 +295,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringCoop() {
+    void testExecuteUserStringListOfStringCoop() {
         // Coop
         when(invite.getType()).thenReturn(Type.COOP);
         assertTrue(c.execute(user, "accept", Collections.emptyList()));
@@ -306,7 +306,7 @@ public class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteAcceptCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringTrust() {
+    void testExecuteUserStringListOfStringTrust() {
         // Trust
         when(invite.getType()).thenReturn(Type.TRUST);
         assertTrue(c.execute(user, "accept", Collections.emptyList()));

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
+class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private IslandTeamCommand ic;
@@ -174,7 +174,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteCoolDownActive() {
+    void testCanExecuteCoolDownActive() {
         // 10 minutes = 600 seconds
         when(s.getInviteCooldown()).thenReturn(10);
         itl.setCooldown(islandUUID, notUUID, 100);
@@ -186,7 +186,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteDifferentPlayerInTeam() {
+    void testCanExecuteDifferentPlayerInTeam() {
         when(im.inTeam(any(), any())).thenReturn(true);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
         verify(user).sendMessage("commands.island.team.invite.errors.already-on-team");
@@ -196,7 +196,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteLowRank() {
+    void testCanExecuteLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
@@ -207,7 +207,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoIsland() {
+    void testCanExecuteNoIsland() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
@@ -220,7 +220,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      */
     @Disabled("PaperAPI Material issue with Material.get")
     @Test
-    public void testCanExecuteNoTarget() {
+    void testCanExecuteNoTarget() {
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
         // Show panel
         verify(mockPlayer).openInventory(any(Inventory.class));
@@ -230,7 +230,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteOfflinePlayer() {
+    void testCanExecuteOfflinePlayer() {
         when(target.isOnline()).thenReturn(false);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
         verify(user).sendMessage("general.errors.offline-player");
@@ -240,7 +240,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteVanishedPlayer() {
+    void testCanExecuteVanishedPlayer() {
         when(mockPlayer.canSee(any())).thenReturn(false);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
         verify(user).sendMessage("general.errors.offline-player");
@@ -251,7 +251,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSamePlayer() {
+    void testCanExecuteSamePlayer() {
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
         verify(user).sendMessage("commands.island.team.invite.errors.cannot-invite-self");
     }
@@ -261,7 +261,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSuccess() {
+    void testCanExecuteSuccess() {
         assertTrue(itl.canExecute(user, itl.getLabel(), List.of("target")));
     }
 
@@ -269,7 +269,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         when(pm.getUUID("target")).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "target");
@@ -279,7 +279,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteFullIsland() {
+    void testCanExecuteFullIsland() {
         when(im.getMaxMembers(eq(island), anyInt())).thenReturn(0);
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
         verify(user).sendMessage("commands.island.team.invite.errors.island-is-full");
@@ -289,7 +289,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessTargetHasIsland() {
+    void testExecuteSuccessTargetHasIsland() {
         when(im.getIsland(world, uuid)).thenReturn(island);
         when(im.hasIsland(world, notUUID)).thenReturn(true);
         testCanExecuteSuccess();
@@ -309,7 +309,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessTargetHasNoIsland() {
+    void testExecuteSuccessTargetHasNoIsland() {
         testCanExecuteSuccess();
         when(im.getIsland(world, uuid)).thenReturn(island);
         assertTrue(itl.execute(user, itl.getLabel(), List.of("target")));
@@ -330,7 +330,7 @@ public class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#execute(User, String, java.util.List)}.
      */
     @Test
-    public void testExecuteTargetAlreadyInvited() {
+    void testExecuteTargetAlreadyInvited() {
         testCanExecuteSuccess();
         when(im.getIsland(world, uuid)).thenReturn(island);
         when(ic.isInvited(notUUID)).thenReturn(true);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommandTest.java
@@ -49,7 +49,7 @@ import world.bentobox.bentobox.managers.RanksManager;
 /**
  * @author tastybento
  */
-public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
+class IslandTeamKickCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -161,7 +161,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoTeam() {
+    void testExecuteNoTeam() {
         when(im.inTeam(any(), eq(uuid))).thenReturn(false);
         IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
@@ -172,7 +172,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteLowerTeamRank() {
+    void testExecuteLowerTeamRank() {
         when(island.getRank(user)).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRank(notUUID)).thenReturn(RanksManager.SUB_OWNER_RANK);
 
@@ -190,7 +190,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteEqualTeamRank() {
+    void testExecuteEqualTeamRank() {
         when(island.getRank(user)).thenReturn(RanksManager.SUB_OWNER_RANK);
         when(island.getRank(notUUID)).thenReturn(RanksManager.SUB_OWNER_RANK);
 
@@ -208,7 +208,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteLargerTeamRank() {
+    void testExecuteLargerTeamRank() {
         when(island.getRank(user)).thenReturn(RanksManager.SUB_OWNER_RANK);
         when(island.getRank(notUUID)).thenReturn(RanksManager.MEMBER_RANK);
 
@@ -227,7 +227,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoCommandRank() {
+    void testExecuteNoCommandRank() {
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.SUB_OWNER_RANK);
         when(island.getRank(user)).thenReturn(RanksManager.MEMBER_RANK);
 
@@ -241,7 +241,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoTarget() {
+    void testExecuteNoTarget() {
         IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
         // Show help
@@ -252,7 +252,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("poslovitch")));
@@ -264,7 +264,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteSamePlayer() {
+    void testExecuteSamePlayer() {
         IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
         when(pm.getUUID(any())).thenReturn(uuid);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("poslovitch")));
@@ -276,7 +276,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteDifferentPlayerNotInTeam() {
+    void testExecuteDifferentPlayerNotInTeam() {
         IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
         when(pm.getUUID(any())).thenReturn(notUUID);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("poslovitch")));
@@ -288,7 +288,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * {@link IslandTeamKickCommand#canExecute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteDifferentPlayerNoRank() {
+    void testExecuteDifferentPlayerNoRank() {
         IslandTeamKickCommand itl = new IslandTeamKickCommand(ic);
         when(pm.getUUID(any())).thenReturn(notUUID);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
@@ -301,7 +301,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoConfirmation() {
+    void testExecuteNoConfirmation() {
         when(s.isKickConfirmation()).thenReturn(false);
 
         when(pm.getUUID(any())).thenReturn(notUUID);
@@ -319,7 +319,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoConfirmationKeepInventory() {
+    void testExecuteNoConfirmationKeepInventory() {
         when(iwm.isOnLeaveResetInventory(any())).thenReturn(true);
         when(iwm.isKickedKeepInventory(any())).thenReturn(true);
         when(s.isKickConfirmation()).thenReturn(false);
@@ -341,7 +341,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoConfirmationLoseInventoryOffline() {
+    void testExecuteNoConfirmationLoseInventoryOffline() {
         when(iwm.isOnLeaveResetInventory(any())).thenReturn(true);
         when(iwm.isKickedKeepInventory(any())).thenReturn(false);
         when(s.isKickConfirmation()).thenReturn(false);
@@ -367,7 +367,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteWithConfirmation() {
+    void testExecuteWithConfirmation() {
         when(s.isKickConfirmation()).thenReturn(true);
 
         when(pm.getUUID(any())).thenReturn(notUUID);
@@ -384,7 +384,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamKickCommand#setCooldown(UUID, UUID, int)}
      */
     @Test
-    public void testCooldown() {
+    void testCooldown() {
         // 10 minutes = 600 seconds
         when(s.getInviteCooldown()).thenReturn(10);
         testExecuteNoConfirmation();
@@ -392,7 +392,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteNoArgument() {
+    void testTabCompleteNoArgument() {
 
         Builder<UUID> memberSet = new ImmutableSet.Builder<>();
         for (int j = 0; j < 11; j++) {
@@ -424,7 +424,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteWithArgument() {
+    void testTabCompleteWithArgument() {
 
         Builder<UUID> memberSet = new ImmutableSet.Builder<>();
         for (int j = 0; j < 11; j++) {
@@ -457,7 +457,7 @@ public class IslandTeamKickCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteWithWrongArgument() {
+    void testTabCompleteWithWrongArgument() {
 
         Builder<UUID> memberSet = new ImmutableSet.Builder<>();
         for (int j = 0; j < 11; j++) {

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommandTest.java
@@ -33,7 +33,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
+class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -111,7 +111,7 @@ public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamLeaveCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoTeam() {
+    void testExecuteNoTeam() {
         when(im.inTeam(any(), eq(uuid))).thenReturn(false);
         IslandTeamLeaveCommand itl = new IslandTeamLeaveCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), new ArrayList<>()));
@@ -123,7 +123,7 @@ public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamLeaveCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteIsOwner() {
+    void testExecuteIsOwner() {
         when(island.getOwner()).thenReturn(uuid);
         IslandTeamLeaveCommand itl = new IslandTeamLeaveCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), new ArrayList<>()));
@@ -134,7 +134,7 @@ public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamLeaveCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteNoConfirmation() {
+    void testExecuteNoConfirmation() {
         when(s.isLeaveConfirmation()).thenReturn(false);
 
         IslandTeamLeaveCommand itl = new IslandTeamLeaveCommand(ic);
@@ -147,7 +147,7 @@ public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamLeaveCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteWithConfirmation() {
+    void testExecuteWithConfirmation() {
         when(s.isLeaveConfirmation()).thenReturn(true);
         // 3 second timeout
         when(s.getConfirmationTime()).thenReturn(3);
@@ -161,7 +161,7 @@ public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamLeaveCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteWithLoseResetCheckNoResets() {
+    void testExecuteWithLoseResetCheckNoResets() {
         // Leaves lose resets
         when(iwm.isLeaversLoseReset(any())).thenReturn(true);
 
@@ -176,7 +176,7 @@ public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamLeaveCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testExecuteWithLoseResetCheckHasResets() {
+    void testExecuteWithLoseResetCheckHasResets() {
         // Leaves lose resets
         when(iwm.isLeaversLoseReset(any())).thenReturn(true);
         when(pm.getResetsLeft(any(),any(UUID.class))).thenReturn(100);
@@ -195,7 +195,7 @@ public class IslandTeamLeaveCommandTest extends RanksManagerTestSetup {
      * Test method for {@link IslandTeamLeaveCommand#execute(User, String, java.util.List)}
      */
     @Test
-    public void testCooldown() {
+    void testCooldown() {
         // 10 minutes = 600 seconds
         when(s.getInviteCooldown()).thenReturn(10);
         testExecuteNoConfirmation();

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommandTest.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
+class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private IslandTeamCommand ic;
@@ -132,7 +132,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#IslandTeamPromoteCommand(world.bentobox.bentobox.api.commands.CompositeCommand, java.lang.String)}.
      */
     @Test
-    public void testIslandTeamPromoteCommand() {
+    void testIslandTeamPromoteCommand() {
         assertNotNull(ipc);
         assertNotNull(idc);
     }
@@ -141,7 +141,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("island.team.promote", ipc.getPermission());
         assertEquals("island.team.promote", idc.getPermission());
         assertTrue(ipc.isOnlyPlayer());
@@ -158,7 +158,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringShowHelp() {
+    void testCanExecuteUserStringListOfStringShowHelp() {
         assertFalse(ipc.canExecute(user, "promote", List.of())); // Nothing
         verify(user).sendMessage("commands.help.header", TextVariables.LABEL, "BSkyBlock");
     }
@@ -167,7 +167,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringNoTeam() {
+    void testCanExecuteUserStringListOfStringNoTeam() {
         when(im.inTeam(any(), any())).thenReturn(false);
         assertFalse(ipc.canExecute(user, "promote", List.of("tastybento")));
         verify(user).sendMessage("general.errors.no-team");
@@ -177,7 +177,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringInsufficientRank() {
+    void testCanExecuteUserStringListOfStringInsufficientRank() {
         when(island.getRank(user)).thenReturn(RanksManager.MEMBER_RANK);
         assertFalse(ipc.canExecute(user, "promote", List.of("tastybento")));
         verify(user).sendMessage("general.errors.insufficient-rank", TextVariables.RANK, "");
@@ -187,7 +187,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringUnknownPlayer() {
+    void testCanExecuteUserStringListOfStringUnknownPlayer() {
         when(pm.getUser(anyString())).thenReturn(null);
         assertFalse(ipc.canExecute(user, "promote", List.of("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "tastybento");
@@ -197,7 +197,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringSameUser() {
+    void testCanExecuteUserStringListOfStringSameUser() {
         when(pm.getUser(anyString())).thenReturn(user);
         assertFalse(ipc.canExecute(user, "promote", List.of("tastybento")));
         verify(user).sendMessage("commands.island.team.promote.errors.cant-promote-yourself");
@@ -209,7 +209,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringDemoteOwner() {
+    void testCanExecuteUserStringListOfStringDemoteOwner() {
         when(island.getRank(target)).thenReturn(RanksManager.OWNER_RANK);
         assertFalse(idc.canExecute(user, "demote", List.of("target")));
         verify(user).sendMessage("commands.island.team.demote.errors.cant-demote");
@@ -219,7 +219,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringPromoteAboveSelf() {
+    void testCanExecuteUserStringListOfStringPromoteAboveSelf() {
         when(island.getRank(target)).thenReturn(RanksManager.SUB_OWNER_RANK);
         assertFalse(ipc.canExecute(user, "promote", List.of("target")));
         verify(user).sendMessage("commands.island.team.promote.errors.cant-promote");
@@ -229,7 +229,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringSuccess() {
+    void testCanExecuteUserStringListOfStringSuccess() {
         when(island.getRank(target)).thenReturn(RanksManager.MEMBER_RANK);
         assertTrue(ipc.canExecute(user, "promote", List.of("target")));
         assertTrue(idc.canExecute(user, "demote", List.of("target")));
@@ -240,7 +240,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfString() {
+    void testExecuteUserStringListOfString() {
         when(island.getRank(target)).thenReturn(RanksManager.MEMBER_RANK);
         when(rm.getRankUpValue(RanksManager.MEMBER_RANK)).thenReturn(RanksManager.SUB_OWNER_RANK);
         ipc.canExecute(user, "promote", List.of("target"));
@@ -255,7 +255,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringNoIsland() {
+    void testTabCompleteUserStringListOfStringNoIsland() {
         when(im.getIsland(world, user)).thenReturn(null);
         Optional<List<String>> options = ipc.tabComplete(user, "promote", List.of("p"));
         assertTrue(options.isEmpty());
@@ -265,7 +265,7 @@ public class IslandTeamPromoteCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamPromoteCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         Optional<List<String>> options = ipc.tabComplete(user, "promote", List.of("p"));
         assertFalse(options.isEmpty());
         assertTrue(options.get().isEmpty());

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommandTest.java
@@ -41,7 +41,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
+class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -126,7 +126,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("island.team.setowner", its.getPermission());
         assertTrue(its.isOnlyPlayer());
         assertEquals("commands.island.team.setowner.parameters", its.getParameters());
@@ -139,7 +139,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringNullOwner() {
+    void testCanExecuteUserStringListOfStringNullOwner() {
         when(island.getOwner()).thenReturn(null);
         assertFalse(its.canExecute(user, "", List.of("gibby")));
         verify(user).sendMessage("general.errors.not-owner");
@@ -149,7 +149,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringNotInTeamNoIsland() {
+    void testCanExecuteUserStringListOfStringNotInTeamNoIsland() {
         when(im.getPrimaryIsland(any(), any())).thenReturn(null);
         assertFalse(its.canExecute(user, "", List.of("gibby")));
         verify(user).sendMessage("general.errors.no-team");
@@ -159,7 +159,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringNotInTeam() {
+    void testCanExecuteUserStringListOfStringNotInTeam() {
         when(island.inTeam(uuid)).thenReturn(false);
         assertFalse(its.canExecute(user, "", List.of("gibby")));
         verify(user).sendMessage("general.errors.no-team");
@@ -169,7 +169,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringNotOwner() {
+    void testCanExecuteUserStringListOfStringNotOwner() {
         when(im.inTeam(any(), any())).thenReturn(true);
         when(island.getOwner()).thenReturn(UUID.randomUUID());
         assertFalse(its.canExecute(user, "", List.of("gibby")));
@@ -180,7 +180,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringShowHelp() {
+    void testCanExecuteUserStringListOfStringShowHelp() {
         when(im.inTeam(any(), any())).thenReturn(true);
         assertFalse(its.canExecute(user, "", List.of()));
         verify(user).sendMessage("commands.help.header","[label]", "BSkyBlock");
@@ -190,7 +190,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringUnknownPlayer() {
+    void testCanExecuteUserStringListOfStringUnknownPlayer() {
         when(im.inTeam(any(), any())).thenReturn(true);
         when(pm.getUUID(anyString())).thenReturn(null);
         assertFalse(its.canExecute(user, "", List.of("tastybento")));
@@ -201,7 +201,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringSamePlayer() {
+    void testCanExecuteUserStringListOfStringSamePlayer() {
         when(im.inTeam(any(), any())).thenReturn(true);
         when(pm.getUUID(anyString())).thenReturn(uuid);
         assertFalse(its.canExecute(user, "", List.of("tastybento")));
@@ -212,7 +212,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUserStringListOfStringTargetNotInTeam() {
+    void testCanExecuteUserStringListOfStringTargetNotInTeam() {
         when(im.inTeam(any(), any())).thenReturn(true);
         when(pm.getUUID(anyString())).thenReturn(UUID.randomUUID());
         assertFalse(its.canExecute(user, "", List.of("tastybento")));
@@ -223,7 +223,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringHasManyConcurrentAndPerm() {
+    void testExecuteUserStringListOfStringHasManyConcurrentAndPerm() {
         when(user.getPermissionValue(anyString(), anyInt())).thenReturn(40);
         when(im.getNumberOfConcurrentIslands(any(), eq(world))).thenReturn(20);
         UUID target = UUID.randomUUID();
@@ -240,7 +240,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringSuccess() {
+    void testExecuteUserStringListOfStringSuccess() {
         when(im.inTeam(any(), any())).thenReturn(true);
         UUID target = UUID.randomUUID();
         when(pm.getUUID(anyString())).thenReturn(target);
@@ -256,7 +256,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfString() {
+    void testTabCompleteUserStringListOfString() {
         assertTrue(its.tabComplete(user, "", List.of()).get().isEmpty());
     }
 
@@ -265,7 +265,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringUnknown() {
+    void testTabCompleteUserStringListOfStringUnknown() {
         assertTrue(its.tabComplete(user, "ta", List.of()).get().isEmpty());
     }
 
@@ -274,7 +274,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringMember() {
+    void testTabCompleteUserStringListOfStringMember() {
         UUID target = UUID.randomUUID();
         when(pm.getName(any())).thenReturn("tastybento");
         when(island.getMemberSet()).thenReturn(ImmutableSet.of(target));
@@ -286,7 +286,7 @@ public class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testTabCompleteUserStringListOfStringMemberNoIsland() {
+    void testTabCompleteUserStringListOfStringMemberNoIsland() {
         when(im.getPrimaryIsland(any(), any())).thenReturn(null);
         assertTrue(its.tabComplete(user, "", List.of()).isEmpty());
     }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamTrustCommandTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
+class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private IslandTeamCommand ic;
@@ -132,7 +132,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoisland() {
+    void testCanExecuteNoisland() {
         when(im.hasIsland(any(), Mockito.any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), Mockito.any(UUID.class))).thenReturn(false);
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
@@ -144,7 +144,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteLowRank() {
+    void testCanExecuteLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
@@ -157,7 +157,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoTarget() {
+    void testCanExecuteNoTarget() {
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
         assertFalse(itl.canExecute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
@@ -168,7 +168,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteUnknownPlayer() {
+    void testCanExecuteUnknownPlayer() {
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -180,7 +180,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSamePlayer() {
+    void testCanExecuteSamePlayer() {
         MockedStatic<User> mockUser = Mockito.mockStatic(User.class);
         mockUser.when(() -> User.getInstance(Mockito.any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -195,7 +195,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecutePlayerHasRank() {
+    void testCanExecutePlayerHasRank() {
         MockedStatic<User> mockUser = Mockito.mockStatic(User.class);
         mockUser.when(() -> User.getInstance(Mockito.any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -210,7 +210,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteCannottrustSelf() {
+    void testCanExecuteCannottrustSelf() {
         when(pm.getUUID(any())).thenReturn(uuid);
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
         assertFalse(itl.canExecute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -222,7 +222,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteCannotAlreadyHasRank() {
+    void testCanExecuteCannotAlreadyHasRank() {
         UUID other = UUID.randomUUID();
         when(pm.getUUID(any())).thenReturn(other);
         IslandTeamTrustCommand itl = new IslandTeamTrustCommand(ic);
@@ -234,7 +234,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNullIsland() {
+    void testExecuteNullIsland() {
         // Can execute
         when(pm.getUUID(any())).thenReturn(notUUID);
         when(island.getRank(any(User.class))).thenReturn(RanksManager.VISITOR_RANK);
@@ -250,7 +250,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessNoConfirmationTooMany() {
+    void testExecuteSuccessNoConfirmationTooMany() {
         // Can execute
         when(pm.getUUID(any())).thenReturn(notUUID);
         when(island.getRank(any(User.class))).thenReturn(RanksManager.VISITOR_RANK);
@@ -268,7 +268,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessNoConfirmation() {
+    void testExecuteSuccessNoConfirmation() {
         User target = User.getInstance(mockPlayer);
         // Can execute
         when(pm.getUUID(any())).thenReturn(notUUID);
@@ -290,7 +290,7 @@ public class IslandTeamTrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamTrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccessConfirmation() {
+    void testExecuteSuccessConfirmation() {
         when(s.isInviteConfirmation()).thenReturn(true);
         User target = User.getInstance(mockPlayer);
         // Can execute

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUncoopCommandTest.java
@@ -44,7 +44,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
+class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -119,7 +119,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUncoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNoisland() {
+    void testExecuteNoisland() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         IslandTeamUncoopCommand itl = new IslandTeamUncoopCommand(ic);
@@ -131,7 +131,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUncoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteLowRank() {
+    void testExecuteLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(anyString())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamUncoopCommand itl = new IslandTeamUncoopCommand(ic);
@@ -144,7 +144,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUncoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNoTarget() {
+    void testExecuteNoTarget() {
         IslandTeamUncoopCommand itl = new IslandTeamUncoopCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
@@ -155,7 +155,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUncoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         IslandTeamUncoopCommand itl = new IslandTeamUncoopCommand(ic);
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -167,7 +167,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUncoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSamePlayer() {
+    void testExecuteSamePlayer() {
         MockedStatic<User> mockUser = Mockito.mockStatic(User.class);
         mockUser.when(() -> User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -182,7 +182,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUncoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayerHasRank() {
+    void testExecutePlayerHasRank() {
         MockedStatic<User> mockUser = Mockito.mockStatic(User.class);
         mockUser.when(() -> User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -199,7 +199,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUncoopCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteCoolDownActive() {
+    void testExecuteCoolDownActive() {
         // 10 minutes = 600 seconds
         when(s.getInviteCooldown()).thenReturn(10);
         IslandTeamUncoopCommand itl = new IslandTeamUncoopCommand(ic);
@@ -208,7 +208,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteNoIsland() {
+    void testTabCompleteNoIsland() {
         // No island
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         IslandTeamUncoopCommand ibc = new IslandTeamUncoopCommand(ic);
@@ -235,7 +235,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteNoArgument() {
+    void testTabCompleteNoArgument() {
 
         Map<UUID, Integer> map = new HashMap<>();
         map.put(UUID.randomUUID(), RanksManager.COOP_RANK);
@@ -269,7 +269,7 @@ public class IslandTeamUncoopCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteWithArgument() {
+    void testTabCompleteWithArgument() {
 
         Map<UUID, Integer> map = new HashMap<>();
         map.put(UUID.randomUUID(), RanksManager.COOP_RANK);

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamUntrustCommandTest.java
@@ -43,7 +43,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
+class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
 
     @Mock
     private CompositeCommand ic;
@@ -116,7 +116,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUntrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNoisland() {
+    void testExecuteNoisland() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
@@ -128,7 +128,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUntrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteLowRank() {
+    void testExecuteLowRank() {
         when(island.getRank(any(User.class))).thenReturn(RanksManager.MEMBER_RANK);
         when(island.getRankCommand(any())).thenReturn(RanksManager.OWNER_RANK);
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
@@ -141,7 +141,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUntrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNoTarget() {
+    void testExecuteNoTarget() {
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
         assertFalse(itl.execute(user, itl.getLabel(), new ArrayList<>()));
         // Show help
@@ -152,7 +152,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUntrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUnknownPlayer() {
+    void testExecuteUnknownPlayer() {
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
         when(pm.getUUID(any())).thenReturn(null);
         assertFalse(itl.execute(user, itl.getLabel(), Collections.singletonList("tastybento")));
@@ -164,7 +164,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUntrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSamePlayer() {
+    void testExecuteSamePlayer() {
         MockedStatic<User> mockUser = Mockito.mockStatic(User.class);
         mockUser.when(() -> User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -179,7 +179,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUntrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecutePlayerHasRank() {
+    void testExecutePlayerHasRank() {
         MockedStatic<User> mockUser = Mockito.mockStatic(User.class);
         mockUser.when(() -> User.getInstance(any(UUID.class))).thenReturn(user);
         when(user.isOnline()).thenReturn(true);
@@ -196,7 +196,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamUntrustCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteCoolDownActive() {
+    void testExecuteCoolDownActive() {
         // 10 minutes = 600 seconds
         when(s.getInviteCooldown()).thenReturn(10);
         IslandTeamUntrustCommand itl = new IslandTeamUntrustCommand(ic);
@@ -205,7 +205,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteNoIsland() {
+    void testTabCompleteNoIsland() {
         // No island
         when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
         IslandTeamUntrustCommand ibc = new IslandTeamUntrustCommand(ic);
@@ -232,7 +232,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteNoArgument() {
+    void testTabCompleteNoArgument() {
 
         Map<UUID, Integer> map = new HashMap<>();
         map.put(UUID.randomUUID(), RanksManager.TRUSTED_RANK);
@@ -266,7 +266,7 @@ public class IslandTeamUntrustCommandTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testTabCompleteWithArgument() {
+    void testTabCompleteWithArgument() {
 
         Map<UUID, Integer> map = new HashMap<>();
         map.put(UUID.randomUUID(), RanksManager.TRUSTED_RANK);

--- a/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEnableEventTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEnableEventTest.java
@@ -20,7 +20,7 @@ import world.bentobox.bentobox.api.addons.Addon;
  * @author tastybento
  *
  */
-public class AddonEnableEventTest extends CommonTestSetup {
+class AddonEnableEventTest extends CommonTestSetup {
 
     private AddonEnableEvent aee;
     @Mock
@@ -44,7 +44,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.addon.AddonEnableEvent#getHandlers()}.
      */
     @Test
-    public void testGetHandlers() {
+    void testGetHandlers() {
         assertNotNull(aee.getHandlers());
     }
 
@@ -52,7 +52,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.addon.AddonEnableEvent#getHandlerList()}.
      */
     @Test
-    public void testGetHandlerList() {
+    void testGetHandlerList() {
         assertNotNull(AddonEnableEvent.getHandlerList());
     }
 
@@ -60,7 +60,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.addon.AddonEnableEvent#AddonEnableEvent(world.bentobox.bentobox.api.addons.Addon, java.util.Map)}.
      */
     @Test
-    public void testAddonEnableEvent() {
+    void testAddonEnableEvent() {
         assertNotNull(aee);
     }
 
@@ -68,7 +68,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.addon.AddonBaseEvent#getKeyValues()}.
      */
     @Test
-    public void testGetKeyValues() {
+    void testGetKeyValues() {
         assertTrue(aee.getKeyValues().isEmpty());
     }
 
@@ -76,7 +76,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.addon.AddonBaseEvent#getAddon()}.
      */
     @Test
-    public void testGetAddon() {
+    void testGetAddon() {
         assertSame(addon, aee.getAddon());
     }
 
@@ -84,7 +84,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.addon.AddonBaseEvent#getNewEvent()}.
      */
     @Test
-    public void testGetNewEvent() {
+    void testGetNewEvent() {
         assertTrue(aee.getNewEvent().isEmpty());
     }
 
@@ -92,7 +92,7 @@ public class AddonEnableEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.addon.AddonBaseEvent#setNewEvent(world.bentobox.bentobox.api.events.addon.AddonBaseEvent)}.
      */
     @Test
-    public void testSetNewEvent() {
+    void testSetNewEvent() {
         aee.setNewEvent(aee);
         assertSame(aee, aee.getNewEvent().get());
     }

--- a/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEventTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/events/addon/AddonEventTest.java
@@ -15,7 +15,7 @@ import world.bentobox.bentobox.api.addons.Addon;
  * @author tastybento
  */
 
-public class AddonEventTest extends CommonTestSetup {
+class AddonEventTest extends CommonTestSetup {
 
     @Mock
     private Addon mockAddon;
@@ -33,7 +33,7 @@ public class AddonEventTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddonEventBuilderWithEnableReason() {
+    void testAddonEventBuilderWithEnableReason() {
         AddonEvent addonEvent = new AddonEvent();
         AddonBaseEvent event = addonEvent.builder().addon(mockAddon).reason(AddonEvent.Reason.ENABLE).build();
 
@@ -42,7 +42,7 @@ public class AddonEventTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddonEventBuilderWithDisableReason() {
+    void testAddonEventBuilderWithDisableReason() {
         AddonEvent addonEvent = new AddonEvent();
         AddonBaseEvent event = addonEvent.builder().addon(mockAddon).reason(AddonEvent.Reason.DISABLE).build();
 
@@ -51,7 +51,7 @@ public class AddonEventTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddonEventBuilderWithLoadReason() {
+    void testAddonEventBuilderWithLoadReason() {
         AddonEvent addonEvent = new AddonEvent();
         AddonBaseEvent event = addonEvent.builder().addon(mockAddon).reason(AddonEvent.Reason.LOAD).build();
 
@@ -60,7 +60,7 @@ public class AddonEventTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddonEventBuilderWithUnknownReason() {
+    void testAddonEventBuilderWithUnknownReason() {
         AddonEvent addonEvent = new AddonEvent();
         AddonBaseEvent event = addonEvent.builder().addon(mockAddon).build(); // Default reason is UNKNOWN
 

--- a/src/test/java/world/bentobox/bentobox/api/events/island/IslandEventTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/events/island/IslandEventTest.java
@@ -26,7 +26,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
  * @author tastybento
  *
  */
-public class IslandEventTest extends CommonTestSetup {
+class IslandEventTest extends CommonTestSetup {
 
     @Mock
     private @NonNull BlueprintBundle blueprintBundle;
@@ -57,7 +57,7 @@ public class IslandEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.island.IslandEvent#IslandEvent(world.bentobox.bentobox.database.objects.Island, java.util.UUID, boolean, org.bukkit.Location, world.bentobox.bentobox.api.events.island.IslandEvent.Reason)}.
      */
     @Test
-    public void testIslandEvent() {
+    void testIslandEvent() {
         for (Reason reason: Reason.values()) {
             IslandEvent e = new IslandEvent(testIsland, uuid, false, location, reason);
             assertEquals(reason, e.getReason());
@@ -71,7 +71,7 @@ public class IslandEventTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.events.island.IslandEvent#builder()}.
      */
     @Test
-    public void testBuilder() {
+    void testBuilder() {
         for (Reason reason: Reason.values()) {
             IslandBaseEvent e = IslandEvent.builder()
                     .admin(true)

--- a/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class FlagTest extends RanksManagerTestSetup {
+class FlagTest extends RanksManagerTestSetup {
 
     private Flag f;
     @Mock
@@ -101,7 +101,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#hashCode()}.
      */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         Flag flag1 = new Flag.Builder("id", Material.ACACIA_BOAT).build();
         Flag flag2 = new Flag.Builder("id", Material.ACACIA_BOAT).build();
         Flag flag3 = new Flag.Builder("id2", Material.ACACIA_BUTTON).build();
@@ -113,7 +113,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for .
      */
     @Test
-    public void testFlag() {
+    void testFlag() {
         assertNotNull(f);
     }
 
@@ -121,7 +121,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getID()}.
      */
     @Test
-    public void testGetID() {
+    void testGetID() {
         assertEquals("flagID", f.getID());
     }
 
@@ -129,7 +129,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getIcon()}.
      */
     @Test
-    public void testGetIcon() {
+    void testGetIcon() {
         assertEquals(Material.ACACIA_PLANKS, f.getIcon());
     }
 
@@ -137,7 +137,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getListener()}.
      */
     @Test
-    public void testGetListener() {
+    void testGetListener() {
         assertEquals(listener, f.getListener().get());
     }
 
@@ -145,7 +145,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getListener()}.
      */
     @Test
-    public void testGetListenerNone() {
+    void testGetListenerNone() {
         f = new Flag.Builder("flagID", Material.ACACIA_PLANKS).build();
         assertEquals(Optional.empty(), f.getListener());
     }
@@ -154,7 +154,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#isSetForWorld(org.bukkit.World)}.
      */
     @Test
-    public void testIsSetForWorld() {
+    void testIsSetForWorld() {
         assertFalse(f.isSetForWorld(world));
     }
 
@@ -162,7 +162,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#isSetForWorld(org.bukkit.World)}.
      */
     @Test
-    public void testIsSetForWorldWorldSetting() {
+    void testIsSetForWorldWorldSetting() {
         f = new Flag.Builder("flagID", Material.ACACIA_PLANKS).type(Flag.Type.WORLD_SETTING).build();
         // Nothing in world flags
         assertFalse(f.isSetForWorld(world));
@@ -174,7 +174,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setSetting(org.bukkit.World, boolean)}.
      */
     @Test
-    public void testSetSetting() {
+    void testSetSetting() {
         f = new Flag.Builder("flagID", Material.ACACIA_PLANKS).type(Flag.Type.WORLD_SETTING).build();
         assertTrue(worldFlags.isEmpty());
         f.setSetting(world, true);
@@ -185,7 +185,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setDefaultSetting(boolean)}.
      */
     @Test
-    public void testSetDefaultSettingBoolean() {
+    void testSetDefaultSettingBoolean() {
         f.setDefaultSetting(true);
         // Checking will set it to the default
         assertTrue(f.isSetForWorld(world));
@@ -198,7 +198,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setDefaultSetting(org.bukkit.World, boolean)}.
      */
     @Test
-    public void testSetDefaultSettingWorldBoolean() {
+    void testSetDefaultSettingWorldBoolean() {
 
         f.setDefaultSetting(world, true);
         assertTrue(f.isSetForWorld(world));
@@ -210,7 +210,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setDefaultSetting(org.bukkit.World, boolean)}.
      */
     @Test
-    public void testSetDefaultSettingWorldBooleanNullWorldSettings() {
+    void testSetDefaultSettingWorldBooleanNullWorldSettings() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         f.setDefaultSetting(world, true);
         verify(plugin).logError("Attempt to set default world setting for unregistered world. Register flags in onEnable.");
@@ -220,7 +220,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getType()}.
      */
     @Test
-    public void testGetType() {
+    void testGetType() {
         assertEquals(Flag.Type.PROTECTION, f.getType());
     }
 
@@ -228,7 +228,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getDefaultRank()}.
      */
     @Test
-    public void testGetDefaultRank() {
+    void testGetDefaultRank() {
         assertEquals(RanksManager.MEMBER_RANK, f.getDefaultRank());
     }
 
@@ -236,7 +236,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#hasSubPanel()}.
      */
     @Test
-    public void testHasSubPanel() {
+    void testHasSubPanel() {
         assertFalse(f.hasSubPanel());
         f = new Flag.Builder("flagID", Material.ACACIA_PLANKS).type(Flag.Type.WORLD_SETTING).usePanel(true).build();
         assertTrue(f.hasSubPanel());
@@ -246,7 +246,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#equals(java.lang.Object)}.
      */
     @Test
-    public void testEqualsObject() {
+    void testEqualsObject() {
         Flag flag1 = null;
 
         assertNotEquals(null, f);
@@ -264,7 +264,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getNameReference()}.
      */
     @Test
-    public void testGetNameReference() {
+    void testGetNameReference() {
         assertEquals("protection.flags.flagID.name", f.getNameReference());
     }
 
@@ -272,7 +272,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getDescriptionReference()}.
      */
     @Test
-    public void testGetDescriptionReference() {
+    void testGetDescriptionReference() {
         assertEquals("protection.flags.flagID.description", f.getDescriptionReference());
     }
 
@@ -280,7 +280,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getHintReference()}.
      */
     @Test
-    public void testGetHintReference() {
+    void testGetHintReference() {
         assertEquals("protection.flags.flagID.hint", f.getHintReference());
     }
 
@@ -288,7 +288,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getGameModes()}.
      */
     @Test
-    public void testGetGameModes() {
+    void testGetGameModes() {
         assertTrue(f.getGameModes().isEmpty());
     }
 
@@ -296,7 +296,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setGameModes(java.util.Set)}.
      */
     @Test
-    public void testSetGameModes() {
+    void testSetGameModes() {
         Set<GameModeAddon> set = new HashSet<>();
         set.add(mock(GameModeAddon.class));
         assertTrue(f.getGameModes().isEmpty());
@@ -308,7 +308,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#addGameModeAddon(world.bentobox.bentobox.api.addons.GameModeAddon)}.
      */
     @Test
-    public void testAddGameModeAddon() {
+    void testAddGameModeAddon() {
         GameModeAddon gameModeAddon = mock(GameModeAddon.class);
         f.addGameModeAddon(gameModeAddon);
         assertTrue(f.getGameModes().contains(gameModeAddon));
@@ -318,7 +318,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#removeGameModeAddon(world.bentobox.bentobox.api.addons.GameModeAddon)}.
      */
     @Test
-    public void testRemoveGameModeAddon() {
+    void testRemoveGameModeAddon() {
         GameModeAddon gameModeAddon = mock(GameModeAddon.class);
         f.addGameModeAddon(gameModeAddon);
         assertTrue(f.getGameModes().contains(gameModeAddon));
@@ -331,7 +331,7 @@ public class FlagTest extends RanksManagerTestSetup {
      */
     @Disabled("Panel issue with Paper")
     @Test
-    public void testToPanelItem() {
+    void testToPanelItem() {
         when(island.getFlag(any())).thenReturn(RanksManager.VISITOR_RANK);
 
         User user = mock(User.class);
@@ -367,7 +367,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setTranslatedName(java.util.Locale, String)}.
      */
     @Test
-    public void testSetTranslatedName() {
+    void testSetTranslatedName() {
         assertFalse(f.setTranslatedName(Locale.CANADA, "Good eh?"));
         assertTrue(f.setTranslatedName(Locale.US, "Yihaa"));
     }
@@ -376,7 +376,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setTranslatedDescription(java.util.Locale, String)}.
      */
     @Test
-    public void testSetTranslatedDescription() {
+    void testSetTranslatedDescription() {
         assertFalse(f.setTranslatedDescription(Locale.CANADA, "Good eh?"));
         assertTrue(f.setTranslatedDescription(Locale.US, "Yihaa"));
     }
@@ -385,7 +385,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#toString()}.
      */
     @Test
-    public void testToString() {
+    void testToString() {
         assertEquals("Flag [id=flagID]", f.toString());
     }
 
@@ -393,7 +393,7 @@ public class FlagTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#compareTo(world.bentobox.bentobox.api.flags.Flag)}.
      */
     @Test
-    public void testCompareTo() {
+    void testCompareTo() {
         Flag aaa = new Flag.Builder("AAA", Material.ACACIA_DOOR).type(Flag.Type.PROTECTION).build();
         Flag bbb = new Flag.Builder("BBB", Material.ACACIA_DOOR).type(Flag.Type.PROTECTION).build();
         assertTrue(aaa.compareTo(bbb) < bbb.compareTo(aaa));

--- a/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/CycleClickTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/CycleClickTest.java
@@ -47,7 +47,7 @@ import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.panels.settings.SettingsTab;
 import world.bentobox.bentobox.util.Util;
 
-public class CycleClickTest extends RanksManagerTestSetup {
+class CycleClickTest extends RanksManagerTestSetup {
 
     private static final Integer PROTECTION_RANGE = 200;
     private static final Integer X = 600;
@@ -198,7 +198,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testNoPremission() {
+    void testNoPremission() {
         when(user.hasPermission(anyString())).thenReturn(false);
         CycleClick udc = new CycleClick(LOCK);
         assertTrue(udc.onClick(panel, user, ClickType.LEFT, 5));
@@ -206,7 +206,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testUpDownClick() {
+    void testUpDownClick() {
         CycleClick udc = new CycleClick(LOCK);
         assertNotNull(udc);
     }
@@ -215,7 +215,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
      * Test for {@link CycleClick#onClick(world.bentobox.bentobox.api.panels.Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnLeftClick() {
+    void testOnLeftClick() {
         final int SLOT = 5;
         CycleClick udc = new CycleClick(LOCK);
         // Rank starts at member
@@ -234,7 +234,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
      * Test for {@link CycleClick#onClick(world.bentobox.bentobox.api.panels.Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnLeftClickSetMinMax() {
+    void testOnLeftClickSetMinMax() {
         // Provide a current rank value - coop
         when(island.getFlag(any())).thenReturn(RanksManager.COOP_RANK);
         final int SLOT = 5;
@@ -255,7 +255,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
      * Test for {@link CycleClick#onClick(world.bentobox.bentobox.api.panels.Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnRightClick() {
+    void testOnRightClick() {
         final int SLOT = 5;
         CycleClick udc = new CycleClick(LOCK);
         // Rank starts at member
@@ -274,7 +274,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
      * Test for {@link CycleClick#onClick(world.bentobox.bentobox.api.panels.Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnRightClickMinMaxSet() {
+    void testOnRightClickMinMaxSet() {
         // Provide a current rank value - coop
         when(island.getFlag(any())).thenReturn(RanksManager.TRUSTED_RANK);
         final int SLOT = 5;
@@ -295,7 +295,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
      * Test for {@link CycleClick#onClick(world.bentobox.bentobox.api.panels.Panel, User, ClickType, int)}
      */
     @Test
-    public void testAllClicks() {
+    void testAllClicks() {
         // Test all possible click types
         CycleClick udc = new CycleClick(LOCK);
         Arrays.asList(ClickType.values()).forEach(c -> assertTrue(udc.onClick(panel, user, c, 0)));
@@ -303,7 +303,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
     }
 
     @Test
-    public void testNoWorld() {
+    void testNoWorld() {
         CycleClick udc = new CycleClick(LOCK);
         when(panel.getWorld()).thenReturn(Optional.empty());
         assertTrue(udc.onClick(panel, user, ClickType.SHIFT_LEFT, SLOT));
@@ -314,7 +314,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
      * Test for {@link CycleClick#onClick(world.bentobox.bentobox.api.panels.Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnShiftLeftClickNotOp() {
+    void testOnShiftLeftClickNotOp() {
         CycleClick udc = new CycleClick(LOCK);
         // Click shift left
         assertTrue(udc.onClick(panel, user, ClickType.SHIFT_LEFT, SLOT));
@@ -325,7 +325,7 @@ public class CycleClickTest extends RanksManagerTestSetup {
      * Test for {@link CycleClick#onClick(world.bentobox.bentobox.api.panels.Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnShiftLeftClickIsOp() {
+    void testOnShiftLeftClickIsOp() {
         when(user.isOp()).thenReturn(true);
         CycleClick udc = new CycleClick(LOCK);
         // Click shift left

--- a/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/IslandToggleClickTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/IslandToggleClickTest.java
@@ -31,7 +31,7 @@ import world.bentobox.bentobox.managers.FlagsManager;
 import world.bentobox.bentobox.panels.settings.SettingsTab;
 import world.bentobox.bentobox.util.Util;
 
-public class IslandToggleClickTest extends CommonTestSetup {
+class IslandToggleClickTest extends CommonTestSetup {
 
     private IslandToggleClick listener;
     @Mock
@@ -93,28 +93,28 @@ public class IslandToggleClickTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnClickNoPermission() {
+    void testOnClickNoPermission() {
         when(user.hasPermission(Mockito.anyString())).thenReturn(false);
         listener.onClick(panel, user, ClickType.LEFT, 0);
         verify(user).sendMessage("general.errors.no-permission", "[permission]", "bskyblock.settings.test");
     }
 
     @Test
-    public void testOnClick() {
+    void testOnClick() {
         listener.onClick(panel, user, ClickType.LEFT, 0);
         verify(island).toggleFlag(flag);
         verify(pim).callEvent(any(FlagSettingChangeEvent.class));
     }
 
     @Test
-    public void testOnClickNoIsland() {
+    void testOnClickNoIsland() {
         when(settingsTab.getIsland()).thenReturn(null);
         listener.onClick(panel, user, ClickType.LEFT, 0);
         verify(island, never()).toggleFlag(flag);
     }
 
     @Test
-    public void testOnClickNotOwner() {
+    void testOnClickNotOwner() {
         // No permission
         when(user.hasPermission(anyString())).thenReturn(false);
         // Pick a different UUID from owner

--- a/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/WorldToggleClickTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/WorldToggleClickTest.java
@@ -30,7 +30,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.managers.FlagsManager;
 import world.bentobox.bentobox.util.Util;
 
-public class WorldToggleClickTest extends CommonTestSetup {
+class WorldToggleClickTest extends CommonTestSetup {
 
     private WorldToggleClick listener;
     @Mock
@@ -87,7 +87,7 @@ public class WorldToggleClickTest extends CommonTestSetup {
      * Test for {@link WorldToggleClick#onClick(Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnClickNoPermission() {
+    void testOnClickNoPermission() {
         when(user.hasPermission(anyString())).thenReturn(false);
         listener.onClick(panel, user, ClickType.LEFT, 0);
         verify(user).sendMessage("general.errors.no-permission", "[permission]", "bskyblock.admin.world.settings.test");
@@ -98,7 +98,7 @@ public class WorldToggleClickTest extends CommonTestSetup {
      * Test for {@link WorldToggleClick#onClick(Panel, User, ClickType, int)}
      */
     @Test
-    public void testOnClick() {
+    void testOnClick() {
         when(user.hasPermission(anyString())).thenReturn(true);
         listener.onClick(panel, user, ClickType.LEFT, 0);
         verify(flag).setSetting(any(), eq(true));

--- a/src/test/java/world/bentobox/bentobox/api/localization/BentoBoxLocaleTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/localization/BentoBoxLocaleTest.java
@@ -28,7 +28,7 @@ import world.bentobox.bentobox.util.ItemParser;
  * @author tastybento
  *
  */
-public class BentoBoxLocaleTest extends CommonTestSetup {
+class BentoBoxLocaleTest extends CommonTestSetup {
 
     private BentoBoxLocale localeObject;
     @Mock
@@ -72,7 +72,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#get(java.lang.String)}.
      */
     @Test
-    public void testGet() {
+    void testGet() {
         assertEquals("test result", localeObject.get("reference.to.test"));
         assertEquals("missing.reference", localeObject.get("missing.reference"));
     }
@@ -81,7 +81,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#getLanguage()}.
      */
     @Test
-    public void testGetLanguage() {
+    void testGetLanguage() {
         assertEquals(Locale.US.getDisplayLanguage(), localeObject.getLanguage());
         assertEquals("unknown", new BentoBoxLocale(null, new YamlConfiguration()).getLanguage());
     }
@@ -90,7 +90,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#getCountry()}.
      */
     @Test
-    public void testGetCountry() {
+    void testGetCountry() {
         assertEquals(Locale.US.getDisplayCountry(), localeObject.getCountry());
         assertEquals("unknown", new BentoBoxLocale(null, new YamlConfiguration()).getCountry());
     }
@@ -99,7 +99,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#toLanguageTag()}.
      */
     @Test
-    public void testToLanguageTag() {
+    void testToLanguageTag() {
         assertEquals(Locale.US.toLanguageTag(), localeObject.toLanguageTag());
         assertEquals("unknown", new BentoBoxLocale(null, new YamlConfiguration()).toLanguageTag());
     }
@@ -108,7 +108,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#getBanner()}.
      */
     @Test
-    public void testGetBanner() {
+    void testGetBanner() {
         ItemStack banner = localeObject.getBanner();
         assertEquals(Material.WHITE_BANNER, banner.getType());
     }
@@ -117,7 +117,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#getAuthors()}.
      */
     @Test
-    public void testGetAuthors() {
+    void testGetAuthors() {
         assertEquals("tastybento", localeObject.getAuthors().getFirst());
         assertEquals("tastybento2", localeObject.getAuthors().get(1));
     }
@@ -126,7 +126,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#merge(org.bukkit.configuration.file.YamlConfiguration)}.
      */
     @Test
-    public void testMerge() {
+    void testMerge() {
         YamlConfiguration config2 = new YamlConfiguration();
         config2.set("meta.banner", "SHOULD NOT BE MERGED");
         List<String> authors = new ArrayList<>();
@@ -149,7 +149,7 @@ public class BentoBoxLocaleTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.localization.BentoBoxLocale#contains(java.lang.String)}.
      */
     @Test
-    public void testContains() {
+    void testContains() {
         assertTrue(localeObject.contains("reference.to.test"));
         assertFalse(localeObject.contains("false.reference.to.test"));
     }

--- a/src/test/java/world/bentobox/bentobox/api/localization/TextVariablesTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/localization/TextVariablesTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
  * Test class just to check that these constants don't accidentally change
  * @author tastybento
  */
-public class TextVariablesTest {
+class TextVariablesTest {
 
     @Test
-    public void test() {
+    void test() {
         assertEquals("[name]", TextVariables.NAME);
         assertEquals("[description]", TextVariables.DESCRIPTION);
         assertEquals("[number]", TextVariables.NUMBER);

--- a/src/test/java/world/bentobox/bentobox/api/metadata/MetaDataValueTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/metadata/MetaDataValueTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Test;
  * @author tastybento
  *
  */
-public class MetaDataValueTest {
+class MetaDataValueTest {
 
     /**
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asInt()}.
      */
     @Test
-    public void testAsInt() {
+    void testAsInt() {
         MetaDataValue mdv = new MetaDataValue(123);
         assertEquals(123, mdv.asInt());
     }
@@ -26,7 +26,7 @@ public class MetaDataValueTest {
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asFloat()}.
      */
     @Test
-    public void testAsFloat() {
+    void testAsFloat() {
         MetaDataValue mdv = new MetaDataValue(123.34F);
         assertEquals(123.34F, mdv.asFloat(), 0F);
     }
@@ -35,7 +35,7 @@ public class MetaDataValueTest {
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asDouble()}.
      */
     @Test
-    public void testAsDouble() {
+    void testAsDouble() {
         MetaDataValue mdv = new MetaDataValue(123.3444D);
         assertEquals(123.3444D, mdv.asDouble(), 0D);
     }
@@ -44,7 +44,7 @@ public class MetaDataValueTest {
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asLong()}.
      */
     @Test
-    public void testAsLong() {
+    void testAsLong() {
         MetaDataValue mdv = new MetaDataValue(123456L);
         assertEquals(123456L, mdv.asLong());
     }
@@ -53,7 +53,7 @@ public class MetaDataValueTest {
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asShort()}.
      */
     @Test
-    public void testAsShort() {
+    void testAsShort() {
         MetaDataValue mdv = new MetaDataValue((short)12);
         assertEquals((short)12, mdv.asShort());
     }
@@ -62,7 +62,7 @@ public class MetaDataValueTest {
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asByte()}.
      */
     @Test
-    public void testAsByte() {
+    void testAsByte() {
         MetaDataValue mdv = new MetaDataValue((byte)12);
         assertEquals((byte)12, mdv.asByte());
     }
@@ -71,7 +71,7 @@ public class MetaDataValueTest {
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asBoolean()}.
      */
     @Test
-    public void testAsBoolean() {
+    void testAsBoolean() {
         MetaDataValue mdv = new MetaDataValue(false);
         assertFalse(mdv.asBoolean());
         mdv = new MetaDataValue(true);
@@ -82,7 +82,7 @@ public class MetaDataValueTest {
      * Test method for {@link world.bentobox.bentobox.api.metadata.MetaDataValue#asString()}.
      */
     @Test
-    public void testAsString() {
+    void testAsString() {
         MetaDataValue mdv = new MetaDataValue("a string");
         assertEquals("a string", mdv.asString());
     }

--- a/src/test/java/world/bentobox/bentobox/api/panels/PanelItemTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/PanelItemTest.java
@@ -29,7 +29,7 @@ import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
  * @author tastybento
  *
  */
-public class PanelItemTest extends CommonTestSetup {
+class PanelItemTest extends CommonTestSetup {
 
     @Mock
     private PanelItemBuilder pib;
@@ -69,7 +69,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#empty()}.
      */
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         PanelItem panelItem = PanelItem.empty();
         assertTrue(panelItem.getName().isEmpty());
     }
@@ -78,7 +78,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#getItem()}.
      */
     @Test
-    public void testGetItem() {
+    void testGetItem() {
         ItemStack i = pi.getItem();
         assertNotNull(i);
         assertEquals(Material.STONE, i.getType());
@@ -88,7 +88,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#getDescription()}.
      */
     @Test
-    public void testGetDescription() {
+    void testGetDescription() {
         assertEquals(2, pi.getDescription().size());
     }
 
@@ -96,7 +96,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#setDescription(java.util.List)}.
      */
     @Test
-    public void testSetDescription() {
+    void testSetDescription() {
         assertEquals(2, pi.getDescription().size());
         pi.setDescription(List.of("1","2","3"));
         assertEquals(3, pi.getDescription().size());
@@ -106,7 +106,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#getName()}.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("Name", pi.getName());
     }
 
@@ -114,7 +114,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#setName(java.lang.String)}.
      */
     @Test
-    public void testSetName() {
+    void testSetName() {
         assertEquals("Name", pi.getName());
         pi.setName("Name2");
         assertEquals("Name2", pi.getName());
@@ -124,7 +124,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#isInvisible()}.
      */
     @Test
-    public void testIsInvisible() {
+    void testIsInvisible() {
         assertFalse(pi.isInvisible());
     }
 
@@ -132,7 +132,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#setInvisible(boolean)}.
      */
     @Test
-    public void testSetInvisible() {
+    void testSetInvisible() {
         assertFalse(pi.isInvisible());
         pi.setInvisible(true);
         assertTrue(pi.isInvisible());
@@ -142,7 +142,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#getClickHandler()}.
      */
     @Test
-    public void testGetClickHandler() {
+    void testGetClickHandler() {
         assertEquals(clickHandler, pi.getClickHandler().get());
     }
 
@@ -150,7 +150,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#setClickHandler(world.bentobox.bentobox.api.panels.PanelItem.ClickHandler)}.
      */
     @Test
-    public void testSetClickHandler() {
+    void testSetClickHandler() {
         assertEquals(clickHandler, pi.getClickHandler().get());
         pi.setClickHandler(null);
         assertEquals(Optional.empty(), pi.getClickHandler());
@@ -160,7 +160,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#isGlow()}.
      */
     @Test
-    public void testIsGlow() {
+    void testIsGlow() {
         assertFalse(pi.isGlow());
 
     }
@@ -169,7 +169,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#setGlow(boolean)}.
      */
     @Test
-    public void testSetGlow() {
+    void testSetGlow() {
         assertFalse(pi.isGlow());
         pi.setGlow(true);
         assertTrue(pi.isGlow());
@@ -179,7 +179,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#isPlayerHead()}.
      */
     @Test
-    public void testIsPlayerHead() {
+    void testIsPlayerHead() {
         assertTrue(pi.isPlayerHead());
 
     }
@@ -188,7 +188,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#getPlayerHeadName()}.
      */
     @Test
-    public void testGetPlayerHeadName() {
+    void testGetPlayerHeadName() {
         assertEquals("tastybento", pi.getPlayerHeadName());
     }
 
@@ -196,7 +196,7 @@ public class PanelItemTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.PanelItem#setHead(org.bukkit.inventory.ItemStack)}.
      */
     @Test
-    public void testSetHead() {
+    void testSetHead() {
         ItemStack ph = mock(ItemStack.class);
         when(ph.getType()).thenReturn(Material.PLAYER_HEAD);
         when(ph.getAmount()).thenReturn(1);

--- a/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
@@ -37,7 +37,7 @@ import world.bentobox.bentobox.util.heads.HeadGetter;
  * @author tastybento
  *
  */
-public class PanelTest extends CommonTestSetup {
+class PanelTest extends CommonTestSetup {
 
     private String name;
     private Map<Integer, PanelItem> items;
@@ -78,7 +78,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#Panel(java.lang.String, java.util.Map, int, world.bentobox.bentobox.api.user.User, world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testPanel() {
+    void testPanel() {
         // Panel
         new Panel(name, items, 10, user, listener);
 
@@ -93,7 +93,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#Panel(java.lang.String, java.util.Map, int, world.bentobox.bentobox.api.user.User, world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testPanelZeroSize() {
+    void testPanelZeroSize() {
         // Panel
         new Panel(name, items, 0, user, listener);
 
@@ -105,7 +105,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#Panel(java.lang.String, java.util.Map, int, world.bentobox.bentobox.api.user.User, world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testPanelTooBig() {
+    void testPanelTooBig() {
         // Panel
         new Panel(name, items, 100, user, listener);
 
@@ -117,7 +117,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#Panel(java.lang.String, java.util.Map, int, world.bentobox.bentobox.api.user.User, world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testPanelNullUser() {
+    void testPanelNullUser() {
         // Panel
         new Panel(name, items, 10, null, listener);
         verify(player, never()).openInventory(any(Inventory.class));
@@ -127,7 +127,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#Panel(java.lang.String, java.util.Map, int, world.bentobox.bentobox.api.user.User, world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testPanelWithItems() {
+    void testPanelWithItems() {
         // Items
         ItemStack itemStack = mock(ItemStack.class);
         PanelItem item = mock(PanelItem.class);
@@ -152,7 +152,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#Panel(java.lang.String, java.util.Map, int, world.bentobox.bentobox.api.user.User, world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testPanelWithHeads() {
+    void testPanelWithHeads() {
         // Items
         ItemStack itemStack = mock(ItemStack.class);
         PanelItem item = mock(PanelItem.class);
@@ -173,7 +173,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#getInventory()}.
      */
     @Test
-    public void testGetInventory() {
+    void testGetInventory() {
         Panel p = new Panel(name, items, 10, null, listener);
         assertEquals(inv, p.getInventory());
     }
@@ -182,7 +182,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#getItems()}.
      */
     @Test
-    public void testGetItems() {
+    void testGetItems() {
         Panel p = new Panel(name, items, 10, null, listener);
         assertEquals(items, p.getItems());
     }
@@ -191,7 +191,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#getListener()}.
      */
     @Test
-    public void testGetListener() {
+    void testGetListener() {
         Panel p = new Panel(name, items, 10, null, listener);
         assertSame(listener, p.getListener().get());
     }
@@ -200,7 +200,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#getUser()}.
      */
     @Test
-    public void testGetUser() {
+    void testGetUser() {
         Panel p = new Panel(name, items, 10, user, listener);
         assertSame(user, p.getUser().get());
 
@@ -212,7 +212,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#open(org.bukkit.entity.Player[])}.
      */
     @Test
-    public void testOpenPlayerArray() {
+    void testOpenPlayerArray() {
         Panel p = new Panel(name, items, 10, user, listener);
         p.open(player, player, player);
         verify(player, times(4)).openInventory(inv);
@@ -222,7 +222,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#open(world.bentobox.bentobox.api.user.User[])}.
      */
     @Test
-    public void testOpenUserArray() {
+    void testOpenUserArray() {
         Panel p = new Panel(name, items, 10, user, listener);
         p.open(user, user, user);
         verify(player, times(4)).openInventory(inv);
@@ -232,7 +232,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#setInventory(org.bukkit.inventory.Inventory)}.
      */
     @Test
-    public void testSetInventory() {
+    void testSetInventory() {
         Panel p = new Panel(name, items, 10, user, listener);
         Inventory inventory = mock(Inventory.class);
         p.setInventory(inventory);
@@ -243,7 +243,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#setItems(java.util.Map)}.
      */
     @Test
-    public void testSetItems() {
+    void testSetItems() {
         Panel p = new Panel(name, items, 10, user, listener);
         Map<Integer, PanelItem> newMap = new HashMap<>();
         newMap.put(23, mock(PanelItem.class));
@@ -255,7 +255,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#setListener(world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testSetListener() {
+    void testSetListener() {
         Panel p = new Panel(name, items, 10, user, null);
         assertEquals(Optional.empty(), p.getListener());
         p.setListener(listener);
@@ -266,7 +266,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#setUser(world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testSetUser() {
+    void testSetUser() {
         Panel p = new Panel(name, items, 10, null, listener);
         assertEquals(Optional.empty(), p.getUser());
         p.setUser(user);
@@ -277,7 +277,7 @@ public class PanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.Panel#getName()}.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         Panel p = new Panel(name, items, 10, null, listener);
         assertEquals(name, p.getName());
     }

--- a/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelBuilderTest.java
@@ -19,7 +19,7 @@ import world.bentobox.bentobox.api.user.User;
  * @author tastybento
  *
  */
-public class PanelBuilderTest extends CommonTestSetup {
+class PanelBuilderTest extends CommonTestSetup {
 
     @Override
     @BeforeEach
@@ -37,7 +37,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#name(java.lang.String)}.
      */
     @Test
-    public void testName() {
+    void testName() {
         PanelBuilder pb = new PanelBuilder();
         assertTrue(pb.name("test") instanceof PanelBuilder);
     }
@@ -46,7 +46,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#item(world.bentobox.bentobox.api.panels.PanelItem)}.
      */
     @Test
-    public void testItemPanelItem() {
+    void testItemPanelItem() {
         PanelItem pi = mock(PanelItem.class);
         PanelBuilder pb = new PanelBuilder();
         pb = pb.item(pi);
@@ -62,7 +62,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#item(int, world.bentobox.bentobox.api.panels.PanelItem)}.
      */
     @Test
-    public void testItemIntPanelItem() {
+    void testItemIntPanelItem() {
         PanelItem pi = mock(PanelItem.class);
         PanelBuilder pb = new PanelBuilder();
         pb = pb.item(0, pi);
@@ -81,7 +81,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#size(int)}.
      */
     @Test
-    public void testSize() {
+    void testSize() {
         PanelBuilder pb = new PanelBuilder();
         assertEquals(pb, pb.size(45));
     }
@@ -90,7 +90,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#user(world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testUser() {
+    void testUser() {
         User user = mock(User.class);
         PanelBuilder pb = new PanelBuilder();
         pb = pb.user(user);
@@ -103,7 +103,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#listener(world.bentobox.bentobox.api.panels.PanelListener)}.
      */
     @Test
-    public void testListener() {
+    void testListener() {
         PanelBuilder pb = new PanelBuilder();
         PanelListener listener = mock(PanelListener.class);
         assertEquals(pb, pb.listener(listener));
@@ -113,7 +113,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#nextSlot()}.
      */
     @Test
-    public void testNextSlot() {
+    void testNextSlot() {
         PanelItem pi = mock(PanelItem.class);
         PanelBuilder pb = new PanelBuilder();
         assertEquals(0, pb.nextSlot());
@@ -132,7 +132,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#slotOccupied(int)}.
      */
     @Test
-    public void testSlotOccupied() {
+    void testSlotOccupied() {
         PanelItem pi = mock(PanelItem.class);
         PanelBuilder pb = new PanelBuilder();
         assertEquals(0, pb.nextSlot());
@@ -153,7 +153,7 @@ public class PanelBuilderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.panels.builders.PanelBuilder#build()}.
      */
     @Test
-    public void testBuild() {
+    void testBuild() {
         PanelBuilder pb = new PanelBuilder();
         pb.name("test");
         Panel p = pb.build();

--- a/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/builders/PanelItemBuilderTest.java
@@ -30,7 +30,7 @@ import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.user.User;
 
-public class PanelItemBuilderTest extends CommonTestSetup {
+class PanelItemBuilderTest extends CommonTestSetup {
 
     @Override
     @BeforeEach
@@ -54,7 +54,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     
     @Test
     @Disabled("Hitting item check issue")
-    public void testIconMaterial() {
+    void testIconMaterial() {
         PanelItemBuilder builder = new PanelItemBuilder();
         Material m = mock(Material.class);
         when(m.isItem()).thenReturn(true);
@@ -65,7 +65,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     }
 
     @Test
-    public void testIconItemStack() {
+    void testIconItemStack() {
         PanelItemBuilder builder = new PanelItemBuilder();
         ItemStack ironOre = mock(ItemStack.class);
         when(ironOre.getType()).thenReturn(Material.IRON_ORE);
@@ -77,7 +77,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
 
     @Test
     @Disabled("Incompatibility with Player Head not being an item")
-    public void testIconString() {
+    void testIconString() {
         PanelItemBuilder builder = new PanelItemBuilder();
         builder.icon("tastybento");
         PanelItem item = builder.build();
@@ -88,7 +88,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     }
 
     @Test
-    public void testName() {
+    void testName() {
         PanelItemBuilder builder = new PanelItemBuilder();
         builder.name("test");
         PanelItem item = builder.build();
@@ -96,7 +96,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     }
 
     @Test
-    public void testDescriptionListOfString() {
+    void testDescriptionListOfString() {
         PanelItemBuilder builder = new PanelItemBuilder();
         List<String> test = Arrays.asList("test line 1", "test line 2");
         builder.description(test);
@@ -105,7 +105,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     }
 
     @Test
-    public void testDescriptionStringArray() {
+    void testDescriptionStringArray() {
         PanelItemBuilder builder = new PanelItemBuilder();
         List<String> test = Arrays.asList("test line 3", "test line 4");
         builder.description("test line 3", "test line 4");
@@ -114,7 +114,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     }
 
     @Test
-    public void testDescriptionString() {
+    void testDescriptionString() {
         PanelItemBuilder builder = new PanelItemBuilder();
         List<String> test = Collections.singletonList("test line 5");
         builder.description("test line 5");
@@ -123,7 +123,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     }
 
     @Test
-    public void testClickHandler() {
+    void testClickHandler() {
         PanelItemBuilder builder = new PanelItemBuilder();
         // Test without click handler
         PanelItem item = builder.clickHandler(null).build();
@@ -135,7 +135,7 @@ public class PanelItemBuilderTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGlow() {
+    void testGlow() {
         PanelItemBuilder builder = new PanelItemBuilder();
         // Test without glowing
         PanelItem item = builder.glow(false).build();

--- a/src/test/java/world/bentobox/bentobox/api/user/NotifierTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/NotifierTest.java
@@ -13,17 +13,17 @@ import org.mockito.Mockito;
  * @author tastybento
  *
  */
-public class NotifierTest {
+class NotifierTest {
 
     private Notifier n;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         n = new Notifier();
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         Mockito.framework().clearInlineMocks();
     }
 
@@ -31,7 +31,7 @@ public class NotifierTest {
      * Test method for {@link world.bentobox.bentobox.api.user.Notifier#notify(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testNotifyUserString() {
+    void testNotifyUserString() {
         User user = mock(User.class);
         String message = "a message";
         assertTrue(n.notify(user, message));
@@ -42,7 +42,7 @@ public class NotifierTest {
      * Test method for {@link world.bentobox.bentobox.api.user.Notifier#notify(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testNotifyUserStringMultisend() {
+    void testNotifyUserStringMultisend() {
         User user = mock(User.class);
         String message = "a message";
         assertTrue(n.notify(user, message));
@@ -57,7 +57,7 @@ public class NotifierTest {
      * Test method for {@link world.bentobox.bentobox.api.user.Notifier#notify(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testNotifyUserStringMultisendWaitSend() throws InterruptedException {
+    void testNotifyUserStringMultisendWaitSend() throws InterruptedException {
         User user = mock(User.class);
         String message = "a message";
         assertTrue(n.notify(user, message));

--- a/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/UserTest.java
@@ -62,7 +62,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  * @author tastybento
  *
  */
-public class UserTest extends CommonTestSetup {
+class UserTest extends CommonTestSetup {
 
     private static final String TEST_TRANSLATION = "mock &a translation &b [test]";
     private static final String TEST_TRANSLATION_WITH_COLOR = "mock §atranslation §b[test]";
@@ -122,19 +122,19 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetInstanceCommandSender() {
+    void testGetInstanceCommandSender() {
         User user = User.getInstance(sender);
         assertNotNull(user);
         assertEquals(sender,user.getSender());
     }
 
     @Test
-    public void testGetInstancePlayer() {
+    void testGetInstancePlayer() {
         assertSame(mockPlayer, user.getPlayer());
     }
 
     @Test
-    public void testGetInstanceUUID() {
+    void testGetInstanceUUID() {
         UUID uuid = UUID.randomUUID();
         User user = User.getInstance(uuid);
         assertNotNull(user);
@@ -142,7 +142,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testRemovePlayer() {
+    void testRemovePlayer() {
         assertNotNull(User.getInstance(uuid));
         assertSame(user, User.getInstance(uuid));
         User.removePlayer(mockPlayer);
@@ -152,7 +152,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSetPlugin() {
+    void testSetPlugin() {
         BentoBox plugin = mock(BentoBox.class);
         User.setPlugin(plugin);
         user.addPerm("testing123");
@@ -160,7 +160,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetEffectivePermissions() {
+    void testGetEffectivePermissions() {
         Set<PermissionAttachmentInfo> value = new HashSet<>();
         PermissionAttachmentInfo perm = new PermissionAttachmentInfo(sender, "perm", null, false);
         value.add(perm);
@@ -170,7 +170,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetInventory() {
+    void testGetInventory() {
         PlayerInventory value = mock(PlayerInventory.class);
         when(mockPlayer.getInventory()).thenReturn(value);
         assertEquals(value, mockPlayer.getInventory());
@@ -180,7 +180,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetLocation() {
+    void testGetLocation() {
         Location loc = mock(Location.class);
         when(mockPlayer.getLocation()).thenReturn(loc);
         User user = User.getInstance(mockPlayer);
@@ -189,7 +189,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         String name = "tastybento";
         when(mockPlayer.getName()).thenReturn(name);
         User user = User.getInstance(mockPlayer);
@@ -199,13 +199,13 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetPlayer() {
+    void testGetPlayer() {
         User user = User.getInstance(mockPlayer);
         assertSame(mockPlayer, user.getPlayer());
     }
 
     @Test
-    public void testIsPlayer() {
+    void testIsPlayer() {
         User user = User.getInstance(sender);
         assertFalse(user.isPlayer());
         user = User.getInstance(mockPlayer);
@@ -213,13 +213,13 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetSender() {
+    void testGetSender() {
         User user = User.getInstance(sender);
         assertEquals(sender, user.getSender());
     }
 
     @Test
-    public void testGetUniqueId() {
+    void testGetUniqueId() {
         UUID uuid = UUID.randomUUID();
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         user = User.getInstance(mockPlayer);
@@ -227,7 +227,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testHasPermission() {
+    void testHasPermission() {
         // default behaviors
         assertTrue(user.hasPermission(""));
         assertTrue(user.hasPermission(null));
@@ -242,25 +242,25 @@ public class UserTest extends CommonTestSetup {
      * @since 1.3.0
      */
     @Test
-    public void testHasNotPermissionButIsOp() {
+    void testHasNotPermissionButIsOp() {
         when(user.isOp()).thenReturn(true);
         assertTrue(user.hasPermission(""));
     }
 
     @Test
-    public void testIsOnline() {
+    void testIsOnline() {
         when(mockPlayer.isOnline()).thenReturn(true);
         assertTrue(user.isOnline());
     }
 
     @Test
-    public void testIsOp() {
+    void testIsOp() {
         when(mockPlayer.isOp()).thenReturn(true);
         assertTrue(user.isOp());
     }
 
     @Test
-    public void testGetTranslation() {
+    void testGetTranslation() {
         assertEquals(TEST_TRANSLATION_WITH_COLOR, user.getTranslation("a.reference"));
     }
 
@@ -268,17 +268,17 @@ public class UserTest extends CommonTestSetup {
      * Test for {@link User#getTranslationNoColor(String, String...)}
      */
     @Test
-    public void testGetTranslationNoColor() {
+    void testGetTranslationNoColor() {
         assertEquals(TEST_TRANSLATION, user.getTranslationNoColor("a.reference"));
     }
 
     @Test
-    public void testGetTranslationWithVariable() {
+    void testGetTranslationWithVariable() {
         assertEquals("mock §atranslation §bvariable", user.getTranslation("a.reference", "[test]", "variable"));
     }
 
     @Test
-    public void testGetTranslationNoTranslationFound() {
+    void testGetTranslationNoTranslationFound() {
         // Test no translation found
         when(testLm.get(any(), any())).thenReturn(null);
         assertEquals("a.reference", user.getTranslation("a.reference"));
@@ -286,7 +286,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetTranslationOrNothing() {
+    void testGetTranslationOrNothing() {
         // Return the original string to pretend that a translation could not be found
         when(testLm.get(any(), any())).thenReturn("fake.reference");
         when(testLm.get(any())).thenReturn("fake.reference");
@@ -297,13 +297,13 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSendMessage() {
+    void testSendMessage() {
         user.sendMessage("a.reference");
         checkSpigotMessage(TEST_TRANSLATION_WITH_COLOR);
     }
 
     @Test
-    public void testSendMessageOverrideWithAddon() {
+    void testSendMessageOverrideWithAddon() {
         GameModeAddon addon = mock(GameModeAddon.class);
         AddonDescription desc = new AddonDescription.Builder("mock", "name", "1.0").build();
         when(addon.getDescription()).thenReturn(desc);
@@ -318,7 +318,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSendMessageBlankTranslation() {
+    void testSendMessageBlankTranslation() {
         // Nothing - blank translation
         when(testLm.get(any(), any())).thenReturn("");
         user.sendMessage("a.reference");
@@ -327,7 +327,7 @@ public class UserTest extends CommonTestSetup {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testSendMessageOnlyColors() {
+    void testSendMessageOnlyColors() {
         // Nothing - just color codes
         StringBuilder allColors = new StringBuilder();
         for (@SuppressWarnings("deprecation") ChatColor cc : ChatColor.values()) {
@@ -340,14 +340,14 @@ public class UserTest extends CommonTestSetup {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testSendMessageColorsAndSpaces() {
+    void testSendMessageColorsAndSpaces() {
         when(testLm.get(any(), any())).thenReturn(ChatColor.COLOR_CHAR + "6 Hello there");
         user.sendMessage("a.reference");
         checkSpigotMessage(ChatColor.COLOR_CHAR + "6Hello there");
     }
 
     @Test
-    public void testSendRawMessage() {
+    void testSendRawMessage() {
         @SuppressWarnings("deprecation")
         String raw = ChatColor.RED + "" + ChatColor.BOLD + "test message";
         user.sendRawMessage(raw);
@@ -355,7 +355,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSendRawMessageNullUser() {
+    void testSendRawMessageNullUser() {
         @SuppressWarnings("deprecation")
         String raw = ChatColor.RED + "" + ChatColor.BOLD + "test message";
         user = User.getInstance((CommandSender)null);
@@ -364,7 +364,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testNotifyStringStringArrayNotifyOK() {
+    void testNotifyStringStringArrayNotifyOK() {
         Notifier notifier = mock(Notifier.class);
 
         when(plugin.getNotifier()).thenReturn(notifier);
@@ -381,7 +381,7 @@ public class UserTest extends CommonTestSetup {
 
 
     @Test
-    public void testSetGameMode() {
+    void testSetGameMode() {
         for (GameMode gm: GameMode.values()) {
             user.setGameMode(gm);
         }
@@ -389,7 +389,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTeleport() {
+    void testTeleport() {
         when(mockPlayer.teleport(any(Location.class))).thenReturn(true);
         Location loc = mock(Location.class);
         user.teleport(loc);
@@ -397,7 +397,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetWorld() {
+    void testGetWorld() {
         World world = mock(World.class);
         when(mockPlayer.getWorld()).thenReturn(world);
         User user = User.getInstance(mockPlayer);
@@ -405,13 +405,13 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCloseInventory() {
+    void testCloseInventory() {
         user.closeInventory();
         verify(mockPlayer).closeInventory();
     }
 
     @Test
-    public void testGetLocalePlayer() {
+    void testGetLocalePlayer() {
         PlayersManager pm = mock(PlayersManager.class);
         when(plugin.getPlayers()).thenReturn(pm);
         when(pm.getLocale(any())).thenReturn("en-US");
@@ -421,7 +421,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetLocaleConsole() {
+    void testGetLocaleConsole() {
         PlayersManager pm = mock(PlayersManager.class);
         when(plugin.getPlayers()).thenReturn(pm);
         when(pm.getLocale(any())).thenReturn("en-US");
@@ -437,19 +437,19 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testUpdateInventory() {
+    void testUpdateInventory() {
         user.updateInventory();
         verify(mockPlayer).updateInventory();
     }
 
     @Test
-    public void testPerformCommand() {
+    void testPerformCommand() {
         user.performCommand("test");
         verify(mockPlayer).performCommand("test");
     }
 
     @Test
-    public void testEqualsObject() {
+    void testEqualsObject() {
         User user1 = User.getInstance(UUID.randomUUID());
         User user2 = User.getInstance(UUID.randomUUID());
         assertEquals(user1, user1);
@@ -464,7 +464,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         UUID uuid = UUID.randomUUID();
         User user1 = User.getInstance(uuid);
         User user2 = User.getInstance(uuid);
@@ -476,7 +476,7 @@ public class UserTest extends CommonTestSetup {
      * Test for {@link User#getPermissionValue(String, int)}
      */
     @Test
-    public void testGetPermissionValue() {
+    void testGetPermissionValue() {
         User.clearUsers();
         Set<PermissionAttachmentInfo> permSet = new HashSet<>();
         PermissionAttachmentInfo pai = mock(PermissionAttachmentInfo.class);
@@ -500,7 +500,7 @@ public class UserTest extends CommonTestSetup {
      * Test for {@link User#getPermissionValue(String, int)}
      */
     @Test
-    public void testGetPermissionValueNegativePerm() {
+    void testGetPermissionValueNegativePerm() {
         User.clearUsers();
         Set<PermissionAttachmentInfo> permSet = new HashSet<>();
         PermissionAttachmentInfo pai = mock(PermissionAttachmentInfo.class);
@@ -524,7 +524,7 @@ public class UserTest extends CommonTestSetup {
      * Test for {@link User#getPermissionValue(String, int)}
      */
     @Test
-    public void testGetPermissionValueConsole() {
+    void testGetPermissionValueConsole() {
         User.clearUsers();
         CommandSender console = mock(CommandSender.class);
         User u = User.getInstance(console);
@@ -535,7 +535,7 @@ public class UserTest extends CommonTestSetup {
      * Test for {@link User#getPermissionValue(String, int)}
      */
     @Test
-    public void testGetPermissionValueNegative() {
+    void testGetPermissionValueNegative() {
         User.clearUsers();
         Set<PermissionAttachmentInfo> permSet = new HashSet<>();
         PermissionAttachmentInfo pai = mock(PermissionAttachmentInfo.class);
@@ -559,7 +559,7 @@ public class UserTest extends CommonTestSetup {
      * Test for {@link User#getPermissionValue(String, int)}
      */
     @Test
-    public void testGetPermissionValueStar() {
+    void testGetPermissionValueStar() {
         User.clearUsers();
         Set<PermissionAttachmentInfo> permSet = new HashSet<>();
         PermissionAttachmentInfo pai = mock(PermissionAttachmentInfo.class);
@@ -580,7 +580,7 @@ public class UserTest extends CommonTestSetup {
      * Test for {@link User#getPermissionValue(String, int)}
      */
     @Test
-    public void testGetPermissionValueSmall() {
+    void testGetPermissionValueSmall() {
         User.clearUsers();
         PermissionAttachmentInfo pai = mock(PermissionAttachmentInfo.class);
         when(pai.getPermission()).thenReturn("bskyblock.max.3");
@@ -591,7 +591,7 @@ public class UserTest extends CommonTestSetup {
     }
 
     @Test
-    public void testMetaData() {
+    void testMetaData() {
         User u = User.getInstance(mockPlayer);
         assertTrue(u.getMetaData().get().isEmpty());
         // Store a string in a new key
@@ -619,7 +619,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getInstance(org.bukkit.OfflinePlayer)}.
      */
     @Test
-    public void testGetInstanceOfflinePlayer() {
+    void testGetInstanceOfflinePlayer() {
         OfflinePlayer op = mock(OfflinePlayer.class);
         when(op.getUniqueId()).thenReturn(uuid);
         @NonNull
@@ -633,7 +633,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getOfflinePlayer()}.
      */
     @Test
-    public void testGetOfflinePlayer() {
+    void testGetOfflinePlayer() {
         User.clearUsers();
         OfflinePlayer op = mock(OfflinePlayer.class);
         when(op.getUniqueId()).thenReturn(uuid);
@@ -646,7 +646,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#isOfflinePlayer()}.
      */
     @Test
-    public void testIsOfflinePlayer() {
+    void testIsOfflinePlayer() {
         User.clearUsers();
         OfflinePlayer op = mock(OfflinePlayer.class);
         when(op.getUniqueId()).thenReturn(uuid);
@@ -665,7 +665,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#addPerm(java.lang.String)}.
      */
     @Test
-    public void testAddPerm() {
+    void testAddPerm() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         p.addPerm("test.perm");
@@ -676,7 +676,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#removePerm(java.lang.String)}.
      */
     @Test
-    public void testRemovePerm() {
+    void testRemovePerm() {
         User.clearUsers();
         // No perms to start
         when(mockPlayer.getEffectivePermissions()).thenReturn(Collections.emptySet());
@@ -700,7 +700,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getTranslation(org.bukkit.World, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testGetTranslationWorldStringStringArray() {
+    void testGetTranslationWorldStringStringArray() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         // No addon
@@ -712,7 +712,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getTranslation(org.bukkit.World, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testGetTranslationWorldStringStringArrayWwithAddon() {
+    void testGetTranslationWorldStringStringArrayWwithAddon() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         World world = mock(World.class);
@@ -728,7 +728,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getTranslation(java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testGetTranslationStringStringArray() {
+    void testGetTranslationStringStringArray() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         assertEquals("mock §atranslation §btastybento", p.getTranslation("test.ref", "[test]", "tastybento"));
@@ -738,7 +738,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#notify(java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testNotifyStringStringArray() {
+    void testNotifyStringStringArray() {
         Notifier notifier = mock(Notifier.class);
         when(plugin.getNotifier()).thenReturn(notifier);
         User.clearUsers();
@@ -752,7 +752,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#notify(org.bukkit.World, java.lang.String, java.lang.String[])}.
      */
     @Test
-    public void testNotifyWorldStringStringArray() {
+    void testNotifyWorldStringStringArray() {
         Notifier notifier = mock(Notifier.class);
         when(plugin.getNotifier()).thenReturn(notifier);
         User.clearUsers();
@@ -772,7 +772,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getLocale()}.
      */
     @Test
-    public void testGetLocaleDefaultLanguage() {
+    void testGetLocaleDefaultLanguage() {
         Settings settings = mock(Settings.class);
         when(settings.getDefaultLanguage()).thenReturn("en-US");
         when(plugin.getSettings()).thenReturn(settings);
@@ -785,7 +785,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getLocale()}.
      */
     @Test
-    public void testGetLocale() {
+    void testGetLocale() {
         Settings settings = mock(Settings.class);
         when(settings.getDefaultLanguage()).thenReturn("en-US");
         when(plugin.getSettings()).thenReturn(settings);
@@ -799,7 +799,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#inWorld()}.
      */
     @Test
-    public void testInWorld() {
+    void testInWorld() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         when(mockPlayer.getLocation()).thenReturn(mock(Location.class));
@@ -813,7 +813,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#spawnParticle(org.bukkit.Particle, java.lang.Object, double, double, double)}.
      */
     @Test
-    public void testSpawnParticleParticleObjectDoubleDoubleDoubleError() {
+    void testSpawnParticleParticleObjectDoubleDoubleDoubleError() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         try {
@@ -828,7 +828,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#spawnParticle(org.bukkit.Particle, java.lang.Object, double, double, double)}.
      */
     @Test
-    public void testSpawnParticleParticleObjectDoubleDoubleDouble() {
+    void testSpawnParticleParticleObjectDoubleDoubleDouble() {
         User.clearUsers();
         Location loc = mock(Location.class);
         when(mockPlayer.getLocation()).thenReturn(loc);
@@ -844,7 +844,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#spawnParticle(org.bukkit.Particle, java.lang.Object, double, double, double)}.
      */
     @Test
-    public void testSpawnParticleParticleObjectDoubleDoubleDoubleRedstone() {
+    void testSpawnParticleParticleObjectDoubleDoubleDoubleRedstone() {
         User.clearUsers();
         Location loc = mock(Location.class);
         when(mockPlayer.getLocation()).thenReturn(loc);
@@ -861,7 +861,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#spawnParticle(org.bukkit.Particle, org.bukkit.Particle.DustOptions, double, double, double)}.
      */
     @Test
-    public void testSpawnParticleParticleDustOptionsDoubleDoubleDouble() {
+    void testSpawnParticleParticleDustOptionsDoubleDoubleDouble() {
         User.clearUsers();
         Location loc = mock(Location.class);
         when(mockPlayer.getLocation()).thenReturn(loc);
@@ -878,7 +878,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#spawnParticle(org.bukkit.Particle, org.bukkit.Particle.DustOptions, int, int, int)}.
      */
     @Test
-    public void testSpawnParticleParticleDustOptionsIntIntInt() {
+    void testSpawnParticleParticleDustOptionsIntIntInt() {
         User.clearUsers();
         Location loc = mock(Location.class);
         when(mockPlayer.getLocation()).thenReturn(loc);
@@ -895,7 +895,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#setAddon(world.bentobox.bentobox.api.addons.Addon)}.
      */
     @Test
-    public void testSetAddon() {
+    void testSetAddon() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         Addon addon = mock(Addon.class);
@@ -909,7 +909,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#getMetaData()}.
      */
     @Test
-    public void testGetMetaData() {
+    void testGetMetaData() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         when(pm.getPlayer(uuid)).thenReturn(players);
@@ -920,7 +920,7 @@ public class UserTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.api.user.User#setMetaData(java.util.Map)}.
      */
     @Test
-    public void testSetMetaData() {
+    void testSetMetaData() {
         User.clearUsers();
         User p = User.getInstance(mockPlayer);
         when(pm.getPlayer(uuid)).thenReturn(players);

--- a/src/test/java/world/bentobox/bentobox/blueprints/BlueprintClipboardTest.java
+++ b/src/test/java/world/bentobox/bentobox/blueprints/BlueprintClipboardTest.java
@@ -32,7 +32,7 @@ import world.bentobox.bentobox.managers.HooksManager;
  * @author tastybento
  *
  */
-public class BlueprintClipboardTest extends CommonTestSetup {
+class BlueprintClipboardTest extends CommonTestSetup {
 
     private BlueprintClipboard bc;
 
@@ -77,7 +77,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#BlueprintClipboard(world.bentobox.bentobox.blueprints.Blueprint)}.
      */
     @Test
-    public void testBlueprintClipboardBlueprint() {
+    void testBlueprintClipboardBlueprint() {
         bc = new BlueprintClipboard(blueprint);
         assertNotNull(bc);
     }
@@ -86,7 +86,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#BlueprintClipboard()}.
      */
     @Test
-    public void testBlueprintClipboard() {
+    void testBlueprintClipboard() {
         assertNotNull(bc);
     }
 
@@ -94,7 +94,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#copy(world.bentobox.bentobox.api.user.User, boolean, boolean)}.
      */
     @Test
-    public void testCopy() {
+    void testCopy() {
         assertFalse(bc.copy(user, false, false, false));
         verify(user, never()).sendMessage("commands.admin.blueprint.mid-copy");
         verify(user).sendMessage("commands.admin.blueprint.need-pos1-pos2");
@@ -104,7 +104,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#getVectors(org.bukkit.util.BoundingBox)}.
      */
     @Test
-    public void testGetVectors() {
+    void testGetVectors() {
         BoundingBox bb = new BoundingBox(10.5, 10.5, 10.5, 19.5, 19.5, 19.5);
         List<Vector> list = bc.getVectors(bb);
         assertEquals(1000, list.size());
@@ -131,7 +131,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#getOrigin()}.
      */
     @Test
-    public void testGetOrigin() {
+    void testGetOrigin() {
         assertNull(bc.getOrigin());
     }
 
@@ -139,7 +139,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#getPos1()}.
      */
     @Test
-    public void testGetPos1() {
+    void testGetPos1() {
         assertNull(bc.getPos1());
     }
 
@@ -147,7 +147,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#getPos2()}.
      */
     @Test
-    public void testGetPos2() {
+    void testGetPos2() {
         assertNull(bc.getPos2());
     }
 
@@ -155,7 +155,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#isFull()}.
      */
     @Test
-    public void testIsFull() {
+    void testIsFull() {
         assertFalse(bc.isFull());
     }
 
@@ -163,7 +163,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#setOrigin(org.bukkit.util.Vector)}.
      */
     @Test
-    public void testSetOrigin() {
+    void testSetOrigin() {
         Vector v = new Vector(1,2,3);
         bc.setOrigin(v);
         assertEquals(v, bc.getOrigin());
@@ -173,7 +173,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#setPos1(org.bukkit.Location)}.
      */
     @Test
-    public void testSetPos1() {
+    void testSetPos1() {
         Location l = new Location(world, 1,2,3);
         bc.setPos1(l);
         assertEquals(l, bc.getPos1());
@@ -183,7 +183,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#setPos2(org.bukkit.Location)}.
      */
     @Test
-    public void testSetPos2() {
+    void testSetPos2() {
         Location l = new Location(world, 1,2,3);
         bc.setPos2(l);
         assertEquals(l, bc.getPos2());
@@ -193,7 +193,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#getBlueprint()}.
      */
     @Test
-    public void testGetBlueprint() {
+    void testGetBlueprint() {
         assertNull(bc.getBlueprint());
     }
 
@@ -201,7 +201,7 @@ public class BlueprintClipboardTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.blueprints.BlueprintClipboard#setBlueprint(world.bentobox.bentobox.blueprints.Blueprint)}.
      */
     @Test
-    public void testSetBlueprint() {
+    void testSetBlueprint() {
         bc.setBlueprint(blueprint);
         assertEquals(blueprint, bc.getBlueprint());
     }

--- a/src/test/java/world/bentobox/bentobox/blueprints/BlueprintPasterTest.java
+++ b/src/test/java/world/bentobox/bentobox/blueprints/BlueprintPasterTest.java
@@ -37,7 +37,7 @@ import world.bentobox.bentobox.util.Util;
 /**
  * @author tastybento
  */
-public class BlueprintPasterTest extends CommonTestSetup {
+class BlueprintPasterTest extends CommonTestSetup {
 
     private BlueprintPaster bp;
     private BlueprintPaster bp2;

--- a/src/test/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntityTest.java
+++ b/src/test/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntityTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.blueprints.dataobjects.BlueprintEntity.MythicMobR
  * @author tastybento
  *
  */
-public class BlueprintEntityTest extends CommonTestSetup {
+class BlueprintEntityTest extends CommonTestSetup {
 
     @Mock
     private Villager villager;
@@ -108,7 +108,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
 
 
     @Test
-    public void testConfigureEntityWithVillager() {
+    void testConfigureEntityWithVillager() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setType(EntityType.VILLAGER);
@@ -125,7 +125,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testConfigureEntityWithColorable() {
+    void testConfigureEntityWithColorable() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setType(EntityType.SHEEP);
@@ -137,7 +137,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testConfigureEntityWithTameable() {
+    void testConfigureEntityWithTameable() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setType(EntityType.WOLF);
@@ -149,7 +149,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testConfigureEntityWithChestedHorse() {
+    void testConfigureEntityWithChestedHorse() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setType(EntityType.HORSE);
@@ -162,7 +162,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testConfigureEntityWithAgeable() {
+    void testConfigureEntityWithAgeable() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setType(EntityType.COW);
@@ -174,7 +174,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testConfigureEntityWithAbstractHorse() {
+    void testConfigureEntityWithAbstractHorse() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setType(EntityType.HORSE);
@@ -186,7 +186,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testConfigureEntityWithHorse() {
+    void testConfigureEntityWithHorse() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setType(EntityType.HORSE);
@@ -198,7 +198,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGettersAndSetters() {
+    void testGettersAndSetters() {
         BlueprintEntity blueprint = new BlueprintEntity();
 
         blueprint.setColor(DyeColor.RED);
@@ -244,7 +244,7 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testMythicMobs() {
+    void testMythicMobs() {
         BlueprintEntity blueprint = new BlueprintEntity();
         MythicMobRecord mmr = new MythicMobRecord("string", "string2", 10D, 1F, "string3");
         blueprint.setMythicMobsRecord(mmr);
@@ -252,43 +252,43 @@ public class BlueprintEntityTest extends CommonTestSetup {
     }
 
     @Test
-    public void testIsGlowing() {
+    void testIsGlowing() {
         blueprint.setGlowing(true);
         assertTrue(blueprint.isGlowing());
     }
 
     @Test
-    public void testIsGravity() {
+    void testIsGravity() {
         blueprint.setGravity(false);
         assertFalse(blueprint.isGravity());
     }
 
     @Test
-    public void testIsVisualFire() {
+    void testIsVisualFire() {
         blueprint.setVisualFire(true);
         assertTrue(blueprint.isVisualFire());
     }
 
     @Test
-    public void testIsSilent() {
+    void testIsSilent() {
         blueprint.setSilent(true);
         assertTrue(blueprint.isSilent());
     }
 
     @Test
-    public void testIsInvulnerable() {
+    void testIsInvulnerable() {
         blueprint.setInvulnerable(true);
         assertTrue(blueprint.isInvulnerable());
     }
 
     @Test
-    public void testFireTicks() {
+    void testFireTicks() {
         blueprint.setFireTicks(20);
         assertEquals(20, blueprint.getFireTicks());
     }
 
     @Test
-    public void testSetDisplay() {
+    void testSetDisplay() {
         when(location.getWorld()).thenReturn(mockWorld);
         when(location.clone()).thenReturn(location);
         when(mockWorld.spawn(any(Location.class), eq(Display.class))).thenReturn(display);

--- a/src/test/java/world/bentobox/bentobox/listeners/BannedCommandsTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/BannedCommandsTest.java
@@ -30,7 +30,7 @@ import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.lists.Flags;
 
-public class BannedCommandsTest extends CommonTestSetup {
+class BannedCommandsTest extends CommonTestSetup {
 
     @Override
     @BeforeEach
@@ -82,7 +82,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Verifies that the command is not cancelled when the player is not in a game world.
      */
     @Test
-    public void testInstantReturnNotInWorld() {
+    void testInstantReturnNotInWorld() {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
         BannedCommands bvc = new BannedCommands(plugin);
         when(iwm.inWorld(any(World.class))).thenReturn(false);
@@ -96,7 +96,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Verifies that the command is not cancelled when the player is an operator.
      */
     @Test
-    public void testInstantReturnOp() {
+    void testInstantReturnOp() {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
         BannedCommands bvc = new BannedCommands(plugin);
         when(mockPlayer.isOp()).thenReturn(true);
@@ -109,7 +109,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Verifies that the command is not cancelled when the player has bypass permission.
      */
     @Test
-    public void testInstantReturnBypassPerm() {
+    void testInstantReturnBypassPerm() {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
         BannedCommands bvc = new BannedCommands(plugin);
         when(mockPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
@@ -122,7 +122,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Verifies that the command is not cancelled when the player is on their own island.
      */
     @Test
-    public void testInstantReturnOnOwnIsland() {
+    void testInstantReturnOnOwnIsland() {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
         BannedCommands bvc = new BannedCommands(plugin);
         when(im.locationIsOnIsland(any(), any())).thenReturn(true);
@@ -134,7 +134,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
      */
     @Test
-    public void testEmptyBannedCommands() {
+    void testEmptyBannedCommands() {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/blah");
         BannedCommands bvc = new BannedCommands(plugin);
         bvc.onVisitorCommand(e);
@@ -147,7 +147,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      */
     @ParameterizedTest
     @MethodSource("provideCancelledVisitorCommands")
-    public void testVisitorBannedCommandCancelled(String command, List<String> bannedList) {
+    void testVisitorBannedCommandCancelled(String command, List<String> bannedList) {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, command);
         BannedCommands bvc = new BannedCommands(plugin);
         when(iwm.getVisitorBannedCommands(any())).thenReturn(bannedList);
@@ -177,7 +177,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      */
     @ParameterizedTest
     @MethodSource("provideNonCancelledVisitorCommands")
-    public void testVisitorBannedCommandNotCancelled(String command, List<String> bannedList) {
+    void testVisitorBannedCommandNotCancelled(String command, List<String> bannedList) {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, command);
         BannedCommands bvc = new BannedCommands(plugin);
         when(iwm.getVisitorBannedCommands(any())).thenReturn(bannedList);
@@ -210,7 +210,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
      */
     @Test
-    public void testBannedCommandsWithNothing() {
+    void testBannedCommandsWithNothing() {
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "");
         BannedCommands bvc = new BannedCommands(plugin);
         bvc.onVisitorCommand(e);
@@ -222,7 +222,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
      */
     @Test
-    public void testBannedCommandsWithBannedFallingCommand() {
+    void testBannedCommandsWithBannedFallingCommand() {
         when(mockPlayer.getFallDistance()).thenReturn(10F);
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/banned_command");
         BannedCommands bvc = new BannedCommands(plugin);
@@ -239,7 +239,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
      */
     @Test
-    public void testBannedCommandsWithBannedFallingCommandNotFalling() {
+    void testBannedCommandsWithBannedFallingCommandNotFalling() {
         when(mockPlayer.getFallDistance()).thenReturn(0F);
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/banned_command");
         BannedCommands bvc = new BannedCommands(plugin);
@@ -256,7 +256,7 @@ public class BannedCommandsTest extends CommonTestSetup {
      * Test for {@link BannedCommands#onCommand(PlayerCommandPreprocessEvent)}
      */
     @Test
-    public void testBannedCommandsWithBannedFallingCommandNoFlag() {
+    void testBannedCommandsWithBannedFallingCommandNoFlag() {
         Flags.PREVENT_TELEPORT_WHEN_FALLING.setSetting(world, false);
         when(mockPlayer.getFallDistance()).thenReturn(0F);
         PlayerCommandPreprocessEvent e = new PlayerCommandPreprocessEvent(mockPlayer, "/banned_command");

--- a/src/test/java/world/bentobox/bentobox/listeners/BlockEndDragonTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/BlockEndDragonTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author tastybento
  *
  */
-public class BlockEndDragonTest extends CommonTestSetup {
+class BlockEndDragonTest extends CommonTestSetup {
 
     private BlockEndDragon bed;
     @Mock
@@ -87,7 +87,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onPlayerChangeWorld(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnPlayerChangeWorld() {
+    void testOnPlayerChangeWorld() {
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(mockPlayer, world);
         bed.onPlayerChangeWorld(event);
         verify(block).setType(Material.END_PORTAL, false);
@@ -97,7 +97,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onPlayerChangeWorld(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnPlayerChangeWorldNotEnd() {
+    void testOnPlayerChangeWorldNotEnd() {
         when(iwm.isIslandEnd(any())).thenReturn(false);
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(mockPlayer, world);
         bed.onPlayerChangeWorld(event);
@@ -108,7 +108,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onPlayerChangeWorld(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnPlayerChangeWorldBlockSet() {
+    void testOnPlayerChangeWorldBlockSet() {
         when(block.getType()).thenReturn(Material.END_PORTAL);
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(mockPlayer, world);
         bed.onPlayerChangeWorld(event);
@@ -119,7 +119,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onPlayerChangeWorld(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnPlayerChangeWorldNoFlag() {
+    void testOnPlayerChangeWorldNoFlag() {
         Flags.REMOVE_END_EXIT_ISLAND.setSetting(world, false);
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(mockPlayer, world);
         bed.onPlayerChangeWorld(event);
@@ -130,7 +130,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onPlayerJoinWorld(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoinWorld() {
+    void testOnPlayerJoinWorld() {
         Component component = mock(Component.class);
         PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
         bed.onPlayerJoinWorld(event);
@@ -141,7 +141,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnEndBlockPlace() {
+    void testOnEndBlockPlace() {
         BlockPlaceEvent e = new BlockPlaceEvent(block, null, block, null, mockPlayer, false, null);
         bed.onEndBlockPlace(e);
         assertTrue(e.isCancelled());
@@ -151,7 +151,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnEndBlockPlaceX() {
+    void testOnEndBlockPlaceX() {
         when(block.getX()).thenReturn(23);
         BlockPlaceEvent e = new BlockPlaceEvent(block, null, block, null, mockPlayer, false, null);
         bed.onEndBlockPlace(e);
@@ -161,7 +161,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnEndBlockPlaceZ() {
+    void testOnEndBlockPlaceZ() {
         when(block.getZ()).thenReturn(23);
         BlockPlaceEvent e = new BlockPlaceEvent(block, null, block, null, mockPlayer, false, null);
         bed.onEndBlockPlace(e);
@@ -172,7 +172,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnEndBlockPlaceY() {
+    void testOnEndBlockPlaceY() {
         when(block.getY()).thenReturn(23);
         BlockPlaceEvent e = new BlockPlaceEvent(block, null, block, null, mockPlayer, false, null);
         bed.onEndBlockPlace(e);
@@ -183,7 +183,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnEndBlockPlaceNether() {
+    void testOnEndBlockPlaceNether() {
         when(world.getEnvironment()).thenReturn(Environment.NETHER);
         BlockPlaceEvent e = new BlockPlaceEvent(block, null, block, null, mockPlayer, false, null);
         bed.onEndBlockPlace(e);
@@ -194,7 +194,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnEndBlockPlaceNoFlag() {
+    void testOnEndBlockPlaceNoFlag() {
         Flags.REMOVE_END_EXIT_ISLAND.setSetting(world, false);
         BlockPlaceEvent e = new BlockPlaceEvent(block, null, block, null, mockPlayer, false, null);
         bed.onEndBlockPlace(e);
@@ -205,7 +205,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnEndBlockPlaceWrongWorld() {
+    void testOnEndBlockPlaceWrongWorld() {
         when(iwm.isEndGenerate(any())).thenReturn(false);
         when(iwm.isEndIslands(any())).thenReturn(true);
         when(iwm.inWorld(any(World.class))).thenReturn(true);
@@ -230,7 +230,7 @@ public class BlockEndDragonTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.BlockEndDragon#onEndBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnEndBlockBreak() {
+    void testOnEndBlockBreak() {
         BlockBreakEvent e = new BlockBreakEvent(block, mockPlayer);
         bed.onEndBlockBreak(e);
         assertTrue(e.isCancelled());

--- a/src/test/java/world/bentobox/bentobox/listeners/DeathListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/DeathListenerTest.java
@@ -18,7 +18,7 @@ import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.managers.PlayersManager;
 
-public class DeathListenerTest extends CommonTestSetup {
+class DeathListenerTest extends CommonTestSetup {
 
     private PlayersManager pm;
     private WorldSettings worldSettings;
@@ -50,7 +50,7 @@ public class DeathListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerDeathEventDeathsCounted() {
+    void testOnPlayerDeathEventDeathsCounted() {
         // Test
         DeathListener dl = new DeathListener(plugin);
 
@@ -60,7 +60,7 @@ public class DeathListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerDeathEventDeathsNotCounted() {
+    void testOnPlayerDeathEventDeathsNotCounted() {
         when(worldSettings.isDeathsCounted()).thenReturn(false);
         // Test
         DeathListener dl = new DeathListener(plugin);
@@ -71,7 +71,7 @@ public class DeathListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerDeathEventDeathsCountedNotInWorld() {
+    void testOnPlayerDeathEventDeathsCountedNotInWorld() {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         // Test
         DeathListener dl = new DeathListener(plugin);

--- a/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
@@ -56,7 +56,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class JoinLeaveListenerTest extends RanksManagerTestSetup {
+class JoinLeaveListenerTest extends RanksManagerTestSetup {
 
     private static final String[] NAMES = { "adam", "ben", "cara", "dave", "ed", "frank", "freddy", "george", "harry",
             "ian", "joe" };
@@ -191,7 +191,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoinNotKnownNoAutoCreate() {
+    void testOnPlayerJoinNotKnownNoAutoCreate() {
         PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
         jll.onPlayerJoin(event);
         // Verify
@@ -210,7 +210,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoinNullWorld() {
+    void testOnPlayerJoinNullWorld() {
         when(mockPlayer.getWorld()).thenReturn(null); // Null
         when(Util.getWorld(any())).thenReturn(null); // Make null
         PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
@@ -230,7 +230,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      */
     @ParameterizedTest
     @MethodSource("provideRangeChangePermissions")
-    public void testOnPlayerJoinRangeChangePerm(int permRange, int expectedRange) {
+    void testOnPlayerJoinRangeChangePerm(int permRange, int expectedRange) {
         PermissionAttachmentInfo pa = mock(PermissionAttachmentInfo.class);
         when(pa.getPermission()).thenReturn("acidisland.island.range." + permRange);
         when(pa.getValue()).thenReturn(true);
@@ -261,7 +261,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoinRangeChangeSamePerm() {
+    void testOnPlayerJoinRangeChangeSamePerm() {
         PermissionAttachmentInfo pa = mock(PermissionAttachmentInfo.class);
         when(pa.getPermission()).thenReturn("acidisland.island.range.50");
         when(pa.getValue()).thenReturn(true);
@@ -281,7 +281,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent)}.
      */
     @Test
-    public void testOnPlayerJoinNotKnownAutoCreate() {
+    void testOnPlayerJoinNotKnownAutoCreate() {
         when(iwm.isCreateIslandOnFirstLoginEnabled(world)).thenReturn(true);
         PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
         jll.onPlayerJoin(event);
@@ -295,7 +295,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerSwitchWorld(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnPlayerSwitchWorld() {
+    void testOnPlayerSwitchWorld() {
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(mockPlayer, world);
         jll.onPlayerSwitchWorld(event);
         // Check inventory cleared
@@ -308,7 +308,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerSwitchWorld(org.bukkit.event.player.PlayerChangedWorldEvent)}.
      */
     @Test
-    public void testOnPlayerSwitchWorldNullWorld() {
+    void testOnPlayerSwitchWorldNullWorld() {
         when(Util.getWorld(any())).thenReturn(null);
         PlayerChangedWorldEvent event = new PlayerChangedWorldEvent(mockPlayer, world);
         jll.onPlayerSwitchWorld(event);
@@ -323,7 +323,7 @@ public class JoinLeaveListenerTest extends RanksManagerTestSetup {
      * {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerQuit(org.bukkit.event.player.PlayerQuitEvent)}.
      */
     @Test
-    public void testOnPlayerQuit() {
+    void testOnPlayerQuit() {
         PlayerQuitEvent event = new PlayerQuitEvent(mockPlayer, component, QuitReason.DISCONNECTED);
         jll.onPlayerQuit(event);
         checkSpigotMessage("commands.island.team.uncoop.all-members-logged-off");

--- a/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
@@ -49,7 +49,7 @@ import world.bentobox.bentobox.api.user.User;
  * @author tastybento
  *
  */
-public class PanelListenerManagerTest extends CommonTestSetup {
+class PanelListenerManagerTest extends CommonTestSetup {
 
     private static final String PANEL_NAME = "name";
     private InventoryView view;
@@ -248,7 +248,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOutsideUnknownPanel() {
+    void testOnInventoryClickOutsideUnknownPanel() {
         SlotType type = SlotType.OUTSIDE;
         InventoryClickEvent e = new InventoryClickEvent(view, type, 0, click, inv);
         plm.onInventoryClick(e);
@@ -259,7 +259,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOutsideKnownPanel() {
+    void testOnInventoryClickOutsideKnownPanel() {
         // Put a panel in the list
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         SlotType type = SlotType.OUTSIDE;
@@ -272,7 +272,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickNoOpenPanels() {
+    void testOnInventoryClickNoOpenPanels() {
         InventoryClickEvent e = new InventoryClickEvent(view, type, 0, click, inv);
         plm.onInventoryClick(e);
         // Nothing should happen
@@ -283,7 +283,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOpenPanelsWrongPanel() {
+    void testOnInventoryClickOpenPanelsWrongPanel() {
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         // Use another name for this panel
         InventoryView otherView = new MyView("another", panel.getInventory());
@@ -298,7 +298,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOpenPanelsDifferentColorPanel() {
+    void testOnInventoryClickOpenPanelsDifferentColorPanel() {
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         // Use another name for this panel
         InventoryView otherView = new MyView(ChatColor.BLACK + PANEL_NAME, panel.getInventory());
@@ -314,7 +314,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOpenPanelsRightPanelWrongSlot() {
+    void testOnInventoryClickOpenPanelsRightPanelWrongSlot() {
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         // Click on 1 instead of 0
         InventoryClickEvent e = new InventoryClickEvent(view, type, 1, click, inv);
@@ -327,7 +327,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOpenPanelsRightPanelRightSlot() {
+    void testOnInventoryClickOpenPanelsRightPanelRightSlot() {
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         // Click on 0
         InventoryClickEvent e = new InventoryClickEvent(view, type, 0, click, inv);
@@ -341,7 +341,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClose(org.bukkit.event.inventory.InventoryCloseEvent)}.
      */
     @Test
-    public void testOnInventoryCloseNoPanels() {
+    void testOnInventoryCloseNoPanels() {
         // Add a panel for another player
         PanelListenerManager.getOpenPanels().put(UUID.randomUUID(), panel);
         // No panels for this player
@@ -354,7 +354,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onInventoryClose(org.bukkit.event.inventory.InventoryCloseEvent)}.
      */
     @Test
-    public void testOnInventoryClosePanels() {
+    void testOnInventoryClosePanels() {
         // Add a panel for player
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         InventoryCloseEvent event = new InventoryCloseEvent(view);
@@ -368,7 +368,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#onLogOut(org.bukkit.event.player.PlayerQuitEvent)}.
      */
     @Test
-    public void testOnLogOut() {
+    void testOnLogOut() {
         // Add a panel for player
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         // Unknown player logs out
@@ -389,7 +389,7 @@ public class PanelListenerManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.PanelListenerManager#getOpenPanels()}.
      */
     @Test
-    public void testGetOpenPanels() {
+    void testGetOpenPanels() {
         PanelListenerManager.getOpenPanels().put(uuid, panel);
         assertSame(panel, PanelListenerManager.getOpenPanels().get(uuid));
     }

--- a/src/test/java/world/bentobox/bentobox/listeners/StandardSpawnProtectionListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/StandardSpawnProtectionListenerTest.java
@@ -37,7 +37,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
+class StandardSpawnProtectionListenerTest extends CommonTestSetup {
 
     @Mock
     private PlayersManager pm;
@@ -108,7 +108,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceDisallowed() {
+    void testOnBlockPlaceDisallowed() {
         BlockPlaceEvent e = new BlockPlaceEvent(block, blockState, null, null, mockPlayer, true, EquipmentSlot.HAND);
         ssp.onBlockPlace(e);
         assertTrue(e.isCancelled());
@@ -119,7 +119,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceDisallowedNoProtection() {
+    void testOnBlockPlaceDisallowedNoProtection() {
         when(iwm.isNetherIslands(any())).thenReturn(true);
         BlockPlaceEvent e = new BlockPlaceEvent(block, blockState, null, null, mockPlayer, true, EquipmentSlot.HAND);
         ssp.onBlockPlace(e);
@@ -131,7 +131,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceAllowed() {
+    void testOnBlockPlaceAllowed() {
         when(mockPlayer.isOp()).thenReturn(true);
         BlockPlaceEvent e = new BlockPlaceEvent(block, blockState, null, null, mockPlayer, true, EquipmentSlot.HAND);
         ssp.onBlockPlace(e);
@@ -143,7 +143,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceAllowedOutsideSpawn() {
+    void testOnBlockPlaceAllowedOutsideSpawn() {
         when(iwm.getNetherSpawnRadius(any())).thenReturn(1);
         BlockPlaceEvent e = new BlockPlaceEvent(block, blockState, null, null, mockPlayer, true, EquipmentSlot.HAND);
         ssp.onBlockPlace(e);
@@ -155,7 +155,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceAllowedWrongWorld() {
+    void testOnBlockPlaceAllowedWrongWorld() {
         when(location.getWorld()).thenReturn(world);
         when(mockPlayer.getWorld()).thenReturn(world);
         BlockPlaceEvent e = new BlockPlaceEvent(block, blockState, null, null, mockPlayer, true, EquipmentSlot.HAND);
@@ -168,7 +168,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceAllowedNetherIslandWorlds() {
+    void testOnBlockPlaceAllowedNetherIslandWorlds() {
         when(iwm.isNetherIslands(any())).thenReturn(true);
         BlockPlaceEvent e = new BlockPlaceEvent(block, blockState, null, null, mockPlayer, true, EquipmentSlot.HAND);
         ssp.onBlockPlace(e);
@@ -180,7 +180,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceAllowedEndIslandWorlds() {
+    void testOnBlockPlaceAllowedEndIslandWorlds() {
         when(location.getWorld()).thenReturn(end);
         when(mockPlayer.getWorld()).thenReturn(end);
         when(spawnLocation.getWorld()).thenReturn(end);
@@ -195,7 +195,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBlockBreakDisallowed() {
+    void testOnBlockBreakDisallowed() {
         BlockBreakEvent e = new BlockBreakEvent(block, mockPlayer);
         ssp.onBlockBreak(e);
         assertTrue(e.isCancelled());
@@ -206,7 +206,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBlockBreakDisallowedNoProtection() {
+    void testOnBlockBreakDisallowedNoProtection() {
         when(ws.isMakeNetherPortals()).thenReturn(true);
         BlockBreakEvent e = new BlockBreakEvent(block, mockPlayer);
         ssp.onBlockBreak(e);
@@ -218,7 +218,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBlockBreakAllowed() {
+    void testOnBlockBreakAllowed() {
         when(mockPlayer.isOp()).thenReturn(true);
         BlockBreakEvent e = new BlockBreakEvent(block, mockPlayer);
         ssp.onBlockBreak(e);
@@ -230,7 +230,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosion() {
+    void testOnExplosion() {
         List<Block> blockList = new ArrayList<>();
         blockList.add(block);
         blockList.add(block);
@@ -254,7 +254,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionNoProtection() {
+    void testOnExplosionNoProtection() {
         when(ws.isMakeNetherPortals()).thenReturn(true);
         List<Block> blockList = new ArrayList<>();
         blockList.add(block);
@@ -279,7 +279,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBucketEmpty(org.bukkit.event.player.PlayerBucketEmptyEvent)}.
      */
     @Test
-    public void testOnBucketEmptyDisallowed() {
+    void testOnBucketEmptyDisallowed() {
         PlayerBucketEmptyEvent e = new PlayerBucketEmptyEvent(mockPlayer, block, block, BlockFace.DOWN, null, null,
                 null);
         ssp.onBucketEmpty(e);
@@ -291,7 +291,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBucketEmpty(org.bukkit.event.player.PlayerBucketEmptyEvent)}.
      */
     @Test
-    public void testOnBucketEmptyDisallowedNoProtection() {
+    void testOnBucketEmptyDisallowedNoProtection() {
         when(ws.isMakeNetherPortals()).thenReturn(true);
         PlayerBucketEmptyEvent e = new PlayerBucketEmptyEvent(mockPlayer, block, block, BlockFace.DOWN, null, null,
                 null);
@@ -304,7 +304,7 @@ public class StandardSpawnProtectionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.StandardSpawnProtectionListener#onBucketEmpty(org.bukkit.event.player.PlayerBucketEmptyEvent)}.
      */
     @Test
-    public void testOnBucketEmptyAllowed() {
+    void testOnBucketEmptyAllowed() {
         when(mockPlayer.isOp()).thenReturn(true);
         PlayerBucketEmptyEvent e = new PlayerBucketEmptyEvent(mockPlayer, block, block, BlockFace.DOWN, null, null,
                 null);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandRankClickListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandRankClickListenerTest.java
@@ -43,7 +43,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class CommandRankClickListenerTest extends RanksManagerTestSetup {
+class CommandRankClickListenerTest extends RanksManagerTestSetup {
     @Mock
     private User user;
     @Mock
@@ -126,7 +126,7 @@ public class CommandRankClickListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.CommandRankClickListener#onClick(world.bentobox.bentobox.api.panels.Panel, world.bentobox.bentobox.api.user.User, org.bukkit.event.inventory.ClickType, int)}.
      */
     @Test
-    public void testOnClickWrongWorld() {
+    void testOnClickWrongWorld() {
         when(user.inWorld()).thenReturn(false);
         assertTrue(crcl.onClick(panel, user, ClickType.LEFT, 0));
         verify(user).sendMessage("general.errors.wrong-world");
@@ -136,7 +136,7 @@ public class CommandRankClickListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.CommandRankClickListener#onClick(world.bentobox.bentobox.api.panels.Panel, world.bentobox.bentobox.api.user.User, org.bukkit.event.inventory.ClickType, int)}.
      */
     @Test
-    public void testOnClickNoPermission() {
+    void testOnClickNoPermission() {
         when(user.isOp()).thenReturn(false);
         when(user.hasPermission(anyString())).thenReturn(false);
         assertTrue(crcl.onClick(panel, user, ClickType.LEFT, 0));
@@ -148,7 +148,7 @@ public class CommandRankClickListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.CommandRankClickListener#onClick(world.bentobox.bentobox.api.panels.Panel, world.bentobox.bentobox.api.user.User, org.bukkit.event.inventory.ClickType, int)}.
      */
     @Test
-    public void testOnClickNoFlag() {
+    void testOnClickNoFlag() {
         when(island.isAllowed(user, Flags.CHANGE_SETTINGS)).thenReturn(false);
         assertTrue(crcl.onClick(panel, user, ClickType.LEFT, 0));
         verify(user).sendMessage("general.errors.insufficient-rank", TextVariables.RANK, "");
@@ -159,7 +159,7 @@ public class CommandRankClickListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.CommandRankClickListener#onClick(world.bentobox.bentobox.api.panels.Panel, world.bentobox.bentobox.api.user.User, org.bukkit.event.inventory.ClickType, int)}.
      */
     @Test
-    public void testOnClickDifferentPanelName() {
+    void testOnClickDifferentPanelName() {
         when(panel.getName()).thenReturn("different");
         assertTrue(crcl.onClick(panel, user, ClickType.LEFT, 0));
         verify(inv, never()).setItem(eq(0), any());
@@ -170,7 +170,7 @@ public class CommandRankClickListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.CommandRankClickListener#onClick(world.bentobox.bentobox.api.panels.Panel, world.bentobox.bentobox.api.user.User, org.bukkit.event.inventory.ClickType, int)}.
      */
     @Test
-    public void testOnClick() {
+    void testOnClick() {
         assertTrue(crcl.onClick(panel, user, ClickType.LEFT, 0));
         verify(inv).setItem(eq(0), any());
     }
@@ -179,7 +179,7 @@ public class CommandRankClickListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.CommandRankClickListener#onClick(world.bentobox.bentobox.api.panels.Panel, world.bentobox.bentobox.api.user.User, org.bukkit.event.inventory.ClickType, int)}.
      */
     @Test
-    public void testOnClickTooManyCommands() {
+    void testOnClickTooManyCommands() {
         Map<String, CompositeCommand> map = new HashMap<>();
         for (int i = 0; i < 55; i++) {
             CompositeCommand cc = mock(CompositeCommand.class);
@@ -201,7 +201,7 @@ public class CommandRankClickListenerTest extends RanksManagerTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.CommandRankClickListener#getPanelItem(java.lang.String, world.bentobox.bentobox.api.user.User, org.bukkit.World)}.
      */
     @Test
-    public void testGetPanelItem() {
+    void testGetPanelItem() {
         assertTrue(crcl.onClick(panel, user, ClickType.LEFT, 0));
         PanelItem pi = crcl.getPanelItem("test", user, world);
         assertEquals(Material.MAP, pi.getItem().getType());

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class GeoMobLimitTabTest extends CommonTestSetup {
+class GeoMobLimitTabTest extends CommonTestSetup {
 
     @Mock
     private User user;
@@ -80,7 +80,7 @@ public class GeoMobLimitTabTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab#onClick(world.bentobox.bentobox.api.panels.Panel, world.bentobox.bentobox.api.user.User, org.bukkit.event.inventory.ClickType, int)}.
      */
     @Test
-    public void testOnClick() {
+    void testOnClick() {
         GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         // ARMADILLO, AXOLOTL, BAT, and COW in list
         assertEquals(4, list.size());
@@ -110,7 +110,7 @@ public class GeoMobLimitTabTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab#getIcon()}.
      */
     @Test
-    public void testGetIcon() {
+    void testGetIcon() {
         GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world);
         PanelItem icon = tab.getIcon();
         assertEquals("protection.flags.LIMIT_MOBS.name", icon.getName());
@@ -121,7 +121,7 @@ public class GeoMobLimitTabTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab#getIcon()}.
      */
     @Test
-    public void testGetIconGeoLimit() {
+    void testGetIconGeoLimit() {
         GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         PanelItem icon = tab.getIcon();
         assertEquals("protection.flags.GEO_LIMIT_MOBS.name", icon.getName());
@@ -132,7 +132,7 @@ public class GeoMobLimitTabTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab#getName()}.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world);
         assertEquals("protection.flags.LIMIT_MOBS.name", tab.getName());
         tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
@@ -143,7 +143,7 @@ public class GeoMobLimitTabTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab#getPanelItems()}.
      */
     @Test
-    public void testGetPanelItemsMobLimit() {
+    void testGetPanelItemsMobLimit() {
         GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.MOB_LIMIT, world);
         List<@Nullable PanelItem> items = tab.getPanelItems();
         assertFalse(items.isEmpty());
@@ -161,7 +161,7 @@ public class GeoMobLimitTabTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab#getPanelItems()}.
      */
     @Test
-    public void testGetPanelItemsGeoLimit() {
+    void testGetPanelItemsGeoLimit() {
         GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         List<@Nullable PanelItem> items = tab.getPanelItems();
         assertFalse(items.isEmpty());
@@ -179,7 +179,7 @@ public class GeoMobLimitTabTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.clicklisteners.GeoMobLimitTab#getPermission()}.
      */
     @Test
-    public void testGetPermission() {
+    void testGetPermission() {
         GeoMobLimitTab tab = new GeoMobLimitTab(user, EntityLimitTabType.GEO_LIMIT, world);
         assertTrue(tab.getPermission().isEmpty());
     }

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BlockInteractionListenerTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.lists.Flags;
  *
  */
 @Disabled("Issues with NotAMock")
-public class BlockInteractionListenerTest extends CommonTestSetup {
+class BlockInteractionListenerTest extends CommonTestSetup {
     private EquipmentSlot hand;
 
     private BlockInteractionListener bil;
@@ -157,7 +157,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractItemFrameNotAllowed() {
+    void testOnPlayerInteractItemFrameNotAllowed() {
         when(clickedBlock.getType()).thenReturn(itemFrame);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, item, clickedBlock, BlockFace.EAST, hand);
         bil.onPlayerInteract(e);
@@ -169,7 +169,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractItemFrameNotAllowedOtherFlagsOkay() {
+    void testOnPlayerInteractItemFrameNotAllowedOtherFlagsOkay() {
         when(island.isAllowed(any(), eq(Flags.BREAK_BLOCKS))).thenReturn(true);
         when(island.isAllowed(any(), eq(Flags.PLACE_BLOCKS))).thenReturn(true);
         when(clickedBlock.getType()).thenReturn(itemFrame);
@@ -183,7 +183,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractNothingInHandPotsNotAllowed() {
+    void testOnPlayerInteractNothingInHandPotsNotAllowed() {
         when(Tag.FLOWER_POTS.isTagged(Material.POTTED_ACACIA_SAPLING)).thenReturn(true);
         when(Tag.FLOWER_POTS.isTagged(Material.POTTED_ALLIUM)).thenReturn(true);
         when(Tag.FLOWER_POTS.isTagged(Material.POTTED_AZALEA_BUSH)).thenReturn(true);
@@ -234,7 +234,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractNothingInHandNotAllowed() {
+    void testOnPlayerInteractNothingInHandNotAllowed() {
         when(Tag.COPPER_CHESTS.isTagged(Material.COPPER_CHEST)).thenReturn(true);
         when(Tag.COPPER_GOLEM_STATUES.isTagged(Material.COPPER_GOLEM_STATUE)).thenReturn(true);
         when(Tag.COPPER_GOLEM_STATUES.isTagged(Material.EXPOSED_COPPER_GOLEM_STATUE)).thenReturn(true);
@@ -270,7 +270,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractNothingInHandAllowed() {
+    void testOnPlayerInteractNothingInHandAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(true);
         for (Material bm : clickedBlocks.keySet()) {
             // Allow flags
@@ -292,7 +292,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractSpawnEggInHandNotAllowed() {
+    void testOnPlayerInteractSpawnEggInHandNotAllowed() {
         when(clickedBlock.getType()).thenReturn(Material.SPAWNER);
         when(item.getType()).thenReturn(Material.BLAZE_SPAWN_EGG);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, item, clickedBlock, BlockFace.EAST, hand);
@@ -306,7 +306,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractSpawnEggInHandAllowed() {
+    void testOnPlayerInteractSpawnEggInHandAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(true);
         when(clickedBlock.getType()).thenReturn(Material.SPAWNER);
         when(item.getType()).thenReturn(Material.BLAZE_SPAWN_EGG);
@@ -321,7 +321,7 @@ public class BlockInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BlockInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractSpawnEggInHandOnItemFrameNotAllowed() {
+    void testOnPlayerInteractSpawnEggInHandOnItemFrameNotAllowed() {
         when(island.isAllowed(any(), eq(Flags.BREAK_BLOCKS))).thenReturn(true);
         when(island.isAllowed(any(), eq(Flags.PLACE_BLOCKS))).thenReturn(true);
         when(clickedBlock.getType()).thenReturn(Material.ITEM_FRAME);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BreakBlocksListenerTest.java
@@ -51,7 +51,7 @@ import world.bentobox.bentobox.lists.Flags;
  *
  */
 @Disabled("Issues with NotAMock")
-public class BreakBlocksListenerTest extends CommonTestSetup {
+class BreakBlocksListenerTest extends CommonTestSetup {
 
     private BreakBlocksListener bbl;
     @Mock
@@ -82,7 +82,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBlockBreakAllowed() {
+    void testOnBlockBreakAllowed() {
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
         when(block.getType()).thenReturn(Material.DIRT);
@@ -95,7 +95,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBlockBreakNotAllowed() {
+    void testOnBlockBreakNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Block block = mock(Block.class);
         when(block.getType()).thenReturn(Material.DIRT);
@@ -110,7 +110,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBlockHarvestNotAllowed() {
+    void testOnBlockHarvestNotAllowed() {
         when(island.isAllowed(any(), 
                 eq(Flags.HARVEST))).thenReturn(false);
         Block block = mock(Block.class);
@@ -126,7 +126,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBlockBreak(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBlockHarvestAllowed() {
+    void testOnBlockHarvestAllowed() {
         when(island.isAllowed(any(), eq(Flags.BREAK_BLOCKS))).thenReturn(false);
         when(island.isAllowed(any(), eq(Flags.HARVEST))).thenReturn(true);
         Block block = mock(Block.class);
@@ -141,7 +141,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBreakHanging(org.bukkit.event.hanging.HangingBreakByEntityEvent)}.
      */
     @Test
-    public void testOnBreakHangingAllowed() {
+    void testOnBreakHangingAllowed() {
         Hanging hanging = mock(Hanging.class);
         when(hanging.getLocation()).thenReturn(location);
         RemoveCause cause = RemoveCause.ENTITY;
@@ -154,7 +154,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBreakHanging(org.bukkit.event.hanging.HangingBreakByEntityEvent)}.
      */
     @Test
-    public void testOnBreakHangingNotAllowed() {
+    void testOnBreakHangingNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Hanging hanging = mock(Hanging.class);
         when(hanging.getLocation()).thenReturn(location);
@@ -169,7 +169,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBreakHanging(org.bukkit.event.hanging.HangingBreakByEntityEvent)}.
      */
     @Test
-    public void testOnBreakHangingNotPlayer() {
+    void testOnBreakHangingNotPlayer() {
         Hanging hanging = mock(Hanging.class);
         when(hanging.getLocation()).thenReturn(location);
         RemoveCause cause = RemoveCause.EXPLOSION;
@@ -182,7 +182,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBreakHanging(org.bukkit.event.hanging.HangingBreakByEntityEvent)}.
      */
     @Test
-    public void testOnBreakHangingNotPlayerProjectile() {
+    void testOnBreakHangingNotPlayerProjectile() {
         Hanging hanging = mock(Hanging.class);
         when(hanging.getLocation()).thenReturn(location);
         RemoveCause cause = RemoveCause.PHYSICS;
@@ -197,7 +197,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBreakHanging(org.bukkit.event.hanging.HangingBreakByEntityEvent)}.
      */
     @Test
-    public void testOnBreakHangingPlayerProjectileNotAllowed() {
+    void testOnBreakHangingPlayerProjectileNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Hanging hanging = mock(Hanging.class);
         when(hanging.getLocation()).thenReturn(location);
@@ -214,7 +214,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onBreakHanging(org.bukkit.event.hanging.HangingBreakByEntityEvent)}.
      */
     @Test
-    public void testOnBreakHangingPlayerProjectileAllowed() {
+    void testOnBreakHangingPlayerProjectileAllowed() {
         Hanging hanging = mock(Hanging.class);
         when(hanging.getLocation()).thenReturn(location);
         RemoveCause cause = RemoveCause.PHYSICS;
@@ -230,7 +230,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractNotHit() {
+    void testOnPlayerInteractNotHit() {
         ItemStack item = mock(ItemStack.class);
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
@@ -243,7 +243,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractHitWrongType() {
+    void testOnPlayerInteractHitWrongType() {
         ItemStack item = mock(ItemStack.class);
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
@@ -259,7 +259,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      */
     @SuppressWarnings("deprecation")
     @Test
-    public void testOnPlayerInteractHitCakeSpawnerDragonEggOK() {
+    void testOnPlayerInteractHitCakeSpawnerDragonEggOK() {
         ItemStack item = mock(ItemStack.class);
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
@@ -282,7 +282,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractHitCakeSpawnerDragonEggNotOK() {
+    void testOnPlayerInteractHitCakeSpawnerDragonEggNotOK() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         ItemStack item = mock(ItemStack.class);
         Block block = mock(Block.class);
@@ -307,7 +307,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onVehicleDamageEvent(org.bukkit.event.vehicle.VehicleDamageEvent)}.
      */
     @Test
-    public void testOnVehicleDamageEventAllowed() {
+    void testOnVehicleDamageEventAllowed() {
         Vehicle vehicle = mock(Vehicle.class);
         when(vehicle.getLocation()).thenReturn(location);
         when(vehicle.getType()).thenReturn(EntityType.MINECART);
@@ -320,7 +320,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onVehicleDamageEvent(org.bukkit.event.vehicle.VehicleDamageEvent)}.
      */
     @Test
-    public void testOnVehicleDamageEventNotAllowedMinecart() {
+    void testOnVehicleDamageEventNotAllowedMinecart() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Vehicle vehicle = mock(Vehicle.class);
         when(vehicle.getLocation()).thenReturn(location);
@@ -335,7 +335,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onVehicleDamageEvent(org.bukkit.event.vehicle.VehicleDamageEvent)}.
      */
     @Test
-    public void testOnVehicleDamageEventNotAllowedBoat() {
+    void testOnVehicleDamageEventNotAllowedBoat() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Vehicle vehicle = mock(Vehicle.class);
         when(vehicle.getLocation()).thenReturn(location);
@@ -350,7 +350,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onVehicleDamageEvent(org.bukkit.event.vehicle.VehicleDamageEvent)}.
      */
     @Test
-    public void testOnVehicleDamageEventNotAllowedElse() {
+    void testOnVehicleDamageEventNotAllowedElse() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Vehicle vehicle = mock(Vehicle.class);
         when(vehicle.getLocation()).thenReturn(location);
@@ -365,7 +365,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onVehicleDamageEvent(org.bukkit.event.vehicle.VehicleDamageEvent)}.
      */
     @Test
-    public void testOnVehicleDamageEventWrongWorld() {
+    void testOnVehicleDamageEventWrongWorld() {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         Vehicle vehicle = mock(Vehicle.class);
         when(vehicle.getLocation()).thenReturn(location);
@@ -378,7 +378,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onVehicleDamageEvent(org.bukkit.event.vehicle.VehicleDamageEvent)}.
      */
     @Test
-    public void testOnVehicleDamageEventNotPlayer() {
+    void testOnVehicleDamageEventNotPlayer() {
         Vehicle vehicle = mock(Vehicle.class);
         when(vehicle.getLocation()).thenReturn(location);
         VehicleDamageEvent e = new VehicleDamageEvent(vehicle, mock(Creeper.class), 10);
@@ -390,7 +390,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageNotCovered() {
+    void testOnEntityDamageNotCovered() {
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Entity damagee = mockPlayer;
         Entity damager = mockPlayer;
@@ -403,7 +403,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageAllowed() {
+    void testOnEntityDamageAllowed() {
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Entity damagee = mock(ArmorStand.class);
         Entity damager = mockPlayer;
@@ -424,7 +424,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageNotAllowed() {
+    void testOnEntityDamageNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Entity damagee = mock(ArmorStand.class);
@@ -450,7 +450,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageAllowedProjectile() {
+    void testOnEntityDamageAllowedProjectile() {
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Entity damagee = mock(ArmorStand.class);
         Projectile damager = mock(Projectile.class);
@@ -472,7 +472,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageAllowedProjectileNotPlayer() {
+    void testOnEntityDamageAllowedProjectileNotPlayer() {
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Entity damagee = mock(ArmorStand.class);
         Projectile damager = mock(Projectile.class);
@@ -494,7 +494,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageNotAllowedProjectile() {
+    void testOnEntityDamageNotAllowedProjectile() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Entity damagee = mock(ArmorStand.class);
@@ -526,7 +526,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testRightClickCaveVinesWithBerries() {
+    void testRightClickCaveVinesWithBerries() {
         when(mockBlock.getType()).thenReturn(Material.CAVE_VINES);
         when(mockBlock.getLocation()).thenReturn(location);
         CaveVinesPlant mockCaveVinesPlant = mock(CaveVinesPlant.class);
@@ -544,7 +544,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testRightClickSweetBerryBush() {
+    void testRightClickSweetBerryBush() {
         when(mockBlock.getType()).thenReturn(Material.SWEET_BERRY_BUSH);
         when(mockBlock.getLocation()).thenReturn(location);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, mockItem, mockBlock,
@@ -558,7 +558,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testRightClickRootedDirt() {
+    void testRightClickRootedDirt() {
         when(mockBlock.getType()).thenReturn(Material.ROOTED_DIRT);
         when(mockBlock.getLocation()).thenReturn(location);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, mockItem, mockBlock,
@@ -572,7 +572,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testLeftClickCake() {
+    void testLeftClickCake() {
         when(mockBlock.getType()).thenReturn(Material.CAKE);
         when(mockBlock.getLocation()).thenReturn(location);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_BLOCK, mockItem, mockBlock,
@@ -585,7 +585,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testLeftClickSpawner() {
+    void testLeftClickSpawner() {
         when(mockBlock.getType()).thenReturn(Material.SPAWNER);
         when(mockBlock.getLocation()).thenReturn(location);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_BLOCK, mockItem, mockBlock,
@@ -599,7 +599,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testLeftClickDragonEgg() {
+    void testLeftClickDragonEgg() {
         when(mockBlock.getType()).thenReturn(Material.DRAGON_EGG);
         when(mockBlock.getLocation()).thenReturn(location);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_BLOCK, mockItem, mockBlock,
@@ -613,7 +613,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testLeftClickHopper() {
+    void testLeftClickHopper() {
         when(mockBlock.getType()).thenReturn(Material.HOPPER);
         when(mockBlock.getLocation()).thenReturn(location);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_BLOCK, mockItem, mockBlock,
@@ -627,7 +627,7 @@ public class BreakBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BreakBlocksListener#onPlayerInteract(PlayerInteractEvent)}
      */
     @Test
-    public void testNoClick() {
+    void testNoClick() {
         PlayerInteractEvent e = mock(PlayerInteractEvent.class);
         when(e.getClickedBlock()).thenReturn(null);
         bbl.onPlayerInteract(e);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BreedingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BreedingListenerTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  * @author tastybento
  *
  */
-public class BreedingListenerTest extends CommonTestSetup {
+class BreedingListenerTest extends CommonTestSetup {
 
     private ItemStack itemInMainHand;
     private ItemStack itemInOffHand;
@@ -82,7 +82,7 @@ public class BreedingListenerTest extends CommonTestSetup {
      * Test method for {@link BreedingListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractNotAnimal() {
+    void testOnPlayerInteractNotAnimal() {
         Entity clickedEntity = mock(Entity.class);
         Vector position = new Vector(0,0,0);
         PlayerInteractAtEntityEvent e = new PlayerInteractAtEntityEvent(mockPlayer, clickedEntity, position);
@@ -94,7 +94,7 @@ public class BreedingListenerTest extends CommonTestSetup {
      * Test method for {@link BreedingListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAnimalNothingInMainHand() {
+    void testOnPlayerInteractAnimalNothingInMainHand() {
         Animals clickedEntity = mock(Animals.class);
         Vector position = new Vector(0,0,0);
         PlayerInteractAtEntityEvent e = new PlayerInteractAtEntityEvent(mockPlayer, clickedEntity, position);
@@ -106,7 +106,7 @@ public class BreedingListenerTest extends CommonTestSetup {
      * Test method for {@link BreedingListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAnimalNothingInOffHand() {
+    void testOnPlayerInteractAnimalNothingInOffHand() {
         Animals clickedEntity = mock(Animals.class);
         Vector position = new Vector(0,0,0);
         PlayerInteractAtEntityEvent e = new PlayerInteractAtEntityEvent(mockPlayer, clickedEntity, position, EquipmentSlot.OFF_HAND);
@@ -119,7 +119,7 @@ public class BreedingListenerTest extends CommonTestSetup {
      * Test method for {@link BreedingListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAnimalBreedingFoodInMainHandNotRightWorld() {
+    void testOnPlayerInteractAnimalBreedingFoodInMainHandNotRightWorld() {
         Animals clickedEntity = mock(Animals.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(ENTITY_TYPE);
@@ -143,7 +143,7 @@ public class BreedingListenerTest extends CommonTestSetup {
      * Test method for {@link BreedingListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAnimalBreedingFoodInMainHand() {
+    void testOnPlayerInteractAnimalBreedingFoodInMainHand() {
         Animals clickedEntity = mock(Animals.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(EntityType.COW);
@@ -165,7 +165,7 @@ public class BreedingListenerTest extends CommonTestSetup {
      * Test method for {@link BreedingListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAnimalBreedingFoodInOffHandNotRightWorld() {
+    void testOnPlayerInteractAnimalBreedingFoodInOffHandNotRightWorld() {
         Animals clickedEntity = mock(Animals.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(iwm.inWorld(any(World.class))).thenReturn(false);
@@ -188,7 +188,7 @@ public class BreedingListenerTest extends CommonTestSetup {
      * Test method for {@link BreedingListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAnimalBreedingFoodInOffHand() {
+    void testOnPlayerInteractAnimalBreedingFoodInOffHand() {
         Animals clickedEntity = mock(Animals.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(ENTITY_TYPE);
@@ -206,7 +206,7 @@ public class BreedingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerIntereactAnimalBreedingWrongFood() {
+    void testOnPlayerIntereactAnimalBreedingWrongFood() {
         Animals clickedEntity = mock(Animals.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(EntityType.COW);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BucketListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/BucketListenerTest.java
@@ -31,7 +31,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author tastybento
  *
  */
-public class BucketListenerTest extends CommonTestSetup {
+class BucketListenerTest extends CommonTestSetup {
 
 
     private BucketListener l;
@@ -59,7 +59,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onBucketEmpty(org.bukkit.event.player.PlayerBucketEmptyEvent)}.
      */
     @Test
-    public void testOnBucketEmptyAllowed() {
+    void testOnBucketEmptyAllowed() {
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
         when(block.getRelative(any())).thenReturn(block);
@@ -73,7 +73,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onBucketEmpty(org.bukkit.event.player.PlayerBucketEmptyEvent)}.
      */
     @Test
-    public void testOnBucketEmptyNotAllowed() {
+    void testOnBucketEmptyNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
@@ -89,7 +89,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onBucketFill(org.bukkit.event.player.PlayerBucketFillEvent)}.
      */
     @Test
-    public void testOnBucketFillAllowed() {
+    void testOnBucketFillAllowed() {
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
         when(block.getRelative(any())).thenReturn(block);
@@ -119,7 +119,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onBucketFill(org.bukkit.event.player.PlayerBucketFillEvent)}.
      */
     @Test
-    public void testOnBucketFillNotAllowed() {
+    void testOnBucketFillNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
@@ -152,7 +152,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onBucketFill(org.bukkit.event.player.PlayerBucketFillEvent)}.
      */
     @Test
-    public void testOnBucketFillMixedAllowed() {
+    void testOnBucketFillMixedAllowed() {
         when(island.isAllowed(any(), eq(Flags.BUCKET))).thenReturn(false);
         when(island.isAllowed(any(), eq(Flags.COLLECT_WATER))).thenReturn(true);
         when(island.isAllowed(any(), eq(Flags.COLLECT_LAVA))).thenReturn(true);
@@ -188,7 +188,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onTropicalFishScooping(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnTropicalFishScoopingNotFish() {
+    void testOnTropicalFishScoopingNotFish() {
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, mockPlayer);
         l.onTropicalFishScooping(e);
         assertFalse(e.isCancelled());
@@ -198,7 +198,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onTropicalFishScooping(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnTropicalFishScoopingFishNoWaterBucket() {
+    void testOnTropicalFishScoopingFishNoWaterBucket() {
         TropicalFish fish = mock(TropicalFish.class);
         when(fish.getLocation()).thenReturn(location);
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, fish );
@@ -215,7 +215,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onTropicalFishScooping(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnTropicalFishScoopingFishWaterBucket() {
+    void testOnTropicalFishScoopingFishWaterBucket() {
         TropicalFish fish = mock(TropicalFish.class);
         when(fish.getLocation()).thenReturn(location);
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, fish );
@@ -232,7 +232,7 @@ public class BucketListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.BucketListener#onTropicalFishScooping(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnTropicalFishScoopingFishWaterBucketNotAllowed() {
+    void testOnTropicalFishScoopingFishWaterBucketNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         TropicalFish fish = mock(TropicalFish.class);
         when(fish.getLocation()).thenReturn(location);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/CandleListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/CandleListenerTest.java
@@ -21,7 +21,7 @@ import org.mockito.Mock;
 import world.bentobox.bentobox.CommonTestSetup;
 
 @Disabled("Issues with NotAMock")
-public class CandleListenerTest extends CommonTestSetup {
+class CandleListenerTest extends CommonTestSetup {
 
     private CandleListener l;
     @Mock
@@ -50,7 +50,7 @@ public class CandleListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.CandleListener#onCandleInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnCandleInteract() {
+    void testOnCandleInteract() {
         // Block
         when(block.getType()).thenReturn(Material.CANDLE);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_BLOCK, null, block, BlockFace.UP);
@@ -62,7 +62,7 @@ public class CandleListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.CandleListener#onCandleInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnCandleCakeInteract() {
+    void testOnCandleCakeInteract() {
         // Block
         when(block.getType()).thenReturn(Material.CANDLE_CAKE);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_BLOCK, null, block, BlockFace.UP);
@@ -74,7 +74,7 @@ public class CandleListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.CandleListener#onCandleInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnCandleInteractFail() {
+    void testOnCandleInteractFail() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         // Block
         when(block.getType()).thenReturn(Material.CANDLE);
@@ -88,7 +88,7 @@ public class CandleListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.CandleListener#onCandleInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnCandleCakeInteractFail() {
+    void testOnCandleCakeInteractFail() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         // Block
         when(block.getType()).thenReturn(Material.CANDLE_CAKE);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/EggListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/EggListenerTest.java
@@ -22,7 +22,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  * @author tastybento
  *
  */
-public class EggListenerTest extends CommonTestSetup {
+class EggListenerTest extends CommonTestSetup {
 
     private EggListener el;
 
@@ -49,7 +49,7 @@ public class EggListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EggListener#onEggThrow(org.bukkit.event.player.PlayerEggThrowEvent)}.
      */
     @Test
-    public void testOnEggThrowAllowed() {
+    void testOnEggThrowAllowed() {
         Egg egg = mock(Egg.class);
         when(egg.getLocation()).thenReturn(location);
         PlayerEggThrowEvent e = new PlayerEggThrowEvent(mockPlayer, egg, false, (byte) 0, EntityType.CHICKEN);
@@ -61,7 +61,7 @@ public class EggListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EggListener#onEggThrow(org.bukkit.event.player.PlayerEggThrowEvent)}.
      */
     @Test
-    public void testOnEggThrowNotAllowed() {
+    void testOnEggThrowNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Egg egg = mock(Egg.class);
         when(egg.getLocation()).thenReturn(location);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/ElytraListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/ElytraListenerTest.java
@@ -21,7 +21,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  * @author tastybento
  *
  */
-public class ElytraListenerTest extends CommonTestSetup {
+class ElytraListenerTest extends CommonTestSetup {
 
     private ElytraListener el;
 
@@ -52,7 +52,7 @@ public class ElytraListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.ElytraListener#onGlide(org.bukkit.event.entity.EntityToggleGlideEvent)}.
      */
     @Test
-    public void testOnGlideAllowed() {
+    void testOnGlideAllowed() {
         EntityToggleGlideEvent e = new EntityToggleGlideEvent(mockPlayer, false);
         el.onGlide(e);
         assertFalse(e.isCancelled());
@@ -63,7 +63,7 @@ public class ElytraListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.ElytraListener#onGlide(org.bukkit.event.entity.EntityToggleGlideEvent)}.
      */
     @Test
-    public void testOnGlideNotAllowed() {
+    void testOnGlideNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         EntityToggleGlideEvent e = new EntityToggleGlideEvent(mockPlayer, false);
         el.onGlide(e);
@@ -75,7 +75,7 @@ public class ElytraListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.ElytraListener#onGliding(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testGlidingAllowed() {
+    void testGlidingAllowed() {
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, location, location);
         el.onGliding(e);
         verify(notifier, never()).notify(any(), anyString());
@@ -86,7 +86,7 @@ public class ElytraListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.ElytraListener#onGliding(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testGlidingNotAllowed() {
+    void testGlidingNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, location, location);
         el.onGliding(e);
@@ -97,7 +97,7 @@ public class ElytraListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.ElytraListener#onGliding(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testGlidingNotGliding() {
+    void testGlidingNotGliding() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         when(mockPlayer.isGliding()).thenReturn(false);
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, location, location);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/EntityInteractListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/EntityInteractListenerTest.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author tastybento
  *
  */
-public class EntityInteractListenerTest extends CommonTestSetup {
+class EntityInteractListenerTest extends CommonTestSetup {
 
     private EntityInteractListener eil;
     @Mock
@@ -81,7 +81,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractAtEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAtEntityArmorStandNoInteraction() {
+    void testOnPlayerInteractAtEntityArmorStandNoInteraction() {
         clickedEntity = mock(ArmorStand.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         PlayerInteractAtEntityEvent e = new PlayerInteractAtEntityEvent(mockPlayer, clickedEntity, position, hand);
@@ -94,7 +94,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractAtEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAtEntityArmorStandAllowed() {
+    void testOnPlayerInteractAtEntityArmorStandAllowed() {
         when(island.isAllowed(any(User.class), any())).thenReturn(true);
         clickedEntity = mock(ArmorStand.class);
         when(clickedEntity.getLocation()).thenReturn(location);
@@ -108,7 +108,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityHorseNoInteraction() {
+    void testOnPlayerInteractEntityHorseNoInteraction() {
         clickedEntity = mock(Horse.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, clickedEntity, hand);
@@ -121,7 +121,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityHorseAllowed() {
+    void testOnPlayerInteractEntityHorseAllowed() {
         when(island.isAllowed(any(User.class), any())).thenReturn(true);
         clickedEntity = mock(Horse.class);
         when(clickedEntity.getLocation()).thenReturn(location);
@@ -135,7 +135,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityMinecartNoInteraction() {
+    void testOnPlayerInteractEntityMinecartNoInteraction() {
         clickedEntity = mock(RideableMinecart.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, clickedEntity, hand);
@@ -148,7 +148,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityMinecartAllowed() {
+    void testOnPlayerInteractEntityMinecartAllowed() {
         when(island.isAllowed(any(User.class), any())).thenReturn(true);
         clickedEntity = mock(RideableMinecart.class);
         when(clickedEntity.getLocation()).thenReturn(location);
@@ -162,7 +162,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityBoatNoInteraction() {
+    void testOnPlayerInteractEntityBoatNoInteraction() {
         clickedEntity = mock(Boat.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, clickedEntity, hand);
@@ -175,7 +175,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityBoatAllowed() {
+    void testOnPlayerInteractEntityBoatAllowed() {
         when(island.isAllowed(any(User.class), any())).thenReturn(true);
         clickedEntity = mock(Boat.class);
         when(clickedEntity.getLocation()).thenReturn(location);
@@ -189,7 +189,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityVillagerNoInteraction() {
+    void testOnPlayerInteractEntityVillagerNoInteraction() {
         clickedEntity = mock(Villager.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, clickedEntity, hand);
@@ -202,7 +202,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAtEntityVillagerAllowed() {
+    void testOnPlayerInteractAtEntityVillagerAllowed() {
         when(island.isAllowed(any(User.class), any())).thenReturn(true);
         clickedEntity = mock(Villager.class);
         when(clickedEntity.getLocation()).thenReturn(location);
@@ -232,7 +232,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityNamingVillagerAllowedTradingNoNaming() {
+    void testOnPlayerInteractEntityNamingVillagerAllowedTradingNoNaming() {
         when(island.isAllowed(any(User.class), eq(Flags.TRADING))).thenReturn(true);
         when(island.isAllowed(any(User.class), eq(Flags.NAME_TAG))).thenReturn(false);
         clickedEntity = mock(Villager.class);
@@ -247,7 +247,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityWanderingTraderNoInteraction() {
+    void testOnPlayerInteractEntityWanderingTraderNoInteraction() {
         clickedEntity = mock(WanderingTrader.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(EntityType.WANDERING_TRADER);
@@ -264,7 +264,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractAtEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractAtEntityWanderingTraderAllowed() {
+    void testOnPlayerInteractAtEntityWanderingTraderAllowed() {
         when(island.isAllowed(any(User.class), any())).thenReturn(true);
         clickedEntity = mock(WanderingTrader.class);
         when(clickedEntity.getType()).thenReturn(EntityType.WANDERING_TRADER);
@@ -315,7 +315,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntitySheepAllowed() {
+    void testOnPlayerInteractEntitySheepAllowed() {
         clickedEntity = mock(Sheep.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(EntityType.SHEEP);
@@ -332,7 +332,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntitySheepNameTagNoInteraction() {
+    void testOnPlayerInteractEntitySheepNameTagNoInteraction() {
         clickedEntity = mock(Sheep.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(EntityType.SHEEP);
@@ -347,7 +347,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Copper Golem interaction should be blocked by the ALLAY flag when not allowed.
      */
     @Test
-    public void testOnPlayerInteractEntityCopperGolemNoInteraction() {
+    void testOnPlayerInteractEntityCopperGolemNoInteraction() {
         clickedEntity = mock(Entity.class);
         when(clickedEntity.getLocation()).thenReturn(location);
         when(clickedEntity.getType()).thenReturn(EntityType.COPPER_GOLEM);
@@ -366,7 +366,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Copper Golem interaction should be allowed when the island permits it.
      */
     @Test
-    public void testOnPlayerInteractEntityCopperGolemAllowed() {
+    void testOnPlayerInteractEntityCopperGolemAllowed() {
         when(island.isAllowed(any(User.class), any())).thenReturn(true);
         clickedEntity = mock(Entity.class);
         when(clickedEntity.getLocation()).thenReturn(location);
@@ -385,7 +385,7 @@ public class EntityInteractListenerTest extends CommonTestSetup {
      * Copper Golem interaction with a name tag should also check NAME_TAG flag.
      */
     @Test
-    public void testOnPlayerInteractEntityCopperGolemNameTagNoInteraction() {
+    void testOnPlayerInteractEntityCopperGolemNameTagNoInteraction() {
         when(island.isAllowed(any(User.class), eq(Flags.ALLAY))).thenReturn(true);
         when(island.isAllowed(any(User.class), eq(Flags.NAME_TAG))).thenReturn(false);
         clickedEntity = mock(Entity.class);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/ExperiencePickupListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/ExperiencePickupListenerTest.java
@@ -27,7 +27,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  * @author tastybento
  *
  */
-public class ExperiencePickupListenerTest extends CommonTestSetup {
+class ExperiencePickupListenerTest extends CommonTestSetup {
 
     private EntityTargetLivingEntityEvent e;
     private ExperiencePickupListener epl;
@@ -55,7 +55,7 @@ public class ExperiencePickupListenerTest extends CommonTestSetup {
      * Test method for {@link ExperiencePickupListener#onExperienceOrbTargetPlayer(org.bukkit.event.entity.EntityTargetLivingEntityEvent)}.
      */
     @Test
-    public void testOnExperienceOrbTargetPlayerNotAllowed() {
+    void testOnExperienceOrbTargetPlayerNotAllowed() {
         // Not allowed
         when(island.isAllowed(any(), any())).thenReturn(false);
         epl.onExperienceOrbTargetPlayer(e);
@@ -67,7 +67,7 @@ public class ExperiencePickupListenerTest extends CommonTestSetup {
      * Test method for {@link ExperiencePickupListener#onExperienceOrbTargetPlayer(org.bukkit.event.entity.EntityTargetLivingEntityEvent)}.
      */
     @Test
-    public void testOnExperienceOrbTargetPlayerAllowed() {
+    void testOnExperienceOrbTargetPlayerAllowed() {
         epl.onExperienceOrbTargetPlayer(e);
         assertNotNull(e.getTarget());
         verify(notifier, never()).notify(any(), anyString());
@@ -77,7 +77,7 @@ public class ExperiencePickupListenerTest extends CommonTestSetup {
      * Test method for {@link ExperiencePickupListener#onExperienceOrbTargetPlayer(org.bukkit.event.entity.EntityTargetLivingEntityEvent)}.
      */
     @Test
-    public void testOnExperienceOrbTargetNotPlayer() {
+    void testOnExperienceOrbTargetNotPlayer() {
         LivingEntity zombie = mock(Zombie.class);
         e = new EntityTargetLivingEntityEvent(entity, zombie, TargetReason.CLOSEST_ENTITY);
         epl.onExperienceOrbTargetPlayer(e);
@@ -89,7 +89,7 @@ public class ExperiencePickupListenerTest extends CommonTestSetup {
      * Test method for {@link ExperiencePickupListener#onExperienceOrbTargetPlayer(org.bukkit.event.entity.EntityTargetLivingEntityEvent)}.
      */
     @Test
-    public void testOnExperienceOrbTargetPlayerNotOrb() {
+    void testOnExperienceOrbTargetPlayerNotOrb() {
         entity = mock(ArmorStand.class);
         epl.onExperienceOrbTargetPlayer(e);
         assertNotNull(e.getTarget());

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/FireListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/FireListenerTest.java
@@ -41,7 +41,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.bentobox.util.Util;
 
-public class FireListenerTest extends CommonTestSetup {
+class FireListenerTest extends CommonTestSetup {
 
     private final Map<String, Boolean> worldFlags = new HashMap<>();
 
@@ -109,7 +109,7 @@ public class FireListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testCheckFire() {
+    void testCheckFire() {
         // Island
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
@@ -152,7 +152,7 @@ public class FireListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnBlockBurn() {
+    void testOnBlockBurn() {
         // Island
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
@@ -202,7 +202,7 @@ public class FireListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnBlockSpread() {
+    void testOnBlockSpread() {
         // Island
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
@@ -256,7 +256,7 @@ public class FireListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnBlockIgnite() {
+    void testOnBlockIgnite() {
         // Island
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/HurtingListenerTest.java
@@ -55,7 +55,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class HurtingListenerTest extends CommonTestSetup {
+class HurtingListenerTest extends CommonTestSetup {
 
     @Mock
     private Enderman enderman;
@@ -100,7 +100,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageMonsteronMonster() {
+    void testOnEntityDamageMonsteronMonster() {
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(enderman, enderman, null, null, 0);
         HurtingListener hl = new HurtingListener();
         hl.onEntityDamage(e);
@@ -111,7 +111,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamagePlayeronMonster() {
+    void testOnEntityDamagePlayeronMonster() {
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(mockPlayer, enderman, null, null, 0);
         HurtingListener hl = new HurtingListener();
         hl.onEntityDamage(e);
@@ -124,7 +124,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamagePlayeronMonsterOp() {
+    void testOnEntityDamagePlayeronMonsterOp() {
         when(mockPlayer.isOp()).thenReturn(true);
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(mockPlayer, enderman, null, null, 0);
         HurtingListener hl = new HurtingListener();
@@ -137,7 +137,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingDisallowArmorStandCatching() {
+    void testOnFishingDisallowArmorStandCatching() {
         ArmorStand entity = mock(ArmorStand.class);
         when(entity.getLocation()).thenReturn(location);
         State state = State.CAUGHT_ENTITY;
@@ -152,7 +152,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingAllowArmorStandCatching() {
+    void testOnFishingAllowArmorStandCatching() {
         ArmorStand entity = mock(ArmorStand.class);
         when(entity.getLocation()).thenReturn(location);
         State state = State.CAUGHT_ENTITY;
@@ -169,7 +169,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingDisallowAnimalCatching() {
+    void testOnFishingDisallowAnimalCatching() {
         Animals entity = mock(Animals.class);
         when(entity.getLocation()).thenReturn(location);
         State state = State.CAUGHT_ENTITY;
@@ -184,7 +184,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingAllowAnimalsCatching() {
+    void testOnFishingAllowAnimalsCatching() {
         Animals entity = mock(Animals.class);
         when(entity.getLocation()).thenReturn(location);
         State state = State.CAUGHT_ENTITY;
@@ -201,7 +201,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingDisallowMonsterCatching() {
+    void testOnFishingDisallowMonsterCatching() {
         Monster entity = mock(Monster.class);
         when(entity.getLocation()).thenReturn(location);
         State state = State.CAUGHT_ENTITY;
@@ -216,7 +216,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingAllowMonsterCatching() {
+    void testOnFishingAllowMonsterCatching() {
         Monster entity = mock(Monster.class);
         when(entity.getLocation()).thenReturn(location);
         State state = State.CAUGHT_ENTITY;
@@ -233,7 +233,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingDisallowVillagerCatching() {
+    void testOnFishingDisallowVillagerCatching() {
         Villager entity = mock(Villager.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getType()).thenReturn(EntityType.VILLAGER);
@@ -249,7 +249,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingDisallowWanderingTraderCatching() {
+    void testOnFishingDisallowWanderingTraderCatching() {
         WanderingTrader entity = mock(WanderingTrader.class);
         when(entity.getType()).thenReturn(EntityType.WANDERING_TRADER);
         when(entity.getLocation()).thenReturn(location);
@@ -266,7 +266,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingAllowVillagerCatching() {
+    void testOnFishingAllowVillagerCatching() {
         Villager entity = mock(Villager.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getType()).thenReturn(EntityType.VILLAGER);
@@ -284,7 +284,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Test method for {@link HurtingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingAllowWanderingTraderCatching() {
+    void testOnFishingAllowWanderingTraderCatching() {
         WanderingTrader entity = mock(WanderingTrader.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getType()).thenReturn(EntityType.WANDERING_TRADER);
@@ -307,7 +307,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Non-parrot entity → no flag check.
      */
     @Test
-    public void testOnPlayerFeedParrotsNotParrot() {
+    void testOnPlayerFeedParrotsNotParrot() {
         Villager villager = mock(Villager.class);
         when(villager.getLocation()).thenReturn(location);
         PlayerInteractEntityEvent e = new PlayerInteractEntityEvent(mockPlayer, villager, EquipmentSlot.HAND);
@@ -320,7 +320,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Tamed parrot + COOKIE in main hand, island disallows → HURT_TAMED_ANIMALS blocked.
      */
     @Test
-    public void testOnPlayerFeedParrotsTamedCookieMainHandDisallowed() {
+    void testOnPlayerFeedParrotsTamedCookieMainHandDisallowed() {
         Parrot parrot = mock(Parrot.class);
         when(parrot.getLocation()).thenReturn(location);
         when(parrot.isTamed()).thenReturn(true);
@@ -338,7 +338,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Tamed parrot + COOKIE in main hand, island allows → no notification.
      */
     @Test
-    public void testOnPlayerFeedParrotsTamedCookieMainHandAllowed() {
+    void testOnPlayerFeedParrotsTamedCookieMainHandAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(true);
         Parrot parrot = mock(Parrot.class);
         when(parrot.getLocation()).thenReturn(location);
@@ -357,7 +357,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Untamed parrot + COOKIE in main hand → HURT_ANIMALS blocked.
      */
     @Test
-    public void testOnPlayerFeedParrotsUntamedCookieMainHandDisallowed() {
+    void testOnPlayerFeedParrotsUntamedCookieMainHandDisallowed() {
         Parrot parrot = mock(Parrot.class);
         when(parrot.getLocation()).thenReturn(location);
         when(parrot.isTamed()).thenReturn(false);
@@ -375,7 +375,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Tamed parrot + COOKIE in off hand → HURT_TAMED_ANIMALS blocked.
      */
     @Test
-    public void testOnPlayerFeedParrotsTamedCookieOffHandDisallowed() {
+    void testOnPlayerFeedParrotsTamedCookieOffHandDisallowed() {
         Parrot parrot = mock(Parrot.class);
         when(parrot.getLocation()).thenReturn(location);
         when(parrot.isTamed()).thenReturn(true);
@@ -393,7 +393,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Parrot + non-COOKIE item in main hand → no flag check.
      */
     @Test
-    public void testOnPlayerFeedParrotsNonCookieItem() {
+    void testOnPlayerFeedParrotsNonCookieItem() {
         Parrot parrot = mock(Parrot.class);
         when(parrot.getLocation()).thenReturn(location);
         ItemStack stick = mock(ItemStack.class);
@@ -423,7 +423,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Shooter is a non-player entity → nothing happens.
      */
     @Test
-    public void testOnSplashPotionSplashNonPlayerShooter() {
+    void testOnSplashPotionSplashNonPlayerShooter() {
         ThrownPotion tp = mock(ThrownPotion.class);
         Monster shooter = mock(Monster.class);
         when(tp.getShooter()).thenReturn(shooter);
@@ -441,7 +441,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Attacker is in the affected list (self-damage) → skipped.
      */
     @Test
-    public void testOnSplashPotionSplashSelfDamage() {
+    void testOnSplashPotionSplashSelfDamage() {
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         Map<LivingEntity, Double> map = new HashMap<>();
@@ -456,7 +456,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Monster in splash radius, island disallows → HURT_MONSTERS blocked, effects removed.
      */
     @Test
-    public void testOnSplashPotionSplashMonsterDisallowed() {
+    void testOnSplashPotionSplashMonsterDisallowed() {
         PotionEffectType effectType = mock(PotionEffectType.class);
         ThrownPotion tp = mockThrownPotion(effectType);
         when(tp.getShooter()).thenReturn(mockPlayer);
@@ -476,7 +476,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Monster in splash radius, island allows → no notification, no effect removal.
      */
     @Test
-    public void testOnSplashPotionSplashMonsterAllowed() {
+    void testOnSplashPotionSplashMonsterAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(true);
         PotionEffectType effectType = mock(PotionEffectType.class);
         ThrownPotion tp = mockThrownPotion(effectType);
@@ -497,7 +497,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Passive animal in splash radius, island disallows → HURT_ANIMALS blocked.
      */
     @Test
-    public void testOnSplashPotionSplashAnimalDisallowed() {
+    void testOnSplashPotionSplashAnimalDisallowed() {
         PotionEffectType effectType = mock(PotionEffectType.class);
         ThrownPotion tp = mockThrownPotion(effectType);
         when(tp.getShooter()).thenReturn(mockPlayer);
@@ -516,7 +516,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Villager in splash radius, island disallows → HURT_VILLAGERS blocked.
      */
     @Test
-    public void testOnSplashPotionSplashVillagerDisallowed() {
+    void testOnSplashPotionSplashVillagerDisallowed() {
         PotionEffectType effectType = mock(PotionEffectType.class);
         ThrownPotion tp = mockThrownPotion(effectType);
         when(tp.getShooter()).thenReturn(mockPlayer);
@@ -536,7 +536,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Tamed animal in splash radius, island disallows → HURT_TAMED_ANIMALS blocked.
      */
     @Test
-    public void testOnSplashPotionSplashTamedAnimalDisallowed() {
+    void testOnSplashPotionSplashTamedAnimalDisallowed() {
         PotionEffectType effectType = mock(PotionEffectType.class);
         ThrownPotion tp = mockThrownPotion(effectType);
         when(tp.getShooter()).thenReturn(mockPlayer);
@@ -560,7 +560,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Non-player shooter → nothing stored, no scheduler invoked.
      */
     @Test
-    public void testOnLingeringPotionSplashNonPlayerShooter() {
+    void testOnLingeringPotionSplashNonPlayerShooter() {
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mock(Monster.class));
         org.bukkit.entity.AreaEffectCloud cloud = mock(org.bukkit.entity.AreaEffectCloud.class);
@@ -574,7 +574,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Player shooter → entity ID stored, scheduler task registered.
      */
     @Test
-    public void testOnLingeringPotionSplashPlayerShooter() {
+    void testOnLingeringPotionSplashPlayerShooter() {
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         org.bukkit.entity.AreaEffectCloud cloud = mock(org.bukkit.entity.AreaEffectCloud.class);
@@ -595,7 +595,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Wrong DamageCause → event ignored.
      */
     @Test
-    public void testOnLingeringPotionDamageWrongCause() {
+    void testOnLingeringPotionDamageWrongCause() {
         Monster cloud = mock(Monster.class);
         when(cloud.getEntityId()).thenReturn(99);
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(cloud, enderman, DamageCause.MAGIC, null, 5);
@@ -608,7 +608,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Correct cause but damager not in thrownPotions map → event ignored.
      */
     @Test
-    public void testOnLingeringPotionDamageNotInMap() {
+    void testOnLingeringPotionDamageNotInMap() {
         Monster cloud = mock(Monster.class);
         when(cloud.getEntityId()).thenReturn(99);
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(cloud, enderman, DamageCause.ENTITY_ATTACK, null, 5);
@@ -621,7 +621,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Damager is in thrownPotions, hits a monster, island disallows → HURT_MONSTERS blocked.
      */
     @Test
-    public void testOnLingeringPotionDamageMonsterDisallowed() {
+    void testOnLingeringPotionDamageMonsterDisallowed() {
         // First, fire a lingering potion to populate thrownPotions
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
@@ -647,7 +647,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Damager in thrownPotions, hits monster, island allows → not cancelled.
      */
     @Test
-    public void testOnLingeringPotionDamageMonsterAllowed() {
+    void testOnLingeringPotionDamageMonsterAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(true);
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
@@ -671,7 +671,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Self-damage (attacker == entity) → skipped.
      */
     @Test
-    public void testOnLingeringPotionDamageSelfDamage() {
+    void testOnLingeringPotionDamageSelfDamage() {
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         org.bukkit.entity.AreaEffectCloud cloud = mock(org.bukkit.entity.AreaEffectCloud.class);
@@ -697,7 +697,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Non-player entity type → firework not stored.
      */
     @Test
-    public void testOnPlayerShootEventNotPlayer() {
+    void testOnPlayerShootEventNotPlayer() {
         HurtingListener hl = new HurtingListener();
         Firework firework = mock(Firework.class);
         when(firework.getEntityId()).thenReturn(100);
@@ -716,7 +716,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Player shoots an arrow (not a firework) → not stored.
      */
     @Test
-    public void testOnPlayerShootEventNotFirework() {
+    void testOnPlayerShootEventNotFirework() {
         HurtingListener hl = new HurtingListener();
         Projectile arrow = mock(Projectile.class);
         EntityShootBowEvent e = new EntityShootBowEvent(mockPlayer, null, null, arrow, EquipmentSlot.HAND, 1F, false);
@@ -729,7 +729,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Player shoots a firework → stored; subsequent onFireworkDamage on monster is blocked.
      */
     @Test
-    public void testOnPlayerShootEventPlayerFireworkStoredThenDamageBlocked() {
+    void testOnPlayerShootEventPlayerFireworkStoredThenDamageBlocked() {
         HurtingListener hl = new HurtingListener();
         Firework firework = mock(Firework.class);
         when(firework.getEntityId()).thenReturn(101);
@@ -753,7 +753,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Damager is not a Firework → event ignored.
      */
     @Test
-    public void testOnFireworkDamageDamagerNotFirework() {
+    void testOnFireworkDamageDamagerNotFirework() {
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(enderman, enderman, DamageCause.ENTITY_EXPLOSION, null, 5);
         new HurtingListener().onFireworkDamage(e);
         assertFalse(e.isCancelled());
@@ -765,7 +765,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Damager is a Firework but not tracked in firedFireworks → event ignored.
      */
     @Test
-    public void testOnFireworkDamageFireworkNotInMap() {
+    void testOnFireworkDamageFireworkNotInMap() {
         Firework firework = mock(Firework.class);
         when(firework.getEntityId()).thenReturn(200);
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(firework, enderman, DamageCause.ENTITY_EXPLOSION, null, 5);
@@ -778,7 +778,7 @@ public class HurtingListenerTest extends CommonTestSetup {
      * Player-fired firework, island allows → not cancelled.
      */
     @Test
-    public void testOnFireworkDamageAllowed() {
+    void testOnFireworkDamageAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(true);
         HurtingListener hl = new HurtingListener();
         Firework firework = mock(Firework.class);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/InventoryListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/InventoryListenerTest.java
@@ -45,7 +45,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  * @author tastybento
  *
  */
-public class InventoryListenerTest extends CommonTestSetup {
+class InventoryListenerTest extends CommonTestSetup {
 
     private static final List<Class<?>> HOLDERS = Arrays.asList(Horse.class, Chest.class,
             DoubleChest.class,
@@ -83,7 +83,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickEnchantingAllowed() {
+    void testOnInventoryClickEnchantingAllowed() {
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);
         EnchantingInventory inv = mock(EnchantingInventory.class);
@@ -102,7 +102,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickAllowed() {
+    void testOnInventoryClickAllowed() {
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);
         Inventory inv = mock(Inventory.class);
@@ -133,7 +133,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickAllowedTrappedChest() {
+    void testOnInventoryClickAllowedTrappedChest() {
         type = Material.TRAPPED_CHEST;
         testOnInventoryClickAllowed();
     }
@@ -142,7 +142,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickNullHolder() {
+    void testOnInventoryClickNullHolder() {
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);
         Inventory inv = mock(Inventory.class);
@@ -163,7 +163,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickNotPlayer() {
+    void testOnInventoryClickNotPlayer() {
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(null);
         Inventory inv = mock(Inventory.class);
@@ -184,7 +184,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickNotAllowed() {
+    void testOnInventoryClickNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);
@@ -215,7 +215,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickEnchantingNotAllowed() {
+    void testOnInventoryClickEnchantingNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);
@@ -236,7 +236,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickNotAllowedTrappedChest() {
+    void testOnInventoryClickNotAllowedTrappedChest() {
         type = Material.TRAPPED_CHEST;
         testOnInventoryClickNotAllowed();
     }
@@ -246,7 +246,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOtherHolderAllowed() {
+    void testOnInventoryClickOtherHolderAllowed() {
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);
         Inventory inv = mock(Inventory.class);
@@ -267,7 +267,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOtherHolderNotAllowed() {
+    void testOnInventoryClickOtherHolderNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);
@@ -289,7 +289,7 @@ public class InventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.InventoryListener#onInventoryClick(org.bukkit.event.inventory.InventoryClickEvent)}.
      */
     @Test
-    public void testOnInventoryClickOtherHolderPlayerNotAllowed() {
+    void testOnInventoryClickOtherHolderPlayerNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         InventoryView view = mock(InventoryView.class);
         when(view.getPlayer()).thenReturn(mockPlayer);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
@@ -41,7 +41,7 @@ import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.PlayersManager;
 
-public class LockAndBanListenerTest extends CommonTestSetup {
+class LockAndBanListenerTest extends CommonTestSetup {
 
     private static final Integer PROTECTION_RANGE = 200;
     private static final Integer X = 600;
@@ -160,7 +160,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTeleportToNotBannedIsland() {
+    void testTeleportToNotBannedIsland() {
         // Setup location outside island, one inside banned island
         // Make player
         Player player = mock(Player.class);
@@ -176,7 +176,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTeleportToBannedIsland() {
+    void testTeleportToBannedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
 
@@ -193,7 +193,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
 
     
     @Test
-    public void testLoginToBannedIsland() {
+    void testLoginToBannedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Give player an island
@@ -217,7 +217,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testVerticalMoveOnly() {
+    void testVerticalMoveOnly() {
         // Move vertically only
         Location from = mock(Location.class);
         when(from.getWorld()).thenReturn(world);
@@ -237,7 +237,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testVerticalVehicleMoveOnly() {
+    void testVerticalVehicleMoveOnly() {
         // Move vertically only
         Location from = mock(Location.class);
         when(from.getWorld()).thenReturn(world);
@@ -265,7 +265,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveIntoBannedIsland() {
+    void testPlayerMoveIntoBannedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Give player an island
@@ -285,7 +285,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveInsideBannedIsland() {
+    void testPlayerMoveInsideBannedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Give player an island
@@ -310,7 +310,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testVehicleMoveIntoBannedIsland() {
+    void testVehicleMoveIntoBannedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Give player an island
@@ -349,7 +349,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
      */
 
     @Test
-    public void testTeleportToLockedIsland() {
+    void testTeleportToLockedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Lock island for player
@@ -363,7 +363,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testTeleportToLockedIslandAsMember() {
+    void testTeleportToLockedIslandAsMember() {
         // Make player
         Player player = mock(Player.class);
         when(player.getUniqueId()).thenReturn(uuid);
@@ -378,7 +378,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testLoginToLockedIsland() {
+    void testLoginToLockedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Give player an island
@@ -402,7 +402,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testLoginToLockedIslandAsOp() {
+    void testLoginToLockedIslandAsOp() {
         // Make player
         Player player = mock(Player.class);
         when(player.isOp()).thenReturn(true);
@@ -425,7 +425,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testLoginToLockedIslandWithBypassPerm() {
+    void testLoginToLockedIslandWithBypassPerm() {
         // Make player
         Player player = mock(Player.class);
         when(player.isOp()).thenReturn(false);
@@ -449,7 +449,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testLoginToLockedIslandAsMember() {
+    void testLoginToLockedIslandAsMember() {
         // Make player
         Player player = mock(Player.class);
         when(player.getUniqueId()).thenReturn(uuid);
@@ -466,7 +466,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveIntoLockedIsland() {
+    void testPlayerMoveIntoLockedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Give player an island
@@ -486,7 +486,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveIntoLockedIslandAsOp() {
+    void testPlayerMoveIntoLockedIslandAsOp() {
         // Make player
         Player player = mock(Player.class);
         when(player.isOp()).thenReturn(true);
@@ -507,7 +507,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveIntoLockedIslandAsNPC() {
+    void testPlayerMoveIntoLockedIslandAsNPC() {
         // Make player
         Player player = mock(Player.class);
         when(player.hasMetadata("NPC")).thenReturn(true);
@@ -527,7 +527,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveIntoLockedIslandWithBypass() {
+    void testPlayerMoveIntoLockedIslandWithBypass() {
         // Make player
         when(mockPlayer.isOp()).thenReturn(false);
         when(mockPlayer.hasPermission(anyString())).thenReturn(true);
@@ -548,7 +548,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveIntoLockedIslandAsMember() {
+    void testPlayerMoveIntoLockedIslandAsMember() {
         // Make player
         Player player = mock(Player.class);
         when(player.getUniqueId()).thenReturn(uuid);
@@ -568,7 +568,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveInsideLockedIsland() {
+    void testPlayerMoveInsideLockedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);
         // Give player an island
@@ -594,7 +594,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveInsideLockedIslandAsOp() {
+    void testPlayerMoveInsideLockedIslandAsOp() {
         // Make player
         Player player = mock(Player.class);
         when(player.getUniqueId()).thenReturn(uuid);
@@ -614,7 +614,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveInsideLockedIslandWithBypass() {
+    void testPlayerMoveInsideLockedIslandWithBypass() {
         // Make player
         Player player = mock(Player.class);
         when(player.getUniqueId()).thenReturn(uuid);
@@ -635,7 +635,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPlayerMoveInsideLockedIslandAsMember() {
+    void testPlayerMoveInsideLockedIslandAsMember() {
         // Make player
         Player player = mock(Player.class);
         when(player.getUniqueId()).thenReturn(uuid);
@@ -654,7 +654,7 @@ public class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testVehicleMoveIntoLockedIsland() {
+    void testVehicleMoveIntoLockedIsland() {
         // Make player
         Player player = mock(Player.class);
         when(player.getUniqueId()).thenReturn(uuid);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/PhysicalInteractionListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/PhysicalInteractionListenerTest.java
@@ -43,7 +43,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  *
  */
 @Disabled("Issues with NotAMock")
-public class PhysicalInteractionListenerTest extends CommonTestSetup {
+class PhysicalInteractionListenerTest extends CommonTestSetup {
 
     private ItemStack item;
     private Block clickedBlock;
@@ -76,7 +76,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractNotPhysical() {
+    void testOnPlayerInteractNotPhysical() {
         when(clickedBlock.getType()).thenReturn(Material.STONE);
         PlayerInteractEvent e  = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_AIR, item, clickedBlock, BlockFace.UP);
         new PhysicalInteractionListener().onPlayerInteract(e);
@@ -87,7 +87,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractWrongMaterial() {
+    void testOnPlayerInteractWrongMaterial() {
         when(clickedBlock.getType()).thenReturn(Material.STONE);
         PlayerInteractEvent e  = new PlayerInteractEvent(mockPlayer, Action.PHYSICAL, item, clickedBlock, BlockFace.UP);
         new PhysicalInteractionListener().onPlayerInteract(e);
@@ -98,7 +98,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractFarmland() {
+    void testOnPlayerInteractFarmland() {
         when(clickedBlock.getType()).thenReturn(Material.FARMLAND);
         PlayerInteractEvent e  = new PlayerInteractEvent(mockPlayer, Action.PHYSICAL, item, clickedBlock, BlockFace.UP);
         PhysicalInteractionListener i = new PhysicalInteractionListener();
@@ -112,7 +112,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractFarmlandOp() {
+    void testOnPlayerInteractFarmlandOp() {
         when(mockPlayer.isOp()).thenReturn(true);
         when(clickedBlock.getType()).thenReturn(Material.FARMLAND);
         PlayerInteractEvent e  = new PlayerInteractEvent(mockPlayer, Action.PHYSICAL, item, clickedBlock, BlockFace.UP);
@@ -125,7 +125,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractFarmlandPermission() {
+    void testOnPlayerInteractFarmlandPermission() {
         when(mockPlayer.hasPermission(anyString())).thenReturn(true);
         when(clickedBlock.getType()).thenReturn(Material.FARMLAND);
         PlayerInteractEvent e  = new PlayerInteractEvent(mockPlayer, Action.PHYSICAL, item, clickedBlock, BlockFace.UP);
@@ -138,7 +138,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractTurtleEgg() {
+    void testOnPlayerInteractTurtleEgg() {
         when(clickedBlock.getType()).thenReturn(Material.TURTLE_EGG);
         PlayerInteractEvent e  = new PlayerInteractEvent(mockPlayer, Action.PHYSICAL, item, clickedBlock, BlockFace.UP);
         PhysicalInteractionListener i = new PhysicalInteractionListener();
@@ -152,7 +152,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onPlayerInteract(org.bukkit.event.player.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnPlayerInteractPressurePlate() {
+    void testOnPlayerInteractPressurePlate() {
         Arrays.stream(Material.values()).filter(m -> m.name().contains("PRESSURE_PLATE")).forEach(p -> {
             when(clickedBlock.getType()).thenReturn(p);
             PlayerInteractEvent e  = new PlayerInteractEvent(mockPlayer, Action.PHYSICAL, item, clickedBlock, BlockFace.UP);
@@ -167,7 +167,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onProjectileHit(org.bukkit.event.entity.EntityInteractEvent)}.
      */
     @Test
-    public void testOnProjectileHitNotProjectile() {
+    void testOnProjectileHitNotProjectile() {
         Entity entity = mock(Entity.class);
         Block block = mock(Block.class);
         EntityInteractEvent e = new EntityInteractEvent(entity, block);
@@ -180,7 +180,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onProjectileHit(org.bukkit.event.entity.EntityInteractEvent)}.
      */
     @Test
-    public void testOnProjectileHitProjectileBlockNull() {
+    void testOnProjectileHitProjectileBlockNull() {
         Projectile entity = mock(Projectile.class);
         ProjectileSource source = mock(Creeper.class);
         when(entity.getShooter()).thenReturn(source);
@@ -195,7 +195,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onProjectileHit(org.bukkit.event.entity.EntityInteractEvent)}.
      */
     @Test
-    public void testOnProjectileHitProjectile() {
+    void testOnProjectileHitProjectile() {
         Projectile entity = mock(Projectile.class);
         ProjectileSource source = mock(Creeper.class);
         when(entity.getShooter()).thenReturn(source);
@@ -210,7 +210,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onProjectileHit(org.bukkit.event.entity.EntityInteractEvent)}.
      */
     @Test
-    public void testOnProjectileHitProjectilePlayer() {
+    void testOnProjectileHitProjectilePlayer() {
         Projectile entity = mock(Projectile.class);
         ProjectileSource source = mockPlayer ;
         when(entity.getShooter()).thenReturn(source);
@@ -231,7 +231,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onProjectileExplode(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnProjectileExplodeNotProjectile() {
+    void testOnProjectileExplodeNotProjectile() {
         Entity entity = mock(Entity.class);
         List<Block> blocks = new ArrayList<>();
         EntityExplodeEvent e = getExplodeEvent(entity, location, blocks);
@@ -244,7 +244,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onProjectileExplode(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnProjectileExplodeProjectileNoPlayer() {
+    void testOnProjectileExplodeProjectileNoPlayer() {
         Projectile entity = mock(Projectile.class);
         ProjectileSource source = mock(Creeper.class);
         when(entity.getShooter()).thenReturn(source);
@@ -259,7 +259,7 @@ public class PhysicalInteractionListenerTest extends CommonTestSetup {
      * Test method for {@link PhysicalInteractionListener#onProjectileExplode(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnProjectileExplodeProjectilePlayer() {
+    void testOnProjectileExplodeProjectilePlayer() {
         Projectile entity = mock(Projectile.class);
         when(entity.getShooter()).thenReturn(mockPlayer);
         List<Block> blocks = new ArrayList<>();

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/PlaceBlocksListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/PlaceBlocksListenerTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.lists.Flags;
  *
  */
 @Disabled("Issues with NotAMock")
-public class PlaceBlocksListenerTest extends CommonTestSetup {
+class PlaceBlocksListenerTest extends CommonTestSetup {
 
     private PlaceBlocksListener pbl;
 
@@ -65,7 +65,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceFire() {
+    void testOnBlockPlaceFire() {
         Block placedBlock = mock(Block.class);
         when(placedBlock.getType()).thenReturn(Material.FIRE);
         BlockState replacedBlockState = mock(BlockState.class);
@@ -81,7 +81,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlace() {
+    void testOnBlockPlace() {
         Block placedBlock = mock(Block.class);
         when(placedBlock.getType()).thenReturn(Material.STONE);
         when(placedBlock.getLocation()).thenReturn(location);
@@ -100,7 +100,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onHangingPlace(org.bukkit.event.hanging.HangingPlaceEvent)}.
      */
     @Test
-    public void testOnHangingPlaceAllowed() {
+    void testOnHangingPlaceAllowed() {
         Hanging hanging = mock(Hanging.class);
         Block block = mock(Block.class);
         when(block.getLocation()).thenReturn(location);
@@ -114,7 +114,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onHangingPlace(org.bukkit.event.hanging.HangingPlaceEvent)}.
      */
     @Test
-    public void testOnHangingPlaceNotAllowed() {
+    void testOnHangingPlaceNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Hanging hanging = mock(Hanging.class);
         Block block = mock(Block.class);
@@ -129,7 +129,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceNullItemInHand() {
+    void testOnBlockPlaceNullItemInHand() {
         Block placedBlock = mock(Block.class);
         when(placedBlock.getType()).thenReturn(Material.STONE);
         when(placedBlock.getLocation()).thenReturn(location);
@@ -145,7 +145,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockPlaceNotAllowed() {
+    void testOnBlockPlaceNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Block placedBlock = mock(Block.class);
         when(placedBlock.getType()).thenReturn(Material.STONE);
@@ -166,7 +166,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockCropsAllowed() {
+    void testOnBlockCropsAllowed() {
         when(island.isAllowed(any(), eq(Flags.PLACE_BLOCKS))).thenReturn(false);
         when(island.isAllowed(any(), eq(Flags.CROP_PLANTING))).thenReturn(true);
         Block placedBlock = mock(Block.class);
@@ -188,7 +188,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      */
     @Disabled("Issues with NotAMock")
     @Test
-    public void testOnBlockCropsAllowedNotCrop() {
+    void testOnBlockCropsAllowedNotCrop() {
         when(island.isAllowed(any(), eq(Flags.PLACE_BLOCKS))).thenReturn(false);
         when(island.isAllowed(any(), eq(Flags.CROP_PLANTING))).thenReturn(true);
         Block placedBlock = mock(Block.class);
@@ -210,7 +210,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onBlockPlace(org.bukkit.event.block.BlockPlaceEvent)}.
      */
     @Test
-    public void testOnBlockCropsNotAllowed() {
+    void testOnBlockCropsNotAllowed() {
         when(island.isAllowed(any(), eq(Flags.PLACE_BLOCKS))).thenReturn(false);
         when(island.isAllowed(any(), eq(Flags.CROP_PLANTING))).thenReturn(false);
         Block placedBlock = mock(Block.class);
@@ -233,7 +233,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Ensures that books are not protected by this listener.
      */
     @Test
-    public void testOnBlockPlaceBook() {
+    void testOnBlockPlaceBook() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         Block placedBlock = mock(Block.class);
         when(placedBlock.getType()).thenReturn(Material.LECTERN);
@@ -259,7 +259,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onPlayerHitItemFrame(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerHitItemFrameNotItemFrame() {
+    void testOnPlayerHitItemFrameNotItemFrame() {
         Creeper creeper = mock(Creeper.class);
         when(creeper.getLocation()).thenReturn(location);
         when(creeper.getType()).thenReturn(EntityType.CREEPER);
@@ -272,7 +272,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onPlayerHitItemFrame(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerHitItemFrame() {
+    void testOnPlayerHitItemFrame() {
         ItemFrame itemFrame = mock(ItemFrame.class);
         when(itemFrame.getType()).thenReturn(EntityType.ITEM_FRAME);
         when(itemFrame.getLocation()).thenReturn(location);
@@ -285,7 +285,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      * Test method for {@link PlaceBlocksListener#onPlayerHitItemFrame(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerHitItemFrameNotAllowed() {
+    void testOnPlayerHitItemFrameNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         ItemFrame itemFrame = mock(ItemFrame.class);
         when(itemFrame.getType()).thenReturn(EntityType.ITEM_FRAME);
@@ -301,7 +301,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Issues with NotAMock")
-    public void testOnPlayerInteract() {
+    void testOnPlayerInteract() {
         ItemStack item = mock(ItemStack.class);
         when(item.getType()).thenReturn(Material.ARMOR_STAND, Material.FIREWORK_ROCKET, Material.ITEM_FRAME, Material.END_CRYSTAL, Material.CHEST, Material.TRAPPED_CHEST, Material.JUNGLE_BOAT);
         Block clickedBlock = mock(Block.class);
@@ -319,7 +319,7 @@ public class PlaceBlocksListenerTest extends CommonTestSetup {
      */
     @Disabled("Issues with NotAMock")
     @Test
-    public void testOnPlayerInteractNotAllowed() {
+    void testOnPlayerInteractNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         ItemStack item = mock(ItemStack.class);
         when(item.getType()).thenReturn(Material.ARMOR_STAND, Material.FIREWORK_ROCKET, Material.ITEM_FRAME, Material.END_CRYSTAL, Material.CHEST, Material.TRAPPED_CHEST, Material.DARK_OAK_BOAT);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/RaidTriggerListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/RaidTriggerListenerTest.java
@@ -19,7 +19,7 @@ import world.bentobox.bentobox.lists.Flags;
 /**
  * Tests for {@link RaidTriggerListener}.
  */
-public class RaidTriggerListenerTest extends CommonTestSetup {
+class RaidTriggerListenerTest extends CommonTestSetup {
 
     private RaidTriggerListener listener;
     private RaidTriggerEvent event;
@@ -50,7 +50,7 @@ public class RaidTriggerListenerTest extends CommonTestSetup {
      * Test that a player without the required rank cannot trigger a raid.
      */
     @Test
-    public void testOnRaidTriggerNotAllowed() {
+    void testOnRaidTriggerNotAllowed() {
         when(island.isAllowed(any(User.class), eq(Flags.RAID_TRIGGER))).thenReturn(false);
         listener.onRaidTrigger(event);
         verify(notifier).notify(any(), eq("protection.protected"));
@@ -61,7 +61,7 @@ public class RaidTriggerListenerTest extends CommonTestSetup {
      * Test that a player with the required rank can trigger a raid.
      */
     @Test
-    public void testOnRaidTriggerAllowed() {
+    void testOnRaidTriggerAllowed() {
         when(island.isAllowed(any(User.class), eq(Flags.RAID_TRIGGER))).thenReturn(true);
         listener.onRaidTrigger(event);
         verify(notifier, never()).notify(any(), eq("protection.protected"));

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/SculkSensorListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/SculkSensorListenerTest.java
@@ -22,7 +22,7 @@ import world.bentobox.bentobox.api.user.User;
  * @author tastybento
  *
  */
-public class SculkSensorListenerTest extends CommonTestSetup {
+class SculkSensorListenerTest extends CommonTestSetup {
 
     private SculkSensorListener ssl;
     @Mock
@@ -64,7 +64,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorNotAllowed() {
+    void testOnSculkSensorNotAllowed() {
         when(island.isAllowed(any(), any())).thenReturn(false);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
         ssl.onSculkSensor(e);
@@ -75,7 +75,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorAllowed() {
+    void testOnSculkSensorAllowed() {
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
         ssl.onSculkSensor(e);
         assertFalse(e.isCancelled());
@@ -85,7 +85,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorNotInWorld() {
+    void testOnSculkSensorNotInWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
         ssl.onSculkSensor(e);
@@ -96,7 +96,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorNotAllowedCalibrated() {
+    void testOnSculkSensorNotAllowedCalibrated() {
         when(block.getType()).thenReturn(Material.CALIBRATED_SCULK_SENSOR);
         when(island.isAllowed(any(), any())).thenReturn(false);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
@@ -108,7 +108,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorAllowedCalibrated() {
+    void testOnSculkSensorAllowedCalibrated() {
         when(block.getType()).thenReturn(Material.CALIBRATED_SCULK_SENSOR);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
         ssl.onSculkSensor(e);
@@ -119,7 +119,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorNotInWorldCalibrated() {
+    void testOnSculkSensorNotInWorldCalibrated() {
         when(block.getType()).thenReturn(Material.CALIBRATED_SCULK_SENSOR);
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
@@ -131,7 +131,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorNotAllowedNotSculk() {
+    void testOnSculkSensorNotAllowedNotSculk() {
         when(block.getType()).thenReturn(Material.SHULKER_BOX);
         when(island.isAllowed(any(), any())).thenReturn(false);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
@@ -143,7 +143,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorAllowedNotSculk() {
+    void testOnSculkSensorAllowedNotSculk() {
         when(block.getType()).thenReturn(Material.SHULKER_BOX);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);
         ssl.onSculkSensor(e);
@@ -154,7 +154,7 @@ public class SculkSensorListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.SculkSensorListener#onSculkSensor(org.bukkit.event.block.BlockReceiveGameEvent)}.
      */
     @Test
-    public void testOnSculkSensorNotInWorldNotSculk() {
+    void testOnSculkSensorNotInWorldNotSculk() {
         when(block.getType()).thenReturn(Material.SHULKER_BOX);
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         BlockReceiveGameEvent e = new BlockReceiveGameEvent(GameEvent.BLOCK_ACTIVATE, block, mockPlayer);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/TNTListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/TNTListenerTest.java
@@ -47,7 +47,7 @@ import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.util.Util;
 
-public class TNTListenerTest extends CommonTestSetup {
+class TNTListenerTest extends CommonTestSetup {
 
     @Mock
     private Block block;
@@ -105,7 +105,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTPriming() {
+    void testOnTNTPriming() {
         BlockFace clickedFace = BlockFace.DOWN;
         Block clickedBlock = mock(Block.class);
         when(clickedBlock.getType()).thenReturn(Material.TNT);
@@ -120,7 +120,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnExplosion() {
+    void testOnExplosion() {
         List<Block> list = new ArrayList<>();
         list.add(block);
         EntityExplodeEvent e = getExplodeEvent(entity, location, list);
@@ -129,7 +129,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnExplosionOutsideIsland() {
+    void testOnExplosionOutsideIsland() {
         Flags.WORLD_TNT_DAMAGE.setDefaultSetting(false);
         assertFalse(Flags.WORLD_TNT_DAMAGE.isSetForWorld(world));
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.empty());
@@ -141,7 +141,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnExplosionOutsideIslandAllowed() {
+    void testOnExplosionOutsideIslandAllowed() {
         Flags.WORLD_TNT_DAMAGE.setDefaultSetting(true);
         assertTrue(Flags.WORLD_TNT_DAMAGE.isSetForWorld(world));
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.empty());
@@ -154,7 +154,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnExplosionWrongWorld() {
+    void testOnExplosionWrongWorld() {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         List<Block> list = new ArrayList<>();
         list.add(block);
@@ -165,7 +165,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTDamageInWorldTNTNotProjectile() {
+    void testOnTNTDamageInWorldTNTNotProjectile() {
         // Block on fire
         when(block.getType()).thenReturn(Material.TNT);
         // Entity is not a projectile
@@ -175,7 +175,7 @@ public class TNTListenerTest extends CommonTestSetup {
 
     }
     @Test
-    public void testOnTNTDamageTNTWrongWorld() {
+    void testOnTNTDamageTNTWrongWorld() {
         // Block on fire
         when(block.getType()).thenReturn(Material.TNT);
         // Out of world
@@ -185,7 +185,7 @@ public class TNTListenerTest extends CommonTestSetup {
         assertFalse(e.isCancelled());
     }
     @Test
-    public void testOnTNTDamageObsidianWrongWorld() {
+    void testOnTNTDamageObsidianWrongWorld() {
         // Block on fire
         when(block.getType()).thenReturn(Material.OBSIDIAN);
         // Out of world
@@ -196,7 +196,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTDamageInWorldTNTProjectileWitherSkelly() {
+    void testOnTNTDamageInWorldTNTProjectileWitherSkelly() {
         // Block on fire
         when(block.getType()).thenReturn(Material.TNT);
         // Entity is a projectile
@@ -215,7 +215,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTDamageInWorldTNTProjectilePlayerNotFireArrow() {
+    void testOnTNTDamageInWorldTNTProjectilePlayerNotFireArrow() {
         // Block on fire
         when(block.getType()).thenReturn(Material.TNT);
         // Entity is a projectile
@@ -234,7 +234,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTDamageInWorldTNTProjectilePlayerFireArrow() {
+    void testOnTNTDamageInWorldTNTProjectilePlayerFireArrow() {
         // Block on fire
         when(block.getType()).thenReturn(Material.TNT);
         // Entity is a projectile
@@ -253,7 +253,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTDamageInWorldTNTProjectilePlayerFireArrowAllowed() {
+    void testOnTNTDamageInWorldTNTProjectilePlayerFireArrowAllowed() {
         // Block on fire
         when(block.getType()).thenReturn(Material.TNT);
         // Entity is a projectile
@@ -274,7 +274,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTDamageInWorldTNTProjectilePlayerFireArrowNotIsland() {
+    void testOnTNTDamageInWorldTNTProjectilePlayerFireArrowNotIsland() {
         Flags.TNT_PRIMING.setSetting(world, false);
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.empty());
         // Block on fire
@@ -295,7 +295,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnTNTDamageInWorldTNTProjectilePlayerFireArrowNotIslandNotAllowed() {
+    void testOnTNTDamageInWorldTNTProjectilePlayerFireArrowNotIslandNotAllowed() {
         Flags.TNT_PRIMING.setSetting(world, true);
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.empty());
         // Block on fire
@@ -316,7 +316,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnEntityExplosion() {
+    void testOnEntityExplosion() {
         /*
          * org.bukkit.event.entity.EntityDamageByEntityEvent.EntityDamageByEntityEvent(
          * @NotNull @NotNull Entity damager, 
@@ -345,7 +345,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnEntityExplosionOutsideIsland() {
+    void testOnEntityExplosionOutsideIsland() {
         Flags.WORLD_TNT_DAMAGE.setDefaultSetting(false);
         assertFalse(Flags.WORLD_TNT_DAMAGE.isSetForWorld(world));
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.empty());
@@ -356,7 +356,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnEntityExplosionOutsideIslandAllowed() {
+    void testOnEntityExplosionOutsideIslandAllowed() {
         Flags.WORLD_TNT_DAMAGE.setDefaultSetting(true);
         assertTrue(Flags.WORLD_TNT_DAMAGE.isSetForWorld(world));
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.empty());
@@ -367,7 +367,7 @@ public class TNTListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnEntityExplosionWrongWorld() {
+    void testOnEntityExplosionWrongWorld() {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(entity, mockPlayer, DamageCause.ENTITY_EXPLOSION, null,
                 20D);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/ThrowingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/ThrowingListenerTest.java
@@ -21,7 +21,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  * @author tastybento
  *
  */
-public class ThrowingListenerTest extends CommonTestSetup {
+class ThrowingListenerTest extends CommonTestSetup {
 
     private ThrowingListener tl;
 
@@ -45,7 +45,7 @@ public class ThrowingListenerTest extends CommonTestSetup {
      * Test method for {@link ThrowingListener#onPlayerThrowPotion(org.bukkit.event.entity.ProjectileLaunchEvent)}.
      */
     @Test
-    public void testOnPlayerThrowPotion() {
+    void testOnPlayerThrowPotion() {
         ThrownPotion entity = mock(ThrownPotion.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getShooter()).thenReturn(mockPlayer);
@@ -59,7 +59,7 @@ public class ThrowingListenerTest extends CommonTestSetup {
      * Test method for {@link ThrowingListener#onPlayerThrowPotion(org.bukkit.event.entity.ProjectileLaunchEvent)}.
      */
     @Test
-    public void testOnPlayerThrowPotionNotAllowed() {
+    void testOnPlayerThrowPotionNotAllowed() {
         when(island.isAllowed(Mockito.any(), Mockito.any())).thenReturn(false);
         ThrownPotion entity = mock(ThrownPotion.class);
         when(entity.getLocation()).thenReturn(location);
@@ -74,7 +74,7 @@ public class ThrowingListenerTest extends CommonTestSetup {
      * Test method for {@link ThrowingListener#onPlayerThrowPotion(org.bukkit.event.entity.ProjectileLaunchEvent)}.
      */
     @Test
-    public void testOnPlayerThrowPotionNonHuman() {
+    void testOnPlayerThrowPotionNonHuman() {
         ThrownPotion entity = mock(ThrownPotion.class);
         when(entity.getLocation()).thenReturn(location);
         Witch witch = mock(Witch.class);
@@ -93,7 +93,7 @@ public class ThrowingListenerTest extends CommonTestSetup {
      * Test method for {@link ThrowingListener#onPlayerThrowPotion(org.bukkit.event.entity.ProjectileLaunchEvent)}.
      */
     @Test
-    public void testOnPlayerThrowPotionNotAllowedNonHuman() {
+    void testOnPlayerThrowPotionNotAllowedNonHuman() {
         when(island.isAllowed(Mockito.any(), Mockito.any())).thenReturn(false);
         ThrownPotion entity = mock(ThrownPotion.class);
         when(entity.getLocation()).thenReturn(location);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/settings/MobSpawnListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/settings/MobSpawnListenerTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.util.Util;
 
 
-public class MobSpawnListenerTest extends CommonTestSetup {
+class MobSpawnListenerTest extends CommonTestSetup {
 
     @Mock
     private Zombie zombie;
@@ -104,7 +104,7 @@ public class MobSpawnListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testNotInWorld() {
+    void testNotInWorld() {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
@@ -127,7 +127,7 @@ public class MobSpawnListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnNaturalMonsterSpawnBlocked() {
+    void testOnNaturalMonsterSpawnBlocked() {
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
         Island island = mock(Island.class);
@@ -176,7 +176,7 @@ public class MobSpawnListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnNaturalMobSpawnUnBlocked() {
+    void testOnNaturalMobSpawnUnBlocked() {
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
         Island island = mock(Island.class);
@@ -206,7 +206,7 @@ public class MobSpawnListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnNaturalMonsterSpawnBlockedNoIsland() {
+    void testOnNaturalMonsterSpawnBlockedNoIsland() {
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
@@ -230,7 +230,7 @@ public class MobSpawnListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnNaturalMobSpawnUnBlockedNoIsland() {
+    void testOnNaturalMobSpawnUnBlockedNoIsland() {
         IslandsManager im = mock(IslandsManager.class);
         when(plugin.getIslands()).thenReturn(im);
         when(im.getIslandAt(any())).thenReturn(Optional.empty());

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/settings/MobTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/settings/MobTeleportListenerTest.java
@@ -24,7 +24,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author tastybento
  *
  */
-public class MobTeleportListenerTest extends CommonTestSetup {
+class MobTeleportListenerTest extends CommonTestSetup {
 
     private MobTeleportListener mtl;
 
@@ -74,7 +74,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventEndermanNotAllowed() {
+    void testOnEntityTeleportEventEndermanNotAllowed() {
         Flags.ENDERMAN_TELEPORT.setSetting(world, false);
         when(island.isAllowed(Flags.ENDERMAN_TELEPORT)).thenReturn(false);
         EntityTeleportEvent e = new EntityTeleportEvent(enderman, from, to);
@@ -86,7 +86,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventEndermanNotAllowedWrongWorld() {
+    void testOnEntityTeleportEventEndermanNotAllowedWrongWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         Flags.ENDERMAN_TELEPORT.setSetting(world, false);
         when(island.isAllowed(Flags.ENDERMAN_TELEPORT)).thenReturn(false);
@@ -99,7 +99,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventEndermanNotAllowedNotOnIsland() {
+    void testOnEntityTeleportEventEndermanNotAllowedNotOnIsland() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         Flags.ENDERMAN_TELEPORT.setSetting(world, false);
         EntityTeleportEvent e = new EntityTeleportEvent(enderman, from, to);
@@ -111,7 +111,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventEndermanAllowedDefault() {
+    void testOnEntityTeleportEventEndermanAllowedDefault() {
         EntityTeleportEvent e = new EntityTeleportEvent(enderman, from, to);
         mtl.onEntityTeleportEvent(e);
         assertFalse(e.isCancelled());
@@ -121,7 +121,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventOther() {
+    void testOnEntityTeleportEventOther() {
         EntityTeleportEvent e = new EntityTeleportEvent(other, from, to);
         mtl.onEntityTeleportEvent(e);
         assertFalse(e.isCancelled());
@@ -131,7 +131,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventEndermanNotAllowedButOther() {
+    void testOnEntityTeleportEventEndermanNotAllowedButOther() {
         Flags.ENDERMAN_TELEPORT.setSetting(world, false);
         Flags.SHULKER_TELEPORT.setSetting(world, false);
         when(island.isAllowed(Flags.ENDERMAN_TELEPORT)).thenReturn(false);
@@ -145,7 +145,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventShulkerNotAllowed() {
+    void testOnEntityTeleportEventShulkerNotAllowed() {
         Flags.SHULKER_TELEPORT.setSetting(world, false);
         when(island.isAllowed(Flags.SHULKER_TELEPORT)).thenReturn(false);
         EntityTeleportEvent e = new EntityTeleportEvent(shulker, from, to);
@@ -157,7 +157,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventShulkerNotAllowedWrongWorld() {
+    void testOnEntityTeleportEventShulkerNotAllowedWrongWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         Flags.SHULKER_TELEPORT.setSetting(world, false);
         when(island.isAllowed(Flags.SHULKER_TELEPORT)).thenReturn(false);
@@ -170,7 +170,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventShulkerNotAllowedNotOnIsland() {
+    void testOnEntityTeleportEventShulkerNotAllowedNotOnIsland() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         Flags.SHULKER_TELEPORT.setSetting(world, false);
         EntityTeleportEvent e = new EntityTeleportEvent(shulker, from, to);
@@ -182,7 +182,7 @@ public class MobTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.settings.MobTeleportListener#onEntityTeleportEvent(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnEntityTeleportEventShulkerAllowedDefault() {
+    void testOnEntityTeleportEventShulkerAllowedDefault() {
         EntityTeleportEvent e = new EntityTeleportEvent(shulker, from, to);
         mtl.onEntityTeleportEvent(e);
         assertFalse(e.isCancelled());

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/settings/PVPListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/settings/PVPListenerTest.java
@@ -77,7 +77,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class PVPListenerTest extends CommonTestSetup {
+class PVPListenerTest extends CommonTestSetup {
 
     @Mock
     private Player player2;
@@ -212,7 +212,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageNotPlayer() {
+    void testOnEntityDamageNotPlayer() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Creeper.class);
         EntityDamageByEntityEvent e = createDamageEvent(damager, damagee, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
@@ -224,7 +224,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageSelfDamage() {
+    void testOnEntityDamageSelfDamage() {
         Entity damager = mock(Player.class);
         EntityDamageByEntityEvent e = createDamageEvent(damager, damager, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
@@ -235,7 +235,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageNPC() {
+    void testOnEntityDamageNPC() {
         // Player 2 is an NPC
         when(player2.hasMetadata("NPC")).thenReturn(true);
         // PVP is not allowed
@@ -252,7 +252,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageNPCAttacks() {
+    void testOnEntityDamageNPCAttacks() {
         // Player 2 is an NPC
         when(player2.hasMetadata("NPC")).thenReturn(true);
         // PVP is not allowed
@@ -269,7 +269,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnPlayerByZombie() {
+    void testOnEntityDamageOnPlayerByZombie() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Player.class);
         World world = mock(World.class);
@@ -299,7 +299,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnPlayerByZombieVisitorProtected() {
+    void testOnEntityDamageOnPlayerByZombieVisitorProtected() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Player.class);
         World world = mock(World.class);
@@ -328,7 +328,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnVisitorByZombieVisitorProtected() {
+    void testOnEntityDamageOnVisitorByZombieVisitorProtected() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Player.class);
         when(damager.getWorld()).thenReturn(world);
@@ -349,7 +349,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnVisitorByZombieVisitorProtectedWrongWorld() {
+    void testOnEntityDamageOnVisitorByZombieVisitorProtectedWrongWorld() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Player.class);
         World world = mock(World.class);
@@ -375,7 +375,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnVisitorByZombieVisitorProtectedWrongDamage() {
+    void testOnEntityDamageOnVisitorByZombieVisitorProtectedWrongDamage() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Player.class);
         World world = mock(World.class);
@@ -404,7 +404,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnVisitorByZombieVisitorNotProtected() {
+    void testOnEntityDamageOnVisitorByZombieVisitorNotProtected() {
         Entity damager = mock(Zombie.class);
         Entity damagee = mock(Player.class);
         World world = mock(World.class);
@@ -441,7 +441,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamagePVPNotAllowed() {
+    void testOnEntityDamagePVPNotAllowed() {
         // No visitor protection
         EntityDamageByEntityEvent e = createDamageEvent(mockPlayer, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         new PVPListener().onEntityDamage(e);
@@ -455,7 +455,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamagePVPNotAllowedInvVisitor() {
+    void testOnEntityDamagePVPNotAllowedInvVisitor() {
         EntityDamageByEntityEvent e = createDamageEvent(mockPlayer, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
 
         // Enable visitor protection
@@ -472,7 +472,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnPVPAllowed() {
+    void testOnEntityDamageOnPVPAllowed() {
         // PVP is allowed
         when(island.isAllowed(any())).thenReturn(true);
         EntityDamageByEntityEvent e = createDamageEvent(mockPlayer, player2, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
@@ -495,7 +495,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageOnPVPNotAllowedProjectile() {
+    void testOnEntityDamageOnPVPNotAllowedProjectile() {
         Projectile p = mock(Projectile.class);
         when(p.getShooter()).thenReturn(mockPlayer);
         when(p.getLocation()).thenReturn(location);
@@ -522,7 +522,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamageSelfDamageProjectile() {
+    void testOnEntityDamageSelfDamageProjectile() {
         Projectile p = mock(Projectile.class);
         when(p.getShooter()).thenReturn(mockPlayer);
         when(p.getLocation()).thenReturn(location);
@@ -536,7 +536,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamagePVPAllowedProjectile() {
+    void testOnEntityDamagePVPAllowedProjectile() {
         Projectile p = mock(Projectile.class);
         when(p.getShooter()).thenReturn(mockPlayer);
         when(p.getLocation()).thenReturn(location);
@@ -562,7 +562,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamagePVPAllowedProjectileNullSource() {
+    void testOnEntityDamagePVPAllowedProjectileNullSource() {
         Projectile p = mock(Projectile.class);
         when(p.getShooter()).thenReturn(null);
         when(p.getLocation()).thenReturn(location);
@@ -579,7 +579,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onEntityDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnEntityDamagePVPAllowedProjectileNonEntitySource() {
+    void testOnEntityDamagePVPAllowedProjectileNonEntitySource() {
         Projectile p = mock(Projectile.class);
         BlockProjectileSource pSource = mock(BlockProjectileSource.class);
         when(p.getShooter()).thenReturn(pSource);
@@ -597,7 +597,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishing() {
+    void testOnFishing() {
         // Fish hook
         FishHook hook = mock(FishHook.class);
         // Catch a zombie - fine
@@ -651,7 +651,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingProtectVisitors() {
+    void testOnFishingProtectVisitors() {
         // Fish hook
         FishHook hook = mock(FishHook.class);
         // Catch a player
@@ -673,7 +673,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingSelfDamage() {
+    void testOnFishingSelfDamage() {
         // Fish hook
         FishHook hook = mock(FishHook.class);
         // Catch a player
@@ -686,7 +686,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
      */
     @Test
-    public void testOnFishingNoPVPProtectVisitors() {
+    void testOnFishingNoPVPProtectVisitors() {
         // Fish hook
         FishHook hook = mock(FishHook.class);
         // Catch a player
@@ -709,7 +709,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onSplashPotionSplash(org.bukkit.event.entity.PotionSplashEvent)}.
      */
     @Test
-    public void testOnSplashPotionSplashWitch() {
+    void testOnSplashPotionSplashWitch() {
         ThrownPotion tp = mock(ThrownPotion.class);
         ProjectileSource witch = mock(Witch.class);
         when(tp.getShooter()).thenReturn(witch);
@@ -722,7 +722,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onSplashPotionSplash(org.bukkit.event.entity.PotionSplashEvent)}.
      */
     @Test
-    public void testOnSplashPotionSplashNoPlayers() {
+    void testOnSplashPotionSplashNoPlayers() {
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         when(tp.getWorld()).thenReturn(world);
@@ -742,7 +742,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onSplashPotionSplash(org.bukkit.event.entity.PotionSplashEvent)}.
      */
     @Test
-    public void testOnSplashPotionSplash() {
+    void testOnSplashPotionSplash() {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
 
@@ -773,7 +773,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onSplashPotionSplash(org.bukkit.event.entity.PotionSplashEvent)}.
      */
     @Test
-    public void testOnSplashPotionSplashSelfInflicted() {
+    void testOnSplashPotionSplashSelfInflicted() {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
 
@@ -801,7 +801,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onSplashPotionSplash(org.bukkit.event.entity.PotionSplashEvent)}.
      */
     @Test
-    public void testOnSplashPotionSplashAllowPVP() {
+    void testOnSplashPotionSplashAllowPVP() {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(true);
 
@@ -827,7 +827,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onSplashPotionSplash(org.bukkit.event.entity.PotionSplashEvent)}.
      */
     @Test
-    public void testOnSplashPotionSplashAllowPVPProtectVisitors() {
+    void testOnSplashPotionSplashAllowPVPProtectVisitors() {
         // Allow PVP
         when(island.isAllowed(any())).thenReturn(true);
 
@@ -862,7 +862,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onLingeringPotionSplash(org.bukkit.event.entity.LingeringPotionSplashEvent)}.
      */
     @Test
-    public void testOnLingeringPotionSplash() {
+    void testOnLingeringPotionSplash() {
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(mockPlayer);
         when(tp.getWorld()).thenReturn(world);
@@ -881,7 +881,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onLingeringPotionSplash(org.bukkit.event.entity.LingeringPotionSplashEvent)}.
      */
     @Test
-    public void testOnLingeringPotionSplashNonHuman() {
+    void testOnLingeringPotionSplashNonHuman() {
         ThrownPotion tp = mock(ThrownPotion.class);
         when(tp.getShooter()).thenReturn(creeper);
         when(tp.getWorld()).thenReturn(world);
@@ -899,7 +899,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onLingeringPotionDamage(org.bukkit.event.entity.AreaEffectCloudApplyEvent)}.
      */
     @Test
-    public void testOnLingeringPotionDamageNoPVP() {
+    void testOnLingeringPotionDamageNoPVP() {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
         // Throw a potion
@@ -936,7 +936,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onLingeringPotionDamage(org.bukkit.event.entity.AreaEffectCloudApplyEvent)}.
      */
     @Test
-    public void testOnLingeringPotionDamagePVP() {
+    void testOnLingeringPotionDamagePVP() {
         // Allow PVP
         when(island.isAllowed(any())).thenReturn(true);
         // Throw a potion
@@ -971,7 +971,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onLingeringPotionDamage(org.bukkit.event.entity.AreaEffectCloudApplyEvent)}.
      */
     @Test
-    public void testOnLingeringPotionDamageNoPVPVisitor() {
+    void testOnLingeringPotionDamageNoPVPVisitor() {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
         // Throw a potion
@@ -1012,7 +1012,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onLingeringPotionDamage(org.bukkit.event.entity.AreaEffectCloudApplyEvent)}.
      */
     @Test
-    public void testOnLingeringPotionDamagePVPVisitor() {
+    void testOnLingeringPotionDamagePVPVisitor() {
         // Allow PVP
         when(island.isAllowed(any())).thenReturn(true);
         // Throw a potion
@@ -1053,7 +1053,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onPlayerShootFireworkEvent(org.bukkit.event.entity.EntityShootBowEvent)}.
      */
     @Test
-    public void testOnPlayerShootFireworkEventNotPlayer() {
+    void testOnPlayerShootFireworkEventNotPlayer() {
         PVPListener listener = new PVPListener();
         ItemStack bow = new ItemStack(Material.CROSSBOW);
         Firework firework = mock(Firework.class);
@@ -1072,7 +1072,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onPlayerShootFireworkEvent(org.bukkit.event.entity.EntityShootBowEvent)}.
      */
     @Test
-    public void testOnPlayerShootFireworkEventNotFirework() {
+    void testOnPlayerShootFireworkEventNotFirework() {
         PVPListener listener = new PVPListener();
         ItemStack bow = new ItemStack(Material.CROSSBOW);
         Arrow arrow = mock(Arrow.class);
@@ -1088,7 +1088,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onPlayerShootFireworkEvent(org.bukkit.event.entity.EntityShootBowEvent)}.
      */
     @Test
-    public void testOnPlayerShootFireworkEventNoPVPSelfDamage() {
+    void testOnPlayerShootFireworkEventNoPVPSelfDamage() {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
         PVPListener listener = new PVPListener();
@@ -1110,7 +1110,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onPlayerShootFireworkEvent(org.bukkit.event.entity.EntityShootBowEvent)}.
      */
     @Test
-    public void testOnPlayerShootFireworkEventNoPVP() {
+    void testOnPlayerShootFireworkEventNoPVP() {
         // Disallow PVP
         when(island.isAllowed(any())).thenReturn(false);
         PVPListener listener = new PVPListener();
@@ -1133,7 +1133,7 @@ public class PVPListenerTest extends CommonTestSetup {
      * Test method for {@link PVPListener#onPlayerShootFireworkEvent(org.bukkit.event.entity.EntityShootBowEvent)}.
      */
     @Test
-    public void testOnPlayerShootFireworkEventPVPAllowed() {
+    void testOnPlayerShootFireworkEventPVPAllowed() {
         // Allow PVP
         when(island.isAllowed(any())).thenReturn(true);
         PVPListener listener = new PVPListener();

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ChestDamageListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ChestDamageListenerTest.java
@@ -47,7 +47,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class ChestDamageListenerTest extends CommonTestSetup
+class ChestDamageListenerTest extends CommonTestSetup
 {
     @Override
     @BeforeEach
@@ -121,7 +121,7 @@ public class ChestDamageListenerTest extends CommonTestSetup
      */
     @Disabled("Issues with NotAMock")
     @Test
-    public void testOnExplosionChestDamageNotAllowed() {
+    void testOnExplosionChestDamageNotAllowed() {
         // Srt the flag to not allow chest damage
         Flags.CHEST_DAMAGE.setSetting(world, false);
         // Set the entity that is causing the damage (TNT)
@@ -163,7 +163,7 @@ public class ChestDamageListenerTest extends CommonTestSetup
      * Test method for {@link ChestDamageListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionChestDamageAllowed() {
+    void testOnExplosionChestDamageAllowed() {
         Flags.CHEST_DAMAGE.setSetting(world, true);
         Entity entity = mock(Entity.class);
         when(entity.getType()).thenReturn(EntityType.TNT);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListenerTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class CleanSuperFlatListenerTest extends CommonTestSetup {
+class CleanSuperFlatListenerTest extends CommonTestSetup {
 
     @Mock
     private Block block;
@@ -113,7 +113,7 @@ public class CleanSuperFlatListenerTest extends CommonTestSetup {
      * Test method for {@link CleanSuperFlatListener#onChunkLoad(org.bukkit.event.world.ChunkLoadEvent)}.
      */
     @Test
-    public void testOnChunkLoadNotBedrockNoFlsg() {
+    void testOnChunkLoadNotBedrockNoFlsg() {
         when(block.getType()).thenReturn(Material.AIR);
         Flags.CLEAN_SUPER_FLAT.setSetting(world, false);
 
@@ -126,7 +126,7 @@ public class CleanSuperFlatListenerTest extends CommonTestSetup {
      * Test method for {@link CleanSuperFlatListener#onChunkLoad(org.bukkit.event.world.ChunkLoadEvent)}.
      */
     @Test
-    public void testOnChunkLoadBedrock() {
+    void testOnChunkLoadBedrock() {
         ChunkLoadEvent e = new ChunkLoadEvent(chunk, false);
         l.onChunkLoad(e);
         verify(sch).runTaskTimer(any(), any(Runnable.class), Mockito.eq(0L), Mockito.eq(1L));
@@ -136,7 +136,7 @@ public class CleanSuperFlatListenerTest extends CommonTestSetup {
      * Test method for {@link CleanSuperFlatListener#onChunkLoad(org.bukkit.event.world.ChunkLoadEvent)}.
      */
     @Test
-    public void testOnChunkLoadBedrockNoClean() {
+    void testOnChunkLoadBedrockNoClean() {
         Flags.CLEAN_SUPER_FLAT.setSetting(world, false);
 
         ChunkLoadEvent e = new ChunkLoadEvent(chunk, false);
@@ -148,7 +148,7 @@ public class CleanSuperFlatListenerTest extends CommonTestSetup {
      * Test method for {@link CleanSuperFlatListener#onChunkLoad(org.bukkit.event.world.ChunkLoadEvent)}.
      */
     @Test
-    public void testOnChunkLoadBedrockNether() {
+    void testOnChunkLoadBedrockNether() {
         when(world.getEnvironment()).thenReturn(World.Environment.NETHER);
         ChunkLoadEvent e = new ChunkLoadEvent(chunk, false);
         l.onChunkLoad(e);
@@ -167,7 +167,7 @@ public class CleanSuperFlatListenerTest extends CommonTestSetup {
      * Test method for {@link CleanSuperFlatListener#onChunkLoad(org.bukkit.event.world.ChunkLoadEvent)}.
      */
     @Test
-    public void testOnChunkLoadBedrockEnd() {
+    void testOnChunkLoadBedrockEnd() {
         when(world.getEnvironment()).thenReturn(World.Environment.THE_END);
         ChunkLoadEvent e = new ChunkLoadEvent(chunk, false);
         l.onChunkLoad(e);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CoarseDirtTillingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CoarseDirtTillingListenerTest.java
@@ -43,7 +43,7 @@ import world.bentobox.bentobox.managers.PlaceholdersManager;
  * @author tastybento
  *
  */
-public class CoarseDirtTillingListenerTest extends CommonTestSetup {
+class CoarseDirtTillingListenerTest extends CommonTestSetup {
 
     private static final List<Material> HOES = Collections.unmodifiableList(Arrays.stream(Material.values())
             .filter(m -> !m.isLegacy()).filter(m -> m.name().endsWith("_HOE")).toList());
@@ -103,7 +103,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onTillingCoarseDirt(org.bukkit.event.mockPlayer.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnTillingCoarseDirtNotAllowed() {
+    void testOnTillingCoarseDirtNotAllowed() {
         ItemStack itemStack = mock(ItemStack.class);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, itemStack, clickedBlock, BlockFace.UP);
 
@@ -119,7 +119,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onTillingCoarseDirt(org.bukkit.event.mockPlayer.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnTillingCoarseDirtAllowed() {
+    void testOnTillingCoarseDirtAllowed() {
         // Flag
         Flags.COARSE_DIRT_TILLING.setDefaultSetting(world, true);
         ItemStack itemStack = mock(ItemStack.class);
@@ -136,7 +136,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onTillingCoarseDirt(org.bukkit.event.mockPlayer.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnTillingCoarseDirtNotHoe() {
+    void testOnTillingCoarseDirtNotHoe() {
         ItemStack itemStack = mock(ItemStack.class);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, itemStack, clickedBlock, BlockFace.UP);
         NOT_HOES.forEach(m -> {
@@ -151,7 +151,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onTillingCoarseDirt(org.bukkit.event.mockPlayer.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnTillingCoarseDirtWrongAction() {
+    void testOnTillingCoarseDirtWrongAction() {
         ItemStack itemStack = mock(ItemStack.class);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.LEFT_CLICK_AIR, itemStack, clickedBlock, BlockFace.UP);
         ctl.onTillingCoarseDirt(e);
@@ -163,7 +163,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onTillingCoarseDirt(org.bukkit.event.mockPlayer.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnTillingCoarseDirtNullItem() {
+    void testOnTillingCoarseDirtNullItem() {
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, null, clickedBlock, BlockFace.UP);
         ctl.onTillingCoarseDirt(e);
         assertEquals(Result.ALLOW, e.useInteractedBlock());
@@ -174,7 +174,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onTillingCoarseDirt(org.bukkit.event.mockPlayer.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnTillingCoarseDirtNotCoarseDirt() {
+    void testOnTillingCoarseDirtNotCoarseDirt() {
         when(clickedBlock.getType()).thenReturn(Material.DIRT);
         ItemStack itemStack = mock(ItemStack.class);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, itemStack, clickedBlock, BlockFace.UP);
@@ -187,7 +187,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onTillingCoarseDirt(org.bukkit.event.mockPlayer.PlayerInteractEvent)}.
      */
     @Test
-    public void testOnTillingCoarseDirtWrongWorld() {
+    void testOnTillingCoarseDirtWrongWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         ItemStack itemStack = mock(ItemStack.class);
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, itemStack, clickedBlock, BlockFace.UP);
@@ -204,7 +204,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onBreakingPodzol(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBreakingPodzolNotPodzol() {
+    void testOnBreakingPodzolNotPodzol() {
         BlockBreakEvent e = new BlockBreakEvent(clickedBlock, mockPlayer);
         ctl.onBreakingPodzol(e);
         verify(clickedBlock, never()).setType(any());
@@ -214,7 +214,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onBreakingPodzol(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBreakingPodzol() {
+    void testOnBreakingPodzol() {
         when(clickedBlock.getType()).thenReturn(Material.PODZOL);
         BlockBreakEvent e = new BlockBreakEvent(clickedBlock, mockPlayer);
         ctl.onBreakingPodzol(e);
@@ -227,7 +227,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onBreakingPodzol(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBreakingPodzolWrongWorld() {
+    void testOnBreakingPodzolWrongWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(clickedBlock.getType()).thenReturn(Material.PODZOL);
         BlockBreakEvent e = new BlockBreakEvent(clickedBlock, mockPlayer);
@@ -239,7 +239,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onBreakingPodzol(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBreakingPodzolCreative() {
+    void testOnBreakingPodzolCreative() {
         when(mockPlayer.getGameMode()).thenReturn(GameMode.CREATIVE);
         when(clickedBlock.getType()).thenReturn(Material.PODZOL);
         BlockBreakEvent e = new BlockBreakEvent(clickedBlock, mockPlayer);
@@ -251,7 +251,7 @@ public class CoarseDirtTillingListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CoarseDirtTillingListener#onBreakingPodzol(org.bukkit.event.block.BlockBreakEvent)}.
      */
     @Test
-    public void testOnBreakingPodzolFlagAllowed() {
+    void testOnBreakingPodzolFlagAllowed() {
         // Flag
         Flags.COARSE_DIRT_TILLING.setDefaultSetting(world, true);
         when(clickedBlock.getType()).thenReturn(Material.PODZOL);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CreeperListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/CreeperListenerTest.java
@@ -27,7 +27,7 @@ import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.listeners.flags.protection.TestWorldSettings;
 import world.bentobox.bentobox.lists.Flags;
 
-public class CreeperListenerTest extends CommonTestSetup {
+class CreeperListenerTest extends CommonTestSetup {
 
     private CreeperListener cl;
 
@@ -54,7 +54,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionNotCreeper() {
+    void testOnExplosionNotCreeper() {
         List<Block> list = new ArrayList<>();
         Entity entity = mock(Entity.class);
         when(entity.getType()).thenReturn(EntityType.TNT);
@@ -68,7 +68,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionNotInWorld() {
+    void testOnExplosionNotInWorld() {
         List<Block> list = new ArrayList<>();
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);
@@ -83,7 +83,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionCreeperInWorldDamageOK() {
+    void testOnExplosionCreeperInWorldDamageOK() {
         List<Block> list = new ArrayList<>();
         list.add(mock(Block.class));
         list.add(mock(Block.class));
@@ -102,7 +102,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionCreeperInWorldDamageNOK() {
+    void testOnExplosionCreeperInWorldDamageNOK() {
         Flags.CREEPER_DAMAGE.setSetting(world, false);
         List<Block> list = new ArrayList<>();
         list.add(mock(Block.class));
@@ -123,7 +123,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityCancelled() {
+    void testOnPlayerInteractEntityCancelled() {
         Flags.CREEPER_GRIEFING.setSetting(world, false);
         Creeper creeper = mock(Creeper.class);
         when(location.getWorld()).thenReturn(world);
@@ -142,7 +142,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityAllowed() {
+    void testOnPlayerInteractEntityAllowed() {
         Flags.CREEPER_GRIEFING.setSetting(world, true);
         Creeper creeper = mock(Creeper.class);
         when(location.getWorld()).thenReturn(world);
@@ -161,7 +161,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityNotCreeper() {
+    void testOnPlayerInteractEntityNotCreeper() {
         Flags.CREEPER_GRIEFING.setSetting(world, false);
         when(mockPlayer.getInventory()).thenReturn(inv);
         ItemStack item = mock(ItemStack.class);
@@ -177,7 +177,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityOnIsland() {
+    void testOnPlayerInteractEntityOnIsland() {
         Flags.CREEPER_GRIEFING.setSetting(world, false);
         Creeper creeper = mock(Creeper.class);
         when(location.getWorld()).thenReturn(world);
@@ -198,7 +198,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityWrongWorld() {
+    void testOnPlayerInteractEntityWrongWorld() {
         Flags.CREEPER_GRIEFING.setSetting(world, false);
         Creeper creeper = mock(Creeper.class);
         when(location.getWorld()).thenReturn(world);
@@ -217,7 +217,7 @@ public class CreeperListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.CreeperListener#onPlayerInteractEntity(org.bukkit.event.player.PlayerInteractEntityEvent)}.
      */
     @Test
-    public void testOnPlayerInteractEntityNothingInHand() {
+    void testOnPlayerInteractEntityNothingInHand() {
         Flags.CREEPER_GRIEFING.setSetting(world, false);
         Creeper creeper = mock(Creeper.class);
         when(location.getWorld()).thenReturn(world);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnderChestListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnderChestListenerTest.java
@@ -41,7 +41,7 @@ import world.bentobox.bentobox.listeners.flags.protection.TestWorldSettings;
 import world.bentobox.bentobox.lists.Flags;
 
 
-public class EnderChestListenerTest extends CommonTestSetup {
+class EnderChestListenerTest extends CommonTestSetup {
 
     @Mock
     private ItemStack item;
@@ -76,7 +76,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnEnderChestOpenNotRightClick() {
+    void testOnEnderChestOpenNotRightClick() {
         action = Action.LEFT_CLICK_AIR;
         BlockFace clickedBlockFace = BlockFace.EAST;
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, action, item, clickedBlock, clickedBlockFace);
@@ -86,7 +86,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
 
     @Test
     @Disabled("Issues with NotAMock")
-    public void testOnEnderChestOpenEnderChestNotInWorld() {
+    void testOnEnderChestOpenEnderChestNotInWorld() {
         BlockFace clickedBlockFace = BlockFace.EAST;
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, action, item, clickedBlock, clickedBlockFace);
         // Not in world
@@ -98,7 +98,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
 
     @Test
     @Disabled("Issues with NotAMock")
-    public void testOnEnderChestOpenEnderChestOpPlayer() {
+    void testOnEnderChestOpenEnderChestOpPlayer() {
         BlockFace clickedBlockFace = BlockFace.EAST;
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, action, item, clickedBlock, clickedBlockFace);
         // Op player
@@ -109,7 +109,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
 
     @Test
     @Disabled("Issues with NotAMock")
-    public void testOnEnderChestOpenEnderChestHasBypassPerm() {
+    void testOnEnderChestOpenEnderChestHasBypassPerm() {
         BlockFace clickedBlockFace = BlockFace.EAST;
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, action, item, clickedBlock, clickedBlockFace);
         // Has bypass perm
@@ -120,7 +120,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
 
     @Test
     @Disabled("Issues with NotAMock")
-    public void testOnEnderChestOpenEnderChestOkay() {
+    void testOnEnderChestOpenEnderChestOkay() {
         BlockFace clickedBlockFace = BlockFace.EAST;
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, action, item, clickedBlock, clickedBlockFace);
         // Enderchest use is okay
@@ -133,7 +133,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
 
     @Test
     @Disabled("Issues with NotAMock")
-    public void testOnEnderChestOpenEnderChestBlocked() {
+    void testOnEnderChestOpenEnderChestBlocked() {
         BlockFace clickedBlockFace = BlockFace.EAST;
         PlayerInteractEvent e = new PlayerInteractEvent(mockPlayer, action, item, clickedBlock, clickedBlockFace);
         // Enderchest use is blocked
@@ -144,7 +144,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnCraftNotEnderChest() {
+    void testOnCraftNotEnderChest() {
         Recipe recipe = mock(Recipe.class);
         ItemStack item = mock(ItemStack.class);
         when(item.getType()).thenReturn(Material.STONE);
@@ -163,7 +163,7 @@ public class EnderChestListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnCraftEnderChest() {
+    void testOnCraftEnderChest() {
         Recipe recipe = mock(Recipe.class);
         ItemStack item = mock(ItemStack.class);
         when(item.getType()).thenReturn(Material.ENDER_CHEST);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/EndermanListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/EndermanListenerTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class EndermanListenerTest extends CommonTestSetup {
+class EndermanListenerTest extends CommonTestSetup {
 
     private Enderman enderman;
     private Slime slime;
@@ -97,7 +97,7 @@ public class EndermanListenerTest extends CommonTestSetup {
      * Test method for {@link EndermanListener#onEndermanGrief(org.bukkit.event.entity.EntityChangeBlockEvent)}.
      */
     @Test
-    public void testNotEnderman() {
+    void testNotEnderman() {
         EndermanListener listener = new EndermanListener();
         Block to = mock(Block.class);
         Material block = Material.ACACIA_DOOR;
@@ -110,7 +110,7 @@ public class EndermanListenerTest extends CommonTestSetup {
      * Test method for {@link EndermanListener#onEndermanGrief(org.bukkit.event.entity.EntityChangeBlockEvent)}.
      */
     @Test
-    public void testOnEndermanGriefWrongWorld() {
+    void testOnEndermanGriefWrongWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         EndermanListener listener = new EndermanListener();
@@ -125,7 +125,7 @@ public class EndermanListenerTest extends CommonTestSetup {
      * Test method for {@link EndermanListener#onEndermanGrief(org.bukkit.event.entity.EntityChangeBlockEvent)}.
      */
     @Test
-    public void testOnEndermanGriefAllowed() {
+    void testOnEndermanGriefAllowed() {
         Flags.ENDERMAN_GRIEFING.setSetting(world, true);
         EndermanListener listener = new EndermanListener();
         Block to = mock(Block.class);
@@ -139,7 +139,7 @@ public class EndermanListenerTest extends CommonTestSetup {
      * Test method for {@link EndermanListener#onEndermanGrief(org.bukkit.event.entity.EntityChangeBlockEvent)}.
      */
     @Test
-    public void testOnEndermanGrief() {
+    void testOnEndermanGrief() {
         EndermanListener listener = new EndermanListener();
         Block to = mock(Block.class);
         Material block = Material.ACACIA_DOOR;

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListenerTest.java
@@ -44,7 +44,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class EnterExitListenerTest extends CommonTestSetup {
+class EnterExitListenerTest extends CommonTestSetup {
 
     private static final Integer PROTECTION_RANGE = 200;
     private static final Integer X = 600;
@@ -174,7 +174,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnMoveInsideIsland() {
+    void testOnMoveInsideIsland() {
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), inside, inside);
         listener.onMove(e);
         // Moving in the island should result in no messages to the user
@@ -187,7 +187,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnMoveOutsideIsland() {
+    void testOnMoveOutsideIsland() {
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), outside, outside);
         listener.onMove(e);
         // Moving outside the island should result in no messages to the user
@@ -200,7 +200,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnMoveOutsideIslandToNull() {
+    void testOnMoveOutsideIslandToNull() {
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), outside, null);
         listener.onMove(e);
         // Moving outside the island should result in no messages to the user
@@ -213,7 +213,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnGoingIntoIslandEmptyIslandName() {
+    void testOnGoingIntoIslandEmptyIslandName() {
         when(island.getName()).thenReturn("");
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), outside, inside);
         listener.onMove(e);
@@ -230,7 +230,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnGoingIntoIslandWithIslandName() {
+    void testOnGoingIntoIslandWithIslandName() {
         when(island.getName()).thenReturn("fancy name");
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), outside, inside);
         listener.onMove(e);
@@ -248,7 +248,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testExitingIslandEmptyIslandName() {
+    void testExitingIslandEmptyIslandName() {
         when(island.getName()).thenReturn("");
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), inside, outside);
         listener.onMove(e);
@@ -265,7 +265,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testExitingIslandEmptyIslandNameToNull() {
+    void testExitingIslandEmptyIslandNameToNull() {
         when(island.getName()).thenReturn("");
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), inside, null);
         listener.onMove(e);
@@ -282,7 +282,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onMove(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testExitingIslandWithIslandName() {
+    void testExitingIslandWithIslandName() {
         when(island.getName()).thenReturn("fancy name");
         PlayerMoveEvent e = new PlayerMoveEvent(user.getPlayer(), inside, outside);
         listener.onMove(e);
@@ -301,7 +301,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * @since 1.4.0
      */
     @Test
-    public void testNoNotificationIfDisabled() {
+    void testNoNotificationIfDisabled() {
         // No notifications should be sent
         Flags.ENTER_EXIT_MESSAGES.setSetting(world, false);
 
@@ -318,7 +318,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testEnterIslandTeleport() {
+    void testEnterIslandTeleport() {
         PlayerTeleportEvent e = new PlayerTeleportEvent(user.getPlayer(), anotherWorld, inside, TeleportCause.PLUGIN);
         listener.onTeleport(e);
         verify(notifier).notify(any(User.class), eq("protection.flags.ENTER_EXIT_MESSAGES.now-entering"));
@@ -330,7 +330,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testExitIslandTeleport() {
+    void testExitIslandTeleport() {
         PlayerTeleportEvent e = new PlayerTeleportEvent(user.getPlayer(), inside, anotherWorld, TeleportCause.PLUGIN);
         listener.onTeleport(e);
         verify(notifier).notify(any(User.class), eq("protection.flags.ENTER_EXIT_MESSAGES.now-leaving"));
@@ -342,7 +342,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testExitIslandTeleportToNull() {
+    void testExitIslandTeleportToNull() {
         PlayerTeleportEvent e = new PlayerTeleportEvent(user.getPlayer(), inside, null, TeleportCause.PLUGIN);
         listener.onTeleport(e);
         verify(notifier).notify(any(User.class), eq("protection.flags.ENTER_EXIT_MESSAGES.now-leaving"));
@@ -355,7 +355,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testEnterIslandTeleportUnowned() {
+    void testEnterIslandTeleportUnowned() {
         when(island.isOwned()).thenReturn(false);
         PlayerTeleportEvent e = new PlayerTeleportEvent(user.getPlayer(), anotherWorld, inside, TeleportCause.PLUGIN);
         listener.onTeleport(e);
@@ -368,7 +368,7 @@ public class EnterExitListenerTest extends CommonTestSetup {
      * Test method for {@link EnterExitListener#onTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testExitIslandTeleportUnowned() {
+    void testExitIslandTeleportUnowned() {
         when(island.isOwned()).thenReturn(false);
         PlayerTeleportEvent e = new PlayerTeleportEvent(user.getPlayer(), inside, anotherWorld, TeleportCause.PLUGIN);
         listener.onTeleport(e);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListenerTest.java
@@ -51,7 +51,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.FlagsManager;
 import world.bentobox.bentobox.util.Util;
 
-public class InvincibleVisitorsListenerTest extends CommonTestSetup {
+class InvincibleVisitorsListenerTest extends CommonTestSetup {
 
     private InvincibleVisitorsListener listener;
     @Mock
@@ -157,21 +157,21 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnClickWrongWorld() {
+    void testOnClickWrongWorld() {
         when(user.inWorld()).thenReturn(false);
         listener.onClick(panel, user, ClickType.LEFT, 0);
         verify(user).sendMessage("general.errors.wrong-world");
     }
 
     @Test
-    public void testOnClickNoPermission() {
+    void testOnClickNoPermission() {
         when(user.hasPermission(anyString())).thenReturn(false);
         listener.onClick(panel, user, ClickType.LEFT, 0);
         verify(user).sendMessage("general.errors.no-permission", "[permission]", "bskyblock.admin.settings.INVINCIBLE_VISITORS");
     }
 
     @Test
-    public void testOnClickNotIVPanel() {
+    void testOnClickNotIVPanel() {
         ClickType clickType = ClickType.LEFT;
         int slot = 5;
         when(panel.getName()).thenReturn("not_panel");
@@ -182,7 +182,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnClickIVPanel() {
+    void testOnClickIVPanel() {
         ClickType clickType = ClickType.LEFT;
         ivSettings.clear();
         when(panel.getName()).thenReturn("panel");
@@ -213,7 +213,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageNotPlayer() {
+    void testOnVisitorGetDamageNotPlayer() {
         LivingEntity le = mock(LivingEntity.class);
         EntityDamageEvent e = new EntityDamageEvent(le, EntityDamageEvent.DamageCause.CRAMMING, null, 0D);
         listener.onVisitorGetDamage(e);
@@ -221,7 +221,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageNotInWorld() {
+    void testOnVisitorGetDamageNotInWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, EntityDamageEvent.DamageCause.CRAMMING, null, 0D);
@@ -230,7 +230,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageNotInIvSettings() {
+    void testOnVisitorGetDamageNotInIvSettings() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, EntityDamageEvent.DamageCause.BLOCK_EXPLOSION, null, 0D);
@@ -239,7 +239,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageNotVisitor() {
+    void testOnVisitorGetDamageNotVisitor() {
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, EntityDamageEvent.DamageCause.CRAMMING, null, 0D);
         when(im.userIsOnIsland(any(), any())).thenReturn(true);
         listener.onVisitorGetDamage(e);
@@ -247,7 +247,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageNotVoid() {
+    void testOnVisitorGetDamageNotVoid() {
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, EntityDamageEvent.DamageCause.CRAMMING, null, 0D);
         listener.onVisitorGetDamage(e);
         assertTrue(e.isCancelled());
@@ -256,7 +256,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageNPC() {
+    void testOnVisitorGetDamageNPC() {
         when(mockPlayer.hasMetadata("NPC")).thenReturn(true);
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, EntityDamageEvent.DamageCause.CRAMMING, null, 0D);
         listener.onVisitorGetDamage(e);
@@ -265,7 +265,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
 
 
     @Test
-    public void testOnVisitorGetDamageVoidIslandHere() {
+    void testOnVisitorGetDamageVoidIslandHere() {
         when(im.getIslandAt(any())).thenReturn(optionalIsland);
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, EntityDamageEvent.DamageCause.VOID, null, 0D);
         // Player should be teleported to this island
@@ -275,7 +275,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageVoidNoIslandHerePlayerHasNoIsland() {
+    void testOnVisitorGetDamageVoidNoIslandHerePlayerHasNoIsland() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         EntityDamageEvent e = new EntityDamageEvent(mockPlayer, EntityDamageEvent.DamageCause.VOID, null, 0D);
@@ -286,7 +286,7 @@ public class InvincibleVisitorsListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnVisitorGetDamageVoidPlayerHasIsland() {
+    void testOnVisitorGetDamageVoidPlayerHasIsland() {
         // No island at this location
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         // Player has an island

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/IslandRespawnListenerTest.java
@@ -43,7 +43,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class IslandRespawnListenerTest extends CommonTestSetup {
+class IslandRespawnListenerTest extends CommonTestSetup {
 
     @Mock
     private Location safeLocation;
@@ -108,7 +108,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * Test method for {@link IslandRespawnListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnPlayerDeathNotIslandWorld() {
+    void testOnPlayerDeathNotIslandWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         List<ItemStack> drops = new ArrayList<>();
         PlayerDeathEvent e = getPlayerDeathEvent(mockPlayer, drops, 0, 0, 0, 0, "");
@@ -121,7 +121,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * {@link IslandRespawnListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnPlayerDeathNoFlag() {
+    void testOnPlayerDeathNoFlag() {
         Flags.ISLAND_RESPAWN.setSetting(world, false);
         List<ItemStack> drops = new ArrayList<>();
         PlayerDeathEvent e = getPlayerDeathEvent(mockPlayer, drops, 0, 0, 0, 0, "");
@@ -133,7 +133,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * Test method for {@link IslandRespawnListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnPlayerDeathNotOwnerNotTeam() {
+    void testOnPlayerDeathNotOwnerNotTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         List<ItemStack> drops = new ArrayList<>();
@@ -146,7 +146,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * Test method for {@link IslandRespawnListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnPlayerDeathNotOwnerInTeam() {
+    void testOnPlayerDeathNotOwnerInTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(false);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(true);
         List<ItemStack> drops = new ArrayList<>();
@@ -159,7 +159,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * Test method for {@link IslandRespawnListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnPlayerDeathOwnerNoTeam() {
+    void testOnPlayerDeathOwnerNoTeam() {
         when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
         when(im.inTeam(any(), any(UUID.class))).thenReturn(false);
         List<ItemStack> drops = new ArrayList<>();
@@ -173,7 +173,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * {@link IslandRespawnListener#onPlayerDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnPlayerDeath() {
+    void testOnPlayerDeath() {
         List<ItemStack> drops = new ArrayList<>();
         PlayerDeathEvent e = getPlayerDeathEvent(mockPlayer, drops, 0, 0, 0, 0, "");
         new IslandRespawnListener().onPlayerDeath(e);
@@ -185,7 +185,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * {@link IslandRespawnListener#onPlayerRespawn(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnPlayerRespawn() {
+    void testOnPlayerRespawn() {
         // Die
         List<ItemStack> drops = new ArrayList<>();
         PlayerDeathEvent e = getPlayerDeathEvent(mockPlayer, drops, 0, 0, 0, 0, "");
@@ -206,7 +206,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * {@link IslandRespawnListener#onPlayerRespawn(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnPlayerRespawnWithoutDeath() {
+    void testOnPlayerRespawnWithoutDeath() {
         IslandRespawnListener l = new IslandRespawnListener();
         Location location = mock(Location.class);
         when(location.getWorld()).thenReturn(world);
@@ -223,7 +223,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * Test method for {@link IslandRespawnListener#onPlayerRespawn(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnPlayerRespawnWrongWorld() {
+    void testOnPlayerRespawnWrongWorld() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         // Die
@@ -247,7 +247,7 @@ public class IslandRespawnListenerTest extends CommonTestSetup {
      * {@link IslandRespawnListener#onPlayerRespawn(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnPlayerRespawnFlagNotSet() {
+    void testOnPlayerRespawnFlagNotSet() {
         Flags.ISLAND_RESPAWN.setSetting(world, false);
         // Die
         List<ItemStack> drops = new ArrayList<>();

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ItemFrameListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ItemFrameListenerTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class ItemFrameListenerTest extends CommonTestSetup  {
+class ItemFrameListenerTest extends CommonTestSetup  {
 
     @Mock
     private Enderman enderman;
@@ -105,7 +105,7 @@ public class ItemFrameListenerTest extends CommonTestSetup  {
      * Test method for {@link ItemFrameListener#onItemFrameDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testOnItemFrameDamageEntityDamageByEntityEvent() {
+    void testOnItemFrameDamageEntityDamageByEntityEvent() {
         ItemFrameListener ifl = new ItemFrameListener();
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         EntityDamageByEntityEvent e = new EntityDamageByEntityEvent(enderman, entity, cause, null, 0);
@@ -117,7 +117,7 @@ public class ItemFrameListenerTest extends CommonTestSetup  {
      * Test method for {@link ItemFrameListener#onItemFrameDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testNotItemFrame() {
+    void testNotItemFrame() {
         ItemFrameListener ifl = new ItemFrameListener();
         Creeper creeper = mock(Creeper.class);
         when(creeper.getLocation()).thenReturn(location);
@@ -131,7 +131,7 @@ public class ItemFrameListenerTest extends CommonTestSetup  {
      * Test method for {@link ItemFrameListener#onItemFrameDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testProjectile() {
+    void testProjectile() {
         ItemFrameListener ifl = new ItemFrameListener();
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Projectile p = mock(Projectile.class);
@@ -145,7 +145,7 @@ public class ItemFrameListenerTest extends CommonTestSetup  {
      * Test method for {@link ItemFrameListener#onItemFrameDamage(org.bukkit.event.entity.EntityDamageByEntityEvent)}.
      */
     @Test
-    public void testPlayerProjectile() {
+    void testPlayerProjectile() {
         ItemFrameListener ifl = new ItemFrameListener();
         DamageCause cause = DamageCause.ENTITY_ATTACK;
         Projectile p = mock(Projectile.class);
@@ -160,7 +160,7 @@ public class ItemFrameListenerTest extends CommonTestSetup  {
      * Test method for {@link ItemFrameListener#onItemFrameDamage(org.bukkit.event.hanging.HangingBreakByEntityEvent)}.
      */
     @Test
-    public void testOnItemFrameDamageHangingBreakByEntityEvent() {
+    void testOnItemFrameDamageHangingBreakByEntityEvent() {
         ItemFrameListener ifl = new ItemFrameListener();
         HangingBreakByEntityEvent e = new HangingBreakByEntityEvent(entity, enderman);
         ifl.onItemFrameDamage(e);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/LimitMobsListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/LimitMobsListenerTest.java
@@ -24,7 +24,7 @@ import world.bentobox.bentobox.CommonTestSetup;
  * @author tastybento
  *
  */
-public class LimitMobsListenerTest extends CommonTestSetup {
+class LimitMobsListenerTest extends CommonTestSetup {
 
    private List<String> list = new ArrayList<>();
     private LimitMobsListener lml;
@@ -71,7 +71,7 @@ public class LimitMobsListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.LimitMobsListener#onMobSpawn(org.bukkit.event.entity.CreatureSpawnEvent)}.
      */
     @Test
-    public void testOnMobSpawn() {
+    void testOnMobSpawn() {
         CreatureSpawnEvent e = new CreatureSpawnEvent(skelly, SpawnReason.NATURAL);
         lml.onMobSpawn(e);
         assertTrue(e.isCancelled());
@@ -81,7 +81,7 @@ public class LimitMobsListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.LimitMobsListener#onMobSpawn(org.bukkit.event.entity.CreatureSpawnEvent)}.
      */
     @Test
-    public void testOnMobSpawnNotInWorld() {
+    void testOnMobSpawnNotInWorld() {
         when(location.getWorld()).thenReturn(mock(World.class));
         CreatureSpawnEvent e = new CreatureSpawnEvent(skelly, SpawnReason.NATURAL);
         lml.onMobSpawn(e);
@@ -92,7 +92,7 @@ public class LimitMobsListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.LimitMobsListener#onMobSpawn(org.bukkit.event.entity.CreatureSpawnEvent)}.
      */
     @Test
-    public void testOnMobSpawnOkayToSpawn() {
+    void testOnMobSpawnOkayToSpawn() {
         CreatureSpawnEvent e = new CreatureSpawnEvent(zombie, SpawnReason.NATURAL);
         lml.onMobSpawn(e);
         assertFalse(e.isCancelled());
@@ -102,7 +102,7 @@ public class LimitMobsListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.LimitMobsListener#onMobSpawn(org.bukkit.event.entity.CreatureSpawnEvent)}.
      */
     @Test
-    public void testOnMobSpawnJockey() {
+    void testOnMobSpawnJockey() {
         CreatureSpawnEvent e = new CreatureSpawnEvent(jockey, SpawnReason.JOCKEY);
         lml.onMobSpawn(e);
         assertTrue(e.isCancelled());

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListenerTest.java
@@ -29,7 +29,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author Poslovitch, tastybento
  * @since 1.3.0
  */
-public class LiquidsFlowingOutListenerTest extends CommonTestSetup {
+class LiquidsFlowingOutListenerTest extends CommonTestSetup {
 
     /* Blocks */
     private Block from;
@@ -91,7 +91,7 @@ public class LiquidsFlowingOutListenerTest extends CommonTestSetup {
      * Asserts that the event is never cancelled when the 'from' block is not in the world.
      */
     @Test
-    public void testFromIsNotInWorld() {
+    void testFromIsNotInWorld() {
         // Not in world
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
@@ -105,7 +105,7 @@ public class LiquidsFlowingOutListenerTest extends CommonTestSetup {
      * Asserts that the event is never cancelled when {@link Flags#LIQUIDS_FLOWING_OUT} is allowed.
      */
     @Test
-    public void testFlagIsAllowed() {
+    void testFlagIsAllowed() {
         // Allowed
         Flags.LIQUIDS_FLOWING_OUT.setSetting(world, true);
 
@@ -118,7 +118,7 @@ public class LiquidsFlowingOutListenerTest extends CommonTestSetup {
      * Asserts that the event is never cancelled when the liquid flows vertically.
      */
     @Test
-    public void testLiquidFlowsVertically() {
+    void testLiquidFlowsVertically() {
         // "To" is at (1,0,0)
         // Set "from" at (1,1,0) so that the vector's y coordinate != 0, which means the liquid flows vertically.
         when(from.getLocation()).thenReturn(new Location(world, 1, 1, 0));
@@ -132,7 +132,7 @@ public class LiquidsFlowingOutListenerTest extends CommonTestSetup {
      * Asserts that the event is never cancelled when the liquid flows to a location in an island's protection range.
      */
     @Test
-    public void testLiquidFlowsToLocationInIslandProtectionRange() {
+    void testLiquidFlowsToLocationInIslandProtectionRange() {
         // There's a protected island at the "to"
         when(im.getProtectedIslandAt(to.getLocation())).thenReturn(Optional.of(island));
 
@@ -147,7 +147,7 @@ public class LiquidsFlowingOutListenerTest extends CommonTestSetup {
      * Test for {@link LiquidsFlowingOutListener#onLiquidFlow(BlockFromToEvent)}
      */
     @Test
-    public void testLiquidFlowsToAdjacentIsland() {
+    void testLiquidFlowsToAdjacentIsland() {
         // There's a protected island at the "to"
         when(im.getProtectedIslandAt(to.getLocation())).thenReturn(Optional.of(island));
         // There is another island at the "from"
@@ -162,7 +162,7 @@ public class LiquidsFlowingOutListenerTest extends CommonTestSetup {
      * Asserts that the event is cancelled with the default configuration provided in {@link LiquidsFlowingOutListenerTest#setUp()}.
      */
     @Test
-    public void testLiquidFlowIsBlocked() {
+    void testLiquidFlowIsBlocked() {
         // Run
         new LiquidsFlowingOutListener().onLiquidFlow(event);
         assertTrue(event.isCancelled());

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ObsidianScoopingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/ObsidianScoopingListenerTest.java
@@ -32,7 +32,7 @@ import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.user.User;
 
-public class ObsidianScoopingListenerTest extends CommonTestSetup {
+class ObsidianScoopingListenerTest extends CommonTestSetup {
 
     private ObsidianScoopingListener listener;
     @Mock
@@ -110,7 +110,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteract() {
+    void testOnPlayerInteract() {
         // Test incorrect items
         inHand = Material.ACACIA_DOOR;
         block = Material.BROWN_MUSHROOM;
@@ -119,7 +119,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractBucketInHand() {
+    void testOnPlayerInteractBucketInHand() {
         // Test incorrect items
         inHand = Material.BUCKET;
         block = Material.BROWN_MUSHROOM;
@@ -128,7 +128,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractObsidianAnvilInHand() {
+    void testOnPlayerInteractObsidianAnvilInHand() {
         // Test with obsidian in hand
         inHand = Material.ANVIL;
         block = Material.OBSIDIAN;
@@ -137,7 +137,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractObsidianBucketInHand() {
+    void testOnPlayerInteractObsidianBucketInHand() {
         // Positive test with 1 bucket in the stack
         inHand = Material.BUCKET;
         block = Material.OBSIDIAN;
@@ -146,7 +146,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractObsidianManyBucketsInHand() {
+    void testOnPlayerInteractObsidianManyBucketsInHand() {
         // Positive test with 1 bucket in the stack
         inHand = Material.BUCKET;
         block = Material.OBSIDIAN;
@@ -158,7 +158,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractNotInWorld() {
+    void testOnPlayerInteractNotInWorld() {
         PlayerInteractEvent event = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, item, clickedBlock,
                 BlockFace.EAST);
         // Test not in world
@@ -168,14 +168,14 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractInWorld() {
+    void testOnPlayerInteractInWorld() {
         // Put player in world
         when(iwm.inWorld(any(World.class))).thenReturn(true);
         when(iwm.inWorld(any(Location.class))).thenReturn(true);
     }
 
     @Test
-    public void testOnPlayerInteractGameModes() {
+    void testOnPlayerInteractGameModes() {
         PlayerInteractEvent event = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, item, clickedBlock,
                 BlockFace.EAST);
 
@@ -189,7 +189,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractSurvivalNotOnIsland() {
+    void testOnPlayerInteractSurvivalNotOnIsland() {
         PlayerInteractEvent event = new PlayerInteractEvent(mockPlayer, Action.RIGHT_CLICK_BLOCK, item, clickedBlock,
                 BlockFace.EAST);
 
@@ -208,7 +208,7 @@ public class ObsidianScoopingListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerInteractCooldown() {
+    void testOnPlayerInteractCooldown() {
         // Set up for a successful scoop
         inHand = Material.BUCKET;
         block = Material.OBSIDIAN;

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/OfflineGrowthListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/OfflineGrowthListenerTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.util.Util;
 
-public class OfflineGrowthListenerTest extends CommonTestSetup {
+class OfflineGrowthListenerTest extends CommonTestSetup {
 
     @Mock
     private Location inside;
@@ -93,7 +93,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#OnCropGrow(BlockGrowEvent)}.
      */
     @Test
-    public void testOnCropGrowDoNothing() {
+    void testOnCropGrowDoNothing() {
         // Make an event to give some current to block
         BlockGrowEvent e = new BlockGrowEvent(block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -107,7 +107,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#OnCropGrow(BlockGrowEvent)}.
      */
     @Test
-    public void testOnCropGrowMembersOnline() {
+    void testOnCropGrowMembersOnline() {
         // Make an event to give some current to block
         BlockGrowEvent e = new BlockGrowEvent(block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -125,7 +125,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#OnCropGrow(BlockGrowEvent)}.
      */
     @Test
-    public void testOnCropGrowMembersOffline() {
+    void testOnCropGrowMembersOffline() {
         // Make an event to give some current to block
         BlockGrowEvent e = new BlockGrowEvent(block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -143,7 +143,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#OnCropGrow(BlockGrowEvent)}.
      */
     @Test
-    public void testOnCropGrowNonIsland() {
+    void testOnCropGrowNonIsland() {
         // Make an event to give some current to block
         BlockGrowEvent e = new BlockGrowEvent(block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -158,7 +158,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#OnCropGrow(BlockGrowEvent)}.
      */
     @Test
-    public void testOnCropGrowNonBentoBoxWorldIsland() {
+    void testOnCropGrowNonBentoBoxWorldIsland() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         // Make an event to give some current to block
         BlockGrowEvent e = new BlockGrowEvent(block, blockState);
@@ -174,7 +174,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#onSpread(BlockSpreadEvent)}.
      */
     @Test
-    public void testOnSpreadDoNothing() {
+    void testOnSpreadDoNothing() {
         // Make an event to give some current to block
         BlockSpreadEvent e = new BlockSpreadEvent(block, block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -188,7 +188,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#onSpread(BlockSpreadEvent)}.
      */
     @Test
-    public void testOnSpreadMembersOnline() {
+    void testOnSpreadMembersOnline() {
         // Make an event to give some current to block
         BlockSpreadEvent e = new BlockSpreadEvent(block, block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -206,7 +206,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#onSpread(BlockSpreadEvent)}.
      */
     @Test
-    public void testOnSpreadMembersOffline() {
+    void testOnSpreadMembersOffline() {
         // Make an event to give some current to block
         BlockSpreadEvent e = new BlockSpreadEvent(block, block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -234,7 +234,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#onSpread(BlockSpreadEvent)}.
      */
     @Test
-    public void testOnSpreadMembersOfflineTree() {
+    void testOnSpreadMembersOfflineTree() {
         when(block.getType()).thenReturn(Material.SPRUCE_LOG);
         // Make an event to give some current to block
         BlockSpreadEvent e = new BlockSpreadEvent(block, block, blockState);
@@ -253,7 +253,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#onSpread(BlockSpreadEvent)}.
      */
     @Test
-    public void testOnSpreadNonIsland() {
+    void testOnSpreadNonIsland() {
         // Make an event to give some current to block
         BlockSpreadEvent e = new BlockSpreadEvent(block, block, blockState);
         OfflineGrowthListener orl = new OfflineGrowthListener();
@@ -268,7 +268,7 @@ public class OfflineGrowthListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineGrowthListener#onSpread(BlockSpreadEvent)}.
      */
     @Test
-    public void testOnSpreadNonBentoBoxWorldIsland() {
+    void testOnSpreadNonBentoBoxWorldIsland() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         // Make an event to give some current to block
         BlockSpreadEvent e = new BlockSpreadEvent(block, block, blockState);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/OfflineRedstoneListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/OfflineRedstoneListenerTest.java
@@ -34,7 +34,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.util.Util;
 
-public class OfflineRedstoneListenerTest extends CommonTestSetup {
+class OfflineRedstoneListenerTest extends CommonTestSetup {
 
     private static final String[] NAMES = {"adam", "ben", "cara", "dave", "ed", "frank", "freddy", "george", "harry", "ian", "joe"};
 
@@ -104,7 +104,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneDoNothing() {
+    void testOnBlockRedstoneDoNothing() {
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);
         OfflineRedstoneListener orl = new OfflineRedstoneListener();
@@ -118,7 +118,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneMembersOnline() {
+    void testOnBlockRedstoneMembersOnline() {
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);
         OfflineRedstoneListener orl = new OfflineRedstoneListener();
@@ -136,7 +136,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneMembersOffline() {
+    void testOnBlockRedstoneMembersOffline() {
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);
         OfflineRedstoneListener orl = new OfflineRedstoneListener();
@@ -154,7 +154,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneMembersOfflineOpsOnlineNotOnIsland() {
+    void testOnBlockRedstoneMembersOfflineOpsOnlineNotOnIsland() {
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);
         OfflineRedstoneListener orl = new OfflineRedstoneListener();
@@ -172,7 +172,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneMembersOfflineOpsOnlineOnIsland() {
+    void testOnBlockRedstoneMembersOfflineOpsOnlineOnIsland() {
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);
         OfflineRedstoneListener orl = new OfflineRedstoneListener();
@@ -192,7 +192,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneMembersOfflineSpawn() {
+    void testOnBlockRedstoneMembersOfflineSpawn() {
         when(island.isSpawn()).thenReturn(true);
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);
@@ -211,7 +211,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneNonIsland() {
+    void testOnBlockRedstoneNonIsland() {
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);
         OfflineRedstoneListener orl = new OfflineRedstoneListener();
@@ -226,7 +226,7 @@ public class OfflineRedstoneListenerTest extends CommonTestSetup {
      * Test method for {@link OfflineRedstoneListener#onBlockRedstone(BlockRedstoneEvent)}.
      */
     @Test
-    public void testOnBlockRedstoneNonBentoBoxWorldIsland() {
+    void testOnBlockRedstoneNonBentoBoxWorldIsland() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         // Make an event to give some current to block
         BlockRedstoneEvent e = new BlockRedstoneEvent(block, 0, 10);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/PetTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/PetTeleportListenerTest.java
@@ -30,7 +30,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author tastybento
  *
  */
-public class PetTeleportListenerTest extends CommonTestSetup {
+class PetTeleportListenerTest extends CommonTestSetup {
 
     private PetTeleportListener ptl;
     @Mock
@@ -68,7 +68,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportNotTameable() {
+    void testOnPetTeleportNotTameable() {
         EntityTeleportEvent e = new EntityTeleportEvent(mockPlayer, location, location);
         ptl.onPetTeleport(e);
         assertFalse(e.isCancelled());
@@ -78,7 +78,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportNullTo() {
+    void testOnPetTeleportNullTo() {
         EntityTeleportEvent e = new EntityTeleportEvent(mockPlayer, location, null);
         ptl.onPetTeleport(e);
         assertFalse(e.isCancelled());
@@ -88,7 +88,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportWrongWorld() {
+    void testOnPetTeleportWrongWorld() {
         when(iwm.inWorld(location)).thenReturn(false);
         EntityTeleportEvent e = new EntityTeleportEvent(tamed, location, location);
         ptl.onPetTeleport(e);
@@ -99,7 +99,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportFlagNotSet() {
+    void testOnPetTeleportFlagNotSet() {
         Flags.PETS_STAY_AT_HOME.setSetting(world, false);
         EntityTeleportEvent e = new EntityTeleportEvent(tamed, location, location);
         ptl.onPetTeleport(e);
@@ -110,7 +110,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportFlagSetGoingHome() {
+    void testOnPetTeleportFlagSetGoingHome() {
         EntityTeleportEvent e = new EntityTeleportEvent(tamed, location, location);
         ptl.onPetTeleport(e);
         assertFalse(e.isCancelled());
@@ -120,7 +120,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportFlagSetNoIsland() {
+    void testOnPetTeleportFlagSetNoIsland() {
         Location l = mock(Location.class);
         when(im.getProtectedIslandAt(l)).thenReturn(Optional.empty());
         EntityTeleportEvent e = new EntityTeleportEvent(tamed, location, l);
@@ -132,7 +132,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportFlagSetNotHome() {
+    void testOnPetTeleportFlagSetNotHome() {
         Location l = mock(Location.class);
         Island otherIsland = mock(Island.class);
         when(otherIsland.getMemberSet()).thenReturn(ImmutableSet.of());
@@ -146,7 +146,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportFlagSetTamedButNoOwner() {
+    void testOnPetTeleportFlagSetTamedButNoOwner() {
         when(tamed.getOwner()).thenReturn(null);
         EntityTeleportEvent e = new EntityTeleportEvent(tamed, location, location);
         ptl.onPetTeleport(e);
@@ -157,7 +157,7 @@ public class PetTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.PetTeleportListener#onPetTeleport(org.bukkit.event.entity.EntityTeleportEvent)}.
      */
     @Test
-    public void testOnPetTeleportFlagSetNotTamed() {
+    void testOnPetTeleportFlagSetNotTamed() {
         when(tamed.isTamed()).thenReturn(false);
         EntityTeleportEvent e = new EntityTeleportEvent(tamed, location, location);
         ptl.onPetTeleport(e);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/PistonPushListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/PistonPushListenerTest.java
@@ -29,7 +29,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.util.Util;
 
-public class PistonPushListenerTest extends CommonTestSetup {
+class PistonPushListenerTest extends CommonTestSetup {
 
     @Mock
     private Block block;
@@ -93,7 +93,7 @@ public class PistonPushListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPistonExtendFlagNotSet() {
+    void testOnPistonExtendFlagNotSet() {
         Flags.PISTON_PUSH.setSetting(world, false);
         BlockPistonExtendEvent e = new BlockPistonExtendEvent(block, blocks, BlockFace.EAST);
         new PistonPushListener().onPistonExtend(e);
@@ -103,7 +103,7 @@ public class PistonPushListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPistonExtendFlagSetOnIsland() {
+    void testOnPistonExtendFlagSetOnIsland() {
 
         // The blocks in the pushed list are all inside the island
         when(island.onIsland(any())).thenReturn(true);
@@ -116,7 +116,7 @@ public class PistonPushListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPistonExtendFlagSetOffIsland() {
+    void testOnPistonExtendFlagSetOffIsland() {
         // The blocks in the pushed list are all outside the island
         when(island.onIsland(any())).thenReturn(false);
 

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/RemoveMobsListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/RemoveMobsListenerTest.java
@@ -33,7 +33,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class RemoveMobsListenerTest extends CommonTestSetup {
+class RemoveMobsListenerTest extends CommonTestSetup {
 
     @Mock
     private Location inside;
@@ -95,7 +95,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testOnUserTeleport() {
+    void testOnUserTeleport() {
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, inside, inside, PlayerTeleportEvent.TeleportCause.PLUGIN);
         new RemoveMobsListener().onUserTeleport(e);
         verify(sch).runTask(any(), any(Runnable.class));
@@ -105,7 +105,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testOnUserTeleportDifferentWorld() {
+    void testOnUserTeleportDifferentWorld() {
         when(mockPlayer.getWorld()).thenReturn(mock(World.class));
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, inside, inside, PlayerTeleportEvent.TeleportCause.PLUGIN);
         new RemoveMobsListener().onUserTeleport(e);
@@ -116,7 +116,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testOnUserTeleportChorusEtc() {
+    void testOnUserTeleportChorusEtc() {
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, inside, inside, PlayerTeleportEvent.TeleportCause.CONSUMABLE_EFFECT);
         new RemoveMobsListener().onUserTeleport(e);
         e = new PlayerTeleportEvent(mockPlayer, inside, inside, PlayerTeleportEvent.TeleportCause.ENDER_PEARL);
@@ -130,7 +130,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testOnUserTeleportTooClose() {
+    void testOnUserTeleportTooClose() {
         // Teleports are too close
         when(inside.distanceSquared(any())).thenReturn(10D);
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, inside, inside, PlayerTeleportEvent.TeleportCause.PLUGIN);
@@ -142,7 +142,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testOnUserTeleportDoNotRemove() {
+    void testOnUserTeleportDoNotRemove() {
         Flags.REMOVE_MOBS.setSetting(world, false);
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, inside, inside, PlayerTeleportEvent.TeleportCause.PLUGIN);
         new RemoveMobsListener().onUserTeleport(e);
@@ -153,7 +153,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserTeleport(org.bukkit.event.player.PlayerTeleportEvent)}.
      */
     @Test
-    public void testOnUserTeleportToNotIsland() {
+    void testOnUserTeleportToNotIsland() {
         // Not on island
         when(im.locationIsOnIsland(any(), any())).thenReturn(false);
         PlayerTeleportEvent e = new PlayerTeleportEvent(mockPlayer, inside, inside, PlayerTeleportEvent.TeleportCause.PLUGIN);
@@ -165,7 +165,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserRespawn(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnUserRespawn() {
+    void testOnUserRespawn() {
         PlayerRespawnEvent e = new PlayerRespawnEvent(mockPlayer, inside, false, false, false, RespawnReason.DEATH);
         new RemoveMobsListener().onUserRespawn(e);
         verify(sch).runTask(any(), any(Runnable.class));
@@ -175,7 +175,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserRespawn(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnUserRespawnDoNotRemove() {
+    void testOnUserRespawnDoNotRemove() {
         Flags.REMOVE_MOBS.setSetting(world, false);
 
         PlayerRespawnEvent e = new PlayerRespawnEvent(mockPlayer, inside, false, false, false, RespawnReason.DEATH);
@@ -187,7 +187,7 @@ public class RemoveMobsListenerTest extends CommonTestSetup {
      * Test method for {@link RemoveMobsListener#onUserRespawn(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnUserRespawnNotIsland() {
+    void testOnUserRespawnNotIsland() {
         // Not on island
         when(im.locationIsOnIsland(any(), any())).thenReturn(false);
         PlayerRespawnEvent e = new PlayerRespawnEvent(mockPlayer, inside, false, false, false, RespawnReason.DEATH);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/TreesGrowingOutsideRangeListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/TreesGrowingOutsideRangeListenerTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author Poslovitch
  * @since 1.3.0
  */
-public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
+class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
 
     /* Event */
     private StructureGrowEvent event;
@@ -133,7 +133,7 @@ public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
      * Asserts that no interaction is done to the event when it does not happen in the world.
      */
     @Test
-    public void testNotInWorld() {
+    void testNotInWorld() {
         // Not in world
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
@@ -148,7 +148,7 @@ public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
      * Asserts that no interaction is done to the event when {@link Flags#TREES_GROWING_OUTSIDE_RANGE} is allowed.
      */
     @Test
-    public void testFlagIsAllowed() {
+    void testFlagIsAllowed() {
         // Allowed
         Flags.TREES_GROWING_OUTSIDE_RANGE.setSetting(world, true);
 
@@ -162,7 +162,7 @@ public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
      * Asserts that the event is cancelled and that there is no interaction with the blocks list when the sapling is outside an island.
      */
     @Test
-    public void testSaplingOutsideIsland() {
+    void testSaplingOutsideIsland() {
         // No protected island at the sapling's location
         when(im.getProtectedIslandAt(sapling.getLocation())).thenReturn(Optional.empty());
 
@@ -176,7 +176,7 @@ public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
      * Asserts that the event is cancelled and that there is no interaction with the blocks list when the sapling is outside an island but inside another island.
      */
     @Test
-    public void testSaplingOutsideIslandButInAnotherIsland() {
+    void testSaplingOutsideIslandButInAnotherIsland() {
         // Sapling is on the island, but some leaves are in another island. For simplicity
         for (BlockState b: blockStates) {
             if (b.getLocation().getBlockY() == 4) {
@@ -193,7 +193,7 @@ public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
      * Asserts that no interaction is done to the event when everything's inside an island.
      */
     @Test
-    public void testTreeFullyInsideIsland() {
+    void testTreeFullyInsideIsland() {
         // Run
         new TreesGrowingOutsideRangeListener().onTreeGrow(event);
         assertEquals(blockStates, event.getBlocks());
@@ -202,7 +202,7 @@ public class TreesGrowingOutsideRangeListenerTest extends CommonTestSetup {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testTreePartiallyOutsideIsland() {
+    void testTreePartiallyOutsideIsland() {
         // Only the first few blocks are inside the island
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.of(island),
                 Optional.of(island),

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/VisitorKeepInventoryListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/VisitorKeepInventoryListenerTest.java
@@ -41,7 +41,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class VisitorKeepInventoryListenerTest extends CommonTestSetup {
+class VisitorKeepInventoryListenerTest extends CommonTestSetup {
 
     // Class under test
     private VisitorKeepInventoryListener l;
@@ -109,7 +109,7 @@ public class VisitorKeepInventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.VisitorKeepInventoryListener#onVisitorDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnVisitorDeath() {
+    void testOnVisitorDeath() {
         l.onVisitorDeath(e);
     }
 
@@ -117,7 +117,7 @@ public class VisitorKeepInventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.VisitorKeepInventoryListener#onVisitorDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnVisitorDeathFalseFlag() {
+    void testOnVisitorDeathFalseFlag() {
         l.onVisitorDeath(e);
         assertFalse(e.getKeepInventory());
         assertFalse(e.getKeepLevel());
@@ -132,7 +132,7 @@ public class VisitorKeepInventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.VisitorKeepInventoryListener#onVisitorDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnVisitorDeathTrueFlag() {
+    void testOnVisitorDeathTrueFlag() {
         Flags.VISITOR_KEEP_INVENTORY.setSetting(world, true);
         l.onVisitorDeath(e);
         assertTrue(e.getKeepInventory());
@@ -148,7 +148,7 @@ public class VisitorKeepInventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.VisitorKeepInventoryListener#onVisitorDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnVisitorDeathNotInWorld() {
+    void testOnVisitorDeathNotInWorld() {
         when(iwm.inWorld(world)).thenReturn(false);
         Flags.VISITOR_KEEP_INVENTORY.setSetting(world, true);
         l.onVisitorDeath(e);
@@ -165,7 +165,7 @@ public class VisitorKeepInventoryListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.VisitorKeepInventoryListener#onVisitorDeath(org.bukkit.event.entity.PlayerDeathEvent)}.
      */
     @Test
-    public void testOnVisitorDeathTrueFlagNoIsland() {
+    void testOnVisitorDeathTrueFlagNoIsland() {
         when(im.getProtectedIslandAt(any())).thenReturn(Optional.empty());
         Flags.VISITOR_KEEP_INVENTORY.setSetting(world, true);
         l.onVisitorDeath(e);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/WitherListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/WitherListenerTest.java
@@ -33,7 +33,7 @@ import world.bentobox.bentobox.lists.Flags;
  * @author tastybento
  *
  */
-public class WitherListenerTest extends CommonTestSetup {
+class WitherListenerTest extends CommonTestSetup {
 
     private WitherListener wl;
     @Mock
@@ -90,7 +90,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionWither() {
+    void testOnExplosionWither() {
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getWorld()).thenReturn(world);
@@ -106,7 +106,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionWitherWrongWorld() {
+    void testOnExplosionWitherWrongWorld() {
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location2);
         when(entity.getWorld()).thenReturn(world2);
@@ -120,7 +120,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionWitherAllowed() {
+    void testOnExplosionWitherAllowed() {
         Flags.WITHER_DAMAGE.setSetting(world, true);
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);
@@ -136,7 +136,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionWitherSkull() {
+    void testOnExplosionWitherSkull() {
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getWorld()).thenReturn(world);
@@ -151,7 +151,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#onExplosion(org.bukkit.event.entity.EntityExplodeEvent)}.
      */
     @Test
-    public void testOnExplosionNotWither() {
+    void testOnExplosionNotWither() {
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getWorld()).thenReturn(world);
@@ -165,7 +165,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#WitherChangeBlocks(org.bukkit.event.entity.EntityChangeBlockEvent)}.
      */
     @Test
-    public void testWitherChangeBlocks() {
+    void testWitherChangeBlocks() {
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);
         when(entity.getWorld()).thenReturn(world);
@@ -183,7 +183,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#WitherChangeBlocks(org.bukkit.event.entity.EntityChangeBlockEvent)}.
      */
     @Test
-    public void testWitherChangeBlocksWrongWorld() {
+    void testWitherChangeBlocksWrongWorld() {
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location2);
         when(entity.getWorld()).thenReturn(world2);
@@ -201,7 +201,7 @@ public class WitherListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.flags.worldsettings.WitherListener#WitherChangeBlocks(org.bukkit.event.entity.EntityChangeBlockEvent)}.
      */
     @Test
-    public void testWitherChangeBlocksAllowed() {
+    void testWitherChangeBlocksAllowed() {
         Flags.WITHER_DAMAGE.setSetting(world, true);
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);

--- a/src/test/java/world/bentobox/bentobox/listeners/teleports/EntityTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/teleports/EntityTeleportListenerTest.java
@@ -28,7 +28,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class EntityTeleportListenerTest extends CommonTestSetup {
+class EntityTeleportListenerTest extends CommonTestSetup {
 
     private EntityTeleportListener etl;
 
@@ -59,7 +59,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#EntityTeleportListener(world.bentobox.bentobox.BentoBox)}.
      */
     @Test
-    public void testEntityTeleportListener() {
+    void testEntityTeleportListener() {
         assertNotNull(etl);
     }
 
@@ -68,7 +68,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalWrongWorld() {
+    void testOnEntityPortalWrongWorld() {
         mockedUtil.when(() -> Util.getWorld(any())).thenReturn(null);
         EntityPortalEvent event = new EntityPortalEvent(mockPlayer, location, location, 10);
         etl.onEntityPortal(event);
@@ -79,7 +79,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalWrongWorld2() {
+    void testOnEntityPortalWrongWorld2() {
         when(iwm.inWorld(any(World.class))).thenReturn(false);
         EntityPortalEvent event = new EntityPortalEvent(mockPlayer, location, location, 10);
         etl.onEntityPortal(event);
@@ -91,7 +91,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalNullTo() {
+    void testOnEntityPortalNullTo() {
         EntityPortalEvent event = new EntityPortalEvent(mockPlayer, location, null, 10);
         etl.onEntityPortal(event);
         assertFalse(event.isCancelled());
@@ -102,7 +102,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalTeleportDisabled() {
+    void testOnEntityPortalTeleportDisabled() {
         EntityPortalEvent event = new EntityPortalEvent(mockPlayer, location, location, 10);
         etl.onEntityPortal(event);
         assertTrue(event.isCancelled());
@@ -113,7 +113,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalTeleportEnabled() {
+    void testOnEntityPortalTeleportEnabled() {
         mockedUtil.when(() -> Util.getWorld(any())).thenReturn(world);
         when(world.getEnvironment()).thenReturn(Environment.NORMAL);
 
@@ -128,7 +128,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalTeleportEnabledMissingWorld() {
+    void testOnEntityPortalTeleportEnabledMissingWorld() {
         when(iwm.isNetherGenerate(any())).thenReturn(false);
 
         Location location2 = mock(Location.class);
@@ -150,7 +150,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalTeleportEnabledIsNotAllowedInConfig() {
+    void testOnEntityPortalTeleportEnabledIsNotAllowedInConfig() {
         when(iwm.isNetherGenerate(any())).thenReturn(false);
 
         Location location2 = mock(Location.class);
@@ -171,7 +171,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityPortal(org.bukkit.event.entity.EntityPortalEvent)}.
      */
     @Test
-    public void testOnEntityPortalTeleportEnabledIsAllowedInConfig() {
+    void testOnEntityPortalTeleportEnabledIsAllowedInConfig() {
         when(world.getEnvironment()).thenReturn(Environment.NORMAL);
 
         when(iwm.isNetherGenerate(any())).thenReturn(true);
@@ -196,7 +196,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityEnterPortal(org.bukkit.event.entity.EntityPortalEnterEvent)}.
      */
     @Test
-    public void testOnEntityEnterPortal() {
+    void testOnEntityEnterPortal() {
         // TODO
     }
 
@@ -205,7 +205,7 @@ public class EntityTeleportListenerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.listeners.teleports.EntityTeleportListener#onEntityExitPortal(org.bukkit.event.entity.EntityPortalExitEvent)}.
      */
     @Test
-    public void testOnEntityExitPortal() {
+    void testOnEntityExitPortal() {
         // TODO
     }
 

--- a/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
@@ -46,7 +46,7 @@ import world.bentobox.bentobox.util.Util;
 /**
  * @author tastybento
  */
-public class PlayerTeleportListenerTest extends CommonTestSetup {
+class PlayerTeleportListenerTest extends CommonTestSetup {
 
     private PlayerTeleportListener ptl;
     @Mock
@@ -104,7 +104,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#PlayerTeleportListener(world.bentobox.bentobox.BentoBox)}.
      */
     @Test
-    public void testPlayerTeleportListener() {
+    void testPlayerTeleportListener() {
         assertNotNull(ptl);
     }
 
@@ -112,7 +112,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
      */
     @Test
-    public void testOnPlayerPortalEventNether() {
+    void testOnPlayerPortalEventNether() {
         PlayerPortalEvent e = new PlayerPortalEvent(mockPlayer, location, location, TeleportCause.NETHER_PORTAL, 0,
                 false, 0);
         ptl.onPlayerPortalEvent(e);
@@ -123,7 +123,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
      */
     @Test
-    public void testOnPlayerPortalEventEnd() {
+    void testOnPlayerPortalEventEnd() {
         PlayerPortalEvent e = new PlayerPortalEvent(mockPlayer, location, location, TeleportCause.END_PORTAL, 0, false,
                 0);
         ptl.onPlayerPortalEvent(e);
@@ -134,7 +134,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
      */
     @Test
-    public void testOnPlayerPortalEventUnknown() {
+    void testOnPlayerPortalEventUnknown() {
         PlayerPortalEvent e = new PlayerPortalEvent(mockPlayer, location, location, TeleportCause.UNKNOWN, 0, false, 0);
         ptl.onPlayerPortalEvent(e);
         assertFalse(e.isCancelled());
@@ -144,7 +144,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#portalProcess(org.bukkit.event.player.PlayerPortalEvent, org.bukkit.World.Environment)}.
      */
     @Test
-    public void testPortalProcessNotBentoboxWorld() {
+    void testPortalProcessNotBentoboxWorld() {
         when(Util.getWorld(location.getWorld())).thenReturn(null);
         PlayerPortalEvent e = new PlayerPortalEvent(mockPlayer, location, location, TeleportCause.NETHER_PORTAL, 0,
                 false, 0);
@@ -158,7 +158,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#portalProcess(org.bukkit.event.player.PlayerPortalEvent, org.bukkit.World.Environment)}.
      */
     @Test
-    public void testPortalProcessWorldDisabledInConfig() {
+    void testPortalProcessWorldDisabledInConfig() {
         when(Util.getWorld(location.getWorld())).thenReturn(world);
         when(plugin.getIWM().inWorld(world)).thenReturn(true);
         when(ptl.isAllowedInConfig(world, World.Environment.NETHER)).thenReturn(false);
@@ -173,7 +173,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#portalProcess(org.bukkit.event.player.PlayerPortalEvent, org.bukkit.World.Environment)}.
      */
     @Test
-    public void testPortalProcessWorldDisabledOnServer() {
+    void testPortalProcessWorldDisabledOnServer() {
         when(Util.getWorld(location.getWorld())).thenReturn(world);
         when(plugin.getIWM().inWorld(world)).thenReturn(true);
         when(ptl.isAllowedInConfig(world, World.Environment.NETHER)).thenReturn(true);
@@ -189,7 +189,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#portalProcess(org.bukkit.event.player.PlayerPortalEvent, org.bukkit.World.Environment)}.
      */
     @Test
-    public void testPortalProcessAlreadyInTeleport() {
+    void testPortalProcessAlreadyInTeleport() {
         ptl.getInTeleport().add(uuid);
         PlayerPortalEvent e = new PlayerPortalEvent(mockPlayer, location, location, TeleportCause.NETHER_PORTAL, 0,
                 false, 0);
@@ -199,7 +199,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testPortalProcessStandardNetherOrEnd() {
+    void testPortalProcessStandardNetherOrEnd() {
         // Mocking required dependencies
         when(Util.getWorld(location.getWorld())).thenReturn(world);
         when(plugin.getIWM().inWorld(world)).thenReturn(true);
@@ -224,7 +224,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#portalProcess(org.bukkit.event.player.PlayerPortalEvent, org.bukkit.World.Environment)}.
      */
     @Test
-    public void testPortalProcessIslandTeleport() {
+    void testPortalProcessIslandTeleport() {
         when(Util.getWorld(location.getWorld())).thenReturn(world);
         when(plugin.getIWM().inWorld(world)).thenReturn(true);
         when(ptl.isAllowedInConfig(world, World.Environment.NETHER)).thenReturn(true);
@@ -242,7 +242,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#portalProcess(org.bukkit.event.player.PlayerPortalEvent, org.bukkit.World.Environment)}.
      */
     @Test
-    public void testPortalProcessEndVelocityReset() {
+    void testPortalProcessEndVelocityReset() {
         when(Util.getWorld(location.getWorld())).thenReturn(world);
         when(plugin.getIWM().inWorld(world)).thenReturn(true);
         PlayerPortalEvent e = new PlayerPortalEvent(mockPlayer, location, location, TeleportCause.END_PORTAL, 0, false,
@@ -257,7 +257,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortal(org.bukkit.event.entity.EntityPortalEnterEvent)}.
      */
     @Test
-    public void testOnPlayerPortalNonPlayerEntity() {
+    void testOnPlayerPortalNonPlayerEntity() {
         // Mock a non-player entity
         Entity mockEntity = mock(Entity.class);
         when(mockEntity.getType()).thenReturn(EntityType.ZOMBIE);
@@ -273,7 +273,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortal(org.bukkit.event.entity.EntityPortalEnterEvent)}.
      */
     @Test
-    public void testOnPlayerPortalAlreadyInPortal() {
+    void testOnPlayerPortalAlreadyInPortal() {
         // Simulate player already in portal
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getInPortal().add(playerId);
@@ -289,7 +289,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortal(org.bukkit.event.entity.EntityPortalEnterEvent)}.
      */
     @Test
-    public void testOnPlayerPortalNetherPortalDisabled() {
+    void testOnPlayerPortalNetherPortalDisabled() {
         // Mock configuration for Nether disabled
         when(Bukkit.getAllowNether()).thenReturn(false);
         when(Util.getWorld(location.getWorld())).thenReturn(world);
@@ -309,7 +309,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * portalProcess() directly.
      */
     @Test
-    public void testOnPlayerPortalNetherPortalDisabledCallsEvent() {
+    void testOnPlayerPortalNetherPortalDisabledCallsEvent() {
         when(Bukkit.getAllowNether()).thenReturn(false);
         when(Util.getWorld(location.getWorld())).thenReturn(world);
         when(plugin.getIWM().inWorld(world)).thenReturn(true);
@@ -331,7 +331,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerPortalEndPortalDisabled() {
+    void testOnPlayerPortalEndPortalDisabled() {
         // Mock configuration for End disabled
         when(Bukkit.getAllowEnd()).thenReturn(false);
         when(Util.getWorld(location.getWorld())).thenReturn(world);
@@ -358,7 +358,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerPortalEndGatewayDisabled() {
+    void testOnPlayerPortalEndGatewayDisabled() {
         // Mock configuration for End disabled
         when(Bukkit.getAllowEnd()).thenReturn(false);
         when(Util.getWorld(location.getWorld())).thenReturn(world);
@@ -385,7 +385,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerPortalValidBentoBoxWorld() {
+    void testOnPlayerPortalValidBentoBoxWorld() {
         // Mock configuration for a valid BentoBox world
         when(Bukkit.getAllowNether()).thenReturn(true);
         when(Bukkit.getAllowEnd()).thenReturn(true);
@@ -411,7 +411,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onExitPortal(org.bukkit.event.player.PlayerMoveEvent)}.
      */
     @Test
-    public void testOnExitPortalPlayerNotInPortal() {
+    void testOnExitPortalPlayerNotInPortal() {
         // Mock a player who is not in the inPortal list
         UUID playerId = mockPlayer.getUniqueId();
 
@@ -428,7 +428,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnExitPortalPlayerStillInPortal() {
+    void testOnExitPortalPlayerStillInPortal() {
         // Mock a player in the inPortal list
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getInPortal().add(playerId);
@@ -451,7 +451,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnExitPortalPlayerExitsPortal() {
+    void testOnExitPortalPlayerExitsPortal() {
         // Mock a player in the inPortal list
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getInPortal().add(playerId);
@@ -479,7 +479,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerExitPortal(org.bukkit.event.player.PlayerRespawnEvent)}.
      */
     @Test
-    public void testOnPlayerExitPortalPlayerAlreadyProcessed() {
+    void testOnPlayerExitPortalPlayerAlreadyProcessed() {
         // Create the event
         @SuppressWarnings("deprecation")
         PlayerRespawnEvent event = new PlayerRespawnEvent(mockPlayer, location, false);
@@ -492,7 +492,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerExitPortalNotBentoBoxWorld() {
+    void testOnPlayerExitPortalNotBentoBoxWorld() {
         // Mock teleportOrigin with a world not in BentoBox
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getTeleportOrigin().put(playerId, world);
@@ -511,7 +511,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerExitPortalIslandExistsRespawnInsideProtection() {
+    void testOnPlayerExitPortalIslandExistsRespawnInsideProtection() {
         // Set up teleportOrigin with a valid world
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getTeleportOrigin().put(playerId, world);
@@ -527,7 +527,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerExitPortalIslandExistsRespawnOutsideProtection() {
+    void testOnPlayerExitPortalIslandExistsRespawnOutsideProtection() {
         // Set up teleportOrigin with a valid world
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getTeleportOrigin().put(playerId, world);
@@ -543,7 +543,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerExitPortalIslandExistsNoSpawnPoint() {
+    void testOnPlayerExitPortalIslandExistsNoSpawnPoint() {
         // Set up teleportOrigin with a valid world
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getTeleportOrigin().put(playerId, world);
@@ -560,7 +560,7 @@ public class PlayerTeleportListenerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnPlayerExitPortalNoIsland() {
+    void testOnPlayerExitPortalNoIsland() {
         // Set up teleportOrigin with a valid world
         UUID playerId = mockPlayer.getUniqueId();
         ptl.getTeleportOrigin().put(playerId, world);

--- a/src/test/java/world/bentobox/bentobox/lists/GameModePlaceholderTest.java
+++ b/src/test/java/world/bentobox/bentobox/lists/GameModePlaceholderTest.java
@@ -34,7 +34,7 @@ import world.bentobox.bentobox.managers.RanksManager;
  * @author tastybento
  *
  */
-public class GameModePlaceholderTest extends CommonTestSetup {
+class GameModePlaceholderTest extends CommonTestSetup {
 
     @Mock
     private GameModeAddon addon;
@@ -85,7 +85,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerIsland() {
+    void testGetReplacerIsland() {
         assertEquals("0", GameModePlaceholder.ISLAND_BANS_COUNT.getReplacer().onReplace(addon, user, island));
         assertEquals("123,456,789", GameModePlaceholder.ISLAND_CENTER.getReplacer().onReplace(addon, user, island));
         assertEquals("123", GameModePlaceholder.ISLAND_CENTER_X.getReplacer().onReplace(addon, user, island));
@@ -112,7 +112,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerNullIsland() {
+    void testGetReplacerNullIsland() {
         island = null;
         assertEquals("", GameModePlaceholder.ISLAND_BANS_COUNT.getReplacer().onReplace(addon, user, island));
         assertEquals("", GameModePlaceholder.ISLAND_CENTER.getReplacer().onReplace(addon, user, island));
@@ -138,7 +138,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerPlayer() {
+    void testGetReplacerPlayer() {
         assertEquals("deaths", GameModePlaceholder.DEATHS.getPlaceholder());
         assertEquals("0", GameModePlaceholder.DEATHS.getReplacer().onReplace(addon, user, island));
         assertEquals("true", GameModePlaceholder.HAS_ISLAND.getReplacer().onReplace(addon, user, island));
@@ -153,7 +153,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerPlayerOnIsland() {
+    void testGetReplacerPlayerOnIsland() {
         @Nullable
         World netherWorld = mock(World.class);
         when(addon.getNetherWorld()).thenReturn(netherWorld);
@@ -187,7 +187,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerNullPlayer() {
+    void testGetReplacerNullPlayer() {
         user = null;
         assertEquals("", GameModePlaceholder.DEATHS.getReplacer().onReplace(addon, user, island));
         assertEquals("false", GameModePlaceholder.HAS_ISLAND.getReplacer().onReplace(addon, user, island));
@@ -202,7 +202,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerVisitedIslands() {
+    void testGetReplacerVisitedIslands() {
         assertEquals("0", GameModePlaceholder.VISITED_ISLAND_BANS_COUNT.getReplacer().onReplace(addon, user, island));
         assertEquals("123,456,789",
                 GameModePlaceholder.VISITED_ISLAND_CENTER.getReplacer().onReplace(addon, user, island));
@@ -237,7 +237,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerVisitedIslandsNoIsland() {
+    void testGetReplacerVisitedIslandsNoIsland() {
         when(im.getIslandAt(any())).thenReturn(Optional.empty());
         assertEquals("", GameModePlaceholder.VISITED_ISLAND_BANS_COUNT.getReplacer().onReplace(addon, user, island));
         assertEquals("", GameModePlaceholder.VISITED_ISLAND_CENTER.getReplacer().onReplace(addon, user, island));
@@ -262,7 +262,7 @@ public class GameModePlaceholderTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.lists.GameModePlaceholder#getReplacer()}.
      */
     @Test
-    public void testGetReplacerWorld() {
+    void testGetReplacerWorld() {
         assertEquals("0", GameModePlaceholder.ISLAND_DISTANCE.getReplacer().onReplace(addon, user, island));
         assertEquals("0", GameModePlaceholder.ISLAND_DISTANCE_DIAMETER.getReplacer().onReplace(addon, user, island));
         assertEquals("friendly_name",

--- a/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
@@ -42,7 +42,7 @@ import world.bentobox.bentobox.api.addons.exceptions.InvalidAddonDescriptionExce
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.database.objects.DataObject;
 
-public class AddonsManagerTest extends CommonTestSetup {
+class AddonsManagerTest extends CommonTestSetup {
 
     private AddonsManager am;
     @Mock
@@ -82,7 +82,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#AddonsManager(world.bentobox.bentobox.BentoBox)}.
      */
     @Test
-    public void testAddonsManager() {
+    void testAddonsManager() {
         AddonsManager addonsManager = new AddonsManager(plugin);
 
         assertNotNull(addonsManager.getAddons());
@@ -92,7 +92,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#loadAddons()}.
      */
     @Test
-    public void testLoadAddonsNoAddons() {
+    void testLoadAddonsNoAddons() {
         am.loadAddons();
         verify(plugin, never()).logError("Cannot create addons folder!");
         verify(plugin).log("Loaded 0 addons.");
@@ -102,7 +102,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#enableAddons()}.
      */
     @Test
-    public void testEnableAddonsNoAddon() {
+    void testEnableAddonsNoAddon() {
         am.enableAddons();
         verify(plugin, never()).log("Enabling addons...");
     }
@@ -111,7 +111,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#reloadAddons()}.
      */
     @Test
-    public void testReloadAddonsNoAddons() {
+    void testReloadAddonsNoAddons() {
         am.reloadAddons();
         verify(plugin, never()).log("Disabling addons...");
     }
@@ -120,7 +120,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getAddonByName(java.lang.String)}.
      */
     @Test
-    public void testGetAddonByNameNoAddons() {
+    void testGetAddonByNameNoAddons() {
         assertFalse(am.getAddonByName("name").isPresent());
     }
 
@@ -128,7 +128,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#disableAddons()}.
      */
     @Test
-    public void testDisableAddonsNoAddons() {
+    void testDisableAddonsNoAddons() {
         am.disableAddons();
         verify(plugin, never()).log("Disabling addons...");
     }
@@ -137,7 +137,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getAddons()}.
      */
     @Test
-    public void testGetAddonsNoAddons() {
+    void testGetAddonsNoAddons() {
         assertTrue(am.getAddons().isEmpty());
     }
 
@@ -145,7 +145,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getGameModeAddons()}.
      */
     @Test
-    public void testGetGameModeAddonsNoAddons() {
+    void testGetGameModeAddonsNoAddons() {
         assertTrue(am.getGameModeAddons().isEmpty());
     }
 
@@ -153,7 +153,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getLoadedAddons()}.
      */
     @Test
-    public void testGetLoadedAddonsnoAddons() {
+    void testGetLoadedAddonsnoAddons() {
         assertTrue(am.getLoadedAddons().isEmpty());
     }
 
@@ -161,7 +161,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getEnabledAddons()}.
      */
     @Test
-    public void testGetEnabledAddonsNoAddons() {
+    void testGetEnabledAddonsNoAddons() {
         assertTrue(am.getEnabledAddons().isEmpty());
     }
 
@@ -169,7 +169,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getLoader(world.bentobox.bentobox.api.addons.Addon)}.
      */
     @Test
-    public void testGetLoaderNoSuchAddon() {
+    void testGetLoaderNoSuchAddon() {
         Addon addon = mock(Addon.class);
         assertNull(am.getLoader(addon));
     }
@@ -178,7 +178,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getClassByName(java.lang.String)}.
      */
     @Test
-    public void testGetClassByNameNull() {
+    void testGetClassByNameNull() {
         assertNull(am.getClassByName("name"));
     }
 
@@ -186,7 +186,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#setClass(java.lang.String, java.lang.Class)}.
      */
     @Test
-    public void testSetClass() {
+    void testSetClass() {
         am.setClass("name", Class.class);
         assertNotNull(am.getClassByName("name"));
         assertEquals(Class.class, am.getClassByName("name"));
@@ -196,7 +196,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getDefaultWorldGenerator(java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testGetDefaultWorldGeneratorNoWorlds() {
+    void testGetDefaultWorldGeneratorNoWorlds() {
         assertNull(am.getDefaultWorldGenerator("BSkyBlock", ""));
     }
 
@@ -204,7 +204,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#registerListener(world.bentobox.bentobox.api.addons.Addon, org.bukkit.event.Listener)}.
      */
     @Test
-    public void testRegisterListener() {
+    void testRegisterListener() {
         @NonNull
         Addon addon = mock(Addon.class);
 
@@ -218,7 +218,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getDataObjects()}.
      */
     @Test
-    public void testGetDataObjectsNone() {
+    void testGetDataObjectsNone() {
         assertTrue(am.getDataObjects().isEmpty());
     }
 
@@ -226,7 +226,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#getDataObjects()}.
      */
     @Test
-    public void testGetDataObjects() {
+    void testGetDataObjects() {
         am.setClass("dataobj", DataObject.class);
         assertFalse(am.getDataObjects().isEmpty());
         assertEquals(1, am.getDataObjects().size());
@@ -236,7 +236,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxSnapshotNoAPIVersion() {
+    void testIsAddonCompatibleWithBentoBoxSnapshotNoAPIVersion() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -247,7 +247,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxReleaseAPIVersion() {
+    void testIsAddonCompatibleWithBentoBoxReleaseAPIVersion() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.1").apiVersion("1.0.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -258,7 +258,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxSnapshotAPIVersion() {
+    void testIsAddonCompatibleWithBentoBoxSnapshotAPIVersion() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.1").apiVersion("1.0.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -269,7 +269,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxReleaseNoAPIVersion() {
+    void testIsAddonCompatibleWithBentoBoxReleaseNoAPIVersion() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -280,7 +280,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxSnapshotAPIVersionVariableDigits() {
+    void testIsAddonCompatibleWithBentoBoxSnapshotAPIVersionVariableDigits() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.1").apiVersion("1.2.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -291,7 +291,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxOldSnapshot() {
+    void testIsAddonCompatibleWithBentoBoxOldSnapshot() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.0").apiVersion("1.11.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -302,7 +302,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxOldRelease() {
+    void testIsAddonCompatibleWithBentoBoxOldRelease() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.0").apiVersion("1.11.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -313,7 +313,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxOldReleaseLong() {
+    void testIsAddonCompatibleWithBentoBoxOldReleaseLong() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.0").apiVersion("1.11.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -324,7 +324,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#isAddonCompatibleWithBentoBox(Addon, String)}.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxOldReleaseLongAPI() {
+    void testIsAddonCompatibleWithBentoBoxOldReleaseLongAPI() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.0").apiVersion("1.11.1.0.0.0.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -336,7 +336,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Prevents regression on <a href="https://github.com/BentoBoxWorld/BentoBox/issues/1346">issue 1346</a>.
      */
     @Test
-    public void testIsAddonCompatibleWithBentoBoxNewRelease() {
+    void testIsAddonCompatibleWithBentoBoxNewRelease() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.0").apiVersion("1.13.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -347,7 +347,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#setPerms(Addon)}
      */
     @Test
-    public void testSetPermsNoPerms() {
+    void testSetPermsNoPerms() {
         Addon addon = mock(Addon.class);
         AddonDescription addonDesc = new AddonDescription.Builder("main.class", "Addon-name", "1.0.0").apiVersion("1.11.1.0.0.0.1").build();
         when(addon.getDescription()).thenReturn(addonDesc);
@@ -358,7 +358,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#setPerms(Addon)}
      */
     @Test
-    public void testSetPermsHasPerms() throws InvalidConfigurationException {
+    void testSetPermsHasPerms() throws InvalidConfigurationException {
         String perms = """
                   '[gamemode].intopten':
                     description: Player is in the top ten.
@@ -381,7 +381,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#setPerms(Addon)}
      */
     @Test
-    public void testSetPermsHasPermsError() throws InvalidConfigurationException {
+    void testSetPermsHasPermsError() throws InvalidConfigurationException {
         String perms = """
                   '[gamemode].intopten':
                     description: Player is in the top ten.
@@ -407,7 +407,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#registerPermission(org.bukkit.configuration.ConfigurationSection, String)}
      */
     @Test
-    public void testRegisterPermissionStandardPerm() throws InvalidAddonDescriptionException, InvalidConfigurationException {
+    void testRegisterPermissionStandardPerm() throws InvalidAddonDescriptionException, InvalidConfigurationException {
         String perms = """
                   'bskyblock.intopten':
                     description: Player is in the top ten.
@@ -423,7 +423,7 @@ public class AddonsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.AddonsManager#registerPermission(org.bukkit.configuration.ConfigurationSection, String)}
      */
     @Test
-    public void testRegisterPermissionGameModePerm() throws InvalidAddonDescriptionException, InvalidConfigurationException {
+    void testRegisterPermissionGameModePerm() throws InvalidAddonDescriptionException, InvalidConfigurationException {
         String perms = """
                   '[gamemode].intopten':
                     description: Player is in the top ten.

--- a/src/test/java/world/bentobox/bentobox/managers/BlueprintClipboardManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/BlueprintClipboardManagerTest.java
@@ -40,7 +40,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class BlueprintClipboardManagerTest extends CommonTestSetup {
+class BlueprintClipboardManagerTest extends CommonTestSetup {
 
     private static final String BLUEPRINT = "blueprint";
 
@@ -157,7 +157,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#BlueprintClipboardManager(world.bentobox.bentobox.BentoBox, java.io.File)}.
      */
     @Test
-    public void testBlueprintClipboardManagerBentoBoxFile() {
+    void testBlueprintClipboardManagerBentoBoxFile() {
         new BlueprintClipboardManager(plugin, blueprintFolder);
         assertTrue(blueprintFolder.exists());
     }
@@ -166,7 +166,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#BlueprintClipboardManager(world.bentobox.bentobox.BentoBox, java.io.File, world.bentobox.bentobox.blueprints.BlueprintClipboard)}.
      */
     @Test
-    public void testBlueprintClipboardManagerBentoBoxFileBlueprintClipboard() {
+    void testBlueprintClipboardManagerBentoBoxFileBlueprintClipboard() {
         new BlueprintClipboardManager(plugin, blueprintFolder, clipboard);
         assertTrue(blueprintFolder.exists());
     }
@@ -175,7 +175,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#getClipboard()}.
      */
     @Test
-    public void testGetClipboard() {
+    void testGetClipboard() {
         BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder, clipboard);
         assertEquals(clipboard, bcm.getClipboard());
     }
@@ -184,7 +184,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#loadBlueprint(java.lang.String)}.
      */
     @Test
-    public void testLoadBlueprintNoSuchFile() {
+    void testLoadBlueprintNoSuchFile() {
         BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder);
         try {
             bcm.loadBlueprint("test");
@@ -199,7 +199,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#loadBlueprint(java.lang.String)}.
      */
     @Test
-    public void testLoadBlueprintNoFileInZip() throws IOException {
+    void testLoadBlueprintNoFileInZip() throws IOException {
         blueprintFolder.mkdirs();
         // Make a blueprint file
         YamlConfiguration config = new YamlConfiguration();
@@ -221,7 +221,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#loadBlueprint(java.lang.String)}.
      */
     @Test
-    public void testLoadBlueprintFileInZipJSONError() throws IOException {
+    void testLoadBlueprintFileInZipJSONError() throws IOException {
         blueprintFolder.mkdirs();
         // Make a blueprint file
         YamlConfiguration config = new YamlConfiguration();
@@ -244,7 +244,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#loadBlueprint(java.lang.String)}.
      */
     @Test
-    public void testLoadBlueprintFileInZipNoBedrock() throws IOException {
+    void testLoadBlueprintFileInZipNoBedrock() throws IOException {
         blueprintFolder.mkdirs();
         // Make a blueprint file
         File configFile = new File(blueprintFolder, BLUEPRINT);
@@ -264,7 +264,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#loadBlueprint(java.lang.String)}.
      */
     @Test
-    public void testLoadBlueprintFileInZip() throws IOException {
+    void testLoadBlueprintFileInZip() throws IOException {
         blueprintFolder.mkdirs();
         // Make a blueprint file
         File configFile = new File(blueprintFolder, BLUEPRINT);
@@ -285,7 +285,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#load(java.lang.String)}.
      */
     @Test
-    public void testLoadString() throws IOException {
+    void testLoadString() throws IOException {
         blueprintFolder.mkdirs();
         // Make a blueprint file
         File configFile = new File(blueprintFolder, BLUEPRINT);
@@ -307,7 +307,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#load(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testLoadUserString() throws IOException {
+    void testLoadUserString() throws IOException {
         blueprintFolder.mkdirs();
         // Make a blueprint file
         File configFile = new File(blueprintFolder, BLUEPRINT);
@@ -324,7 +324,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#load(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testLoadUserStringFail() throws IOException {
+    void testLoadUserStringFail() throws IOException {
         BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder);
         User user = mock(User.class);
         assertFalse(bcm.load(user, BLUEPRINT));
@@ -336,7 +336,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#save(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testSave() throws IOException {
+    void testSave() throws IOException {
         // Load a blueprint, then save it
         blueprintFolder.mkdirs();
         // Make a blueprint file
@@ -357,7 +357,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#save(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testSaveBadChars() throws IOException {
+    void testSaveBadChars() throws IOException {
         // Load a blueprint, then save it
         blueprintFolder.mkdirs();
         // Make a blueprint file
@@ -378,7 +378,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#save(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testSaveForeignChars() throws IOException {
+    void testSaveForeignChars() throws IOException {
         // Load a blueprint, then save it
         blueprintFolder.mkdirs();
         // Make a blueprint file
@@ -399,7 +399,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#save(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testSaveForeignBadChars() throws IOException {
+    void testSaveForeignBadChars() throws IOException {
         // Load a blueprint, then save it
         blueprintFolder.mkdirs();
         // Make a blueprint file
@@ -421,7 +421,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#saveBlueprint(world.bentobox.bentobox.blueprints.Blueprint)}.
      */
     @Test
-    public void testSaveBlueprintNoName() {
+    void testSaveBlueprintNoName() {
         BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder);
         Blueprint blueprint = mock(Blueprint.class);
         when(blueprint.getName()).thenReturn("");
@@ -433,7 +433,7 @@ public class BlueprintClipboardManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.BlueprintClipboardManager#saveBlueprint(world.bentobox.bentobox.blueprints.Blueprint)}.
      */
     @Test
-    public void testSaveBlueprintSuccess() {
+    void testSaveBlueprintSuccess() {
         BlueprintClipboardManager bcm = new BlueprintClipboardManager(plugin, blueprintFolder);
         Blueprint blueprint = new Blueprint();
         blueprint.setName("test123");

--- a/src/test/java/world/bentobox/bentobox/managers/FlagsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/FlagsManagerTest.java
@@ -29,7 +29,7 @@ import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.util.Util;
 
-public class FlagsManagerTest extends CommonTestSetup {
+class FlagsManagerTest extends CommonTestSetup {
 
     /**
      * Update this value if the number of registered listeners changes
@@ -60,19 +60,19 @@ public class FlagsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testFlagsManager() {
+    void testFlagsManager() {
         assertNotNull(new FlagsManager(plugin));
     }
 
     @Test
-    public void testRegisterDuplicateFlag() {
+    void testRegisterDuplicateFlag() {
         FlagsManager fm = new FlagsManager(plugin);
         // Try to register every single flag - it should fail every time
         Flags.values().forEach(dupe -> assertFalse(fm.registerFlag(dupe)));
     }
 
     @Test
-    public void testRegisterOriginalFlagOriginalListener() {
+    void testRegisterOriginalFlagOriginalListener() {
         when(plugin.isLoaded()).thenReturn(true);
         FlagsManager fm = new FlagsManager(plugin);
         verify(pim, times(NUMBER_OF_LISTENERS)).registerEvents(any(), eq(plugin));
@@ -99,7 +99,7 @@ public class FlagsManagerTest extends CommonTestSetup {
      * Test for {@link FlagsManager#getFlags()}
      */
     @Test
-    public void testGetFlags() {
+    void testGetFlags() {
         FlagsManager fm = new FlagsManager(plugin);
         assertTrue(Flags.values().containsAll(fm.getFlags()));
         assertTrue(fm.getFlags().containsAll(Flags.values()));
@@ -109,7 +109,7 @@ public class FlagsManagerTest extends CommonTestSetup {
      * Test for {@link FlagsManager#getFlag(String)}
      */
     @Test
-    public void testGetFlagByID() {
+    void testGetFlagByID() {
         FlagsManager fm = new FlagsManager(plugin);
         // Test in forward and reverse order so that any duplicates are caught
         Flags.values().stream().sorted().forEach(flag -> assertEquals(flag, fm.getFlag(flag.getID()).get()));
@@ -121,7 +121,7 @@ public class FlagsManagerTest extends CommonTestSetup {
      * Test for {@link FlagsManager#unregister(Flag)}
      */
     @Test
-    public void testUnregisterFlag() {
+    void testUnregisterFlag() {
         MockedStatic<HandlerList> mockedHandler = Mockito.mockStatic(HandlerList.class);
         when(plugin.isLoaded()).thenReturn(true);
         FlagsManager fm = new FlagsManager(plugin);

--- a/src/test/java/world/bentobox/bentobox/managers/IslandWorldManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandWorldManagerTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.api.flags.Flag;
  * @author tastybento
  *
  */
-public class IslandWorldManagerTest extends CommonTestSetup {
+class IslandWorldManagerTest extends CommonTestSetup {
 
     private IslandWorldManager testIwm;
 
@@ -99,7 +99,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#registerWorldsToMultiverse()}.
      */
     @Test
-    public void testRegisterWorldsToMultiverse() {
+    void testRegisterWorldsToMultiverse() {
         testIwm.registerWorldsToMultiverse(true);
     }
 
@@ -107,7 +107,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#inWorld(org.bukkit.Location)}.
      */
     @Test
-    public void testInWorldLocation() {
+    void testInWorldLocation() {
         assertTrue(testIwm.inWorld(location));
     }
 
@@ -115,7 +115,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#inWorld(org.bukkit.Location)}.
      */
     @Test
-    public void testInWorldLocationNull() {
+    void testInWorldLocationNull() {
         assertFalse(testIwm.inWorld((Location)null));
     }
 
@@ -123,7 +123,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#inWorld(org.bukkit.World)}.
      */
     @Test
-    public void testInWorldWorld() {
+    void testInWorldWorld() {
         assertTrue(testIwm.inWorld(testWorld));
     }
 
@@ -131,7 +131,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#inWorld(org.bukkit.World)}.
      */
     @Test
-    public void testInWorldWorldNull() {
+    void testInWorldWorldNull() {
         assertFalse(testIwm.inWorld((World)null));
     }
 
@@ -139,7 +139,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getWorlds()}.
      */
     @Test
-    public void testGetWorlds() {
+    void testGetWorlds() {
         assertTrue(testIwm.getWorlds().contains(testWorld));
     }
 
@@ -147,7 +147,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getOverWorlds()}.
      */
     @Test
-    public void testGetOverWorlds() {
+    void testGetOverWorlds() {
         assertTrue(testIwm.getOverWorlds().contains(testWorld));
     }
 
@@ -155,7 +155,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getOverWorldNames()}.
      */
     @Test
-    public void testGetOverWorldNames() {
+    void testGetOverWorldNames() {
         Map<String, String> map = testIwm.getOverWorldNames();
         map.forEach((k,v) -> {
             assertEquals("test-world", k);
@@ -167,7 +167,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isKnownFriendlyWorldName(java.lang.String)}.
      */
     @Test
-    public void testIsKnownFriendlyWorldName() {
+    void testIsKnownFriendlyWorldName() {
         assertTrue(testIwm.isKnownFriendlyWorldName("friendly"));
         assertFalse(testIwm.isKnownFriendlyWorldName("not-friendly"));
     }
@@ -176,7 +176,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#addGameMode(world.bentobox.bentobox.api.addons.GameModeAddon)}.
      */
     @Test
-    public void testAddGameMode() {
+    void testAddGameMode() {
         // Add a second one
         // Gamemode
         GameModeAddon gm = mock(GameModeAddon.class);
@@ -192,7 +192,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getWorldSettings(org.bukkit.World)}.
      */
     @Test
-    public void testGetWorldSettings() {
+    void testGetWorldSettings() {
         assertEquals(ws, testIwm.getWorldSettings(testWorld));
     }
 
@@ -200,7 +200,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getOverWorld(java.lang.String)}.
      */
     @Test
-    public void testGetOverWorld() {
+    void testGetOverWorld() {
         assertEquals(testWorld, testIwm.getOverWorld("friendly"));
         assertNull(testIwm.getOverWorld("not-friendly"));
     }
@@ -209,7 +209,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandDistance(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandDistance() {
+    void testGetIslandDistance() {
         assertEquals(0, testIwm.getIslandDistance(testWorld));
     }
 
@@ -217,7 +217,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandHeight(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandHeight() {
+    void testGetIslandHeight() {
         assertEquals(0, testIwm.getIslandHeight(testWorld));
     }
 
@@ -225,7 +225,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandHeight(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandHeightOverMax() {
+    void testGetIslandHeightOverMax() {
         when(ws.getIslandHeight()).thenReturn(500);
         assertEquals(255, testIwm.getIslandHeight(testWorld));
     }
@@ -234,7 +234,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandHeight(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandHeightSubZero() {
+    void testGetIslandHeightSubZero() {
         when(ws.getIslandHeight()).thenReturn(-50);
         assertEquals(0, testIwm.getIslandHeight(testWorld));
     }
@@ -243,7 +243,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandProtectionRange(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandProtectionRange() {
+    void testGetIslandProtectionRange() {
         assertEquals(0, testIwm.getIslandProtectionRange(testWorld));
     }
 
@@ -251,7 +251,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandStartX(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandStartX() {
+    void testGetIslandStartX() {
         assertEquals(0, testIwm.getIslandStartX(testWorld));
     }
 
@@ -259,7 +259,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandStartZ(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandStartZ() {
+    void testGetIslandStartZ() {
         assertEquals(0, testIwm.getIslandStartZ(testWorld));
     }
 
@@ -267,7 +267,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandXOffset(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandXOffset() {
+    void testGetIslandXOffset() {
         assertEquals(0, testIwm.getIslandXOffset(testWorld));
     }
 
@@ -275,7 +275,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandZOffset(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandZOffset() {
+    void testGetIslandZOffset() {
         assertEquals(0, testIwm.getIslandZOffset(testWorld));
     }
 
@@ -283,7 +283,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getMaxIslands(org.bukkit.World)}.
      */
     @Test
-    public void testGetMaxIslands() {
+    void testGetMaxIslands() {
         assertEquals(0, testIwm.getMaxIslands(testWorld));
     }
 
@@ -291,7 +291,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getNetherSpawnRadius(org.bukkit.World)}.
      */
     @Test
-    public void testGetNetherSpawnRadius() {
+    void testGetNetherSpawnRadius() {
         assertEquals(0, testIwm.getNetherSpawnRadius(testWorld));
     }
 
@@ -299,7 +299,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getSeaHeight(org.bukkit.World)}.
      */
     @Test
-    public void testGetSeaHeight() {
+    void testGetSeaHeight() {
         assertEquals(0, testIwm.getSeaHeight(testWorld));
     }
 
@@ -307,7 +307,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getWorldName(org.bukkit.World)}.
      */
     @Test
-    public void testGetWorldName() {
+    void testGetWorldName() {
         when(ws.getWorldName()).thenReturn("test-world");
         assertEquals("test-world", testIwm.getWorldName(testWorld));
     }
@@ -316,7 +316,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isEndGenerate(org.bukkit.World)}.
      */
     @Test
-    public void testIsEndGenerate() {
+    void testIsEndGenerate() {
         assertFalse(testIwm.isEndGenerate(testWorld));
     }
 
@@ -324,7 +324,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isEndIslands(org.bukkit.World)}.
      */
     @Test
-    public void testIsEndIslands() {
+    void testIsEndIslands() {
         assertFalse(testIwm.isEndIslands(testWorld));
     }
 
@@ -332,7 +332,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isNetherGenerate(org.bukkit.World)}.
      */
     @Test
-    public void testIsNetherGenerate() {
+    void testIsNetherGenerate() {
         assertFalse(testIwm.isNetherGenerate(testWorld));
     }
 
@@ -340,7 +340,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isNetherIslands(org.bukkit.World)}.
      */
     @Test
-    public void testIsNetherIslands() {
+    void testIsNetherIslands() {
         assertFalse(testIwm.isNetherIslands(testWorld));
     }
 
@@ -348,7 +348,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isNether(org.bukkit.World)}.
      */
     @Test
-    public void testIsNether() {
+    void testIsNether() {
         assertFalse(testIwm.isNether(testWorld));
     }
 
@@ -356,7 +356,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isIslandNether(org.bukkit.World)}.
      */
     @Test
-    public void testIsIslandNether() {
+    void testIsIslandNether() {
         assertFalse(testIwm.isIslandNether(testWorld));
     }
 
@@ -364,7 +364,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isEnd(org.bukkit.World)}.
      */
     @Test
-    public void testIsEnd() {
+    void testIsEnd() {
         assertFalse(testIwm.isEnd(testWorld));
     }
 
@@ -372,7 +372,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isIslandEnd(org.bukkit.World)}.
      */
     @Test
-    public void testIsIslandEnd() {
+    void testIsIslandEnd() {
         assertFalse(testIwm.isIslandEnd(testWorld));
     }
 
@@ -380,7 +380,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getNetherWorld(org.bukkit.World)}.
      */
     @Test
-    public void testGetNetherWorld() {
+    void testGetNetherWorld() {
         assertEquals(netherWorld, testIwm.getNetherWorld(testWorld));
     }
 
@@ -388,7 +388,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getNetherWorld(org.bukkit.World)}.
      */
     @Test
-    public void testGetNetherWorldNull() {
+    void testGetNetherWorldNull() {
         assertNull(testIwm.getNetherWorld(null));
     }
 
@@ -396,7 +396,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getEndWorld(org.bukkit.World)}.
      */
     @Test
-    public void testGetEndWorld() {
+    void testGetEndWorld() {
         assertEquals(endWorld, testIwm.getEndWorld(testWorld));
     }
 
@@ -404,7 +404,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getEndWorld(org.bukkit.World)}.
      */
     @Test
-    public void testGetEndWorldNull() {
+    void testGetEndWorldNull() {
         assertNull(testIwm.getEndWorld(null));
     }
 
@@ -412,7 +412,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isDragonSpawn(org.bukkit.World)}.
      */
     @Test
-    public void testIsDragonSpawn() {
+    void testIsDragonSpawn() {
         assertTrue(testIwm.isDragonSpawn(endWorld));
     }
 
@@ -420,7 +420,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isDragonSpawn(org.bukkit.World)}.
      */
     @Test
-    public void testIsDragonSpawnNull() {
+    void testIsDragonSpawnNull() {
         assertTrue(testIwm.isDragonSpawn(null));
     }
 
@@ -428,7 +428,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getFriendlyNames()}.
      */
     @Test
-    public void testGetFriendlyNames() {
+    void testGetFriendlyNames() {
         // Add a second one
         // Gamemode
         GameModeAddon gm2 = mock(GameModeAddon.class);
@@ -448,7 +448,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIslandWorld(java.lang.String)}.
      */
     @Test
-    public void testGetIslandWorld() {
+    void testGetIslandWorld() {
         assertEquals(testWorld, testIwm.getIslandWorld("friendly"));
         assertNull(testIwm.getIslandWorld("not-friendly"));
     }
@@ -457,7 +457,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getMaxTeamSize(org.bukkit.World)}.
      */
     @Test
-    public void testGetMaxTeamSize() {
+    void testGetMaxTeamSize() {
         assertEquals(0, testIwm.getMaxTeamSize(testWorld));
     }
 
@@ -465,7 +465,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getMaxHomes(org.bukkit.World)}.
      */
     @Test
-    public void testGetMaxHomes() {
+    void testGetMaxHomes() {
         assertEquals(0, testIwm.getMaxHomes(testWorld));
     }
 
@@ -473,7 +473,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getFriendlyName(org.bukkit.World)}.
      */
     @Test
-    public void testGetFriendlyName() {
+    void testGetFriendlyName() {
         assertEquals("friendly", testIwm.getFriendlyName(testWorld));
     }
 
@@ -481,7 +481,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getPermissionPrefix(org.bukkit.World)}.
      */
     @Test
-    public void testGetPermissionPrefix() {
+    void testGetPermissionPrefix() {
         when(ws.getPermissionPrefix()).thenReturn("bsky");
         assertEquals("bsky.", testIwm.getPermissionPrefix(testWorld));
     }
@@ -490,7 +490,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getIvSettings(org.bukkit.World)}.
      */
     @Test
-    public void testGetIvSettings() {
+    void testGetIvSettings() {
         List<String> list = Collections.singletonList("blah");
         when(ws.getIvSettings()).thenReturn(list);
         assertEquals(list, testIwm.getIvSettings(testWorld));
@@ -500,7 +500,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isWorldFlag(org.bukkit.World, world.bentobox.bentobox.api.flags.Flag)}.
      */
     @Test
-    public void testIsWorldFlag() {
+    void testIsWorldFlag() {
         // TODO
     }
 
@@ -508,7 +508,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getDefaultGameMode(org.bukkit.World)}.
      */
     @Test
-    public void testGetDefaultGameMode() {
+    void testGetDefaultGameMode() {
         when(ws.getDefaultGameMode()).thenReturn(GameMode.ADVENTURE);
         assertEquals(GameMode.ADVENTURE, testIwm.getDefaultGameMode(testWorld));
     }
@@ -517,7 +517,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getRemoveMobsWhitelist(org.bukkit.World)}.
      */
     @Test
-    public void testGetRemoveMobsWhitelist() {
+    void testGetRemoveMobsWhitelist() {
         Set<EntityType> set = new HashSet<>();
         when(ws.getRemoveMobsWhitelist()).thenReturn(set);
         assertEquals(set, testIwm.getRemoveMobsWhitelist(testWorld));
@@ -527,7 +527,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isOnJoinResetMoney(org.bukkit.World)}.
      */
     @Test
-    public void testIsOnJoinResetMoney() {
+    void testIsOnJoinResetMoney() {
         assertFalse(testIwm.isOnJoinResetMoney(testWorld));
     }
 
@@ -535,7 +535,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isOnJoinResetInventory(org.bukkit.World)}.
      */
     @Test
-    public void testIsOnJoinResetInventory() {
+    void testIsOnJoinResetInventory() {
         assertFalse(testIwm.isOnJoinResetInventory(testWorld));
     }
 
@@ -543,7 +543,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isOnJoinResetEnderChest(org.bukkit.World)}.
      */
     @Test
-    public void testIsOnJoinResetEnderChest() {
+    void testIsOnJoinResetEnderChest() {
         assertFalse(testIwm.isOnJoinResetEnderChest(testWorld));
     }
 
@@ -551,7 +551,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isOnLeaveResetMoney(org.bukkit.World)}.
      */
     @Test
-    public void testIsOnLeaveResetMoney() {
+    void testIsOnLeaveResetMoney() {
         assertFalse(testIwm.isOnLeaveResetMoney(testWorld));
     }
 
@@ -559,7 +559,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isOnLeaveResetInventory(org.bukkit.World)}.
      */
     @Test
-    public void testIsOnLeaveResetInventory() {
+    void testIsOnLeaveResetInventory() {
         assertFalse(testIwm.isOnLeaveResetInventory(testWorld));
     }
 
@@ -567,7 +567,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isOnLeaveResetEnderChest(org.bukkit.World)}.
      */
     @Test
-    public void testIsOnLeaveResetEnderChest() {
+    void testIsOnLeaveResetEnderChest() {
         assertFalse(testIwm.isOnLeaveResetEnderChest(testWorld));
     }
 
@@ -575,7 +575,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getDataFolder(org.bukkit.World)}.
      */
     @Test
-    public void testGetDataFolder() {
+    void testGetDataFolder() {
         File dataFolder = mock(File.class);
         when(gm.getDataFolder()).thenReturn(dataFolder);
         assertEquals(dataFolder, testIwm.getDataFolder(testWorld));
@@ -585,7 +585,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getAddon(org.bukkit.World)}.
      */
     @Test
-    public void testGetAddon() {
+    void testGetAddon() {
         assertEquals(gm, testIwm.getAddon(testWorld).get());
     }
 
@@ -593,7 +593,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getAddon(org.bukkit.World)}.
      */
     @Test
-    public void testGetAddonNull() {
+    void testGetAddonNull() {
         assertEquals(Optional.empty(), testIwm.getAddon(null));
     }
 
@@ -602,7 +602,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @SuppressWarnings("removal")
     @Test
-    public void testGetDefaultIslandFlags() {
+    void testGetDefaultIslandFlags() {
         Map<Flag, Integer> flags = new HashMap<>();
         when(ws.getDefaultIslandFlags()).thenReturn(flags);
         assertEquals(flags, testIwm.getDefaultIslandFlags(testWorld));
@@ -612,7 +612,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getHiddenFlags(org.bukkit.World)}.
      */
     @Test
-    public void testGetVisibleSettings() {
+    void testGetVisibleSettings() {
         List<String> list = new ArrayList<>();
         when(ws.getHiddenFlags()).thenReturn(list);
         assertEquals(list, testIwm.getHiddenFlags(testWorld));
@@ -623,7 +623,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      */
     @SuppressWarnings("removal")
     @Test
-    public void testGetDefaultIslandSettings() {
+    void testGetDefaultIslandSettings() {
         Map<Flag, Integer> flags = new HashMap<>();
         when(ws.getDefaultIslandFlags()).thenReturn(flags);
         assertEquals(flags,testIwm.getDefaultIslandSettings(testWorld));
@@ -633,7 +633,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isUseOwnGenerator(org.bukkit.World)}.
      */
     @Test
-    public void testIsUseOwnGenerator() {
+    void testIsUseOwnGenerator() {
         assertFalse(testIwm.isUseOwnGenerator(testWorld));
     }
 
@@ -641,7 +641,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getVisitorBannedCommands(org.bukkit.World)}.
      */
     @Test
-    public void testGetVisitorBannedCommands() {
+    void testGetVisitorBannedCommands() {
         List<String> list = new ArrayList<>();
         when(ws.getVisitorBannedCommands()).thenReturn(list);
         assertEquals(list, testIwm.getVisitorBannedCommands(testWorld));
@@ -651,7 +651,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isWaterNotSafe(org.bukkit.World)}.
      */
     @Test
-    public void testIsWaterNotSafe() {
+    void testIsWaterNotSafe() {
         assertFalse(testIwm.isWaterNotSafe(testWorld));
     }
 
@@ -659,7 +659,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getGeoLimitSettings(org.bukkit.World)}.
      */
     @Test
-    public void testGetGeoLimitSettings() {
+    void testGetGeoLimitSettings() {
         List<String> list = new ArrayList<>();
         when(ws.getGeoLimitSettings()).thenReturn(list);
         assertEquals(list, testIwm.getGeoLimitSettings(testWorld));
@@ -669,7 +669,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getResetLimit(org.bukkit.World)}.
      */
     @Test
-    public void testGetResetLimit() {
+    void testGetResetLimit() {
         assertEquals(0,testIwm.getResetLimit(testWorld));
     }
 
@@ -677,7 +677,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getResetEpoch(org.bukkit.World)}.
      */
     @Test
-    public void testGetResetEpoch() {
+    void testGetResetEpoch() {
         assertEquals(0,testIwm.getResetEpoch(testWorld));
     }
 
@@ -685,7 +685,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#setResetEpoch(org.bukkit.World)}.
      */
     @Test
-    public void testSetResetEpoch() {
+    void testSetResetEpoch() {
         testIwm.setResetEpoch(testWorld);
         Mockito.verify(ws).setResetEpoch(Mockito.anyLong());
     }
@@ -694,7 +694,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#isTeamJoinDeathReset(org.bukkit.World)}.
      */
     @Test
-    public void testIsTeamJoinDeathReset() {
+    void testIsTeamJoinDeathReset() {
         assertFalse(testIwm.isTeamJoinDeathReset(testWorld));
     }
 
@@ -702,7 +702,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getDeathsMax(org.bukkit.World)}.
      */
     @Test
-    public void testGetDeathsMax() {
+    void testGetDeathsMax() {
         assertEquals(0, testIwm.getDeathsMax(testWorld));
     }
 
@@ -710,7 +710,7 @@ public class IslandWorldManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandWorldManager#getBanLimit(org.bukkit.World)}.
      */
     @Test
-    public void testGetBanLimit() {
+    void testGetBanLimit() {
         assertEquals(0, testIwm.getBanLimit(testWorld));
     }
 

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -81,7 +81,7 @@ import world.bentobox.bentobox.lists.Flags;
 import world.bentobox.bentobox.managers.island.IslandCache;
 import world.bentobox.bentobox.util.Util;
 
-public class IslandsManagerTest extends CommonTestSetup {
+class IslandsManagerTest extends CommonTestSetup {
 
     private AbstractDatabaseHandler<Island> h;
     private MockedStatic<DatabaseSetup> mockedDatabaseSetup;
@@ -357,7 +357,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Block mocks do not return correct BlockData for isSafeLocation checks")
-    public void testIsSafeLocationSafe() {
+    void testIsSafeLocationSafe() {
         assertTrue(islandsManager.isSafeLocation(location));
     }
 
@@ -365,7 +365,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    public void testIsSafeLocationNullWorld() {
+    void testIsSafeLocationNullWorld() {
         when(location.getWorld()).thenReturn(null);
         assertFalse(islandsManager.isSafeLocation(location));
     }
@@ -374,7 +374,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    public void testIsSafeLocationNonSolidGround() {
+    void testIsSafeLocationNonSolidGround() {
         when(ground.getType()).thenReturn(Material.WATER);
         assertFalse(islandsManager.isSafeLocation(location));
     }
@@ -384,13 +384,13 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Block mock types are commented out; test body needs rewrite for water submersion check")
-    public void testIsSafeLocationSubmerged() {
+    void testIsSafeLocationSubmerged() {
         assertTrue(islandsManager.isSafeLocation(location)); // Since poseidon this is ok
     }
 
     @Test
     @Disabled("Reason: Material.values() iteration causes mock framework issues with BlockData types")
-    public void testCheckIfSafeTrapdoor() {
+    void testCheckIfSafeTrapdoor() {
         for (Material d : Material.values()) {
             if (d.name().contains("DOOR")) {
                 for (Material s : Material.values()) {
@@ -407,7 +407,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Block mocks do not return correct BlockData for portal type checks")
-    public void testIsSafeLocationPortals() {
+    void testIsSafeLocationPortals() {
         when(ground.getType()).thenReturn(Material.STONE);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.NETHER_PORTAL);
@@ -451,7 +451,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#isSafeLocation(org.bukkit.Location)}.
      */
     @Test
-    public void testIsSafeLocationLava() {
+    void testIsSafeLocationLava() {
         when(ground.getType()).thenReturn(Material.LAVA);
         when(space1.getType()).thenReturn(Material.AIR);
         when(space2.getType()).thenReturn(Material.AIR);
@@ -471,7 +471,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Block mocks do not return correct BlockData for trapdoor open/closed state")
-    public void testTrapDoor() {
+    void testTrapDoor() {
         when(ground.getType()).thenReturn(Material.OAK_TRAPDOOR);
         assertFalse( islandsManager.isSafeLocation(location), "Open trapdoor");
         when(ground.getType()).thenReturn(Material.IRON_TRAPDOOR);
@@ -483,7 +483,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Block mocks do not return correct BlockData for fence/sign/cactus type checks")
-    public void testBadBlocks() {
+    void testBadBlocks() {
         // Fences
         when(ground.getType()).thenReturn(Material.SPRUCE_FENCE);
         assertFalse( islandsManager.isSafeLocation(location), "Fence :" + Material.SPRUCE_FENCE.toString());
@@ -508,7 +508,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Block mocks do not return correct BlockData for solid block type checks")
-    public void testSolidBlocks() {
+    void testSolidBlocks() {
         when(space1.getType()).thenReturn(Material.STONE);
         assertFalse(islandsManager.isSafeLocation(location), "Solid");
 
@@ -538,7 +538,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#createIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testCreateIslandLocation() {
+    void testCreateIslandLocation() {
         Island island = islandsManager.createIsland(location);
         assertNotNull(island);
         assertEquals(island.getCenter().getWorld(), location.getWorld());
@@ -549,7 +549,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#createIsland(org.bukkit.Location, java.util.UUID)}.
      */
     @Test
-    public void testCreateIslandLocationUUID() {
+    void testCreateIslandLocationUUID() {
         UUID owner = UUID.randomUUID();
         Island island = islandsManager.createIsland(location, owner);
         assertNotNull(island);
@@ -562,7 +562,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#deleteIsland(world.bentobox.bentobox.database.objects.Island, boolean)}.
      */
     @Test
-    public void testDeleteIslandIslandBooleanNoBlockRemoval() {
+    void testDeleteIslandIslandBooleanNoBlockRemoval() {
         UUID owner = UUID.randomUUID();
         Island island = islandsManager.createIsland(location, owner);
         islandsManager.deleteIsland(island, false, owner);
@@ -575,7 +575,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#deleteIsland(world.bentobox.bentobox.database.objects.Island, boolean)}.
      */
     @Test
-    public void testDeleteIslandIslandBooleanRemoveBlocks() {
+    void testDeleteIslandIslandBooleanRemoveBlocks() {
         verify(pim, never()).callEvent(any());
         UUID owner = UUID.randomUUID();
         Island island = islandsManager.createIsland(location, owner);
@@ -589,7 +589,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getIslandCount()}.
      */
     @Test
-    public void testGetCount() {
+    void testGetCount() {
         assertEquals(0, islandsManager.getIslandCount());
         islandsManager.createIsland(location, UUID.randomUUID());
         assertEquals(1, islandsManager.getIslandCount());
@@ -601,7 +601,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Island cache mock does not integrate with IslandsManager.getIsland(World, User)")
-    public void testGetIslandWorldUser()  {
+    void testGetIslandWorldUser()  {
         assertEquals(is, islandsManager.getIsland(world, user));
         assertNull(islandsManager.getIsland(world, (User) null));
     }
@@ -613,7 +613,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Reason: Database load/mock integration prevents getIsland(World, UUID) from returning expected island")
-    public void testGetIsland() throws IOException  {
+    void testGetIsland() throws IOException  {
         islandsManager.load();
         assertEquals(is, islandsManager.getIsland(staticWorld, owner));
         assertNull(islandsManager.getIsland(staticWorld, UUID.randomUUID()));
@@ -624,7 +624,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getIslandAt(org.bukkit.Location)}.
      */
     @Test
-    public void testGetIslandAtLocation() {
+    void testGetIslandAtLocation() {
         islandsManager.setIslandCache(islandCache);
         // In world, correct island
         assertEquals(optionalIsland, islandsManager.getIslandAt(location));
@@ -651,7 +651,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * @throws InstantiationException 
      */
     @Test
-    public void testGetIslandLocation()  {
+    void testGetIslandLocation()  {
         islandsManager.createIsland(location, uuid);
         assertEquals(world, islandsManager.getIslandLocation(world, uuid).getWorld());
         Location l = islandsManager.getIslandLocation(world, uuid);
@@ -667,7 +667,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getLast(World)}.
      */
     @Test
-    public void testGetLast() {
+    void testGetLast() {
         islandsManager.setLast(location);
         assertEquals(location, islandsManager.getLast(world));
     }
@@ -677,7 +677,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMembers(World, UUID)}.
      */
     @Test
-    public void testGetMembers() {
+    void testGetMembers() {
         // Mock island cache
         Set<UUID> members = new HashSet<>();
         members.add(UUID.randomUUID());
@@ -690,7 +690,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getProtectedIslandAt(org.bukkit.Location)}.
      */
     @Test
-    public void testGetProtectedIslandAt() {
+    void testGetProtectedIslandAt() {
         // Mock island cache
         Island is = mock(Island.class);
 
@@ -724,7 +724,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getSpawnPoint(World)}.
      */
     @Test
-    public void testGetSpawnPoint() {
+    void testGetSpawnPoint() {
         assertNull(islandsManager.getSpawnPoint(world));
         // Create a spawn island for this world
         Island island = mock(Island.class);
@@ -741,7 +741,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#isAtSpawn(org.bukkit.Location)}.
      */
     @Test
-    public void testIsAtSpawn() {
+    void testIsAtSpawn() {
         assertFalse(islandsManager.isAtSpawn(location));
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
@@ -762,7 +762,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * @throws InstantiationException 
      */
     @Test
-    public void testLoad() throws IOException {
+    void testLoad() throws IOException {
         try {
             islandsManager.load();
         } catch (IOException e) {
@@ -777,7 +777,7 @@ public class IslandsManagerTest extends CommonTestSetup {
     }
 
     @Test
-    public void testLoadNoDistanceCheck() throws IOException  {
+    void testLoadNoDistanceCheck() throws IOException  {
         settings.setOverrideSafetyCheck(true);
         islandsManager.load();
         // No exception should be thrown
@@ -788,7 +788,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#locationIsOnIsland(org.bukkit.entity.Player, org.bukkit.Location)}.
      */
     @Test
-    public void testLocationIsOnIsland() {
+    void testLocationIsOnIsland() {
         // Mock island cache
         Island is = mock(Island.class);
 
@@ -827,7 +827,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link IslandsManager#userIsOnIsland(World, User)}.
      */
     @Test
-    public void testUserIsOnIsland() {
+    void testUserIsOnIsland() {
         islandsManager.setIslandCache(islandCache);
 
         // ----- CHECK INVALID ARGUMENTS -----
@@ -922,7 +922,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#removePlayer(World, User)}.
      */
     @Test
-    public void testRemovePlayer() {
+    void testRemovePlayer() {
 
         islandsManager.removePlayer(world, uuid);
     }
@@ -932,7 +932,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#removePlayersFromIsland(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testRemovePlayersFromIsland() {
+    void testRemovePlayersFromIsland() {
 
         Island is = mock(Island.class);
         islandsManager.removePlayersFromIsland(is);
@@ -943,14 +943,14 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#updateIsland(Island)}.
      */
     @Test
-    public void testSave() {
+    void testSave() {
     }
 
     /**
      * Test method for .
      */
     @Test
-    public void testSetIslandName() {
+    void testSetIslandName() {
     }
 
     /**
@@ -958,7 +958,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#setJoinTeam(world.bentobox.bentobox.database.objects.Island, java.util.UUID)}.
      */
     @Test
-    public void testSetJoinTeam() {
+    void testSetJoinTeam() {
     }
 
     /**
@@ -966,14 +966,14 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#setLast(org.bukkit.Location)}.
      */
     @Test
-    public void testSetLast() {
+    void testSetLast() {
     }
 
     /**
      * Test method for .
      */
     @Test
-    public void testSetLeaveTeam() {
+    void testSetLeaveTeam() {
     }
 
     /**
@@ -981,7 +981,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#shutdown()}.
      */
     @Test
-    public void testShutdown() {
+    void testShutdown() {
         // Mock island cache
         Island is = mock(Island.class);
 
@@ -1021,7 +1021,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#clearRank(int, UUID)}.
      */
     @Test
-    public void testClearRank() {
+    void testClearRank() {
         // Mock island cache
         Island is = mock(Island.class);
 
@@ -1063,7 +1063,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.IslandsManager#clearArea(Location)}.
      */
     @Test
-    public void testClearAreaWrongWorld() {
+    void testClearAreaWrongWorld() {
         when(iwm.inWorld(any(Location.class))).thenReturn(false);
         islandsManager.clearArea(location);
         // No entities should be cleared
@@ -1083,7 +1083,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#clearArea(Location)}.
      */
     @Test
-    public void testClearArea() {
+    void testClearArea() {
         islandsManager.clearArea(location);
         // Only the correct entities should be cleared
         verify(zombie).remove();
@@ -1101,7 +1101,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getIslandById(String)}.
      */
     @Test
-    public void testGetIslandByIdString() {
+    void testGetIslandByIdString() {
         Island island = mock(Island.class);
         String uuid = UUID.randomUUID().toString();
         when(islandCache.getIslandById(anyString())).thenReturn(island);
@@ -1115,7 +1115,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#fixIslandCenter(Island)}.
      */
     @Test
-    public void testFixIslandCenter() {
+    void testFixIslandCenter() {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         // Island center
@@ -1142,7 +1142,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#fixIslandCenter(Island)}.
      */
     @Test
-    public void testFixIslandCenterOff() {
+    void testFixIslandCenterOff() {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         // Island center
@@ -1177,7 +1177,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#fixIslandCenter(Island)}.
      */
     @Test
-    public void testFixIslandCenterOffStart() {
+    void testFixIslandCenterOffStart() {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         // Island center
@@ -1212,7 +1212,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#fixIslandCenter(Island)}.
      */
     @Test
-    public void testFixIslandCenterStartOnGrid() {
+    void testFixIslandCenterStartOnGrid() {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         // Island center
@@ -1239,7 +1239,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#fixIslandCenter(Island)}.
      */
     @Test
-    public void testFixIslandCenterStartOnGridOffset() {
+    void testFixIslandCenterStartOnGridOffset() {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         // Island center
@@ -1266,7 +1266,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#fixIslandCenter(Island)}.
      */
     @Test
-    public void testFixIslandCenterOffStartOffOffset() {
+    void testFixIslandCenterOffStartOffOffset() {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(world);
         // Island center
@@ -1301,7 +1301,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#fixIslandCenter(Island)}.
      */
     @Test
-    public void testFixIslandCenterNulls() {
+    void testFixIslandCenterNulls() {
         Island island = mock(Island.class);
         when(island.getWorld()).thenReturn(null);
         // Test
@@ -1319,7 +1319,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island, int)}.
      */
     @Test
-    public void testGetMaxMembersNoOwner() {
+    void testGetMaxMembersNoOwner() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(null);
         // Test
@@ -1332,7 +1332,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island, int)}.
      */
     @Test
-    public void testGetMaxMembersOfflineOwner() {
+    void testGetMaxMembersOfflineOwner() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1351,7 +1351,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island, int)}.
      */
     @Test
-    public void testGetMaxMembersOnlineOwnerNoPerms() {
+    void testGetMaxMembersOnlineOwnerNoPerms() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1370,7 +1370,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island, int)}.
      */
     @Test
-    public void testGetMaxMembersOnlineOwnerNoPermsCoopTrust() {
+    void testGetMaxMembersOnlineOwnerNoPermsCoopTrust() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1393,7 +1393,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island, int)}
      */
     @Test
-    public void testGetMaxMembersOnlineOwnerNoPermsPreset() {
+    void testGetMaxMembersOnlineOwnerNoPermsPreset() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1411,7 +1411,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island, int)}.
      */
     @Test
-    public void testGetMaxMembersOnlineOwnerNoPermsPresetLessThanDefault() {
+    void testGetMaxMembersOnlineOwnerNoPermsPresetLessThanDefault() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1429,7 +1429,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxMembers(Island, int)}.
      */
     @Test
-    public void testGetMaxMembersOnlineOwnerHasPerm() {
+    void testGetMaxMembersOnlineOwnerHasPerm() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1454,7 +1454,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#setMaxMembers(Island, int, Integer)}.
      */
     @Test
-    public void testsetMaxMembers() {
+    void testsetMaxMembers() {
         Island island = mock(Island.class);
         // Test
         islandsManager.setMaxMembers(island, RanksManager.MEMBER_RANK, 40);
@@ -1466,7 +1466,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxHomes(Island)}.
      */
     @Test
-    public void testGetMaxHomesOnlineOwnerHasPerm() {
+    void testGetMaxHomesOnlineOwnerHasPerm() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1492,7 +1492,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxHomes(Island)}.
      */
     @Test
-    public void testGetMaxHomesOnlineOwnerHasNoPerm() {
+    void testGetMaxHomesOnlineOwnerHasNoPerm() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1518,7 +1518,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxHomes(Island)}.
      */
     @Test
-    public void testGetMaxHomesIslandSetOnlineOwner() {
+    void testGetMaxHomesIslandSetOnlineOwner() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1544,7 +1544,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#getMaxHomes(Island)}.
      */
     @Test
-    public void testGetMaxHomesIslandSetOnlineOwnerLowerPerm() {
+    void testGetMaxHomesIslandSetOnlineOwnerLowerPerm() {
         Island island = mock(Island.class);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
@@ -1570,7 +1570,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#setMaxHomes(Island, Integer)}.
      */
     @Test
-    public void testsetMaxHomes() {
+    void testsetMaxHomes() {
         Island island = mock(Island.class);
         // Test
         IslandsManager localIM = new IslandsManager(plugin);
@@ -1583,7 +1583,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.IslandsManager#homeTeleportAsync(Island, User)}.
      */
     @Test
-    public void testHomeTeleportAsyncIslandUser() throws Exception {
+    void testHomeTeleportAsyncIslandUser() throws Exception {
         // Setup
         Island island = mock(Island.class);
         Location homeLoc = mock(Location.class);
@@ -1618,7 +1618,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test with a default home location.
      */
     @Test
-    public void testHomeTeleportAsyncIslandUserBooleanWithDefaultHome() throws Exception {
+    void testHomeTeleportAsyncIslandUserBooleanWithDefaultHome() throws Exception {
         // Setup
         Island island = mock(Island.class);
         Location homeLoc = mock(Location.class);
@@ -1655,7 +1655,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test with newIsland parameter set to true.
      */
     @Test
-    public void testHomeTeleportAsyncIslandUserBooleanNewIsland() throws Exception {
+    void testHomeTeleportAsyncIslandUserBooleanNewIsland() throws Exception {
         // Setup
         Island island = mock(Island.class);
         Location homeLoc = mock(Location.class);
@@ -1692,7 +1692,7 @@ public class IslandsManagerTest extends CommonTestSetup {
      * Test with failed teleport - should not set primary island and remove from goingHome.
      */
     @Test
-    public void testHomeTeleportAsyncIslandUserBooleanFailedTeleport() throws Exception {
+    void testHomeTeleportAsyncIslandUserBooleanFailedTeleport() throws Exception {
         // Setup
         Island island = mock(Island.class);
         Location homeLoc = mock(Location.class);

--- a/src/test/java/world/bentobox/bentobox/managers/LocalesManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/LocalesManagerTest.java
@@ -39,7 +39,7 @@ import world.bentobox.bentobox.api.user.User;
  * @author tastybento
  *
  */
-public class LocalesManagerTest  extends CommonTestSetup {
+class LocalesManagerTest  extends CommonTestSetup {
 
     private static final String LOCALE_FOLDER = "locales";
     private static final String BENTOBOX = "BentoBox";
@@ -100,7 +100,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#LocalesManager(BentoBox)}.
      */
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         new LocalesManager(plugin);
         File localeDir = new File(plugin.getDataFolder(), LOCALE_FOLDER + File.separator + BENTOBOX);
         assertTrue(localeDir.exists());
@@ -110,7 +110,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#get(java.lang.String)}.
      */
     @Test
-    public void testGetString() throws IOException {
+    void testGetString() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         assertEquals("test string", lm.get("test.test"));
@@ -120,7 +120,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#get(java.lang.String)}.
      */
     @Test
-    public void testGetStringFail() throws IOException {
+    void testGetStringFail() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         assertNull(lm.get("test.test.test"));
@@ -130,7 +130,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#getOrDefault(java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testGetOrDefaultStringString() throws IOException {
+    void testGetOrDefaultStringString() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         assertEquals("test string", lm.getOrDefault("test.test", ""));
@@ -140,7 +140,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#getOrDefault(java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testGetOrDefaultStringStringFail() throws IOException {
+    void testGetOrDefaultStringStringFail() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         assertEquals("", lm.getOrDefault("test.test.test",""));
@@ -150,7 +150,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#get(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testGetNullUserString() throws IOException {
+    void testGetNullUserString() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         User user = null;
@@ -161,7 +161,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#get(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testGetUserString() throws IOException {
+    void testGetUserString() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         User user = mock(User.class);
@@ -173,7 +173,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#getOrDefault(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testGetOrDefaultUserStringString() throws IOException {
+    void testGetOrDefaultUserStringString() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         User user = mock(User.class);
@@ -185,7 +185,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#get(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testGetCanadianUserString() throws IOException {
+    void testGetCanadianUserString() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         User user = mock(User.class);
@@ -197,7 +197,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#get(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testGetUserStringFail() throws IOException {
+    void testGetUserStringFail() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         User user = mock(User.class);
@@ -209,7 +209,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#getOrDefault(world.bentobox.bentobox.api.user.User, java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testGetOrDefaultUserStringStringFail() throws IOException {
+    void testGetOrDefaultUserStringStringFail() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         User user = mock(User.class);
@@ -222,7 +222,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#getAvailableLocales(boolean)}.
      */
     @Test
-    public void testGetAvailableLocales() throws IOException {
+    void testGetAvailableLocales() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
 
@@ -241,7 +241,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#getLanguages()}.
      */
     @Test
-    public void testGetLanguages() throws IOException {
+    void testGetLanguages() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         lm.getLanguages().forEach((k,v) -> assertEquals(k.toLanguageTag(), v.toLanguageTag()));
@@ -251,7 +251,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#reloadLanguages()}.
      */
     @Test
-    public void testReloadLanguagesNoAddons() throws IOException {
+    void testReloadLanguagesNoAddons() throws IOException {
         AddonsManager am = mock(AddonsManager.class);
         List<Addon> none = new ArrayList<>();
         when(am.getAddons()).thenReturn(none);
@@ -268,7 +268,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#reloadLanguages()}.
      */
     @Test
-    public void testReloadLanguages() throws IOException {
+    void testReloadLanguages() throws IOException {
         AddonsManager am = mock(AddonsManager.class);
         List<Addon> none = new ArrayList<>();
         Addon addon = mock(Addon.class);
@@ -364,7 +364,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#reloadLanguages()}.
      */
     @Test
-    public void testReloadLanguagesNoLocaleFolder() throws IOException {
+    void testReloadLanguagesNoLocaleFolder() throws IOException {
         AddonsManager am = mock(AddonsManager.class);
         List<Addon> none = new ArrayList<>();
         when(am.getAddons()).thenReturn(none);
@@ -380,7 +380,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#setTranslation(Locale, String, String)}.
      */
     @Test
-    public void testSetTranslationUnknownLocale() throws IOException {
+    void testSetTranslationUnknownLocale() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         assertFalse(lm.setTranslation(Locale.GERMAN, "anything.ref", "a translation"));
@@ -391,7 +391,7 @@ public class LocalesManagerTest  extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.LocalesManager#setTranslation(Locale, String, String)}.
      */
     @Test
-    public void testSetTranslationKnownLocale() throws IOException {
+    void testSetTranslationKnownLocale() throws IOException {
         makeFakeLocaleFile();
         LocalesManager lm = new LocalesManager(plugin);
         assertEquals("test string", lm.get("test.test"));

--- a/src/test/java/world/bentobox/bentobox/managers/PlaceholdersManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PlaceholdersManagerTest.java
@@ -28,7 +28,7 @@ import world.bentobox.bentobox.lists.GameModePlaceholder;
  * @author tastybento
  * @since 1.5.0
  */
-public class PlaceholdersManagerTest extends CommonTestSetup {
+class PlaceholdersManagerTest extends CommonTestSetup {
 
     @Mock
     private GameModeAddon addon;
@@ -79,7 +79,7 @@ public class PlaceholdersManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.PlaceholdersManager#registerDefaultPlaceholders(GameModeAddon)}.
      */
     @Test
-    public void testRegisterGameModePlaceholdersAllDefaults() {
+    void testRegisterGameModePlaceholdersAllDefaults() {
         pm.registerDefaultPlaceholders(addon);
         // + 304 because we register team member placeholders up to 50 members (6 per member * 50 = 300) + 4 extra
         // All registrations now use the 4-arg overload (addon, placeholder, description, replacer)
@@ -91,7 +91,7 @@ public class PlaceholdersManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.PlaceholdersManager#registerDefaultPlaceholders(GameModeAddon)}.
      */
     @Test
-    public void testRegisterDefaultPlaceholdersSomePreregistered() {
+    void testRegisterDefaultPlaceholdersSomePreregistered() {
         // Some duplicates
         when(hook.isPlaceholder(any(), any())).thenReturn(false, true, true, false, false, true, false);
 

--- a/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
@@ -57,7 +57,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class PlayersManagerTest extends CommonTestSetup {
+class PlayersManagerTest extends CommonTestSetup {
 
     private AbstractDatabaseHandler<Players> playerHandler;
     private AbstractDatabaseHandler<Names> namesHandler;
@@ -251,7 +251,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#addDeath(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testAddDeath() {
+    void testAddDeath() {
         int deaths = pm.getDeaths(world, uuid);
         pm.addDeath(world, uuid);
         assertEquals(deaths + 1, pm.getDeaths(world, uuid));
@@ -262,7 +262,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#addReset(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testAddReset() {
+    void testAddReset() {
         int resets = pm.getResets(world, uuid);
         pm.addReset(world, uuid);
         assertEquals(resets + 1, pm.getResets(world, uuid));
@@ -273,7 +273,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#cleanLeavingPlayer(World, User, boolean)}.
      */
     @Test
-    public void testCleanLeavingPlayerKicked() {
+    void testCleanLeavingPlayerKicked() {
         // Player is kicked
         pm.cleanLeavingPlayer(world, user, true, island);
         // Tamed animals
@@ -296,7 +296,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.PlayersManager#cleanLeavingPlayer(World, User, boolean)}.
      */
     @Test
-    public void testCleanLeavingPlayerKickedOffline() {
+    void testCleanLeavingPlayerKickedOffline() {
         when(user.isOnline()).thenReturn(false);
         // Player is kicked
         pm.cleanLeavingPlayer(world, user, true, island);
@@ -321,7 +321,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#cleanLeavingPlayer(World, User, boolean)}.
      */
     @Test
-    public void testCleanLeavingPlayerLeave() {
+    void testCleanLeavingPlayerLeave() {
         pm.cleanLeavingPlayer(world, user, false, island);
         // Tamed animals
         verify(tamed).setOwner(null);
@@ -344,7 +344,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getDeaths(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testGetDeaths() {
+    void testGetDeaths() {
         assertEquals(0, pm.getDeaths(world, uuid));
     }
 
@@ -353,7 +353,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getLocale(java.util.UUID)}.
      */
     @Test
-    public void testGetLocale() {
+    void testGetLocale() {
         assertTrue(pm.getLocale(uuid).isEmpty());
     }
 
@@ -362,7 +362,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getName(java.util.UUID)}.
      */
     @Test
-    public void testGetNameNull()  {
+    void testGetNameNull()  {
         // Null UUID
         assertTrue(pm.getName(null).isEmpty());
     }
@@ -372,7 +372,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getName(java.util.UUID)}.
      */
     @Test
-    public void testGetNameKnown()  {
+    void testGetNameKnown()  {
         pm.setPlayerName(user);
         // Known UUID
         assertEquals("tastybento", pm.getName(uuid));
@@ -383,7 +383,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getName(java.util.UUID)}.
      */
     @Test
-    public void testGetNameUnknown()  {
+    void testGetNameUnknown()  {
         assertEquals("", pm.getName(notThere));
     }
 
@@ -392,7 +392,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getPlayers()}.
      */
     @Test
-    public void testGetPlayers() {
+    void testGetPlayers() {
         assertTrue(pm.getPlayers().isEmpty());
     }
 
@@ -401,7 +401,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getResets(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testGetResets() {
+    void testGetResets() {
         assertEquals(0, pm.getResets(world, uuid));
     }
 
@@ -410,7 +410,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getResetsLeft(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testGetResetsLeft() {
+    void testGetResetsLeft() {
         assertEquals(0, pm.getResetsLeft(world, uuid));
     }
 
@@ -419,7 +419,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#setResets(World, UUID, int)}.
      */
     @Test
-    public void testGetSetResetsLeft()  {
+    void testGetSetResetsLeft()  {
         // Add a player
         pm.getPlayer(uuid);
         assertEquals(0, pm.getResets(world, uuid));
@@ -432,7 +432,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getUser(java.lang.String)}.
      */
     @Test
-    public void testGetUserString()  {
+    void testGetUserString()  {
         User user = pm.getUser("random");
         assertNull(user);
         pm.getPlayer(uuid);
@@ -445,7 +445,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getUser(java.util.UUID)}.
      */
     @Test
-    public void testGetUserUUID() {
+    void testGetUserUUID() {
         UUID uuid = pm.getUUID("unknown");
         assertNull(uuid);
     }
@@ -455,7 +455,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
      */
     @Test
-    public void testGetUUID() {
+    void testGetUUID() {
         pm.getPlayer(uuid);
         assertEquals(uuid, pm.getUUID("tastybento"));
         assertNull(pm.getUUID("unknown"));
@@ -466,7 +466,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
      */
     @Test
-    public void testGetUUIDOfflinePlayer() {
+    void testGetUUIDOfflinePlayer() {
         pm.setHandler(db);
         // Add a player to the cache
         pm.getPlayer(uuid);
@@ -479,7 +479,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
      */
     @Test
-    public void testGetUUIDUnknownPlayer() {
+    void testGetUUIDUnknownPlayer() {
         pm.setHandler(db);
         // Add a player to the cache
         pm.getPlayer(uuid);
@@ -492,7 +492,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
      */
     @Test
-    public void testGetUUIDwithUUID() {
+    void testGetUUIDwithUUID() {
         assertEquals(uuid, pm.getUUID(uuid.toString()));
     }
 
@@ -501,7 +501,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#isInTeleport(java.util.UUID)}.
      */
     @Test
-    public void testIsInTeleport() {
+    void testIsInTeleport() {
         assertFalse(pm.isInTeleport(uuid));
     }
 
@@ -510,7 +510,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#isKnown(java.util.UUID)}.
      */
     @Test
-    public void testIsKnown() {
+    void testIsKnown() {
 
         pm.getPlayer(uuid);
         pm.getPlayer(notUUID);
@@ -525,7 +525,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#setHandler(Database)}
      */
     @Test
-    public void testSetHandler() {
+    void testSetHandler() {
         pm.setHandler(db);
     }
 
@@ -534,7 +534,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#PlayersManager(world.bentobox.bentobox.BentoBox)}.
      */
     @Test
-    public void testPlayersManager() {
+    void testPlayersManager() {
         assertNotNull(pm);
     }
 
@@ -543,7 +543,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#removeInTeleport(java.util.UUID)}.
      */
     @Test
-    public void testRemoveInTeleport() {
+    void testRemoveInTeleport() {
         pm.setInTeleport(uuid);
         assertTrue(pm.isInTeleport(uuid));
         pm.removeInTeleport(uuid);
@@ -555,7 +555,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#removePlayer(org.bukkit.entity.Player)}.
      */
     @Test
-    public void testRemovePlayer() {
+    void testRemovePlayer() {
         this.testGetUUID();
         pm.removePlayer(p);
         assertNull(pm.getUUID("tastybeto"));
@@ -566,7 +566,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#setPlayerName(world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testSetandGetPlayerName() {
+    void testSetandGetPlayerName() {
         pm.setHandler(db);
         // Add a player
         pm.getPlayer(uuid);
@@ -580,7 +580,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#setDeaths(org.bukkit.World, java.util.UUID, int)}.
      */
     @Test
-    public void testSetDeaths() {
+    void testSetDeaths() {
         pm.setDeaths(world, uuid, 50);
         assertEquals(50, pm.getDeaths(world, uuid));
 
@@ -591,7 +591,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#setInTeleport(java.util.UUID)}.
      */
     @Test
-    public void testSetInTeleport() {
+    void testSetInTeleport() {
         assertFalse(pm.isInTeleport(uuid));
         pm.setInTeleport(uuid);
         assertTrue(pm.isInTeleport(uuid));
@@ -602,7 +602,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#setLocale(java.util.UUID, java.lang.String)}.
      */
     @Test
-    public void testSetLocale() {
+    void testSetLocale() {
         pm.setLocale(uuid, "en-UK");
         assertEquals("en-UK", pm.getLocale(uuid));
     }
@@ -615,7 +615,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * @throws IllegalAccessException 
      */
     @Test
-    public void testSetPlayerName() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+    void testSetPlayerName() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         pm.setPlayerName(user).thenAccept(result -> assertTrue(result));
     }
 
@@ -624,7 +624,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.PlayersManager#setResets(org.bukkit.World, java.util.UUID, int)}.
      */
     @Test
-    public void testSetResets() {
+    void testSetResets() {
         pm.setResets(world, uuid, 33);
         assertEquals(33, pm.getResets(world, uuid));
     }
@@ -633,7 +633,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.PlayersManager#getPlayer(java.util.UUID)}.
      */
     @Test
-    public void testGetPlayer() {
+    void testGetPlayer() {
         Players p = pm.getPlayer(uuid);
         assertNotNull(p);
     }
@@ -642,7 +642,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.PlayersManager#loadPlayer(java.util.UUID)}.
      */
     @Test
-    public void testLoadPlayer() {
+    void testLoadPlayer() {
         assertNotNull(pm.loadPlayer(uuid));
     }
 
@@ -650,7 +650,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.PlayersManager#getName(java.util.UUID)}.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         assertEquals("tastybento", pm.getName(uuid));
     }
 
@@ -658,7 +658,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.PlayersManager#cleanLeavingPlayer(org.bukkit.World, world.bentobox.bentobox.api.user.User, boolean, world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testCleanLeavingPlayer() {
+    void testCleanLeavingPlayer() {
         when(user.isOnline()).thenReturn(true);
         when(iwm.isOnLeaveResetEnderChest(world)).thenReturn(true);
         when(iwm.isOnLeaveResetInventory(world)).thenReturn(true);
@@ -684,7 +684,7 @@ public class PlayersManagerTest extends CommonTestSetup {
      * @throws IllegalAccessException 
      */
     @Test
-    public void testSavePlayer() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+    void testSavePlayer() throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         pm.savePlayer(uuid).thenAccept(result -> assertTrue(result));
     }
 

--- a/src/test/java/world/bentobox/bentobox/managers/RanksManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/RanksManagerTest.java
@@ -29,7 +29,7 @@ import world.bentobox.bentobox.database.objects.Ranks;
  * @author tastybento
  *
  */
-public class RanksManagerTest extends CommonTestSetup {
+class RanksManagerTest extends CommonTestSetup {
 
     private  AbstractDatabaseHandler<Ranks> handler;
 
@@ -73,7 +73,7 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#addRank(java.lang.String, int)}.
      */
     @Test
-    public void testAddRank() {
+    void testAddRank() {
         assertTrue(rm.addRank("test.rank.reference", 750));
     }
 
@@ -81,7 +81,7 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#removeRank(java.lang.String)}.
      */
     @Test
-    public void testRemoveRank() {
+    void testRemoveRank() {
         assertTrue(rm.addRank("test.rank.reference2", 650));
         assertTrue(rm.removeRank("test.rank.reference2"));
         // Second time should fail
@@ -92,7 +92,7 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#getRankValue(java.lang.String)}.
      */
     @Test
-    public void testGetRankValue() {
+    void testGetRankValue() {
         rm.addRank("test.rank.reference.value", 600);
         assertEquals(600, rm.getRankValue("test.rank.reference.value"));
     }
@@ -101,7 +101,7 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#getRanks()}.
      */
     @Test
-    public void testGetRanks() {
+    void testGetRanks() {
         Map<String, Integer> ranks = rm.getRanks();
         assertTrue(ranks.containsKey(RanksManager.BANNED_RANK_REF));
         assertTrue(ranks.containsKey(RanksManager.VISITOR_RANK_REF));
@@ -113,7 +113,7 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#getRankUpValue(int)}.
      */
     @Test
-    public void testGetNextRankValue() {
+    void testGetNextRankValue() {
         assertEquals(RanksManager.BANNED_RANK, rm.getRankUpValue(-20));
         assertEquals(RanksManager.VISITOR_RANK, rm.getRankUpValue(RanksManager.BANNED_RANK));
         assertEquals(RanksManager.COOP_RANK, rm.getRankUpValue(RanksManager.VISITOR_RANK));
@@ -126,7 +126,7 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#getRankDownValue(int)}.
      */
     @Test
-    public void testGetPreviousRankValue() {
+    void testGetPreviousRankValue() {
         // Lowest rank is Visitor
         assertEquals(RanksManager.VISITOR_RANK, rm.getRankDownValue(-20));
         assertEquals(RanksManager.VISITOR_RANK, rm.getRankDownValue(RanksManager.VISITOR_RANK));
@@ -138,7 +138,7 @@ public class RanksManagerTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.RanksManager#getRank(int)}.
      */
     @Test
-    public void testGetRank() {
+    void testGetRank() {
         assertEquals(RanksManager.BANNED_RANK_REF, rm.getRank(RanksManager.BANNED_RANK));
         assertEquals(RanksManager.VISITOR_RANK_REF, rm.getRank(RanksManager.VISITOR_RANK));
         assertEquals(RanksManager.MEMBER_RANK_REF, rm.getRank(RanksManager.MEMBER_RANK));

--- a/src/test/java/world/bentobox/bentobox/managers/island/DefaultNewIslandLocationStrategyTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/island/DefaultNewIslandLocationStrategyTest.java
@@ -28,7 +28,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
+class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
 
     private DefaultNewIslandLocationStrategy dnils;
 
@@ -97,7 +97,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#getNextLocation(org.bukkit.World)}.
      */
     @Test
-    public void testGetNextLocationSuccess() {
+    void testGetNextLocationSuccess() {
         assertEquals(location,dnils.getNextLocation(world));
         verify(im).setLast(location);
     }
@@ -106,7 +106,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#getNextLocation(org.bukkit.World)}.
      */
     @Test
-    public void testGetNextLocationFailBlocks() {
+    void testGetNextLocationFailBlocks() {
         when(adjBlock.getType()).thenReturn(Material.STONE);
         when(adjBlock.isEmpty()).thenReturn(false);
         assertNull(dnils.getNextLocation(world));
@@ -121,7 +121,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      */
     @SuppressWarnings("unchecked")
     @Test
-    public void testGetNextLocationSuccessSomeIslands() {
+    void testGetNextLocationSuccessSomeIslands() {
         Optional<Island> opIsland = Optional.of(new Island());
         Optional<Island> emptyIsland = Optional.empty();
         when(im.getIslandAt(any())).thenReturn(opIsland, opIsland, opIsland, opIsland, emptyIsland);
@@ -133,7 +133,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#getNextLocation(org.bukkit.World)}.
      */
     @Test
-    public void testGetNextLocationSuccessSomeIslands10() {
+    void testGetNextLocationSuccessSomeIslands10() {
         Optional<Island> opIsland = Optional.of(new Island());
         Optional<Island> emptyIsland = Optional.empty();
         count = 0;
@@ -146,7 +146,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandIslandFound() {
+    void testIsIslandIslandFound() {
         Optional<Island> opIsland = Optional.of(new Island());
         when(im.getIslandAt(any())).thenReturn(opIsland);
         assertEquals(Result.ISLAND_FOUND, dnils.isIsland(location));
@@ -156,7 +156,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandIslandInDeletion() {
+    void testIsIslandIslandInDeletion() {
         when(idm.inDeletion(any())).thenReturn(true);
         assertEquals(Result.ISLAND_FOUND, dnils.isIsland(location));
     }
@@ -165,7 +165,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandChunkNotGenerated() {
+    void testIsIslandChunkNotGenerated() {
         mockedUtil.when(() -> Util.isChunkGenerated(any())).thenReturn(false);
         assertEquals(Result.FREE, dnils.isIsland(location));
     }
@@ -174,7 +174,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandUseOwnGenerator() {
+    void testIsIslandUseOwnGenerator() {
         when(iwm.isUseOwnGenerator(world)).thenReturn(true);
         assertEquals(Result.FREE, dnils.isIsland(location));
     }
@@ -183,7 +183,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandFreeAirBlocks() {
+    void testIsIslandFreeAirBlocks() {
         assertEquals(Result.FREE, dnils.isIsland(location));
     }
 
@@ -191,7 +191,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandFreeWaterBlocks() {
+    void testIsIslandFreeWaterBlocks() {
         when(adjBlock.getType()).thenReturn(Material.WATER);
         when(adjBlock.isEmpty()).thenReturn(false);
         assertEquals(Result.FREE, dnils.isIsland(location));
@@ -201,7 +201,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandBlocksInArea() {
+    void testIsIslandBlocksInArea() {
         when(adjBlock.getType()).thenReturn(Material.STONE);
         when(adjBlock.isEmpty()).thenReturn(false);
         assertEquals(Result.BLOCKS_IN_AREA, dnils.isIsland(location));
@@ -211,7 +211,7 @@ public class DefaultNewIslandLocationStrategyTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.DefaultNewIslandLocationStrategy#isIsland(org.bukkit.Location)}.
      */
     @Test
-    public void testIsIslandBlocksInAreaNoCheck() {
+    void testIsIslandBlocksInAreaNoCheck() {
         when(iwm.isCheckForBlocks(any())).thenReturn(false);
         when(adjBlock.getType()).thenReturn(Material.STONE);
         when(adjBlock.isEmpty()).thenReturn(false);

--- a/src/test/java/world/bentobox/bentobox/managers/island/IslandCacheTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/island/IslandCacheTest.java
@@ -44,7 +44,7 @@ import world.bentobox.bentobox.database.DatabaseSetup;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 
-public class IslandCacheTest extends CommonTestSetup {
+class IslandCacheTest extends CommonTestSetup {
 
     private AbstractDatabaseHandler<Island> handler;
     // UUID
@@ -126,7 +126,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#addIsland(Island)}
      */
     @Test
-    public void testAddIsland() {
+    void testAddIsland() {
         assertTrue(ic.addIsland(island));
         assertEquals(island, ic.getIslandAt(island.getCenter()));
         // Check if they are added
@@ -137,7 +137,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#addPlayer(UUID, Island)}
      */
     @Test
-    public void testAddPlayer() {
+    void testAddPlayer() {
         ic.addIsland(island);
         UUID playerUUID = UUID.randomUUID();
         ic.addPlayer(playerUUID, island);
@@ -151,7 +151,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#clear()}
      */
     @Test
-    public void testClear() {
+    void testClear() {
         ic.addIsland(island);
         // Check if they are added
         assertEquals(island, ic.getIsland(world, owner));
@@ -163,7 +163,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#getIsland(World, UUID)}
      */
     @Test
-    public void testGetUUID() {
+    void testGetUUID() {
         ic.addIsland(island);
         // Check if they are added
         assertEquals(island, ic.getIsland(world, owner));
@@ -179,7 +179,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * @throws InstantiationException 
      */
     @Test
-    public void testGetIslandAtLocation() throws InstantiationException, IllegalAccessException,
+    void testGetIslandAtLocation() throws InstantiationException, IllegalAccessException,
             InvocationTargetException, ClassNotFoundException, NoSuchMethodException, IntrospectionException {
         // Set coords to be in island space
         when(island.inIslandSpace(any(Integer.class), any(Integer.class))).thenReturn(true);
@@ -203,7 +203,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#hasIsland(World, UUID)}
      */
     @Test
-    public void testHasIsland() {
+    void testHasIsland() {
         ic.addIsland(island);
 
         assertTrue(ic.hasIsland(world, owner));
@@ -214,7 +214,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#removePlayer(World, UUID)}
      */
     @Test
-    public void testRemovePlayer() {
+    void testRemovePlayer() {
         ic.addIsland(island);
         assertTrue(ic.hasIsland(world, owner));
         assertTrue(ic.hasIsland(world, owner));
@@ -228,7 +228,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#size()}
      */
     @Test
-    public void testSize() {
+    void testSize() {
         ic.addIsland(island);
         assertEquals(1, ic.size());
     }
@@ -237,7 +237,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#setOwner(Island, UUID)}
      */
     @Test
-    public void testSetOwner() {
+    void testSetOwner() {
         ic.addIsland(island);
         UUID newOwnerUUID = UUID.randomUUID();
         ic.setOwner(island, newOwnerUUID);
@@ -251,7 +251,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * {@link IslandCache#resetFlag(World, world.bentobox.bentobox.api.flags.Flag)}
      */
     @Test
-    public void testResetFlag() {
+    void testResetFlag() {
         ic.addIsland(island);
         ic.resetFlag(world, flag);
         verify(island).setFlag(flag, 400);
@@ -261,7 +261,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test for {@link IslandCache#resetAllFlags(World)}
      */
     @Test
-    public void testResetAllFlags() {
+    void testResetAllFlags() {
         ic.addIsland(island);
         BukkitScheduler scheduler = mock(BukkitScheduler.class);
         mockedBukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
@@ -274,7 +274,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#IslandCache(world.bentobox.bentobox.database.Database)}.
      */
     @Test
-    public void testIslandCache() {
+    void testIslandCache() {
         assertNotNull(ic);
     }
 
@@ -282,7 +282,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#updateMultiLibIsland(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testUpdateMultiLibIsland() {
+    void testUpdateMultiLibIsland() {
         // Add island to cache
         ic.setIslandById(island);
         // Copy island
@@ -298,7 +298,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#deleteIslandFromCache(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testDeleteIslandFromCacheIsland() {
+    void testDeleteIslandFromCacheIsland() {
         // Fill the cache
         ic.addIsland(island);
         ic.setIslandById(island);
@@ -315,7 +315,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#deleteIslandFromCache(java.lang.String)}.
      */
     @Test
-    public void testDeleteIslandFromCacheString() {
+    void testDeleteIslandFromCacheString() {
         // Fill the cache
         ic.addIsland(island);
         ic.setIslandById(island);
@@ -327,7 +327,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIsland(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testGetIsland() {
+    void testGetIsland() {
         assertNull(ic.getIsland(world, owner));
     }
 
@@ -335,7 +335,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslands(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testGetIslandsWorldUUID() {
+    void testGetIslandsWorldUUID() {
         assertNull(ic.getIsland(world, this.owner));
     }
 
@@ -343,7 +343,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#setPrimaryIsland(java.util.UUID, world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testSetPrimaryIsland() {
+    void testSetPrimaryIsland() {
         ic.setPrimaryIsland(owner, island);
     }
 
@@ -351,7 +351,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslandAt(org.bukkit.Location)}.
      */
     @Test
-    public void testGetIslandAt() {
+    void testGetIslandAt() {
         ic.addIsland(island);
         ic.setIslandById(island);
         assertEquals(island, ic.getIslandAt(location));
@@ -361,7 +361,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslands()}.
      */
     @Test
-    public void testGetIslands() {
+    void testGetIslands() {
         assertTrue(ic.getIslands().isEmpty());
     }
 
@@ -369,7 +369,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslands(org.bukkit.World)}.
      */
     @Test
-    public void testGetIslandsWorld() {
+    void testGetIslandsWorld() {
         assertTrue(ic.getIslands(world).isEmpty());
     }
 
@@ -377,7 +377,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#removePlayer(org.bukkit.World, java.util.UUID)}.
      */
     @Test
-    public void testRemovePlayerWorldUUID() {
+    void testRemovePlayerWorldUUID() {
         assertTrue(ic.getIslands(owner).isEmpty());
     }
 
@@ -385,7 +385,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#removePlayer(world.bentobox.bentobox.database.objects.Island, java.util.UUID)}.
      */
     @Test
-    public void testRemovePlayerIslandUUID() {
+    void testRemovePlayerIslandUUID() {
         ic.addIsland(island);
         ic.setIslandById(island);
         ic.removePlayer(island, owner);
@@ -395,7 +395,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#size(org.bukkit.World)}.
      */
     @Test
-    public void testSizeWorld() {
+    void testSizeWorld() {
         assertEquals(0, ic.size(world));
     }
 
@@ -403,7 +403,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslandById(java.lang.String)}.
      */
     @Test
-    public void testGetIslandById() {
+    void testGetIslandById() {
         ic.addIsland(island);
         ic.setIslandById(island);
 
@@ -414,7 +414,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getAllIslandIds()}.
      */
     @Test
-    public void testGetAllIslandIds() {
+    void testGetAllIslandIds() {
         assertTrue(ic.getAllIslandIds().isEmpty());
     }
 
@@ -422,7 +422,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslands(java.util.UUID)}.
      */
     @Test
-    public void testGetIslandsUUID() {
+    void testGetIslandsUUID() {
         assertTrue(ic.getIslands(owner).isEmpty());
     }
 
@@ -436,7 +436,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * @throws InstantiationException 
      */
     @Test
-    public void testGetIslandsUUIDNoIslands() throws InstantiationException, IllegalAccessException,
+    void testGetIslandsUUIDNoIslands() throws InstantiationException, IllegalAccessException,
             InvocationTargetException, ClassNotFoundException, NoSuchMethodException, IntrospectionException {
         // Test is WIP.
         when(handler.loadObject(anyString())).thenReturn(null);
@@ -447,7 +447,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#addIsland(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testAddIslandIslandNullWorld() {
+    void testAddIslandIslandNullWorld() {
         // Null world
         when(island.getWorld()).thenReturn(null);
         assertFalse(ic.addIsland(island));
@@ -457,7 +457,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#addIsland(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testAddIslandIslandNullCenter() {
+    void testAddIslandIslandNullCenter() {
         // Try to add an island with a null center
         when(island.getCenter()).thenReturn(null);
         assertFalse(ic.addIsland(island));
@@ -467,7 +467,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#addIsland(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testAddIslandIslandDuplicate() {
+    void testAddIslandIslandDuplicate() {
         assertTrue(ic.addIsland(island));
         assertTrue(ic.addIsland(island)); // Okay to add
     }
@@ -476,7 +476,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#addIsland(world.bentobox.bentobox.database.objects.Island, boolean)}.
      */
     @Test
-    public void testAddIslandIslandBooleanNullWorld() {
+    void testAddIslandIslandBooleanNullWorld() {
         // Null world
         when(island.getWorld()).thenReturn(null);
         assertFalse(ic.addIsland(island, true));
@@ -487,7 +487,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#addIsland(world.bentobox.bentobox.database.objects.Island, boolean)}.
      */
     @Test
-    public void testAddIslandIslandBooleanNullCenter() {
+    void testAddIslandIslandBooleanNullCenter() {
         // Try to add an island with a null center
         when(island.getCenter()).thenReturn(null);
         assertFalse(ic.addIsland(island, true));
@@ -498,7 +498,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#addIsland(world.bentobox.bentobox.database.objects.Island, boolean)}.
      */
     @Test
-    public void testAddIslandIslandBooleanDuplicate() {
+    void testAddIslandIslandBooleanDuplicate() {
         // Duplicate
         assertTrue(ic.addIsland(island, true));
         assertTrue(ic.addIsland(island, true));
@@ -513,7 +513,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#loadIsland(java.lang.String)}.
      */
     @Test
-    public void testLoadIsland() {
+    void testLoadIsland() {
         assertNull(ic.loadIsland(""));
         assertNotNull(ic.loadIsland("uniqueId"));
     }
@@ -522,7 +522,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getCachedIslands()}.
      */
     @Test
-    public void testGetCachedIslands() {
+    void testGetCachedIslands() {
         assertTrue(ic.getCachedIslands().isEmpty());
     }
 
@@ -530,7 +530,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslandById(java.lang.String)}.
      */
     @Test
-    public void testGetIslandByIdString() {
+    void testGetIslandByIdString() {
         assertNotNull(ic.getIslandById("uniqueId"));
         assertTrue(ic.isIslandCached("uniqueId"));
     }
@@ -539,7 +539,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#getIslandById(java.lang.String, boolean)}.
      */
     @Test
-    public void testGetIslandByIdStringBoolean() {
+    void testGetIslandByIdStringBoolean() {
         assertNotNull(ic.getIslandById("uniqueId", false));
         assertFalse(ic.isIslandCached("uniqueId"));
     }
@@ -548,7 +548,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#expireIslandById(java.lang.String)}.
      */
     @Test
-    public void testExpireIslandById() {
+    void testExpireIslandById() {
         // Fill the cache
         ic.addIsland(island);
         ic.setIslandById(island);
@@ -564,7 +564,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#setIslandById(world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testSetIslandById() {
+    void testSetIslandById() {
         assertFalse(ic.isIslandId("uniqueId"));
         ic.setIslandById(island);
         assertTrue(ic.isIslandId("uniqueId"));
@@ -574,7 +574,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#isIslandId(java.lang.String)}.
      */
     @Test
-    public void testIsIslandId() {
+    void testIsIslandId() {
         assertFalse(ic.isIslandId("uniqueId"));
     }
 
@@ -582,7 +582,7 @@ public class IslandCacheTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.IslandCache#isIslandCached(java.lang.String)}.
      */
     @Test
-    public void testIsIslandCached() {
+    void testIsIslandCached() {
         assertFalse(ic.isIslandCached("uniqueId"));
     }
 

--- a/src/test/java/world/bentobox/bentobox/managers/island/IslandGridTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/island/IslandGridTest.java
@@ -21,7 +21,7 @@ import world.bentobox.bentobox.managers.island.IslandGrid.IslandData;
 /**
  * Grid test
  */
-public class IslandGridTest extends CommonTestSetup {
+class IslandGridTest extends CommonTestSetup {
 
     private IslandGrid ig;
     @Mock

--- a/src/test/java/world/bentobox/bentobox/managers/island/NewIslandTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/island/NewIslandTest.java
@@ -50,7 +50,7 @@ import world.bentobox.bentobox.util.Util;
  * @author tastybento
  *
  */
-public class NewIslandTest extends CommonTestSetup {
+class NewIslandTest extends CommonTestSetup {
 
     private static final String NAME = "name";
     @Mock
@@ -170,7 +170,7 @@ public class NewIslandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilderNoUser() {
+    void testBuilderNoUser() {
         try {
             NewIsland.builder().build();
         } catch (Exception e) {
@@ -183,7 +183,7 @@ public class NewIslandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilder() throws Exception {
+    void testBuilder() throws Exception {
         NewIsland.builder().addon(addon).name(NAME).player(user).noPaste().reason(Reason.CREATE).oldIsland(oldIsland)
                 .build();
         // Verifications
@@ -202,7 +202,7 @@ public class NewIslandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilderReset() throws Exception {
+    void testBuilderReset() throws Exception {
         when(builder.build()).thenReturn(ire);
         NewIsland.builder().addon(addon).name(NAME).player(user).noPaste().reason(Reason.RESET).oldIsland(oldIsland).build();
         // Verifications
@@ -222,7 +222,7 @@ public class NewIslandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilderNoOldIsland() throws Exception {
+    void testBuilderNoOldIsland() throws Exception {
         NewIsland.builder().addon(addon).name(NAME).player(user).noPaste().reason(Reason.CREATE).build();
         // Verifications
         mockedIslandsManager.verify(() -> IslandsManager.updateIsland(island));
@@ -240,7 +240,7 @@ public class NewIslandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilderNoOldIslandPasteNoNMS() throws Exception {
+    void testBuilderNoOldIslandPasteNoNMS() throws Exception {
         when(location.distance(any())).thenReturn(30D);
         NewIsland.builder().addon(addon).name(NAME).player(user).reason(Reason.CREATE).build();
         // Verifications
@@ -259,7 +259,7 @@ public class NewIslandTest extends CommonTestSetup {
      * {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilderNoOldIslandPasteWithNMS() throws Exception {
+    void testBuilderNoOldIslandPasteWithNMS() throws Exception {
         NewIsland.builder().addon(addon).name(NAME).player(user).reason(Reason.CREATE).build();
         // Verifications
         mockedIslandsManager.verify(() -> IslandsManager.updateIsland(island));
@@ -276,7 +276,7 @@ public class NewIslandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilderHasIsland() throws Exception {
+    void testBuilderHasIsland() throws Exception {
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         NewIsland.builder().addon(addon).name(NAME).player(user).noPaste().reason(Reason.CREATE).oldIsland(oldIsland).build();
         // Verifications
@@ -296,7 +296,7 @@ public class NewIslandTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.managers.island.NewIsland#builder()}.
      */
     @Test
-    public void testBuilderHasIslandFail() throws Exception {
+    void testBuilderHasIslandFail() throws Exception {
         when(im.getIsland(any(), any(User.class))).thenReturn(null);
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         NewIsland.builder().addon(addon).name(NAME).player(user).noPaste().reason(Reason.CREATE).oldIsland(oldIsland).build();
@@ -317,7 +317,7 @@ public class NewIslandTest extends CommonTestSetup {
      */
     @Test
     @Disabled("Not done")
-    public void testBuilderHasIslandFailnoReserve() throws Exception {
+    void testBuilderHasIslandFailnoReserve() throws Exception {
         when(island.isReserved()).thenReturn(false);
         when(im.hasIsland(any(), any(User.class))).thenReturn(true);
         NewIsland.builder().addon(addon).name(NAME).player(user).noPaste().reason(Reason.CREATE).oldIsland(oldIsland).build();

--- a/src/test/java/world/bentobox/bentobox/panels/BlueprintManagementPanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/BlueprintManagementPanelTest.java
@@ -35,7 +35,7 @@ import world.bentobox.bentobox.managers.BlueprintsManager;
  * @author tastybento
  *
  */
-public class BlueprintManagementPanelTest extends CommonTestSetup {
+class BlueprintManagementPanelTest extends CommonTestSetup {
 
     @Mock
     private User user;
@@ -121,7 +121,7 @@ public class BlueprintManagementPanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.BlueprintManagementPanel#openPanel()}.
      */
     @Test
-    public void testOpenPanel() {
+    void testOpenPanel() {
         bmp.openPanel();
         verify(bpm).getBlueprintBundles(addon);
     }
@@ -130,7 +130,7 @@ public class BlueprintManagementPanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.BlueprintManagementPanel#openBB(world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle)}.
      */
     @Test
-    public void testOpenBB() {
+    void testOpenBB() {
         bmp.openBB(bb);
         verify(bb).getDisplayName();
         verify(bb, times(3)).getBlueprint(any());
@@ -140,7 +140,7 @@ public class BlueprintManagementPanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.BlueprintManagementPanel#getBundleIcon(world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle)}.
      */
     @Test
-    public void testGetBundleIcon() {
+    void testGetBundleIcon() {
         PanelItem pi = bmp.getBundleIcon(bb);
         assertEquals("commands.admin.blueprint.management.edit-description", pi.getName());
         assertEquals(Material.STONE, pi.getItem().getType());
@@ -151,7 +151,7 @@ public class BlueprintManagementPanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.BlueprintManagementPanel#getBlueprintItem(world.bentobox.bentobox.api.addons.GameModeAddon, int, world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle, world.bentobox.bentobox.blueprints.Blueprint)}.
      */
     @Test
-    public void testGetBlueprintItem() {
+    void testGetBlueprintItem() {
         PanelItem pi = bmp.getBlueprintItem(addon, 0, bb, blueprint);
         assertEquals("blueprint name", pi.getName());
         assertEquals(Material.PAPER, pi.getItem().getType());
@@ -162,7 +162,7 @@ public class BlueprintManagementPanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.BlueprintManagementPanel#getBlueprintItem(world.bentobox.bentobox.api.addons.GameModeAddon, int, world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle, world.bentobox.bentobox.blueprints.Blueprint)}.
      */
     @Test
-    public void testGetBlueprintItemWithDisplayNameAndIcon() {
+    void testGetBlueprintItemWithDisplayNameAndIcon() {
         when(blueprint.getDisplayName()).thenReturn("Display Name");
         when(blueprint.getIcon()).thenReturn(Material.BEACON);
         PanelItem pi = bmp.getBlueprintItem(addon, 0, bb, blueprint);
@@ -175,7 +175,7 @@ public class BlueprintManagementPanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.BlueprintManagementPanel#getBlueprintItem(world.bentobox.bentobox.api.addons.GameModeAddon, int, world.bentobox.bentobox.blueprints.dataobjects.BlueprintBundle, world.bentobox.bentobox.blueprints.Blueprint)}.
      */
     @Test
-    public void testGetBlueprintItemWithDisplayNameAndIconInWorldSlot() {
+    void testGetBlueprintItemWithDisplayNameAndIconInWorldSlot() {
         when(blueprint.getDisplayName()).thenReturn("Display Name");
         when(blueprint.getIcon()).thenReturn(Material.BEACON);
         PanelItem pi = bmp.getBlueprintItem(addon, 5, bb, blueprint);

--- a/src/test/java/world/bentobox/bentobox/panels/PlaceholderListPanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/PlaceholderListPanelTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.managers.PlaceholdersManager;
  *
  * @since 3.2.0
  */
-public class PlaceholderListPanelTest extends CommonTestSetup {
+class PlaceholderListPanelTest extends CommonTestSetup {
 
     /** Created manually so we can set a custom default Answer for getTranslation. */
     private User user;
@@ -117,13 +117,13 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelCoreNoPlaceholders() {
+    void testOpenPanelCoreNoPlaceholders() {
         assertDoesNotThrow(() -> PlaceholderListPanel.openPanel(command, user, null));
         verify(phm).getRegisteredBentoBoxPlaceholders();
     }
 
     @Test
-    public void testOpenPanelCoreWithPlaceholders() {
+    void testOpenPanelCoreWithPlaceholders() {
         when(phm.getRegisteredBentoBoxPlaceholders())
                 .thenReturn(Set.of("version", "online_players", "max_players"));
         when(phm.getPlaceholderDescription(eq("version")))
@@ -138,13 +138,13 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelAddonNoPlaceholders() {
+    void testOpenPanelAddonNoPlaceholders() {
         assertDoesNotThrow(() -> PlaceholderListPanel.openPanel(command, user, addon));
         verify(phm).getRegisteredPlaceholders(addon);
     }
 
     @Test
-    public void testOpenPanelAddonWithPlaceholders() {
+    void testOpenPanelAddonWithPlaceholders() {
         when(phm.getRegisteredPlaceholders(addon))
                 .thenReturn(Set.of("island_level", "island_rank"));
         when(phm.getPlaceholderDescription(eq(addon), eq("island_level")))
@@ -158,7 +158,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelWithNumericSeries() {
+    void testOpenPanelWithNumericSeries() {
         when(phm.getRegisteredBentoBoxPlaceholders())
                 .thenReturn(Set.of(
                         "island_member_name_1", "island_member_name_2",
@@ -171,7 +171,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelMixedPlaceholders() {
+    void testOpenPanelMixedPlaceholders() {
         when(phm.getRegisteredBentoBoxPlaceholders())
                 .thenReturn(Set.of(
                         "version",
@@ -182,7 +182,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelDisabledCorePlaceholder() {
+    void testOpenPanelDisabledCorePlaceholder() {
         when(phm.getRegisteredBentoBoxPlaceholders()).thenReturn(Set.of("version"));
         when(phm.isPlaceholderEnabled("version")).thenReturn(false);
 
@@ -191,7 +191,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelDisabledAddonPlaceholder() {
+    void testOpenPanelDisabledAddonPlaceholder() {
         when(phm.getRegisteredPlaceholders(addon)).thenReturn(Set.of("island_level"));
         when(phm.isPlaceholderEnabled(addon, "island_level")).thenReturn(false);
 
@@ -200,7 +200,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelLongDescription() {
+    void testOpenPanelLongDescription() {
         String longDesc = "This is a very long description that should definitely exceed the "
                 + "thirty-eight character line width limit and therefore be wrapped across "
                 + "multiple lines when rendered in the panel lore.";
@@ -211,7 +211,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testAddonExpansionId() {
+    void testAddonExpansionId() {
         when(phm.getRegisteredPlaceholders(addon)).thenReturn(Set.of("island_level"));
 
         assertDoesNotThrow(() -> PlaceholderListPanel.openPanel(command, user, addon));
@@ -220,7 +220,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelManyPlaceholders() {
+    void testOpenPanelManyPlaceholders() {
         Set<String> keys = new java.util.LinkedHashSet<>();
         for (int i = 1; i <= 35; i++) {
             keys.add("placeholder_key_x" + i);
@@ -231,7 +231,7 @@ public class PlaceholderListPanelTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOpenPanelSingleNumericSuffix() {
+    void testOpenPanelSingleNumericSuffix() {
         when(phm.getRegisteredBentoBoxPlaceholders()).thenReturn(Set.of("island_level_1"));
 
         assertDoesNotThrow(() -> PlaceholderListPanel.openPanel(command, user, null));

--- a/src/test/java/world/bentobox/bentobox/panels/customizable/IslandCreationPanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/customizable/IslandCreationPanelTest.java
@@ -47,7 +47,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
  *
  */
 @Disabled("Unfinished - needs works")
-public class IslandCreationPanelTest extends CommonTestSetup {
+class IslandCreationPanelTest extends CommonTestSetup {
 
     @Mock
     private User user;
@@ -186,7 +186,7 @@ public class IslandCreationPanelTest extends CommonTestSetup {
      */
     @SuppressWarnings("deprecation")
     @Test
-    public void testOpenPanel() {
+    void testOpenPanel() {
         icp = new  IslandCreationPanel(ic, user, "", false);
         icp.build();
         // Set correctly
@@ -200,7 +200,7 @@ public class IslandCreationPanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.customizable.IslandCreationPanel#openPanel(world.bentobox.bentobox.api.commands.CompositeCommand, world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test
-    public void testOpenPanelSameSlot() {
+    void testOpenPanelSameSlot() {
         when(bb2.getSlot()).thenReturn(5);
         when(bb3.getSlot()).thenReturn(5);
         IslandCreationPanel.openPanel(ic, user, "", false);

--- a/src/test/java/world/bentobox/bentobox/panels/customizable/LanguagePanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/customizable/LanguagePanelTest.java
@@ -36,7 +36,7 @@ import world.bentobox.bentobox.api.user.User;
  * @author tastybento
  *
  */
-public class LanguagePanelTest extends CommonTestSetup {
+class LanguagePanelTest extends CommonTestSetup {
 
     @Mock
     private User user;
@@ -115,7 +115,7 @@ public class LanguagePanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.customizable.LanguagePanel#openPanel(world.bentobox.bentobox.api.commands.CompositeCommand,world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testOpenPanelNoLocales() {
+    void testOpenPanelNoLocales() {
         LanguagePanel.openPanel(command, user);
         verify(plugin).getLocalesManager();
         verify(lm).getAvailableLocales(true);
@@ -127,7 +127,7 @@ public class LanguagePanelTest extends CommonTestSetup {
      * Test method for {@link world.bentobox.bentobox.panels.customizable.LanguagePanel#LanguagePanel(world.bentobox.bentobox.api.commands.CompositeCommand, world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         // Set up locales
         localeList.add(Locale.CANADA);
         localeList.add(Locale.CHINA);
@@ -140,7 +140,7 @@ public class LanguagePanelTest extends CommonTestSetup {
      * Test method to verify panel creation with locales
      */
     @Test
-    public void testLanguagePanelWithLocales() {
+    void testLanguagePanelWithLocales() {
         // Set up locales
         localeList.add(Locale.CANADA);
         localeList.add(Locale.ENGLISH);

--- a/src/test/java/world/bentobox/bentobox/panels/settings/SettingsTabTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/settings/SettingsTabTest.java
@@ -27,7 +27,7 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TabbedPanel;
 import world.bentobox.bentobox.api.user.User;
 
-public class SettingsTabTest extends CommonTestSetup {
+class SettingsTabTest extends CommonTestSetup {
 
     private SettingsTab tab;
     private User user;
@@ -53,35 +53,35 @@ public class SettingsTabTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSettingsTabWorldUserType() {
+    void testSettingsTabWorldUserType() {
         tab = new SettingsTab(world, user, Type.PROTECTION);
     }
 
     @Test
-    public void testSettingsTabWorldUserTypeMode() {
+    void testSettingsTabWorldUserTypeMode() {
         tab = new SettingsTab(world, user, Type.PROTECTION, Mode.ADVANCED);
     }
 
     @Test
-    public void testGetFlags() {
+    void testGetFlags() {
         testSettingsTabWorldUserTypeMode();
         tab.getFlags();
     }
 
     @Test
-    public void testGetIcon() {
+    void testGetIcon() {
         testSettingsTabWorldUserTypeMode();
         tab.getIcon();
     }
 
     @Test
-    public void testGetName() {
+    void testGetName() {
         testSettingsTabWorldUserTypeMode();
         assertEquals("protection.panel.PROTECTION.title", tab.getName());
     }
 
     @Test
-    public void testGetPanelItems() {
+    void testGetPanelItems() {
         testSettingsTabWorldUserTypeMode();
         @NonNull
         List<@Nullable PanelItem> items = tab.getPanelItems();
@@ -89,38 +89,38 @@ public class SettingsTabTest extends CommonTestSetup {
     }
 
     @Test
-    public void testGetTabIcons() {
+    void testGetTabIcons() {
         testSettingsTabWorldUserTypeMode();
         Map<Integer, PanelItem> icons = tab.getTabIcons();
         assertFalse(icons.isEmpty());
     }
 
     @Test
-    public void testGetPermission() {
+    void testGetPermission() {
         testSettingsTabWorldUserTypeMode();
         assertEquals("", tab.getPermission());
     }
 
     @Test
-    public void testGetType() {
+    void testGetType() {
         testSettingsTabWorldUserTypeMode();
         assertEquals(Type.PROTECTION, tab.getType());
     }
 
     @Test
-    public void testGetUser() {
+    void testGetUser() {
         testSettingsTabWorldUserTypeMode();
         assertSame(user, tab.getUser());
     }
 
     @Test
-    public void testGetWorld() {
+    void testGetWorld() {
         testSettingsTabWorldUserTypeMode();
         assertSame(world, tab.getWorld());
     }
 
     @Test
-    public void testGetIsland() {
+    void testGetIsland() {
         testSettingsTabWorldUserTypeMode();
         assertNull(tab.getIsland());
         tab.setParentPanel(parent);
@@ -128,14 +128,14 @@ public class SettingsTabTest extends CommonTestSetup {
     }
 
     @Test
-    public void testOnClick() {
+    void testOnClick() {
         testSettingsTabWorldUserTypeMode();
         Panel panel = mock(Panel.class);
         tab.onClick(panel, user, ClickType.LEFT, 0);
     }
 
     @Test
-    public void testGetParentPanel() {
+    void testGetParentPanel() {
         testSettingsTabWorldUserTypeMode();
 
         TabbedPanel pp = tab.getParentPanel();
@@ -143,7 +143,7 @@ public class SettingsTabTest extends CommonTestSetup {
     }
 
     @Test
-    public void testSetParentPanel() {
+    void testSetParentPanel() {
         testSettingsTabWorldUserTypeMode();
         tab.setParentPanel(parent);
     }


### PR DESCRIPTION
## Summary
In JUnit 5, test classes and their lifecycle/test methods do **not** need to be `public`. This PR removes the unnecessary `public` modifier from 156 test files.
## Changes
- Removed `public` from test class declarations (`class FooTest` instead of `public class FooTest`)
- Removed `public` from `@Test` annotated methods
- Removed `public` from `@BeforeEach` / `@AfterEach` lifecycle methods that are not overrides of `public` superclass methods
## What was kept `public`
- Shared base classes (`CommonTestSetup`, `RanksManagerTestSetup`, `TestWorldSettings`, `TestBentoBox`) — these are extended/accessed across packages
- `setUp()` / `tearDown()` methods that `@Override` `public` superclass methods — Java requires overriding methods to maintain at least the same visibility
- Inner class methods implementing abstract/interface methods
- Utility/helper methods called from other classes
- `public static final` constants and `public` fields accessed from other packages
## Testing
All 156 modified test files compile and the full test suite passes (`./gradlew test` exits 0).