### PR TITLE
feat: add BlueMap hook for island markers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,7 @@ val gsonRecordTypeAdapterFactoryVersion = "0.3.0"
 val jdtAnnotationVersion = "2.2.600"
 val multilibVersion = "1.1.13"
 val oraxenVersion = "1.193.1"
+val blueMapApiVersion = "v2.6.2"
 
 // Store versions in extra properties for resource filtering (used in plugin.yml, config.yml)
 extra["java.version"] = javaVersion
@@ -234,6 +235,8 @@ dependencies {
     compileOnly("de.oliver:FancyHolograms:$fancyHologramsVersion")
     compileOnly("world.bentobox:level:$levelVersion-SNAPSHOT")
     compileOnly("commons-lang:commons-lang:$commonsLangVersion")
+    compileOnly("com.github.BlueMap-Minecraft:BlueMapAPI:$blueMapApiVersion")
+    testImplementation("com.github.BlueMap-Minecraft:BlueMapAPI:$blueMapApiVersion")
     compileOnly("io.th0rgal:oraxen:$oraxenVersion") {
         exclude(group = "me.gabytm.util", module = "actions-spigot")
         exclude(group = "org.jetbrains", module = "annotations")

--- a/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
@@ -48,12 +48,13 @@ public class BentoBoxHookRegistrar {
     }
 
     /**
-     * Registers hooks for plugins that load after BentoBox (Slimefun, ItemsAdder, Oraxen).
+     * Registers hooks for plugins that load after BentoBox (Slimefun, ItemsAdder, Oraxen, BlueMap).
      */
     public void registerLateHooks() {
         hooksManager.registerHook(new SlimefunHook());
         hooksManager.registerHook(new ItemsAdderHook(plugin));
         hooksManager.registerHook(new OraxenHook(plugin));
+        hooksManager.registerHook(new BlueMapHook());
     }
 
     private boolean hasClass(String className) {

--- a/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
@@ -1,0 +1,171 @@
+package world.bentobox.bentobox.hooks;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.eclipse.jdt.annotation.NonNull;
+
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.BlueMapMap;
+import de.bluecolored.bluemap.api.markers.MarkerSet;
+import de.bluecolored.bluemap.api.markers.POIMarker;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
+import world.bentobox.bentobox.api.events.island.IslandNameEvent;
+import world.bentobox.bentobox.api.events.island.IslandNewIslandEvent;
+import world.bentobox.bentobox.api.events.island.IslandResettedEvent;
+import world.bentobox.bentobox.api.hooks.Hook;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+
+/**
+ * Hook to display island markers on BlueMap.
+ * @author tastybento
+ * @since 2.1.0
+ */
+public class BlueMapHook extends Hook implements Listener {
+
+    private final BentoBox plugin;
+    private BlueMapAPI api;
+    /**
+     * One marker set per game mode; key is the friendly name of the game mode.
+     */
+    private final Map<String, MarkerSet> markerSets = new HashMap<>();
+
+    public BlueMapHook() {
+        super("BlueMap", Material.MAP);
+        this.plugin = BentoBox.getInstance();
+    }
+
+    @Override
+    public boolean hook() {
+        if (BlueMapAPI.getInstance().isPresent()) {
+            api = BlueMapAPI.getInstance().get();
+        } else {
+            return false;
+        }
+        // Register markers for all game mode addons known at hook time
+        plugin.getAddonsManager().getGameModeAddons().forEach(this::registerGameMode);
+        // Listen for future island events
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        return true;
+    }
+
+    /**
+     * Register all islands for a given game mode addon and attach the marker set to BlueMap worlds.
+     * @param addon the game mode addon
+     */
+    public void registerGameMode(@NonNull GameModeAddon addon) {
+        String friendlyName = addon.getWorldSettings().getFriendlyName();
+        plugin.logDebug("Setting markers for Game Mode '" + friendlyName + "'");
+        MarkerSet markerSet = markerSets.computeIfAbsent(friendlyName, k -> {
+            plugin.logDebug("Making a new marker set for '" + k + "'");
+            return MarkerSet.builder().toggleable(true).defaultHidden(false).label(k).build();
+        });
+        // Create a marker for each owned island in this addon's overworld
+        plugin.getIslands().getIslands(addon.getOverWorld()).stream()
+                .filter(is -> is.getOwner() != null)
+                .forEach(island -> {
+                    plugin.logDebug("Creating marker for " + island.getCenter());
+                    setMarker(markerSet, island);
+                });
+        // Overworld
+        addMarkerSetToWorld(addon.getOverWorld(), friendlyName, markerSet);
+        // Nether
+        if (addon.getWorldSettings().isNetherGenerate() && addon.getWorldSettings().isNetherIslands()
+                && addon.getNetherWorld() != null) {
+            addMarkerSetToWorld(addon.getNetherWorld(), friendlyName, markerSet);
+        }
+        // End
+        if (addon.getWorldSettings().isEndGenerate() && addon.getWorldSettings().isEndIslands()
+                && addon.getEndWorld() != null) {
+            addMarkerSetToWorld(addon.getEndWorld(), friendlyName, markerSet);
+        }
+    }
+
+    private void addMarkerSetToWorld(World world, String markerSetId, MarkerSet markerSet) {
+        api.getWorld(world).ifPresent(bmWorld -> {
+            plugin.logDebug("BlueMap knows about " + bmWorld.getId());
+            for (BlueMapMap map : bmWorld.getMaps()) {
+                plugin.logDebug("Adding markerSet to " + map.getName() + " map");
+                map.getMarkerSets().put(markerSetId, markerSet);
+            }
+        });
+    }
+
+    private void setMarker(MarkerSet markerSet, Island island) {
+        String label = getIslandLabel(island);
+        plugin.logDebug("Adding a marker called '" + label + "' for island " + island.getUniqueId());
+        POIMarker marker = POIMarker.builder().label(label).listed(true).defaultIcon()
+                .position(island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ())
+                .build();
+        markerSet.put(island.getUniqueId(), marker);
+    }
+
+    private String getIslandLabel(Island island) {
+        if (island.getName() != null && !island.getName().isBlank()) {
+            return island.getName();
+        } else if (island.getOwner() != null) {
+            return User.getInstance(island.getOwner()).getName();
+        }
+        return island.getUniqueId();
+    }
+
+    @Override
+    public String getFailureCause() {
+        return "BlueMap is not loaded or the API version is incompatible.";
+    }
+
+    private void add(Island island, GameModeAddon addon) {
+        MarkerSet markerSet = markerSets.computeIfAbsent(addon.getWorldSettings().getFriendlyName(),
+                k -> MarkerSet.builder().label(k).build());
+        setMarker(markerSet, island);
+    }
+
+    private void remove(String islandUniqueId, GameModeAddon addon) {
+        MarkerSet markerSet = markerSets.get(addon.getWorldSettings().getFriendlyName());
+        if (markerSet != null) {
+            markerSet.remove(islandUniqueId);
+        }
+    }
+
+    // Listeners
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onNewIsland(IslandNewIslandEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld()).ifPresent(addon -> add(e.getIsland(), addon));
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onIslandDelete(IslandDeleteEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld())
+                .ifPresent(addon -> remove(e.getIsland().getUniqueId(), addon));
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onIslandName(IslandNameEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld()).ifPresent(addon -> {
+            remove(e.getIsland().getUniqueId(), addon);
+            add(e.getIsland(), addon);
+        });
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onIslandReset(IslandResettedEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld()).ifPresent(addon -> {
+            remove(e.getOldIsland().getUniqueId(), addon);
+            add(e.getIsland(), addon);
+        });
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,6 +27,7 @@ softdepend:
   - ZNPCsPlus
   - FancyNpcs
   - FancyHolograms
+  - BlueMap
 
 libraries:
   - mysql:mysql-connector-java:${mysql.version}

--- a/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
+++ b/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
@@ -1,0 +1,380 @@
+package world.bentobox.bentobox.hooks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.BlueMapMap;
+import de.bluecolored.bluemap.api.BlueMapWorld;
+import de.bluecolored.bluemap.api.markers.MarkerSet;
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.configuration.WorldSettings;
+import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
+import world.bentobox.bentobox.api.events.island.IslandNameEvent;
+import world.bentobox.bentobox.api.events.island.IslandNewIslandEvent;
+import world.bentobox.bentobox.api.events.island.IslandResettedEvent;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.AddonsManager;
+
+class BlueMapHookTest extends CommonTestSetup {
+
+    @Mock
+    private BlueMapAPI blueMapAPI;
+    @Mock
+    private BlueMapWorld blueMapWorld;
+    @Mock
+    private BlueMapMap blueMapMap;
+    @Mock
+    private GameModeAddon addon;
+    @Mock
+    private WorldSettings worldSettings;
+    @Mock
+    private World overWorld;
+    @Mock
+    private World netherWorld;
+    @Mock
+    private World endWorld;
+    @Mock
+    private AddonsManager addonsManager;
+
+    private MockedStatic<BlueMapAPI> mockedBlueMapAPI;
+    private BlueMapHook hook;
+    private Map<String, MarkerSet> mapMarkerSets;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // BlueMapAPI static mock
+        mockedBlueMapAPI = Mockito.mockStatic(BlueMapAPI.class);
+        mockedBlueMapAPI.when(BlueMapAPI::getInstance).thenReturn(Optional.of(blueMapAPI));
+
+        // BlueMap world/map chain
+        mapMarkerSets = new HashMap<>();
+        when(blueMapAPI.getWorld(any(World.class))).thenReturn(Optional.of(blueMapWorld));
+        when(blueMapWorld.getMaps()).thenReturn(List.of(blueMapMap));
+        when(blueMapWorld.getId()).thenReturn("overworld");
+        when(blueMapMap.getName()).thenReturn("Overworld");
+        when(blueMapMap.getMarkerSets()).thenReturn(mapMarkerSets);
+
+        // Addon + world settings
+        when(addon.getWorldSettings()).thenReturn(worldSettings);
+        when(worldSettings.getFriendlyName()).thenReturn("BSkyBlock");
+        when(addon.getOverWorld()).thenReturn(overWorld);
+        when(addon.getNetherWorld()).thenReturn(netherWorld);
+        when(addon.getEndWorld()).thenReturn(endWorld);
+        when(worldSettings.isNetherGenerate()).thenReturn(false);
+        when(worldSettings.isNetherIslands()).thenReturn(false);
+        when(worldSettings.isEndGenerate()).thenReturn(false);
+        when(worldSettings.isEndIslands()).thenReturn(false);
+
+        // Islands manager: no islands by default
+        when(im.getIslands(any(World.class))).thenReturn(Collections.emptyList());
+
+        // AddonsManager
+        when(plugin.getAddonsManager()).thenReturn(addonsManager);
+        when(addonsManager.getGameModeAddons()).thenReturn(List.of(addon));
+
+        // Island basic setup
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getUniqueId()).thenReturn(uuid.toString());
+        Location center = mock(Location.class);
+        when(center.getX()).thenReturn(0.0);
+        when(center.getY()).thenReturn(64.0);
+        when(center.getZ()).thenReturn(0.0);
+        when(island.getCenter()).thenReturn(center);
+        when(island.getWorld()).thenReturn(overWorld);
+        when(island.getName()).thenReturn(null);
+
+        // IWM: return addon for overWorld
+        when(iwm.getAddon(overWorld)).thenReturn(Optional.of(addon));
+
+        hook = new BlueMapHook();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        mockedBlueMapAPI.close();
+        super.tearDown();
+    }
+
+    // ---- hook() ----
+
+    @Test
+    void testHookSucceeds() {
+        assertTrue(hook.hook());
+    }
+
+    @Test
+    void testHookFailsWhenBlueMapNotPresent() {
+        mockedBlueMapAPI.when(BlueMapAPI::getInstance).thenReturn(Optional.empty());
+        assertFalse(hook.hook());
+    }
+
+    @Test
+    void testHookRegistersEvents() {
+        hook.hook();
+        verify(pim).registerEvents(eq(hook), eq(plugin));
+    }
+
+    @Test
+    void testHookCallsRegisterGameMode() {
+        hook.hook();
+        verify(im).getIslands(overWorld);
+    }
+
+    // ---- getPluginName() / getFailureCause() ----
+
+    @Test
+    void testGetPluginName() {
+        assertEquals("BlueMap", hook.getPluginName());
+    }
+
+    @Test
+    void testGetFailureCause() {
+        assertNotNull(hook.getFailureCause());
+    }
+
+    // ---- registerGameMode() ----
+
+    @Test
+    void testRegisterGameModeNoIslands() {
+        hook.hook();
+        // marker set should be attached to the map
+        assertTrue(mapMarkerSets.containsKey("BSkyBlock"));
+    }
+
+    @Test
+    void testRegisterGameModeWithIsland() {
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertNotNull(ms);
+        assertNotNull(ms.get(uuid.toString()));
+    }
+
+    @Test
+    void testRegisterGameModeUnownedIslandIgnored() {
+        Island unowned = mock(Island.class);
+        when(unowned.getOwner()).thenReturn(null);
+        when(im.getIslands(overWorld)).thenReturn(List.of(unowned));
+        hook.hook();
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertNotNull(ms);
+        assertTrue(ms.getMarkers().isEmpty());
+    }
+
+    @Test
+    void testRegisterGameModeWithNetherWorld() {
+        when(worldSettings.isNetherGenerate()).thenReturn(true);
+        when(worldSettings.isNetherIslands()).thenReturn(true);
+        Map<String, MarkerSet> netherMapSets = new HashMap<>();
+        BlueMapMap netherMap = mock(BlueMapMap.class);
+        BlueMapWorld netherBMWorld = mock(BlueMapWorld.class);
+        when(blueMapAPI.getWorld(netherWorld)).thenReturn(Optional.of(netherBMWorld));
+        when(netherBMWorld.getMaps()).thenReturn(List.of(netherMap));
+        when(netherBMWorld.getId()).thenReturn("nether");
+        when(netherMap.getName()).thenReturn("Nether");
+        when(netherMap.getMarkerSets()).thenReturn(netherMapSets);
+
+        hook.hook();
+        assertTrue(netherMapSets.containsKey("BSkyBlock"));
+    }
+
+    @Test
+    void testRegisterGameModeWithEndWorld() {
+        when(worldSettings.isEndGenerate()).thenReturn(true);
+        when(worldSettings.isEndIslands()).thenReturn(true);
+        Map<String, MarkerSet> endMapSets = new HashMap<>();
+        BlueMapMap endMap = mock(BlueMapMap.class);
+        BlueMapWorld endBMWorld = mock(BlueMapWorld.class);
+        when(blueMapAPI.getWorld(endWorld)).thenReturn(Optional.of(endBMWorld));
+        when(endBMWorld.getMaps()).thenReturn(List.of(endMap));
+        when(endBMWorld.getId()).thenReturn("end");
+        when(endMap.getName()).thenReturn("End");
+        when(endMap.getMarkerSets()).thenReturn(endMapSets);
+
+        hook.hook();
+        assertTrue(endMapSets.containsKey("BSkyBlock"));
+    }
+
+    @Test
+    void testRegisterGameModeNetherWorldNull() {
+        when(worldSettings.isNetherGenerate()).thenReturn(true);
+        when(worldSettings.isNetherIslands()).thenReturn(true);
+        when(addon.getNetherWorld()).thenReturn(null);
+        // should not throw
+        hook.hook();
+        // nether map should not have been touched
+        verify(blueMapAPI, never()).getWorld(netherWorld);
+    }
+
+    @Test
+    void testRegisterGameModeBlueMapDoesNotKnowWorld() {
+        when(blueMapAPI.getWorld(overWorld)).thenReturn(Optional.empty());
+        hook.hook();
+        // No marker sets added since BlueMap doesn't know the world
+        assertFalse(mapMarkerSets.containsKey("BSkyBlock"));
+    }
+
+    // ---- Island label logic ----
+
+    @Test
+    void testIslandLabelUsesCustomName() {
+        when(island.getName()).thenReturn("My Island");
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertNotNull(ms.get(uuid.toString()));
+        assertEquals("My Island", ms.get(uuid.toString()).getLabel());
+    }
+
+    @Test
+    void testIslandLabelUsesOwnerName() {
+        when(island.getName()).thenReturn(null);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        // player name from CommonTestSetup is "tastybento"
+        assertEquals("tastybento", ms.get(uuid.toString()).getLabel());
+    }
+
+    @Test
+    void testIslandLabelFallsBackToUUID() {
+        // The registerGameMode filter skips null-owner islands; test UUID fallback via the event path
+        hook.hook();
+        Island noOwnerIsland = mock(Island.class);
+        UUID noOwnerUuid = UUID.randomUUID();
+        when(noOwnerIsland.getName()).thenReturn(null);
+        when(noOwnerIsland.getOwner()).thenReturn(null);
+        when(noOwnerIsland.getUniqueId()).thenReturn(noOwnerUuid.toString());
+        Location c = mock(Location.class);
+        when(c.getX()).thenReturn(0.0);
+        when(c.getY()).thenReturn(64.0);
+        when(c.getZ()).thenReturn(0.0);
+        when(noOwnerIsland.getCenter()).thenReturn(c);
+        when(noOwnerIsland.getWorld()).thenReturn(overWorld);
+
+        IslandNewIslandEvent event = mock(IslandNewIslandEvent.class);
+        when(event.getIsland()).thenReturn(noOwnerIsland);
+        hook.onNewIsland(event);
+
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertNotNull(ms.get(noOwnerUuid.toString()));
+        assertEquals(noOwnerUuid.toString(), ms.get(noOwnerUuid.toString()).getLabel());
+    }
+
+    // ---- Event handlers ----
+
+    @Test
+    void testOnNewIsland() {
+        hook.hook();
+        // Clear existing markers so we can detect the add
+        mapMarkerSets.get("BSkyBlock").remove(uuid.toString());
+
+        IslandNewIslandEvent event = mock(IslandNewIslandEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        hook.onNewIsland(event);
+
+        assertNotNull(mapMarkerSets.get("BSkyBlock").get(uuid.toString()));
+    }
+
+    @Test
+    void testOnNewIslandNoAddon() {
+        hook.hook();
+        when(iwm.getAddon(overWorld)).thenReturn(Optional.empty());
+        IslandNewIslandEvent event = mock(IslandNewIslandEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        // Should not throw; marker set unchanged
+        int sizeBefore = mapMarkerSets.get("BSkyBlock").getMarkers().size();
+        hook.onNewIsland(event);
+        assertEquals(sizeBefore, mapMarkerSets.get("BSkyBlock").getMarkers().size());
+    }
+
+    @Test
+    void testOnIslandDelete() {
+        hook.hook();
+        // island should be in the marker set after hook()
+        IslandDeleteEvent event = mock(IslandDeleteEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        hook.onIslandDelete(event);
+        // marker should be removed
+        assertFalse(mapMarkerSets.get("BSkyBlock").getMarkers().containsKey(uuid.toString()));
+    }
+
+    @Test
+    void testOnIslandName() {
+        when(island.getName()).thenReturn("Old Name");
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+
+        // Now rename
+        when(island.getName()).thenReturn("New Name");
+        IslandNameEvent event = mock(IslandNameEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        hook.onIslandName(event);
+
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertNotNull(ms.get(uuid.toString()));
+        assertEquals("New Name", ms.get(uuid.toString()).getLabel());
+    }
+
+    @Test
+    void testOnIslandReset() {
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+
+        Island newIsland = mock(Island.class);
+        UUID newUuid = UUID.randomUUID();
+        when(newIsland.getOwner()).thenReturn(newUuid);
+        when(newIsland.getUniqueId()).thenReturn(newUuid.toString());
+        when(newIsland.getName()).thenReturn("Reset Island");
+        Location newCenter = mock(Location.class);
+        when(newCenter.getX()).thenReturn(100.0);
+        when(newCenter.getY()).thenReturn(64.0);
+        when(newCenter.getZ()).thenReturn(100.0);
+        when(newIsland.getCenter()).thenReturn(newCenter);
+        when(newIsland.getWorld()).thenReturn(overWorld);
+
+        IslandResettedEvent event = mock(IslandResettedEvent.class);
+        when(event.getIsland()).thenReturn(newIsland);
+        when(event.getOldIsland()).thenReturn(island);
+        hook.onIslandReset(event);
+
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        // Old island marker removed
+        assertFalse(ms.getMarkers().containsKey(uuid.toString()));
+        // New island marker added
+        assertNotNull(ms.get(newUuid.toString()));
+    }
+}


### PR DESCRIPTION
Implements a BlueMap integration that creates POI markers on BlueMap for each owned island, organised into per-game-mode marker sets.

- BlueMapHook: registers a MarkerSet per GameModeAddon, populates it with a POIMarker for each owned island in the overworld (and nether / end when island variants are enabled), and listens for island create / delete / rename / reset events to keep markers in sync.
- Registers the hook in BentoBoxHookRegistrar.registerLateHooks() so BlueMap worlds are fully loaded before markers are written.
- Adds BlueMap to the softdepend list in plugin.yml.
- Adds com.github.BlueMap-Minecraft:BlueMapAPI:v2.6.2 as a compileOnly + testImplementation dependency via jitpack.
- BlueMapHookTest: 21 JUnit 5 tests covering hook success/failure, registerGameMode with and without nether/end worlds, island label priority (name > owner > UUID), and all four event handlers.

Closes #2295