### PR TITLE
Add area markers and public API to BlueMapHook

### DIFF
--- a/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
@@ -15,6 +15,9 @@ import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
 import de.bluecolored.bluemap.api.markers.POIMarker;
+import de.bluecolored.bluemap.api.markers.ShapeMarker;
+import de.bluecolored.bluemap.api.math.Color;
+import de.bluecolored.bluemap.api.math.Shape;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
@@ -102,11 +105,24 @@ public class BlueMapHook extends Hook implements Listener {
 
     private void setMarker(MarkerSet markerSet, Island island) {
         String label = getIslandLabel(island);
-        plugin.logDebug("Adding a marker called '" + label + "' for island " + island.getUniqueId());
+        String id = island.getUniqueId();
+        plugin.logDebug("Adding a marker called '" + label + "' for island " + id);
+        // Point marker at island center for the label/icon
         POIMarker marker = POIMarker.builder().label(label).listed(true).defaultIcon()
                 .position(island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ())
                 .build();
-        markerSet.put(island.getUniqueId(), marker);
+        markerSet.put(id, marker);
+        // Shape marker showing the protected island border
+        ShapeMarker area = ShapeMarker.builder()
+                .label(label)
+                .shape(Shape.createRect(island.getMinProtectedX(), island.getMinProtectedZ(),
+                        island.getMaxProtectedX(), island.getMaxProtectedZ()),
+                        (float) island.getCenter().getY())
+                .lineColor(new Color(51, 136, 255))
+                .fillColor(new Color(51, 136, 255, 0.15f))
+                .lineWidth(2)
+                .build();
+        markerSet.put(id + "_area", area);
     }
 
     private String getIslandLabel(Island island) {
@@ -136,10 +152,46 @@ public class BlueMapHook extends Hook implements Listener {
         MarkerSet markerSet = markerSets.get(addon.getWorldSettings().getFriendlyName());
         if (markerSet != null) {
             markerSet.remove(islandUniqueId);
+            markerSet.remove(islandUniqueId + "_area");
         }
     }
 
-    // Listeners
+    // --- Public addon API ---
+
+    /**
+     * Returns the BlueMapAPI instance for addons to create custom markers.
+     * @return the BlueMapAPI instance
+     */
+    @NonNull
+    public BlueMapAPI getBlueMapAPI() {
+        return api;
+    }
+
+    /**
+     * Gets the marker set for the given game mode addon, if one has been registered.
+     * @param addon the game mode addon
+     * @return the MarkerSet, or null if not registered
+     */
+    public MarkerSet getMarkerSet(@NonNull GameModeAddon addon) {
+        return markerSets.get(addon.getWorldSettings().getFriendlyName());
+    }
+
+    /**
+     * Creates or retrieves a custom marker set and attaches it to all BlueMap maps.
+     * Useful for addons like Warps that want to display their own markers.
+     * @param id unique identifier for the marker set
+     * @param label display label for the marker set
+     * @return the MarkerSet
+     */
+    @NonNull
+    public MarkerSet createMarkerSet(@NonNull String id, @NonNull String label) {
+        MarkerSet markerSet = MarkerSet.builder().label(label).toggleable(true).defaultHidden(false).build();
+        // Attach to all known BlueMap maps
+        api.getMaps().forEach(map -> map.getMarkerSets().put(id, markerSet));
+        return markerSet;
+    }
+
+    // --- Event handlers ---
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onNewIsland(IslandNewIslandEvent e) {

--- a/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
+++ b/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
@@ -2,7 +2,9 @@ package world.bentobox.bentobox.hooks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,6 +33,7 @@ import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.BlueMapWorld;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
+import de.bluecolored.bluemap.api.markers.ShapeMarker;
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
@@ -178,6 +181,9 @@ class BlueMapHookTest extends CommonTestSetup {
         MarkerSet ms = mapMarkerSets.get("BSkyBlock");
         assertNotNull(ms);
         assertNotNull(ms.get(uuid.toString()));
+        // Area marker should also be created
+        assertNotNull(ms.get(uuid.toString() + "_area"));
+        assertInstanceOf(ShapeMarker.class, ms.get(uuid.toString() + "_area"));
     }
 
     @Test
@@ -320,13 +326,16 @@ class BlueMapHookTest extends CommonTestSetup {
 
     @Test
     void testOnIslandDelete() {
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
         hook.hook();
         // island should be in the marker set after hook()
         IslandDeleteEvent event = mock(IslandDeleteEvent.class);
         when(event.getIsland()).thenReturn(island);
         hook.onIslandDelete(event);
-        // marker should be removed
-        assertFalse(mapMarkerSets.get("BSkyBlock").getMarkers().containsKey(uuid.toString()));
+        // both markers should be removed
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertFalse(ms.getMarkers().containsKey(uuid.toString()));
+        assertFalse(ms.getMarkers().containsKey(uuid.toString() + "_area"));
     }
 
     @Test
@@ -373,5 +382,41 @@ class BlueMapHookTest extends CommonTestSetup {
         assertFalse(ms.getMarkers().containsKey(uuid.toString()));
         // New island marker added
         assertNotNull(ms.get(newUuid.toString()));
+        assertNotNull(ms.get(newUuid.toString() + "_area"));
+    }
+
+    // ---- Public addon API ----
+
+    @Test
+    void testGetBlueMapAPI() {
+        hook.hook();
+        assertEquals(blueMapAPI, hook.getBlueMapAPI());
+    }
+
+    @Test
+    void testGetMarkerSet() {
+        hook.hook();
+        assertEquals(mapMarkerSets.get("BSkyBlock"), hook.getMarkerSet(addon));
+    }
+
+    @Test
+    void testGetMarkerSetNotRegistered() {
+        hook.hook();
+        GameModeAddon unknownAddon = mock(GameModeAddon.class);
+        WorldSettings unknownSettings = mock(WorldSettings.class);
+        when(unknownAddon.getWorldSettings()).thenReturn(unknownSettings);
+        when(unknownSettings.getFriendlyName()).thenReturn("UnknownGame");
+        assertNull(hook.getMarkerSet(unknownAddon));
+    }
+
+    @Test
+    void testCreateMarkerSet() {
+        when(blueMapAPI.getMaps()).thenReturn(List.of(blueMapMap));
+        hook.hook();
+        MarkerSet result = hook.createMarkerSet("warps.markers", "Warps");
+        assertNotNull(result);
+        assertEquals("Warps", result.getLabel());
+        // Should be attached to the BlueMap map
+        assertTrue(mapMarkerSets.containsKey("warps.markers"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `ShapeMarker` rectangles showing island protected borders on BlueMap (blue outline, 15% opacity fill), matching DynmapHook's visualization
- Add public addon API: `getBlueMapAPI()`, `getMarkerSet()`, `createMarkerSet()` for addons to create custom markers
- Update `remove()` to clean up both POI and area markers on island delete/reset

## Test plan
- [x] Unit tests pass (BlueMapHookTest — 21 tests including new area marker and API tests)
- [ ] Verify island borders appear on BlueMap web map after server restart
- [ ] Verify markers update when islands are created, deleted, renamed, or reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)