### PR TITLE
Add Dynmap hook to display island borders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,7 @@ val jdtAnnotationVersion = "2.2.600"
 val multilibVersion = "1.1.13"
 val oraxenVersion = "1.193.1"
 val blueMapApiVersion = "v2.6.2"
+val dynmapApiVersion = "3.4"
 
 // Store versions in extra properties for resource filtering (used in plugin.yml, config.yml)
 extra["java.version"] = javaVersion
@@ -187,6 +188,7 @@ repositories {
     maven("https://repo.fancyplugins.de/releases") { name = "FancyPlugins-Releases" }
     maven("https://repo.pyr.lol/snapshots") { name = "Pyr-Snapshots" }
     maven("https://maven.devs.beer/") { name = "MatteoDev" }
+    maven("https://repo.mikeprimm.com/") { name = "Dynmap" }
     maven("https://repo.oraxen.com/releases") { name = "Oraxen" } // Custom items plugin
     maven("https://repo.codemc.org/repository/bentoboxworld/") { name = "BentoBoxWorld-Repo" }
     maven("https://repo.extendedclip.com/releases/") { name = "Placeholder-API-Releases" }
@@ -238,6 +240,14 @@ dependencies {
     compileOnly("commons-lang:commons-lang:$commonsLangVersion")
     compileOnly("com.github.BlueMap-Minecraft:BlueMapAPI:$blueMapApiVersion")
     testImplementation("com.github.BlueMap-Minecraft:BlueMapAPI:$blueMapApiVersion")
+    compileOnly("us.dynmap:DynmapCoreAPI:$dynmapApiVersion")
+    compileOnly("us.dynmap:dynmap-api:$dynmapApiVersion") {
+        exclude(group = "org.bukkit", module = "bukkit")
+    }
+    testImplementation("us.dynmap:DynmapCoreAPI:$dynmapApiVersion")
+    testImplementation("us.dynmap:dynmap-api:$dynmapApiVersion") {
+        exclude(group = "org.bukkit", module = "bukkit")
+    }
     compileOnly("io.th0rgal:oraxen:$oraxenVersion") {
         exclude(group = "me.gabytm.util", module = "actions-spigot")
         exclude(group = "org.jetbrains", module = "annotations")

--- a/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
@@ -13,6 +13,7 @@ public class BentoBoxHookRegistrar {
     private static final String MV5_CLASS = "org.mvplugins.multiverse.core.MultiverseCore";
     private static final String MV4_CLASS = "com.onarandombox.MultiverseCore.MultiverseCore";
     private static final String BLUEMAP_CLASS = "de.bluecolored.bluemap.api.BlueMapAPI";
+    private static final String DYNMAP_CLASS = "org.dynmap.DynmapAPI";
 
     private final BentoBox plugin;
     private final HooksManager hooksManager;
@@ -57,6 +58,9 @@ public class BentoBoxHookRegistrar {
         hooksManager.registerHook(new OraxenHook(plugin));
         if (hasClass(BLUEMAP_CLASS)) {
             hooksManager.registerHook(new BlueMapHook());
+        }
+        if (hasClass(DYNMAP_CLASS)) {
+            hooksManager.registerHook(new DynmapHook());
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/hooks/DynmapHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/DynmapHook.java
@@ -1,0 +1,242 @@
+package world.bentobox.bentobox.hooks;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.dynmap.DynmapAPI;
+import org.dynmap.markers.AreaMarker;
+import org.dynmap.markers.Marker;
+import org.dynmap.markers.MarkerAPI;
+import org.dynmap.markers.MarkerSet;
+import org.eclipse.jdt.annotation.NonNull;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
+import world.bentobox.bentobox.api.events.island.IslandNameEvent;
+import world.bentobox.bentobox.api.events.island.IslandNewIslandEvent;
+import world.bentobox.bentobox.api.events.island.IslandResettedEvent;
+import world.bentobox.bentobox.api.hooks.Hook;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+
+/**
+ * Hook to display island markers on Dynmap.
+ * @author tastybento
+ * @since 3.12.0
+ */
+public class DynmapHook extends Hook implements Listener {
+
+    private final BentoBox plugin;
+    private MarkerAPI markerAPI;
+    /**
+     * One marker set per game mode; key is the marker set ID (derived from friendly name).
+     */
+    private final Map<String, MarkerSet> markerSets = new HashMap<>();
+
+    public DynmapHook() {
+        super("dynmap", Material.FILLED_MAP);
+        this.plugin = BentoBox.getInstance();
+    }
+
+    @Override
+    public boolean hook() {
+        try {
+            DynmapAPI dynmapAPI = (DynmapAPI) getPlugin();
+            if (dynmapAPI == null) {
+                return false;
+            }
+            MarkerAPI markers = dynmapAPI.getMarkerAPI();
+            if (markers == null) {
+                return false;
+            }
+            markerAPI = markers;
+        } catch (Exception e) {
+            return false;
+        }
+        // Register markers for all game mode addons known at hook time
+        plugin.getAddonsManager().getGameModeAddons().forEach(this::registerGameMode);
+        // Listen for future island events
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        return true;
+    }
+
+    /**
+     * Register all islands for a given game mode addon.
+     * @param addon the game mode addon
+     */
+    public void registerGameMode(@NonNull GameModeAddon addon) {
+        String friendlyName = addon.getWorldSettings().getFriendlyName();
+        String markerSetId = friendlyName.toLowerCase(Locale.ENGLISH) + ".markers";
+        plugin.logDebug("Setting markers for Game Mode '" + friendlyName + "'");
+        MarkerSet markerSet = markerSets.computeIfAbsent(friendlyName, k -> {
+            plugin.logDebug("Making a new marker set for '" + k + "'");
+            // Dynmap persists marker sets — check for existing one first
+            MarkerSet existing = markerAPI.getMarkerSet(markerSetId);
+            if (existing != null) {
+                existing.setMarkerSetLabel(friendlyName);
+                return existing;
+            }
+            return markerAPI.createMarkerSet(markerSetId, friendlyName, null, true);
+        });
+        // Clear stale markers from previous runs
+        markerSet.getMarkers().forEach(Marker::deleteMarker);
+        markerSet.getAreaMarkers().forEach(AreaMarker::deleteMarker);
+        // Create a marker for each owned island in this addon's overworld
+        plugin.getIslands().getIslands(addon.getOverWorld()).stream()
+                .filter(is -> is.getOwner() != null)
+                .forEach(island -> {
+                    plugin.logDebug("Creating marker for " + island.getCenter());
+                    setMarker(markerSet, island);
+                });
+    }
+
+    private void setMarker(MarkerSet markerSet, Island island) {
+        String label = getIslandLabel(island);
+        String id = island.getUniqueId();
+        World w = island.getCenter().getWorld();
+        if (w == null) {
+            return;
+        }
+        String worldName = w.getName();
+        plugin.logDebug("Adding a marker called '" + label + "' for island " + id);
+        // Remove existing markers if present
+        Marker existingMarker = markerSet.findMarker(id);
+        if (existingMarker != null) {
+            existingMarker.deleteMarker();
+        }
+        AreaMarker existingArea = markerSet.findAreaMarker(id + "_area");
+        if (existingArea != null) {
+            existingArea.deleteMarker();
+        }
+        // Point marker at island center for the label/icon
+        markerSet.createMarker(id, label, worldName,
+                island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ(),
+                markerAPI.getMarkerIcon("default"), true);
+        // Area marker showing the protected island border
+        double[] xCorners = { island.getMinProtectedX(), island.getMaxProtectedX(),
+                island.getMaxProtectedX(), island.getMinProtectedX() };
+        double[] zCorners = { island.getMinProtectedZ(), island.getMinProtectedZ(),
+                island.getMaxProtectedZ(), island.getMaxProtectedZ() };
+        AreaMarker area = markerSet.createAreaMarker(id + "_area", label, false, worldName,
+                xCorners, zCorners, true);
+        if (area != null) {
+            area.setLineStyle(2, 0.8, 0x3388FF);
+            area.setFillStyle(0.15, 0x3388FF);
+        }
+    }
+
+    private String getIslandLabel(Island island) {
+        if (island.getName() != null && !island.getName().isBlank()) {
+            return island.getName();
+        } else if (island.getOwner() != null) {
+            User owner = User.getInstance(island.getOwner());
+            if (owner != null) {
+                return owner.getName();
+            }
+        }
+        return island.getUniqueId();
+    }
+
+    @Override
+    public String getFailureCause() {
+        return "Dynmap is not loaded or its Marker API is unavailable.";
+    }
+
+    private void add(Island island, GameModeAddon addon) {
+        MarkerSet markerSet = markerSets.get(addon.getWorldSettings().getFriendlyName());
+        if (markerSet != null) {
+            setMarker(markerSet, island);
+        }
+    }
+
+    private void remove(String islandUniqueId, GameModeAddon addon) {
+        MarkerSet markerSet = markerSets.get(addon.getWorldSettings().getFriendlyName());
+        if (markerSet != null) {
+            Marker marker = markerSet.findMarker(islandUniqueId);
+            if (marker != null) {
+                marker.deleteMarker();
+            }
+            AreaMarker area = markerSet.findAreaMarker(islandUniqueId + "_area");
+            if (area != null) {
+                area.deleteMarker();
+            }
+        }
+    }
+
+    // --- Public addon API ---
+
+    /**
+     * Returns the Dynmap MarkerAPI for addons to create custom markers.
+     * @return the MarkerAPI instance
+     */
+    @NonNull
+    public MarkerAPI getMarkerAPI() {
+        return markerAPI;
+    }
+
+    /**
+     * Gets the marker set for the given game mode addon, if one has been registered.
+     * @param addon the game mode addon
+     * @return the MarkerSet, or null if not registered
+     */
+    public MarkerSet getMarkerSet(@NonNull GameModeAddon addon) {
+        return markerSets.get(addon.getWorldSettings().getFriendlyName());
+    }
+
+    /**
+     * Creates or retrieves a custom marker set. Useful for addons like Warps
+     * that want to display their own markers on Dynmap.
+     * @param id unique identifier for the marker set
+     * @param label display label for the marker set
+     * @return the MarkerSet
+     */
+    @NonNull
+    public MarkerSet createMarkerSet(@NonNull String id, @NonNull String label) {
+        MarkerSet existing = markerAPI.getMarkerSet(id);
+        if (existing != null) {
+            return existing;
+        }
+        return markerAPI.createMarkerSet(id, label, null, true);
+    }
+
+    // --- Event handlers ---
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onNewIsland(IslandNewIslandEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld()).ifPresent(addon -> add(e.getIsland(), addon));
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onIslandDelete(IslandDeleteEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld())
+                .ifPresent(addon -> remove(e.getIsland().getUniqueId(), addon));
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onIslandName(IslandNameEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld()).ifPresent(addon -> {
+            remove(e.getIsland().getUniqueId(), addon);
+            add(e.getIsland(), addon);
+        });
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onIslandReset(IslandResettedEvent e) {
+        plugin.logDebug(e.getEventName());
+        plugin.getIWM().getAddon(e.getIsland().getWorld()).ifPresent(addon -> {
+            remove(e.getOldIsland().getUniqueId(), addon);
+            add(e.getIsland(), addon);
+        });
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/hooks/DynmapHookTest.java
+++ b/src/test/java/world/bentobox/bentobox/hooks/DynmapHookTest.java
@@ -1,0 +1,421 @@
+package world.bentobox.bentobox.hooks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.plugin.Plugin;
+import org.dynmap.DynmapAPI;
+import org.dynmap.markers.AreaMarker;
+import org.dynmap.markers.Marker;
+import org.dynmap.markers.MarkerAPI;
+import org.dynmap.markers.MarkerIcon;
+import org.dynmap.markers.MarkerSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.configuration.WorldSettings;
+import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
+import world.bentobox.bentobox.api.events.island.IslandNameEvent;
+import world.bentobox.bentobox.api.events.island.IslandNewIslandEvent;
+import world.bentobox.bentobox.api.events.island.IslandResettedEvent;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.AddonsManager;
+
+class DynmapHookTest extends CommonTestSetup {
+
+    /**
+     * Combined interface so a single mock satisfies both Plugin (returned by
+     * Bukkit's PluginManager) and DynmapAPI (cast target in DynmapHook).
+     */
+    private interface DynmapPlugin extends Plugin, DynmapAPI {}
+
+    @Mock
+    private DynmapPlugin dynmapPlugin;
+    @Mock
+    private MarkerAPI markerAPI;
+    @Mock
+    private MarkerSet markerSet;
+    @Mock
+    private MarkerIcon defaultIcon;
+    @Mock
+    private Marker marker;
+    @Mock
+    private AreaMarker areaMarker;
+    @Mock
+    private GameModeAddon addon;
+    @Mock
+    private WorldSettings worldSettings;
+    @Mock
+    private World overWorld;
+    @Mock
+    private AddonsManager addonsManager;
+
+    private DynmapHook hook;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Dynmap plugin mock — DynmapAPI extends Plugin
+        when(pim.getPlugin("dynmap")).thenReturn(dynmapPlugin);
+        when(dynmapPlugin.getMarkerAPI()).thenReturn(markerAPI);
+        when(markerAPI.getMarkerIcon("default")).thenReturn(defaultIcon);
+        when(markerAPI.getMarkerSet(anyString())).thenReturn(null);
+        when(markerAPI.createMarkerSet(anyString(), anyString(), isNull(), eq(true)))
+                .thenReturn(markerSet);
+        when(markerSet.getMarkers()).thenReturn(Set.of());
+        when(markerSet.getAreaMarkers()).thenReturn(Set.of());
+        when(markerSet.createMarker(anyString(), anyString(), anyString(),
+                anyDouble(), anyDouble(), anyDouble(), any(MarkerIcon.class), anyBoolean()))
+                .thenReturn(marker);
+        when(markerSet.createAreaMarker(anyString(), anyString(), anyBoolean(), anyString(),
+                any(double[].class), any(double[].class), anyBoolean()))
+                .thenReturn(areaMarker);
+        when(markerSet.findMarker(anyString())).thenReturn(null);
+        when(markerSet.findAreaMarker(anyString())).thenReturn(null);
+
+        // Addon + world settings
+        when(addon.getWorldSettings()).thenReturn(worldSettings);
+        when(worldSettings.getFriendlyName()).thenReturn("BSkyBlock");
+        when(addon.getOverWorld()).thenReturn(overWorld);
+
+        // Islands manager: no islands by default
+        when(im.getIslands(any(World.class))).thenReturn(Collections.emptyList());
+
+        // AddonsManager
+        when(plugin.getAddonsManager()).thenReturn(addonsManager);
+        when(addonsManager.getGameModeAddons()).thenReturn(List.of(addon));
+
+        // Island basic setup
+        when(island.getOwner()).thenReturn(uuid);
+        when(island.getUniqueId()).thenReturn(uuid.toString());
+        Location center = mock(Location.class);
+        when(center.getX()).thenReturn(0.0);
+        when(center.getY()).thenReturn(64.0);
+        when(center.getZ()).thenReturn(0.0);
+        when(center.getWorld()).thenReturn(overWorld);
+        when(island.getCenter()).thenReturn(center);
+        when(island.getWorld()).thenReturn(overWorld);
+        when(island.getName()).thenReturn(null);
+        when(overWorld.getName()).thenReturn("bskyblock_world");
+
+        // IWM: return addon for overWorld
+        when(iwm.getAddon(overWorld)).thenReturn(Optional.of(addon));
+
+        hook = new DynmapHook();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    // ---- hook() ----
+
+    @Test
+    void testHookSucceeds() {
+        assertTrue(hook.hook());
+    }
+
+    @Test
+    void testHookFailsWhenDynmapNotPresent() {
+        when(pim.getPlugin("dynmap")).thenReturn(null);
+        assertFalse(hook.hook());
+    }
+
+    @Test
+    void testHookFailsWhenMarkerAPINull() {
+        when(dynmapPlugin.getMarkerAPI()).thenReturn(null);
+        assertFalse(hook.hook());
+    }
+
+    @Test
+    void testHookRegistersEvents() {
+        hook.hook();
+        verify(pim).registerEvents(hook, plugin);
+    }
+
+    @Test
+    void testHookCallsRegisterGameMode() {
+        hook.hook();
+        verify(im).getIslands(overWorld);
+    }
+
+    // ---- getPluginName() / getFailureCause() ----
+
+    @Test
+    void testGetPluginName() {
+        assertEquals("dynmap", hook.getPluginName());
+    }
+
+    @Test
+    void testGetFailureCause() {
+        assertNotNull(hook.getFailureCause());
+    }
+
+    // ---- registerGameMode() ----
+
+    @Test
+    void testRegisterGameModeNoIslands() {
+        hook.hook();
+        verify(markerAPI).createMarkerSet("bskyblock.markers", "BSkyBlock", null, true);
+    }
+
+    @Test
+    void testRegisterGameModeWithIsland() {
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+        verify(markerSet).createMarker(eq(uuid.toString()), eq("tastybento"),
+                eq("bskyblock_world"), eq(0.0), eq(64.0), eq(0.0), eq(defaultIcon), eq(true));
+    }
+
+    @Test
+    void testRegisterGameModeUnownedIslandIgnored() {
+        Island unowned = mock(Island.class);
+        when(unowned.getOwner()).thenReturn(null);
+        when(im.getIslands(overWorld)).thenReturn(List.of(unowned));
+        hook.hook();
+        verify(markerSet, never()).createMarker(anyString(), anyString(), anyString(),
+                anyDouble(), anyDouble(), anyDouble(), any(MarkerIcon.class), anyBoolean());
+    }
+
+    @Test
+    void testRegisterGameModeReusesExistingMarkerSet() {
+        MarkerSet existingSet = mock(MarkerSet.class);
+        when(existingSet.getMarkers()).thenReturn(Set.of());
+        when(existingSet.getAreaMarkers()).thenReturn(Set.of());
+        when(markerAPI.getMarkerSet("bskyblock.markers")).thenReturn(existingSet);
+        hook.hook();
+        // Should not create a new one
+        verify(markerAPI, never()).createMarkerSet(anyString(), anyString(), isNull(), eq(true));
+        // Should update the label
+        verify(existingSet).setMarkerSetLabel("BSkyBlock");
+    }
+
+    // ---- Island label logic ----
+
+    @Test
+    void testIslandLabelUsesCustomName() {
+        when(island.getName()).thenReturn("My Island");
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+        verify(markerSet).createMarker(eq(uuid.toString()), eq("My Island"),
+                anyString(), anyDouble(), anyDouble(), anyDouble(), any(MarkerIcon.class), anyBoolean());
+    }
+
+    @Test
+    void testIslandLabelUsesOwnerName() {
+        when(island.getName()).thenReturn(null);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+        // player name from CommonTestSetup is "tastybento"
+        verify(markerSet).createMarker(eq(uuid.toString()), eq("tastybento"),
+                anyString(), anyDouble(), anyDouble(), anyDouble(), any(MarkerIcon.class), anyBoolean());
+    }
+
+    @Test
+    void testIslandLabelFallsBackToUUID() {
+        // Test UUID fallback via the event path with no-owner island
+        hook.hook();
+        Island noOwnerIsland = mock(Island.class);
+        UUID noOwnerUuid = UUID.randomUUID();
+        when(noOwnerIsland.getName()).thenReturn(null);
+        when(noOwnerIsland.getOwner()).thenReturn(null);
+        when(noOwnerIsland.getUniqueId()).thenReturn(noOwnerUuid.toString());
+        Location c = mock(Location.class);
+        when(c.getX()).thenReturn(0.0);
+        when(c.getY()).thenReturn(64.0);
+        when(c.getZ()).thenReturn(0.0);
+        when(c.getWorld()).thenReturn(overWorld);
+        when(noOwnerIsland.getCenter()).thenReturn(c);
+        when(noOwnerIsland.getWorld()).thenReturn(overWorld);
+
+        IslandNewIslandEvent event = mock(IslandNewIslandEvent.class);
+        when(event.getIsland()).thenReturn(noOwnerIsland);
+        hook.onNewIsland(event);
+
+        verify(markerSet).createMarker(eq(noOwnerUuid.toString()), eq(noOwnerUuid.toString()),
+                anyString(), anyDouble(), anyDouble(), anyDouble(), any(MarkerIcon.class), anyBoolean());
+    }
+
+    // ---- Event handlers ----
+
+    @Test
+    void testOnNewIsland() {
+        hook.hook();
+        IslandNewIslandEvent event = mock(IslandNewIslandEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        hook.onNewIsland(event);
+
+        // Should have created a marker (once during hook, once from event)
+        verify(markerSet).createMarker(eq(uuid.toString()), eq("tastybento"),
+                eq("bskyblock_world"), eq(0.0), eq(64.0), eq(0.0), eq(defaultIcon), eq(true));
+    }
+
+    @Test
+    void testOnNewIslandNoAddon() {
+        hook.hook();
+        when(iwm.getAddon(overWorld)).thenReturn(Optional.empty());
+        IslandNewIslandEvent event = mock(IslandNewIslandEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        // Should not throw
+        hook.onNewIsland(event);
+    }
+
+    @Test
+    void testOnIslandDelete() {
+        hook.hook();
+        Marker existingMarker = mock(Marker.class);
+        AreaMarker existingArea = mock(AreaMarker.class);
+        when(markerSet.findMarker(uuid.toString())).thenReturn(existingMarker);
+        when(markerSet.findAreaMarker(uuid.toString() + "_area")).thenReturn(existingArea);
+
+        IslandDeleteEvent event = mock(IslandDeleteEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        hook.onIslandDelete(event);
+
+        verify(existingMarker).deleteMarker();
+        verify(existingArea).deleteMarker();
+    }
+
+    @Test
+    void testOnIslandDeleteMarkerNotFound() {
+        hook.hook();
+        when(markerSet.findMarker(uuid.toString())).thenReturn(null);
+
+        IslandDeleteEvent event = mock(IslandDeleteEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        // Should not throw
+        hook.onIslandDelete(event);
+    }
+
+    @Test
+    void testOnIslandName() {
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        when(island.getName()).thenReturn("Old Name");
+        hook.hook();
+
+        // Now rename
+        when(island.getName()).thenReturn("New Name");
+        Marker existingMarker = mock(Marker.class);
+        when(markerSet.findMarker(uuid.toString())).thenReturn(existingMarker);
+
+        IslandNameEvent event = mock(IslandNameEvent.class);
+        when(event.getIsland()).thenReturn(island);
+        hook.onIslandName(event);
+
+        // deleteMarker called twice: once by remove(), once by setMarker() which
+        // finds the same stub before re-creating
+        verify(existingMarker, times(2)).deleteMarker();
+        verify(markerSet).createMarker(eq(uuid.toString()), eq("New Name"),
+                anyString(), anyDouble(), anyDouble(), anyDouble(), any(MarkerIcon.class), anyBoolean());
+    }
+
+    @Test
+    void testOnIslandReset() {
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hook.hook();
+
+        Island newIsland = mock(Island.class);
+        UUID newUuid = UUID.randomUUID();
+        when(newIsland.getOwner()).thenReturn(newUuid);
+        when(newIsland.getUniqueId()).thenReturn(newUuid.toString());
+        when(newIsland.getName()).thenReturn("Reset Island");
+        Location newCenter = mock(Location.class);
+        when(newCenter.getX()).thenReturn(100.0);
+        when(newCenter.getY()).thenReturn(64.0);
+        when(newCenter.getZ()).thenReturn(100.0);
+        when(newCenter.getWorld()).thenReturn(overWorld);
+        when(newIsland.getCenter()).thenReturn(newCenter);
+        when(newIsland.getWorld()).thenReturn(overWorld);
+
+        Marker oldMarker = mock(Marker.class);
+        when(markerSet.findMarker(uuid.toString())).thenReturn(oldMarker);
+
+        IslandResettedEvent event = mock(IslandResettedEvent.class);
+        when(event.getIsland()).thenReturn(newIsland);
+        when(event.getOldIsland()).thenReturn(island);
+        hook.onIslandReset(event);
+
+        // Old island marker removed
+        verify(oldMarker).deleteMarker();
+        // New island marker added
+        verify(markerSet).createMarker(eq(newUuid.toString()), eq("Reset Island"),
+                eq("bskyblock_world"), eq(100.0), eq(64.0), eq(100.0), eq(defaultIcon), eq(true));
+    }
+
+    // ---- Public addon API ----
+
+    @Test
+    void testGetMarkerAPI() {
+        hook.hook();
+        assertEquals(markerAPI, hook.getMarkerAPI());
+    }
+
+    @Test
+    void testGetMarkerSet() {
+        hook.hook();
+        assertEquals(markerSet, hook.getMarkerSet(addon));
+    }
+
+    @Test
+    void testGetMarkerSetNotRegistered() {
+        hook.hook();
+        GameModeAddon unknownAddon = mock(GameModeAddon.class);
+        WorldSettings unknownSettings = mock(WorldSettings.class);
+        when(unknownAddon.getWorldSettings()).thenReturn(unknownSettings);
+        when(unknownSettings.getFriendlyName()).thenReturn("UnknownGame");
+        assertNull(hook.getMarkerSet(unknownAddon));
+    }
+
+    @Test
+    void testCreateMarkerSetNew() {
+        hook.hook();
+        MarkerSet customSet = mock(MarkerSet.class);
+        when(markerAPI.getMarkerSet("warps.markers")).thenReturn(null);
+        when(markerAPI.createMarkerSet("warps.markers", "Warps", null, true)).thenReturn(customSet);
+
+        MarkerSet result = hook.createMarkerSet("warps.markers", "Warps");
+        assertEquals(customSet, result);
+    }
+
+    @Test
+    void testCreateMarkerSetExisting() {
+        hook.hook();
+        MarkerSet existingSet = mock(MarkerSet.class);
+        when(markerAPI.getMarkerSet("warps.markers")).thenReturn(existingSet);
+
+        MarkerSet result = hook.createMarkerSet("warps.markers", "Warps");
+        assertEquals(existingSet, result);
+        // Should not create a new one
+        verify(markerAPI, never()).createMarkerSet(eq("warps.markers"), eq("Warps"), isNull(), eq(true));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `DynmapHook` that integrates with Dynmap's Marker API to display island borders on the web map
- Each owned island gets a point marker (icon + label at center) and an area marker (blue rectangle outlining the protected border)
- Listens for island create, delete, rename, and reset events to keep markers in sync
- Exposes public API (`getMarkerAPI()`, `getMarkerSet()`, `createMarkerSet()`) for addons to create custom markers

## Test plan
- [x] Unit tests pass (`DynmapHookTest` — 20 tests covering hook lifecycle, marker creation/deletion, events, and public API)
- [ ] Verify island borders appear on Dynmap web map after server restart
- [ ] Verify markers update when islands are created, deleted, renamed, or reset
- [ ] Verify marker cleanup on server restart (stale markers removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)