### PR TITLE
Add Paper 26.1.1 support

### DIFF
--- a/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
+++ b/src/main/java/world/bentobox/bentobox/versions/ServerCompatibility.java
@@ -169,8 +169,11 @@ public class ServerCompatibility {
         /**
          * @since 3.11.0
          */
-        V1_21_11(Compatibility.COMPATIBLE)
-        ,;
+        V1_21_11(Compatibility.COMPATIBLE),
+        /**
+         * @since 3.12.2
+         */
+        V26_1_1(Compatibility.COMPATIBLE),;
 
         private final Compatibility compatibility;
 
@@ -275,7 +278,10 @@ public class ServerCompatibility {
      */
     @Nullable
     public ServerVersion getServerVersion() {
-        String serverVersion = Bukkit.getServer().getBukkitVersion().split("-")[0].replace(".", "_");
+        String serverVersion = Bukkit.getServer().getBukkitVersion().split("-")[0];
+        // Handle Paper 26+ version format: "26.1.1.build.14" → "26.1.1"
+        serverVersion = serverVersion.replaceAll("\\.build\\.\\d+$", "");
+        serverVersion = serverVersion.replace(".", "_");
         try {
             return ServerVersion.valueOf("V" + serverVersion.toUpperCase(Locale.ENGLISH));
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
## Summary
- Add `V26_1_1` as `COMPATIBLE` to the `ServerVersion` enum so BentoBox no longer shows a compatibility warning on Paper 26.1.1
- Fix `getServerVersion()` to handle Paper 26+'s new version string format (`26.1.1.build.14-alpha`) by stripping the `.build.N` suffix before parsing
- No build dependency changes — Paper dependency stays at 1.21.11 since MockBukkit doesn't support 26.1.1 yet

## Test plan
- [x] `./gradlew clean build` passes (all tests green)
- [x] Deployed to Paper 26.1.1 server — no compatibility warning on startup, BentoBox enables normally
- [x] Verified backward compatibility: old version strings (e.g. `1.21.11-R0.1-SNAPSHOT`) are unaffected by the regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)