### PR TITLE
Fix #2919: extra blank line in confirmation conversation prompts

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/conversations/NamePrompt.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/conversations/NamePrompt.java
@@ -34,10 +34,7 @@ public class NamePrompt extends StringPrompt {
     @Override
     @NonNull
     public String getPromptText(@NonNull ConversationContext context) {
-        // Send via User to properly render MiniMessage/legacy formatting,
-        // since Bukkit's conversation API sends raw text without formatting.
-        user.sendRawMessage(user.getTranslation("commands.island.renamehome.enter-new-name"));
-        return "";
+        return user.getTranslation("commands.island.renamehome.enter-new-name");
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/conversations/ConfirmPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/conversations/ConfirmPrompt.java
@@ -35,10 +35,7 @@ public class ConfirmPrompt extends StringPrompt {
     @Override
     @NonNull
     public String getPromptText(@NonNull ConversationContext context) {
-        // Send via User to properly render MiniMessage/legacy formatting,
-        // since Bukkit's conversation API sends raw text without formatting.
-        user.sendRawMessage(user.getTranslation(instructions));
-        return "";
+        return user.getTranslation(instructions);
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUI.java
@@ -267,8 +267,7 @@ public class IslandTeamInviteGUI {
         @Override
         @NonNull
         public String getPromptText(@NonNull ConversationContext context) {
-            user.sendRawMessage(user.getTranslation("commands.island.team.invite.gui.enter-name"));
-            return "";
+            return user.getTranslation("commands.island.team.invite.gui.enter-name");
         }
 
         @Override

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/CommandsPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/CommandsPrompt.java
@@ -44,14 +44,10 @@ public class CommandsPrompt extends StringPrompt {
                 sb.append(line);
                 sb.append(System.lineSeparator());
             }
-            // Send formatted message directly since Bukkit conversations don't parse MiniMessage
-            user.sendRawMessage(sb.toString());
-            return "";
+            return sb.toString();
         }
-        String msg = user.getTranslation("commands.admin.blueprint.management.commands.instructions",
+        return user.getTranslation("commands.admin.blueprint.management.commands.instructions",
                 TextVariables.NAME, bb.getDisplayName());
-        user.sendRawMessage(msg);
-        return "";
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/CommandsSuccessPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/CommandsSuccessPrompt.java
@@ -38,18 +38,15 @@ public class CommandsSuccessPrompt extends MessagePrompt {
         User user = User.getInstance((Player) context.getForWhom());
         @SuppressWarnings("unchecked")
         List<String> commands = (List<String>) context.getSessionData("commands");
-        String msg;
         if (commands != null) {
             bb.setCommands(commands);
             BentoBox.getInstance().getBlueprintsManager().addBlueprintBundle(addon, bb);
             BentoBox.getInstance().getBlueprintsManager().saveBlueprintBundle(addon, bb);
             new BlueprintManagementPanel(BentoBox.getInstance(), user, addon).openBB(bb);
-            msg = user.getTranslation("commands.admin.blueprint.management.commands.success");
+            return user.getTranslation("commands.admin.blueprint.management.commands.success");
         } else {
-            msg = user.getTranslation("commands.admin.blueprint.management.commands.cancelling");
+            return user.getTranslation("commands.admin.blueprint.management.commands.cancelling");
         }
-        user.sendRawMessage(msg);
-        return "";
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionPrompt.java
@@ -43,12 +43,9 @@ public class DescriptionPrompt extends StringPrompt {
                 sb.append(line);
                 sb.append(System.lineSeparator());
             }
-            user.sendRawMessage(sb.toString());
-            return "";
+            return sb.toString();
         }
-        String msg = user.getTranslation("commands.admin.blueprint.management.description.instructions", TextVariables.NAME, bb.getDisplayName());
-        user.sendRawMessage(msg);
-        return "";
+        return user.getTranslation("commands.admin.blueprint.management.description.instructions", TextVariables.NAME, bb.getDisplayName());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionSuccessPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/DescriptionSuccessPrompt.java
@@ -33,18 +33,15 @@ public class DescriptionSuccessPrompt extends MessagePrompt {
         User user = User.getInstance((Player)context.getForWhom());
         @SuppressWarnings("unchecked")
         List<String> description = (List<String>)context.getSessionData("description");
-        String msg;
         if (description != null) {
             bb.setDescription(description);
             BentoBox.getInstance().getBlueprintsManager().addBlueprintBundle(addon, bb);
             BentoBox.getInstance().getBlueprintsManager().saveBlueprintBundle(addon, bb);
             new BlueprintManagementPanel(BentoBox.getInstance(), user, addon).openBB(bb);
-            msg = user.getTranslation("commands.admin.blueprint.management.description.success");
+            return user.getTranslation("commands.admin.blueprint.management.description.success");
         } else {
-            msg = user.getTranslation("commands.admin.blueprint.management.description.cancelling");
+            return user.getTranslation("commands.admin.blueprint.management.description.cancelling");
         }
-        user.sendRawMessage(msg);
-        return "";
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NamePrompt.java
@@ -45,8 +45,7 @@ public class NamePrompt extends StringPrompt
     public @NonNull String getPromptText(ConversationContext context)
     {
         User user = User.getInstance((Player) context.getForWhom());
-        user.sendRawMessage(user.getTranslation("commands.admin.blueprint.management.name.prompt"));
-        return "";
+        return user.getTranslation("commands.admin.blueprint.management.name.prompt");
     }
 
 

--- a/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameSuccessPrompt.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/conversation/NameSuccessPrompt.java
@@ -77,9 +77,7 @@ public class NameSuccessPrompt extends MessagePrompt
             // Set the name
         }
 
-        String msg = user.getTranslation("commands.admin.blueprint.management.description.success");
-        user.sendRawMessage(msg);
-        return "";
+        return user.getTranslation("commands.admin.blueprint.management.description.success");
     }
 
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUITest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUITest.java
@@ -429,8 +429,7 @@ class IslandTeamInviteGUITest extends RanksManagerTestSetup {
         IslandTeamInviteGUI.InviteNamePrompt prompt = gui.new InviteNamePrompt();
         ConversationContext ctx = mock(ConversationContext.class);
 
-        // getPromptText sends via User.sendRawMessage and returns empty string
-        assertEquals("", prompt.getPromptText(ctx));
+        assertEquals("commands.island.team.invite.gui.enter-name", prompt.getPromptText(ctx));
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/blueprints/conversation/CommandsPromptTest.java
+++ b/src/test/java/world/bentobox/bentobox/blueprints/conversation/CommandsPromptTest.java
@@ -63,8 +63,9 @@ class CommandsPromptTest extends CommonTestSetup {
     void testGetPromptTextWithSessionData() {
         when(context.getSessionData("commands")).thenReturn(List.of("say hello"));
         String text = prompt.getPromptText(context);
-        // getPromptText sends via User.sendRawMessage and returns empty string
-        assertEquals("", text);
+        assertInstanceOf(String.class, text);
+        // Should contain the command text in the output
+        assertEquals(true, text.contains("say hello"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes #2919 — confirmation conversation prompts (e.g. `/ob settings` → Reset to default) printed an extra blank line above the prompt text.
- Cause: commit 515a7f1e0 worked around a (seemingly) broken `Player.sendRawMessage` formatting path by sending the prompt via `User.sendRawMessage` and returning `""` from `getPromptText`. Bukkit's Conversation API still prints whatever `getPromptText` returns, so the empty string became a blank chat line.
- Verified in-game on current Paper that returning the legacy `§`-coded translation directly from `getPromptText` renders correctly, so the workaround is no longer needed. Reverts the prompt-rendering portion of 515a7f1e0 across all 9 prompt classes (`ConfirmPrompt`, admin/blueprint `NamePrompt`, `InviteNamePrompt`, blueprint `Commands`/`Description`/`Name(Success)Prompt`) and restores the matching test assertions in `IslandTeamInviteGUITest` and `CommandsPromptTest`.
- The unrelated `PanelItemBuilder` multi-line name change from 515a7f1e0 is **not** touched.

## Test plan
- [x] `./gradlew test --tests "*ConfirmPrompt*" --tests "*IslandTeamInviteGUITest*" --tests "*CommandsPromptTest*" --tests "*NamePrompt*"` — green
- [x] In-game: `/ob settings` → Reset to default — prompt renders with colors and no blank line (confirmed by reporter scenario)
- [x] In-game: `/island team invite` name entry prompt
- [x] In-game: `/island renamehome` prompt
- [x] In-game: `/bbox blueprint` admin name / description / commands edit flows (the most format-heavy prompts)