### PR TITLE
Add Flag.Builder minimumRank API

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
@@ -143,6 +143,7 @@ public class Flag implements Comparable<Flag> {
     private final Type type;
     private boolean setting;
     private final int defaultRank;
+    private final int minimumRank;
     private final PanelItem.ClickHandler clickHandler;
     private final boolean subPanel;
     private Set<GameModeAddon> gameModes = new HashSet<>();
@@ -161,6 +162,7 @@ public class Flag implements Comparable<Flag> {
         this.type = builder.type;
         this.setting = builder.defaultSetting;
         this.defaultRank = builder.defaultRank;
+        this.minimumRank = builder.minimumRank;
         this.clickHandler = builder.clickHandler;
         this.subPanel = builder.usePanel;
         if (builder.gameModeAddon != null) {
@@ -282,6 +284,23 @@ public class Flag implements Comparable<Flag> {
      */
     public int getDefaultRank() {
         return defaultRank;
+    }
+
+    /**
+     * @return the minimum rank that may be selected for this flag in the settings
+     * cycle click. Defaults to {@link RanksManager#VISITOR_RANK}.
+     * @since 3.13.0
+     */
+    public int getMinimumRank() {
+        return minimumRank;
+    }
+
+    /**
+     * @return the click handler associated with this flag's panel item
+     * @since 3.13.0
+     */
+    public PanelItem.ClickHandler getClickHandler() {
+        return clickHandler;
     }
 
     /**
@@ -592,6 +611,7 @@ public class Flag implements Comparable<Flag> {
         // Default settings
         private boolean defaultSetting = false;
         private int defaultRank = RanksManager.MEMBER_RANK;
+        private int minimumRank = RanksManager.VISITOR_RANK;
 
         // ClickHandler - default depends on the type
         private PanelItem.ClickHandler clickHandler;
@@ -674,6 +694,19 @@ public class Flag implements Comparable<Flag> {
          */
         public Builder defaultRank(int defaultRank) {
             this.defaultRank = defaultRank;
+            return this;
+        }
+
+        /**
+         * Set the minimum rank that may be selected for this {@link Type#PROTECTION} flag
+         * in the settings cycle click. The default is {@link RanksManager#VISITOR_RANK}.
+         * The cycle click listener will not allow ranks below this value to be chosen.
+         * @param minimumRank minimum rank value (e.g. {@link RanksManager#MEMBER_RANK})
+         * @return Builder
+         * @since 3.13.0
+         */
+        public Builder minimumRank(int minimumRank) {
+            this.minimumRank = minimumRank;
             return this;
         }
 
@@ -764,12 +797,18 @@ public class Flag implements Comparable<Flag> {
          * @return Flag
          */
         public Flag build() {
+            // Ensure the default rank is not below the minimum selectable rank
+            if (defaultRank < minimumRank) {
+                BentoBox.getInstance().logWarning("Flag " + id + " defaultRank (" + defaultRank
+                        + ") is below minimumRank (" + minimumRank + "); raising defaultRank to minimumRank.");
+                defaultRank = minimumRank;
+            }
             // If no clickHandler has been set, then apply default ones
             if (clickHandler == null) {
                 clickHandler = switch (type) {
                 case SETTING -> new IslandToggleClick(id);
                 case WORLD_SETTING -> new WorldToggleClick(id);
-                default -> new CycleClick(id);
+                default -> new CycleClick(id, minimumRank, RanksManager.OWNER_RANK);
                 };
             }
             Flag flag = new Flag(this);

--- a/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
@@ -38,6 +38,7 @@ import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.RanksManagerTestSetup;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
+import world.bentobox.bentobox.api.flags.clicklisteners.CycleClick;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -396,5 +397,57 @@ class FlagTest extends RanksManagerTestSetup {
         Flag bbb = new Flag.Builder("BBB", Material.ACACIA_DOOR).type(Flag.Type.PROTECTION).build();
         assertTrue(aaa.compareTo(bbb) < bbb.compareTo(aaa));
         assertEquals(0, aaa.compareTo(aaa));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.flags.Flag#getMinimumRank()}.
+     */
+    @Test
+    void testMinimumRankDefaultsToVisitor() {
+        Flag flag = new Flag.Builder("minDefault", Material.ACACIA_DOOR).type(Flag.Type.PROTECTION).build();
+        assertEquals(RanksManager.VISITOR_RANK, flag.getMinimumRank());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.flags.Flag.Builder#minimumRank(int)}.
+     */
+    @Test
+    void testMinimumRankSetViaBuilder() {
+        Flag flag = new Flag.Builder("minMember", Material.ACACIA_DOOR)
+                .type(Flag.Type.PROTECTION)
+                .minimumRank(RanksManager.MEMBER_RANK)
+                .build();
+        assertEquals(RanksManager.MEMBER_RANK, flag.getMinimumRank());
+    }
+
+    /**
+     * The auto-assigned CycleClick for a PROTECTION flag must be configured with the
+     * Builder's minimumRank, so the click cycle skips ranks below the minimum.
+     */
+    @Test
+    void testMinimumRankPropagatesToCycleClick() throws Exception {
+        Flag flag = new Flag.Builder("minCycle", Material.ACACIA_DOOR)
+                .type(Flag.Type.PROTECTION)
+                .minimumRank(RanksManager.MEMBER_RANK)
+                .build();
+        PanelItem.ClickHandler handler = flag.getClickHandler();
+        assertTrue(handler instanceof CycleClick, "Expected auto-assigned CycleClick handler");
+        java.lang.reflect.Field minRankField = CycleClick.class.getDeclaredField("minRank");
+        minRankField.setAccessible(true);
+        assertEquals(RanksManager.MEMBER_RANK, minRankField.getInt(handler));
+    }
+
+    /**
+     * If defaultRank is set below minimumRank, build() should clamp it up to minimumRank
+     * so the flag's default value is selectable.
+     */
+    @Test
+    void testDefaultRankClampedToMinimumRank() {
+        Flag flag = new Flag.Builder("clamp", Material.ACACIA_DOOR)
+                .type(Flag.Type.PROTECTION)
+                .defaultRank(RanksManager.VISITOR_RANK)
+                .minimumRank(RanksManager.MEMBER_RANK)
+                .build();
+        assertEquals(RanksManager.MEMBER_RANK, flag.getDefaultRank());
     }
 }


### PR DESCRIPTION
## Summary
- New `Flag.Builder.minimumRank(int)` lets addons declare the lowest rank that may be selected for a `PROTECTION` flag (default `VISITOR_RANK`, so fully backwards-compatible).
- The auto-assigned `CycleClick` listener is now constructed with the configured minimum, so the click-cycle in the settings panel will not let players select ranks below it (e.g. set `minimumRank(MEMBER_RANK)` to restrict a flag to Member/Sub-owner/Owner).
- `build()` clamps `defaultRank` up to `minimumRank` (with a logged warning) so a misconfigured flag still has a selectable default.
- Adds `Flag.getMinimumRank()` and `Flag.getClickHandler()` getters.

## Test plan
- [x] `./gradlew test --tests "world.bentobox.bentobox.api.flags.*"` — all green
- [x] New unit tests in `FlagTest`:
  - default `minimumRank` is `VISITOR_RANK`
  - `Builder.minimumRank(MEMBER_RANK)` is reflected on the built flag
  - the auto-assigned `CycleClick` carries the configured minimum (verified via reflection on the listener's `minRank` field)
  - `defaultRank` below `minimumRank` is clamped up

## Notes
- No changes to `CycleClick` — the existing two-arg constructor and rank-bound enforcement in `leftClick`/`rightClick` already handle this; the Builder just exposes it.
- Binary-compatible: only additive methods, no signature or return-type changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)