### PR TITLE
Preserve addon placeholders across /bbox reload (#2930)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxReloadCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxReloadCommand.java
@@ -8,6 +8,7 @@ import world.bentobox.bentobox.api.panels.reader.TemplateReader;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.commands.reload.BentoBoxReloadLocalesCommand;
 import world.bentobox.bentobox.listeners.PanelListenerManager;
+import world.bentobox.bentobox.managers.PlaceholdersManager;
 
 /**
  * Reloads settings, addons and localization.
@@ -38,8 +39,12 @@ public class BentoBoxReloadCommand extends ConfirmableCommand {
         if (args.isEmpty()) {
             this.askConfirmation(user, user.getTranslation("commands.bentobox.reload.warning"), () -> {
 
-                // Unregister all placeholders
-                getPlugin().getPlaceholdersManager().unregisterAll();
+                // Clear placeholders that this reload will rebuild. Addon-owned
+                // placeholders (e.g. from the Level addon) are intentionally
+                // preserved because reload does not re-invoke addons (#2930).
+                PlaceholdersManager pm = getPlugin().getPlaceholdersManager();
+                pm.unregisterAll();
+                getPlugin().getAddonsManager().getGameModeAddons().forEach(pm::unregisterAll);
 
                 // Close all open panels
                 PanelListenerManager.closeAllPanels();
@@ -55,7 +60,7 @@ public class BentoBoxReloadCommand extends ConfirmableCommand {
                 user.sendMessage("commands.bentobox.reload.locales-reloaded");
 
                 // Register new default gamemode placeholders
-                getPlugin().getAddonsManager().getGameModeAddons().forEach(getPlugin().getPlaceholdersManager()::registerDefaultPlaceholders);
+                getPlugin().getAddonsManager().getGameModeAddons().forEach(pm::registerDefaultPlaceholders);
 
             });
         } else {

--- a/src/main/java/world/bentobox/bentobox/hooks/placeholders/PlaceholderAPIHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/placeholders/PlaceholderAPIHook.java
@@ -285,11 +285,30 @@ public class PlaceholderAPIHook extends PlaceholderHook {
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Only clears the BentoBox-core expansion. Placeholders registered by addons
+     * via {@link #registerPlaceholder(Addon, String, PlaceholderReplacer)} are
+     * intentionally preserved, because callers like {@code /bbox reload} do not
+     * re-invoke addons and would otherwise leave addon placeholders in a stale,
+     * empty state (see #2930). To clear a specific addon's placeholders, use
+     * {@link #unregisterAll(Addon)}.
      */
     @Override
     public void unregisterAll() {
         bentoboxExpansion.getRegisteredPlaceholders().forEach(this::unregisterPlaceholder);
-        addonsExpansions.forEach((addon, exp) ->
-            exp.getRegisteredPlaceholders().forEach(ph -> this.unregisterPlaceholder(addon, ph)));
+    }
+
+    /**
+     * Unregisters all placeholders previously registered for the given addon.
+     * The expansion object stays registered with PlaceholderAPI but its
+     * internal placeholder map is emptied.
+     * @param addon the addon whose placeholders should be cleared, not null.
+     * @since 3.4.0
+     */
+    public void unregisterAll(@NonNull Addon addon) {
+        AddonPlaceholderExpansion exp = addonsExpansions.get(addon);
+        if (exp != null) {
+            exp.getRegisteredPlaceholders().forEach(exp::unregisterPlaceholder);
+        }
     }
 }

--- a/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlaceholdersManager.java
@@ -442,11 +442,21 @@ public class PlaceholdersManager {
     }
 
     /**
-     * Unregisters all the placeholders.
+     * Unregisters all BentoBox-core placeholders. Placeholders registered by addons
+     * are intentionally preserved; use {@link #unregisterAll(Addon)} to clear those.
      * @since 1.15.0
      */
     public void unregisterAll() {
         getPlaceholderAPIHook().ifPresent(PlaceholderAPIHook::unregisterAll);
+    }
+
+    /**
+     * Unregisters all placeholders previously registered for the given addon.
+     * @param addon the addon whose placeholders should be cleared, not null.
+     * @since 3.4.0
+     */
+    public void unregisterAll(@NonNull Addon addon) {
+        getPlaceholderAPIHook().ifPresent(hook -> hook.unregisterAll(addon));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/world/bentobox/bentobox/managers/PlaceholdersManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PlaceholdersManagerTest.java
@@ -297,6 +297,21 @@ class PlaceholdersManagerTest extends CommonTestSetup {
         verify(hook, never()).unregisterAll();
     }
 
+    @Test
+    void testUnregisterAllAddon() {
+        pm.unregisterAll(addon);
+        verify(hook).unregisterAll(addon);
+    }
+
+    @Test
+    void testUnregisterAllAddonNoHook() {
+        when(hm.getHook("PlaceholderAPI")).thenReturn(Optional.empty());
+        pm = new PlaceholdersManager(plugin);
+
+        pm.unregisterAll(addon);
+        verify(hook, never()).unregisterAll(addon);
+    }
+
     // ---------------------------------------------------------------
     // getRegisteredBentoBoxPlaceholders tests
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes BentoBoxWorld/BentoBox#2930: addon placeholders such as `%level_aoneblock_island_level%` silently stop resolving after `/bbox reload`.
- `BentoBoxReloadCommand` was calling `PlaceholderAPIHook.unregisterAll()`, which wiped **every** registered placeholder including ones owned by third-party addons. The reload then only re-registered gamemode-default placeholders, so addon expansions were left cached with empty maps and `onPlaceholderRequest` returned `null`. Addons are not actually disabled by reload, so their replacers were still valid — they were just thrown away.
- Narrow `PlaceholderAPIHook.unregisterAll()` to only clear the BentoBox-core expansion, add a targeted `unregisterAll(Addon)` overload, and have the reload command clear only the gamemode addons it knows how to rebuild.

## Test plan
- [x] `./gradlew test --tests "world.bentobox.bentobox.managers.PlaceholdersManagerTest"`
- [ ] Manual: install BentoBox + AOneBlock + Level + PlaceholderAPI on a Paper test server, display `%level_aoneblock_island_level%` in tab/scoreboard, run `/bbox reload`, confirm the placeholder still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)