### PR TITLE
fix(locale): suppress stack trace for malformed locale files, improve error message

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/LocalesManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/LocalesManager.java
@@ -301,7 +301,8 @@ public class LocalesManager {
             }
 
             try {
-                YamlConfiguration languageYaml = YamlConfiguration.loadConfiguration(language);
+                YamlConfiguration languageYaml = new YamlConfiguration();
+                languageYaml.load(language);
 
                 if (languages.containsKey(localeObject)) {
                     // Merge into current language
@@ -310,10 +311,12 @@ public class LocalesManager {
                     // New language
                     languages.put(localeObject, new BentoBoxLocale(localeObject, languageYaml));
                 }
+            } catch (InvalidConfigurationException e) {
+                plugin.logError("Could not load locale file '" + localeFolder + "/" + language.getName() + "': " + e.getMessage());
+                plugin.logError("The file contains invalid YAML. Delete it and restart to regenerate, or fix the syntax. English will be used as a fallback.");
             } catch (Exception e) {
-                plugin.logError("Could not load '" + language.getName() + "' : " + e.getMessage()
-                + " with the following cause '" + e.getCause() + "'." +
-                        " The file has likely an invalid YML format or has been made unreadable during the process.");
+                plugin.logError("Could not load locale file '" + localeFolder + "/" + language.getName() + "': " + e.getMessage());
+                plugin.logError("English will be used as a fallback for affected players.");
             }
         }
     }


### PR DESCRIPTION
## Summary

- `YamlConfiguration.loadConfiguration(File)` is Bukkit's static helper — it internally catches `InvalidConfigurationException` and logs it at `SEVERE` **with a full stack trace** via `Bukkit.getLogger()`, completely bypassing BentoBox's own try-catch
- Switch to `new YamlConfiguration(); yaml.load(file)` so BentoBox owns the exception and can log a clean, actionable message instead
- Split catch into `InvalidConfigurationException` (bad YAML) and generic `Exception`, both now log two clean lines: what went wrong and a note that English will be used as a fallback
- The locale folder name is included in the message so admins know which addon's file is the culprit

**Before:**
```
[ERROR]: Cannot load plugins\BentoBox\locales\Chat\cs.yml
org.bukkit.configuration.InvalidConfigurationException: mapping values are not allowed here
   at org.bukkit.configuration.file.YamlConfiguration.loadFromString(YamlConfiguration.java:112)
   ... 27 more lines of stack trace ...
```

**After:**
```
[BentoBox] Could not load locale file 'Chat/cs.yml': mapping values are not allowed here in 'reader', line 28, column 71: ...
[BentoBox] The file contains invalid YAML. Delete it and restart to regenerate, or fix the syntax. English will be used as a fallback.
```

Related: BentoBoxWorld/Chat#58 (fixes the specific malformed file that triggered this)
Fixes #2953

## Test plan

- [ ] Place a malformed locale YAML file in a locale folder and start the server — verify only clean BentoBox log lines appear, no stack trace
- [ ] Players using the affected locale fall back to English correctly
- [ ] Valid locale files still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)