### PR TITLE
fix: retain DB row for deleted-sweep islands straddling a blocked region

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
@@ -147,6 +147,8 @@ public class PurgeRegionsService {
 
         IslandGrid islandGrid = plugin.getIslands().getIslandCache().getIslandGrid(world);
         if (islandGrid == null) {
+            plugin.logWarning("Purge deleted-sweep: no island grid for world " + world.getName()
+                    + " — skipping scan");
             return new PurgeScanResult(world, 0, new HashMap<>(), isNether, isEnd,
                     new FilterStats(0, 0, 0, 0));
         }
@@ -194,6 +196,8 @@ public class PurgeRegionsService {
 
         IslandGrid islandGrid = plugin.getIslands().getIslandCache().getIslandGrid(world);
         if (islandGrid == null) {
+            plugin.logWarning("Purge age-sweep: no island grid for world " + world.getName()
+                    + " — skipping scan");
             return new PurgeScanResult(world, days, new HashMap<>(), isNether, isEnd,
                     new FilterStats(0, 0, 0, 0));
         }

--- a/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
@@ -96,7 +96,8 @@ public class PurgeRegionsService {
             Map<Pair<Integer, Integer>, Set<String>> deletableRegions,
             boolean isNether,
             boolean isEnd,
-            FilterStats stats) {
+            FilterStats stats,
+            Set<String> straddlingIslandIds) {
         public boolean isEmpty() {
             return deletableRegions.isEmpty();
         }
@@ -114,6 +115,10 @@ public class PurgeRegionsService {
 
     /** Groups the three folder types (region, entities, poi) for one world dimension. */
     private record DimFolders(File region, File entities, File poi) {}
+
+    /** Return type for {@link #filterForDeletedSweep}: filter statistics plus the set of
+     *  deletable island IDs whose chunks lie in a region that was blocked by a live neighbour. */
+    private record DeleteSweepFilter(FilterStats stats, Set<String> straddlingIds) {}
 
     // ---------------------------------------------------------------
     // Public API
@@ -150,7 +155,7 @@ public class PurgeRegionsService {
             plugin.logWarning("Purge deleted-sweep: no island grid for world " + world.getName()
                     + " — skipping scan");
             return new PurgeScanResult(world, 0, new HashMap<>(), isNether, isEnd,
-                    new FilterStats(0, 0, 0, 0));
+                    new FilterStats(0, 0, 0, 0), Set.of());
         }
 
         // Collect candidate region coords from every deletable island's
@@ -173,9 +178,14 @@ public class PurgeRegionsService {
 
         Map<Pair<Integer, Integer>, Set<String>> deletableRegions =
                 mapIslandsToRegions(new ArrayList<>(candidateRegions), islandGrid);
-        FilterStats stats = filterForDeletedSweep(deletableRegions);
-        logFilterStats(stats);
-        return new PurgeScanResult(world, 0, deletableRegions, isNether, isEnd, stats);
+        DeleteSweepFilter filterResult = filterForDeletedSweep(deletableRegions);
+        logFilterStats(filterResult.stats());
+        if (!filterResult.straddlingIds().isEmpty()) {
+            plugin.log("Purge deleted-sweep: " + filterResult.straddlingIds().size()
+                    + " island(s) straddle a blocked region — DB row(s) retained for next sweep");
+        }
+        return new PurgeScanResult(world, 0, deletableRegions, isNether, isEnd,
+                filterResult.stats(), filterResult.straddlingIds());
     }
 
     /**
@@ -199,14 +209,14 @@ public class PurgeRegionsService {
             plugin.logWarning("Purge age-sweep: no island grid for world " + world.getName()
                     + " — skipping scan");
             return new PurgeScanResult(world, days, new HashMap<>(), isNether, isEnd,
-                    new FilterStats(0, 0, 0, 0));
+                    new FilterStats(0, 0, 0, 0), Set.of());
         }
 
         List<Pair<Integer, Integer>> oldRegions = findOldRegions(world, days, isNether, isEnd);
         Map<Pair<Integer, Integer>, Set<String>> deletableRegions = mapIslandsToRegions(oldRegions, islandGrid);
         FilterStats stats = filterNonDeletableRegions(deletableRegions, days);
         logFilterStats(stats);
-        return new PurgeScanResult(world, days, deletableRegions, isNether, isEnd, stats);
+        return new PurgeScanResult(world, days, deletableRegions, isNether, isEnd, stats, Set.of());
     }
 
     /**
@@ -252,6 +262,16 @@ public class PurgeRegionsService {
             Island island = opt.get();
 
             if (scan.days() == 0) {
+                if (scan.straddlingIslandIds().contains(islandID)) {
+                    // This island has chunks in a region that was blocked by an
+                    // active neighbour island — those blocks are still on disk.
+                    // Retaining the DB row (deletable=true) lets the next
+                    // deleted-sweep retry once the blocker is itself gone.
+                    islandsDeferred++;
+                    plugin.log("Island ID " + islandID
+                            + " straddles a blocked region \u2014 DB row retained for next purge sweep");
+                    continue;
+                }
                 // Deleted sweep: region files are gone from disk but Paper
                 // may still serve stale chunk data from its internal memory
                 // cache. Defer DB row removal to plugin shutdown when the
@@ -606,15 +626,22 @@ public class PurgeRegionsService {
      * region blocks the whole region. Unlike {@link #filterNonDeletableRegions}
      * this has no age/login/level logic — only the {@code deletable} flag
      * matters.
+     *
+     * <p>When a region is blocked, any <em>deletable</em> islands in that region
+     * are recorded as "straddling" — they have chunks in a blocked region that
+     * cannot be reaped this sweep. Their DB rows must be retained so the next
+     * sweep can retry once the blocking island is itself deleted.
      */
-    private FilterStats filterForDeletedSweep(
+    private DeleteSweepFilter filterForDeletedSweep(
             Map<Pair<Integer, Integer>, Set<String>> deletableRegions) {
         int regionsBlockedByProtection = 0;
+        Set<String> straddling = new HashSet<>();
         var iter = deletableRegions.entrySet().iterator();
         while (iter.hasNext()) {
             var entry = iter.next();
+            Set<String> ids = entry.getValue();
             boolean block = false;
-            for (String id : entry.getValue()) {
+            for (String id : ids) {
                 Optional<Island> opt = plugin.getIslands().getIslandById(id);
                 if (opt.isEmpty()) {
                     // Missing rows don't block — they're already gone.
@@ -626,11 +653,19 @@ public class PurgeRegionsService {
                 }
             }
             if (block) {
+                // Collect the deletable islands whose chunks lie in this blocked
+                // region — they straddle the boundary between a reaped region and
+                // this blocked one, so their blocks remain on disk here.
+                for (String id : ids) {
+                    plugin.getIslands().getIslandById(id)
+                            .filter(Island::isDeletable)
+                            .ifPresent(i -> straddling.add(i.getUniqueId()));
+                }
                 iter.remove();
                 regionsBlockedByProtection++;
             }
         }
-        return new FilterStats(0, 0, 0, regionsBlockedByProtection);
+        return new DeleteSweepFilter(new FilterStats(0, 0, 0, regionsBlockedByProtection), straddling);
     }
 
     private int[] evaluateRegionIslands(Set<String> islandIds, int days) {

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -12,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -23,15 +25,19 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.DeleteIslandChunks;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -230,6 +236,62 @@ class AdminDeleteCommandTest extends CommonTestSetup {
         // Confirm
         itl.execute(user, itl.getLabel(), Arrays.asList(name));
         verify(user).sendMessage("commands.confirmation.confirm", "[seconds]", "0");
+    }
+
+    @Test
+    void testDeleteIslandSoftDeleteForNewChunkGeneration() {
+        AdminDeleteCommand itl = setupForDeletion();
+
+        GameModeAddon gm = mock(GameModeAddon.class);
+        when(gm.isUsesNewChunkGeneration()).thenReturn(true);
+        when(iwm.getAddon(world)).thenReturn(Optional.of(gm));
+
+        assertTrue(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        itl.execute(user, itl.getLabel(), List.of("tastybento"));
+        itl.execute(user, itl.getLabel(), List.of("tastybento"));
+
+        verify(im).deleteIsland(eq(island), eq(true), eq(notUUID));
+        verify(im, never()).hardDeleteIsland(any());
+    }
+
+    @Test
+    void testDeleteIslandHardDeleteForSimpleGeneration() {
+        AdminDeleteCommand itl = setupForDeletion();
+
+        GameModeAddon gm = mock(GameModeAddon.class);
+        when(gm.isUsesNewChunkGeneration()).thenReturn(false);
+        when(iwm.getAddon(world)).thenReturn(Optional.of(gm));
+
+        assertTrue(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        itl.execute(user, itl.getLabel(), List.of("tastybento"));
+
+        try (MockedConstruction<DeleteIslandChunks> ignored =
+                Mockito.mockConstruction(DeleteIslandChunks.class)) {
+            itl.execute(user, itl.getLabel(), List.of("tastybento"));
+        }
+
+        verify(im).hardDeleteIsland(island);
+        verify(im, never()).deleteIsland(any(), eq(true), any());
+    }
+
+    private AdminDeleteCommand setupForDeletion() {
+        when(island.hasTeam()).thenReturn(false);
+        when(island.getCenter()).thenReturn(location);
+        when(island.getWorld()).thenReturn(world);
+        when(im.inTeam(any(), any())).thenReturn(false);
+        when(pm.getUUID(any())).thenReturn(notUUID);
+        when(im.getIslands(world, notUUID)).thenReturn(List.of(island));
+
+        BukkitScheduler scheduler = mock(BukkitScheduler.class);
+        BukkitTask task = mock(BukkitTask.class);
+        when(scheduler.runTaskLater(any(), any(Runnable.class), any(Long.class))).thenReturn(task);
+        when(scheduler.runTask(any(), any(Runnable.class))).thenAnswer(inv -> {
+            inv.<Runnable>getArgument(1).run();
+            return task;
+        });
+        mockedBukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+
+        return new AdminDeleteCommand(ac);
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/managers/HousekeepingManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/HousekeepingManagerTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.bukkit.Bukkit;
@@ -326,7 +327,7 @@ class HousekeepingManagerTest extends CommonTestSetup {
 
     private static PurgeScanResult emptyScan(int days) {
         return new PurgeScanResult(mock(World.class), days, Collections.emptyMap(),
-                false, false, new FilterStats(0, 0, 0, 0));
+                false, false, new FilterStats(0, 0, 0, 0), Set.of());
     }
 
     /** Reflective access to the package-private {@code checkAndMaybeRun} so

--- a/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
@@ -106,6 +106,19 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
     }
 
     /**
+     * A world with no island grid returns an empty age-sweep result
+     * rather than crashing.
+     */
+    @Test
+    void testScanNullGrid() {
+        when(islandCache.getIslandGrid(world)).thenReturn(null);
+
+        PurgeScanResult result = service.scan(world, 30);
+        assertTrue(result.isEmpty());
+        assertEquals(30, result.days());
+    }
+
+    /**
      * A world with only non-deletable islands yields no candidate regions.
      */
     @Test

--- a/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
@@ -314,7 +314,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
         regions.put(new Pair<>(0, 0), Set.of("del"));
         PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(false);
         when(world.isChunkLoaded(5, 7)).thenReturn(true);
@@ -340,7 +340,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
         regions.put(new Pair<>(1, -1), Set.of("del"));
         PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(false);
         // The bottom-left corner of r.1.-1 is (32, -32); the top-right is (63, -1).
@@ -387,7 +387,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
         regions.put(new Pair<>(0, 0), Set.of("spans"));
         PurgeScanResult scan = new PurgeScanResult(world, 30, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         boolean ok = service.delete(scan);
         assertTrue(ok);
@@ -422,7 +422,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
         regions.put(new Pair<>(0, 0), Set.of("tiny"));
         PurgeScanResult scan = new PurgeScanResult(world, 30, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         boolean ok = service.delete(scan);
         assertTrue(ok);
@@ -463,7 +463,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
         regions.put(new Pair<>(0, 0), Set.of("tiny", "spans"));
         PurgeScanResult scan = new PurgeScanResult(world, 30, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         boolean ok = service.delete(scan);
         assertTrue(ok);
@@ -479,7 +479,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
     @Test
     void testEvictChunksEmptyScanIsNoop() {
         PurgeScanResult scan = new PurgeScanResult(world, 0, new HashMap<>(), false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         service.evictChunks(scan);
 
@@ -512,7 +512,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
         regions.put(new Pair<>(0, 0), Set.of("del1"));
         PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         boolean ok = service.delete(scan);
         assertTrue(ok);
@@ -557,7 +557,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         regions.put(new Pair<>(0, 0), Set.of("del1"));
         regions.put(new Pair<>(1, 0), Set.of("del2"));
         PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         service.delete(scan);
         // Both deferred — not yet deleted.
@@ -571,6 +571,112 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         verify(islandCache, times(1)).deleteIslandFromCache("del1");
         verify(islandCache, times(1)).deleteIslandFromCache("del2");
         assertTrue(service.getPendingDeletions().isEmpty());
+    }
+
+    /**
+     * Deleted sweep: when an island's chunks appear in BOTH a successfully deleted
+     * region AND a blocked region (it straddles the boundary), the DB row must NOT
+     * be added to {@code pendingDeletions}. The island stays {@code deletable=true}
+     * in the DB so the next sweep can retry once the blocking island is gone.
+     *
+     * <p>This is the fix for the "ghost blocks" bug where soft-deleted islands near
+     * a region boundary left orphaned blocks in the blocked region file.
+     */
+    @Test
+    void testDeletedSweepRetainsDBRowForStraddlingIsland() throws IOException {
+        Island straddles = mock(Island.class);
+        when(straddles.getUniqueId()).thenReturn("strad");
+        when(straddles.isDeletable()).thenReturn(true);
+        when(im.getIslandById("strad")).thenReturn(Optional.of(straddles));
+
+        Path regionDir = Files.createDirectories(tempDir.resolve("region"));
+        // r.0.0.mca was in the deleted set — this file gets reaped.
+        Files.write(regionDir.resolve("r.0.0.mca"), new byte[0]);
+
+        // The island is in both r.0.0 (deletable region) and r.0.-1 (blocked).
+        Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
+        regions.put(new Pair<>(0, 0), Set.of("strad"));
+        // straddlingIslandIds contains "strad" — its chunks in the blocked region remain.
+        PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
+                new FilterStats(0, 0, 0, 1), Set.of("strad"));
+
+        boolean ok = service.delete(scan);
+        assertTrue(ok);
+        // DB row must NOT be deferred to shutdown — the island has orphaned chunks.
+        assertFalse(service.getPendingDeletions().contains("strad"),
+                "Straddling island must not be added to pendingDeletions");
+        // DB row must not be removed immediately either.
+        verify(im, never()).deleteIslandId(anyString());
+        verify(islandCache, never()).deleteIslandFromCache(anyString());
+    }
+
+    /**
+     * Deleted sweep: an island that is NOT in the straddling set (all its regions
+     * were successfully deleted) must still be deferred to shutdown normally.
+     */
+    @Test
+    void testDeletedSweepDefersNonStraddlingIslandToShutdown() throws IOException {
+        Island clean = mock(Island.class);
+        when(clean.getUniqueId()).thenReturn("clean");
+        when(clean.isDeletable()).thenReturn(true);
+        when(im.getIslandById("clean")).thenReturn(Optional.of(clean));
+
+        Path regionDir = Files.createDirectories(tempDir.resolve("region"));
+        Files.write(regionDir.resolve("r.0.0.mca"), new byte[0]);
+
+        Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
+        regions.put(new Pair<>(0, 0), Set.of("clean"));
+        // "clean" is NOT in straddling — all its regions were deleted.
+        PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
+                new FilterStats(0, 0, 0, 0), Set.of());
+
+        boolean ok = service.delete(scan);
+        assertTrue(ok);
+        assertTrue(service.getPendingDeletions().contains("clean"),
+                "Non-straddling island must be added to pendingDeletions for shutdown");
+        verify(im, never()).deleteIslandId(anyString());
+    }
+
+    /**
+     * {@link PurgeRegionsService#scanDeleted} must populate
+     * {@link PurgeScanResult#straddlingIslandIds()} with deletable islands that
+     * appear in a region blocked by a non-deletable neighbour.
+     */
+    @Test
+    void testScanDeletedPopulatesStraddlingIslandIds() throws IOException {
+        Island deletable = mock(Island.class);
+        when(deletable.getUniqueId()).thenReturn("del");
+        when(deletable.isDeletable()).thenReturn(true);
+        // Protection box spans r.0.0 and r.1.0 (X = 500..700).
+        when(deletable.getMinProtectedX()).thenReturn(500);
+        when(deletable.getMaxProtectedX()).thenReturn(700);
+        when(deletable.getMinProtectedZ()).thenReturn(0);
+        when(deletable.getMaxProtectedZ()).thenReturn(100);
+
+        Island active = mock(Island.class);
+        when(active.getUniqueId()).thenReturn("act");
+        when(active.isDeletable()).thenReturn(false);
+
+        when(islandCache.getIslands(world)).thenReturn(List.of(deletable));
+
+        // r.0.0 → only the deletable island; r.1.0 → deletable + active (blocks it).
+        IslandGrid grid = mock(IslandGrid.class);
+        when(grid.getIslandsInBounds(eq(0), anyInt(), eq(511), anyInt()))
+                .thenReturn(List.of(new IslandData("del", 500, 0, 200)));
+        when(grid.getIslandsInBounds(eq(512), anyInt(), eq(1023), anyInt()))
+                .thenReturn(List.of(
+                        new IslandData("del", 500, 0, 200),
+                        new IslandData("act", 600, 0, 100)));
+        when(islandCache.getIslandGrid(world)).thenReturn(grid);
+        when(im.getIslandById("del")).thenReturn(Optional.of(deletable));
+        when(im.getIslandById("act")).thenReturn(Optional.of(active));
+
+        PurgeScanResult result = service.scanDeleted(world);
+
+        // r.0.0 survives the filter; r.1.0 is blocked.
+        assertEquals(1, result.deletableRegions().size(), "Only r.0.0 should survive");
+        assertTrue(result.straddlingIslandIds().contains("del"),
+                "del must be in straddlingIslandIds because it appears in blocked r.1.0");
     }
 
     /**
@@ -596,7 +702,7 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
         regions.put(new Pair<>(0, 0), Set.of("tiny"));
         PurgeScanResult scan = new PurgeScanResult(world, 30, regions, false, false,
-                new FilterStats(0, 0, 0, 0));
+                new FilterStats(0, 0, 0, 0), Set.of());
 
         service.delete(scan);
         // Age sweep: immediate deletion, not deferred.


### PR DESCRIPTION
## Summary

- **Bug:** When a soft-deleted island's protection box straddles two region files and one of those regions is blocked by an active neighbour, the deleted-sweep was removing the island's DB row at shutdown even though its chunks remained in the blocked `.mca`. On the next server start those orphaned blocks loaded from disk — ghost blocks with no island record.
- **Root cause identified from a live server log:** first island at centre (0, 0) spans `r.0.0` and `r.0.-1`; `r.0.-1` was blocked by the player's current active island; `r.0.0` was deleted and the DB row was flushed at shutdown, permanently orphaning the tree blocks at z = −2 in `r.0.-1`.
- **Fix:** `filterForDeletedSweep` now collects deletable island IDs found in blocked regions (`straddlingIslandIds`). `delete()` skips adding those islands to `pendingDeletions` so their DB row (`deletable=true`) survives to the next sweep. When the blocking island is eventually deleted the sweep retries and completes cleanup normally.

## Changes

| File | What changed |
|---|---|
| `PurgeRegionsService` | `PurgeScanResult` gains `straddlingIslandIds`; `filterForDeletedSweep` returns new `DeleteSweepFilter` record; `scanDeleted` logs straddlers; `delete()` gates `pendingDeletions` on straddling check |
| `PurgeRegionsServiceTest` | All `PurgeScanResult` construction sites updated; 3 new tests added |
| `HousekeepingManagerTest` | `PurgeScanResult` construction site updated |

## Test plan

- [x] `testDeletedSweepRetainsDBRowForStraddlingIsland` — straddling island is NOT added to `pendingDeletions`
- [x] `testDeletedSweepDefersNonStraddlingIslandToShutdown` — normal (non-straddling) island IS deferred to shutdown as before
- [x] `testScanDeletedPopulatesStraddlingIslandIds` — `scanDeleted` correctly identifies straddling islands when `filterForDeletedSweep` blocks a mixed region
- [x] All 20 `PurgeRegionsServiceTest` tests pass; all `HousekeepingManagerTest` tests pass
- [ ] Reproduce with the original steps from the bug report (create islands near 0,0 in AcidIsland, reset repeatedly, restart, teleport to 0,80,0) and confirm blocks are gone after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)