### PR TITLE
feat: add CraftEngineHook for centralised custom block support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,7 @@ val gsonRecordTypeAdapterFactoryVersion = "0.3.0"
 val jdtAnnotationVersion = "2.2.600"
 val multilibVersion = "1.1.13"
 val oraxenVersion = "1.193.1"
+val craftEngineVersion = "0.0.67"
 val blueMapApiVersion = "v2.6.2"
 val dynmapApiVersion = "3.4"
 
@@ -190,6 +191,7 @@ repositories {
     maven("https://maven.devs.beer/") { name = "MatteoDev" }
     maven("https://repo.mikeprimm.com/") { name = "Dynmap" }
     maven("https://repo.oraxen.com/releases") { name = "Oraxen" } // Custom items plugin
+    maven("https://repo.momirealms.net/releases/") { name = "MomiRealms" } // CraftEngine custom block plugin
     maven("https://repo.codemc.org/repository/bentoboxworld/") { name = "BentoBoxWorld-Repo" }
     maven("https://repo.extendedclip.com/releases/") { name = "Placeholder-API-Releases" }
 }
@@ -248,6 +250,8 @@ dependencies {
     testImplementation("us.dynmap:dynmap-api:$dynmapApiVersion") {
         exclude(group = "org.bukkit", module = "bukkit")
     }
+    compileOnly("net.momirealms:craft-engine-bukkit:$craftEngineVersion")
+    compileOnly("net.momirealms:craft-engine-core:$craftEngineVersion")
     compileOnly("io.th0rgal:oraxen:$oraxenVersion") {
         exclude(group = "me.gabytm.util", module = "actions-spigot")
         exclude(group = "org.jetbrains", module = "annotations")

--- a/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
@@ -64,12 +64,13 @@ public class BentoBoxHookRegistrar {
     }
 
     /**
-     * Registers hooks for plugins that load after BentoBox (Slimefun, ItemsAdder, Oraxen).
+     * Registers hooks for plugins that load after BentoBox (Slimefun, ItemsAdder, Oraxen, CraftEngine).
      */
     public void registerLateHooks() {
         hooksManager.registerHook(new SlimefunHook());
         hooksManager.registerHook(new ItemsAdderHook(plugin));
         hooksManager.registerHook(new OraxenHook(plugin));
+        hooksManager.registerHook(new CraftEngineHook());
     }
 
     private boolean hasClass(String className) {

--- a/src/main/java/world/bentobox/bentobox/hooks/CraftEngineHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/CraftEngineHook.java
@@ -1,0 +1,80 @@
+package world.bentobox.bentobox.hooks;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+
+import net.momirealms.craftengine.bukkit.api.CraftEngineBlocks;
+import net.momirealms.craftengine.core.block.ImmutableBlockState;
+import net.momirealms.craftengine.core.util.Key;
+import world.bentobox.bentobox.api.hooks.Hook;
+
+/**
+ * Provides CraftEngine API access without requiring addons to depend on CraftEngine directly.
+ */
+public class CraftEngineHook extends Hook {
+
+    public CraftEngineHook() {
+        super("CraftEngine", Material.NOTE_BLOCK);
+    }
+
+    @Override
+    public boolean hook() {
+        return true;
+    }
+
+    @Override
+    public String getFailureCause() {
+        return "CraftEngine is not installed";
+    }
+
+    /**
+     * Returns the namespaced ID (e.g. {@code "mynamespace:my_block"}) of the CraftEngine custom block
+     * at the given location, or {@code null} if no custom block is present.
+     *
+     * @param loc the location to check
+     * @return namespaced block ID or {@code null}
+     */
+    public static String getBlockId(Location loc) {
+        return getBlockId(loc.getBlock());
+    }
+
+    /**
+     * Returns the namespaced ID (e.g. {@code "mynamespace:my_block"}) of the CraftEngine custom block
+     * represented by the given block, or {@code null} if it is not a CraftEngine custom block.
+     *
+     * @param block the block to check
+     * @return namespaced block ID or {@code null}
+     */
+    public static String getBlockId(Block block) {
+        if (!CraftEngineBlocks.isCustomBlock(block)) {
+            return null;
+        }
+        ImmutableBlockState state = CraftEngineBlocks.getCustomBlockState(block);
+        if (state == null) {
+            return null;
+        }
+        return state.owner().value().id().asString();
+    }
+
+    /**
+     * Returns {@code true} if a CraftEngine custom block with the given namespaced ID exists in the registry.
+     *
+     * @param id namespaced block ID (e.g. {@code "mynamespace:my_block"})
+     * @return {@code true} if the block ID is registered
+     */
+    public static boolean exists(String id) {
+        return CraftEngineBlocks.byId(Key.of(id)) != null;
+    }
+
+    /**
+     * Places a CraftEngine custom block at the given location.
+     *
+     * @param location the target location
+     * @param blockId  namespaced block ID (e.g. {@code "mynamespace:my_block"})
+     * @return {@code true} if the block was placed successfully
+     */
+    public static boolean placeBlock(Location location, String blockId) {
+        return CraftEngineBlocks.place(location, Key.of(blockId), false);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,6 +28,7 @@ softdepend:
   - FancyNpcs
   - FancyHolograms
   - BlueMap
+  - CraftEngine
 
 libraries:
   - mysql:mysql-connector-java:${mysql.version}


### PR DESCRIPTION
## Summary

- Adds `CraftEngineHook` to the BentoBox hooks system, following the same pattern as `ItemsAdderHook` and `OraxenHook`
- Registers it in `BentoBoxHookRegistrar.registerLateHooks()` and adds `CraftEngine` to `plugin.yml` soft-depends
- Adds `net.momirealms:craft-engine-bukkit/core` provided compile dependencies and the MomiRealms Maven repo

## API provided

| Method | Purpose |
|---|---|
| `getBlockId(Location/Block)` | Returns the namespaced ID of the CE block at a location, or `null` |
| `exists(String id)` | Checks whether a block ID is registered in CraftEngine |
| `placeBlock(Location, String id)` | Places a CraftEngine custom block |

## Context

CraftEngine support was added to AOneBlock in PR #496 using direct API calls. The Level addon (BentoBoxWorld/Level#418) also needs CraftEngine block detection for island level calculation. Centralising the hook in BentoBox means neither addon needs a direct CraftEngine compile dependency, and future addons get the same benefit for free.

**Dependent PRs:**
- AOneBlock: refactors to use this hook (direct CE imports removed)
- Level: adds CE block counting using `CraftEngineHook.getBlockId()`

## Test plan

- [ ] Server starts with CraftEngine installed → hook registers, `getHooks().getHook("CraftEngine").isPresent()` returns `true`
- [ ] Server starts without CraftEngine → hook silently skipped, no errors logged
- [ ] `CraftEngineHook.getBlockId(location)` returns the correct namespaced ID for a placed CE block
- [ ] `CraftEngineHook.placeBlock(location, id)` places the block (exercised via AOneBlock)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)