### PR TITLE
Don't clear gamemode addon placeholders on reload (#2930 follow-up)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/commands/BentoBoxReloadCommand.java
+++ b/src/main/java/world/bentobox/bentobox/commands/BentoBoxReloadCommand.java
@@ -39,12 +39,14 @@ public class BentoBoxReloadCommand extends ConfirmableCommand {
         if (args.isEmpty()) {
             this.askConfirmation(user, user.getTranslation("commands.bentobox.reload.warning"), () -> {
 
-                // Clear placeholders that this reload will rebuild. Addon-owned
-                // placeholders (e.g. from the Level addon) are intentionally
-                // preserved because reload does not re-invoke addons (#2930).
+                // Clear only BentoBox-core placeholders. Addon-owned placeholders
+                // (both gamemode defaults and any custom ones addons register
+                // themselves) are intentionally preserved because reload does
+                // not re-invoke addons (#2930). registerDefaultPlaceholders
+                // below is idempotent, so any newly-added flag placeholders
+                // will still be picked up.
                 PlaceholdersManager pm = getPlugin().getPlaceholdersManager();
                 pm.unregisterAll();
-                getPlugin().getAddonsManager().getGameModeAddons().forEach(pm::unregisterAll);
 
                 // Close all open panels
                 PanelListenerManager.closeAllPanels();


### PR DESCRIPTION
## Summary
Follow-up to #2931. A user reported that after the first fix, `%level_...%` placeholders survive `/bbox reload` but AOneBlock's own `%aoneblock_...%` placeholders still break.

Root cause: the first fix still cleared each gamemode addon's placeholder map before re-running `registerDefaultPlaceholders`. That wiped out any custom placeholders a gamemode addon registered for itself (beyond the BentoBox defaults), which `registerDefaultPlaceholders` has no way to rebuild.

`registerDefaultPlaceholders` is already idempotent — `BasicPlaceholderExpansion.registerPlaceholder` uses `putIfAbsent`, and `registerFlagPlaceholder` early-returns via `isPlaceholder` — so running it without pre-clearing simply adds any missing entries (e.g. newly-registered flag placeholders) and leaves existing ones alone.

This PR removes the per-addon clear loop from `BentoBoxReloadCommand`. `PlaceholderAPIHook.unregisterAll()` now really does only touch the BentoBox-core expansion, as intended.

## Test plan
- [x] `./gradlew test --tests "world.bentobox.bentobox.managers.PlaceholdersManagerTest"`
- [ ] Manual: install BentoBox + AOneBlock + Level + PlaceholderAPI on Paper. Display both `%aoneblock_island_name%` and `%level_aoneblock_island_level%`. Run `/bbox reload` and confirm both still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)