### PR TITLE
Fix ItemStack quantity > 99 crash during serialization

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/json/adapters/ItemStackTypeAdapter.java
+++ b/src/main/java/world/bentobox/bentobox/database/json/adapters/ItemStackTypeAdapter.java
@@ -23,11 +23,25 @@ import world.bentobox.bentobox.BentoBox;
  */
 public class ItemStackTypeAdapter extends TypeAdapter<ItemStack> {
 
+    private static final int MAX_AMOUNT = 99;
+
     @Override
     public void write(JsonWriter out, ItemStack value) throws IOException {
         if (value == null) {
             out.nullValue();
             return;
+        }
+        // Clamp quantity to valid serialization range [1, 99]
+        if (value.getAmount() > MAX_AMOUNT) {
+            BentoBox.getInstance().logWarning("ItemStack " + value.getType() + " has quantity " + value.getAmount()
+                    + " which exceeds max " + MAX_AMOUNT + ". Clamping to " + MAX_AMOUNT + ".");
+            value = value.clone();
+            value.setAmount(MAX_AMOUNT);
+        } else if (value.getAmount() < 1) {
+            BentoBox.getInstance().logWarning("ItemStack " + value.getType() + " has quantity " + value.getAmount()
+                    + " which is less than 1. Clamping to 1.");
+            value = value.clone();
+            value.setAmount(1);
         }
         YamlConfiguration c = new YamlConfiguration();
         c.set("is", value);

--- a/src/main/java/world/bentobox/bentobox/util/ItemParser.java
+++ b/src/main/java/world/bentobox/bentobox/util/ItemParser.java
@@ -40,6 +40,8 @@ import world.bentobox.bentobox.BentoBox;
 @SuppressWarnings("removal")
 public class ItemParser {
 
+    private static final int MAX_AMOUNT = 99;
+
     private ItemParser() {} // private constructor to hide the implicit public one.
     /**
      * Parse given string to ItemStack.
@@ -184,7 +186,7 @@ public class ItemParser {
      * @return ItemStack with material from first array element and amount based on second array element.
      */
     private static ItemStack parseItemQuantity(String[] part) {
-        int reqAmount = Integer.parseInt(part[1]);
+        int reqAmount = clampAmount(Integer.parseInt(part[1]), part[0]);
         Material reqItem = Material.getMaterial(part[0].toUpperCase(java.util.Locale.ENGLISH));
 
         if (reqItem == null) {
@@ -265,7 +267,7 @@ public class ItemParser {
         // TODO: Set extended and upgraded settings.
         potionMeta.setBasePotionType(type);
         result.setItemMeta(potionMeta);
-        result.setAmount(Integer.parseInt(part[5]));
+        result.setAmount(clampAmount(Integer.parseInt(part[5]), part[0]));
         return result;
     }
 
@@ -312,7 +314,7 @@ public class ItemParser {
             material = Material.POTION;
         }
 
-        ItemStack result = new ItemStack(material, Integer.parseInt(part[2]));
+        ItemStack result = new ItemStack(material, clampAmount(Integer.parseInt(part[2]), part[0]));
 
         if (result.getItemMeta() instanceof PotionMeta meta) {
             PotionType potionType = Enums.getIfPresent(PotionType.class, part[1].toUpperCase(Locale.ENGLISH)).
@@ -337,7 +339,7 @@ public class ItemParser {
                 BentoBox.getInstance().logError("Could not parse banner item " + part[0] + " so using a white banner.");
                 bannerMat = Material.WHITE_BANNER;
             }
-            ItemStack result = new ItemStack(bannerMat, Integer.parseInt(part[1]));
+            ItemStack result = new ItemStack(bannerMat, clampAmount(Integer.parseInt(part[1]), part[0]));
 
             BannerMeta meta = (BannerMeta) result.getItemMeta();
             if (meta != null) {
@@ -450,6 +452,30 @@ public class ItemParser {
 
     /**
      * Check if given sting is an integer.
+    /**
+     * Clamp item stack amount to valid serialization range [1, 99].
+     * Logs a warning if clamping occurs.
+     * @param amount the requested amount
+     * @param context description for the warning message (e.g., the material name)
+     * @return clamped amount
+     */
+    private static int clampAmount(int amount, String context) {
+        if (amount > MAX_AMOUNT) {
+            BentoBox.getInstance().logWarning(
+                    "Item " + context + " has quantity " + amount + " which exceeds max " + MAX_AMOUNT
+                            + ". Clamping to " + MAX_AMOUNT + ".");
+            return MAX_AMOUNT;
+        }
+        if (amount < 1) {
+            BentoBox.getInstance().logWarning(
+                    "Item " + context + " has quantity " + amount + " which is less than 1. Clamping to 1.");
+            return 1;
+        }
+        return amount;
+    }
+
+    /**
+     * Check if given string is an integer.
      * @param string Value that must be checked.
      * @return {@code true} if value is integer, {@code false} otherwise.
      */


### PR DESCRIPTION
## Summary
- Mojang's `ItemStack` codec enforces a `[1, 99]` range on item count (`ExtraCodecs.intRange(1, 99)` in `ItemStack.MAP_CODEC`). When addons provide items with quantities exceeding this limit (e.g., `RED_MUSHROOM:100` in a Biomes template), `CraftMagicNumbers.serializeStack()` throws `IllegalStateException: Value must be within range [1;99]: 100`
- Clamps quantities to `[1, 99]` at both parse time (`ItemParser`) and serialization time (`ItemStackTypeAdapter`) with a warning log, so the operation succeeds gracefully instead of crashing
- Applies to all 4 quantity-parsing paths in `ItemParser`: simple items, potions, old-format potions, and banners

## Test plan
- [x] `./gradlew test` passes
- [ ] Manual test: import a Biomes template with `RED_MUSHROOM:100`, verify warning is logged and import succeeds with quantity clamped to 99

🤖 Generated with [Claude Code](https://claude.com/claude-code)