### PR TITLE
Skip locale files with invalid BCP-47 tags

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/LocalesManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/LocalesManager.java
@@ -269,7 +269,17 @@ public class LocalesManager {
         }
         // Run through the files and store the locales
         for (File language : Objects.requireNonNull(localeDir.listFiles(ymlFilter))) {
-            Locale localeObject = Locale.forLanguageTag(language.getName().substring(0, language.getName().length() - 4));
+            String tag = language.getName().substring(0, language.getName().length() - 4);
+            Locale localeObject = Locale.forLanguageTag(tag);
+
+            // Skip files whose name does not parse to a real BCP-47 language tag.
+            // e.g. "zh_CN.yml" (underscore) yields Locale.ROOT, which would otherwise show
+            // up as a blank entry in the language selector panel.
+            if (localeObject.getLanguage().isEmpty()) {
+                plugin.logWarning("Ignoring locale file '" + localeFolder + "/" + language.getName()
+                        + "': '" + tag + "' is not a valid BCP-47 language tag (use '-' not '_').");
+                continue;
+            }
 
             try {
                 YamlConfiguration languageYaml = YamlConfiguration.loadConfiguration(language);


### PR DESCRIPTION
## Summary
- A blank entry was appearing in the language selector panel next to US English.
- Cause: filenames like `zh_CN.yml` (underscore instead of dash) parse via `Locale.forLanguageTag` to `Locale.ROOT`, which has an empty language and empty display name. When any addon ships such a file, `reloadLanguages()` adds the ROOT entry to the shared `languages` map and it surfaces in the panel as a banner with no name.
- `LocalesManager.loadLocalesFromFile` now skips files whose name does not parse to a real BCP-47 language tag and logs a warning naming the offending file so addon authors can fix the tag (e.g. rename `zh_CN.yml` → `zh-CN.yml`).

## Test plan
- [x] Place a `zh_CN.yml` file in an addon's locales folder, start the server, and confirm the language panel no longer shows a blank entry.
- [x] Confirm a warning is logged identifying the bad file.
- [x] Existing `LocalesManagerTest` suite still passes (uses real `Locale.US` / `Locale.FRANCE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)