### PR TITLE
Refuse setowner when recipient is at the concurrent-islands cap

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
@@ -69,6 +69,17 @@ public class AdminTeamSetownerCommand extends ConfirmableCommand {
             user.sendMessage("commands.admin.team.setowner.already-owner", TextVariables.NAME, args.getFirst());
             return false;
         }
+        // Refuse if the recipient is already at their concurrent-islands cap (#2908).
+        User target = User.getInstance(targetUUID);
+        int num = this.getIslands().getNumberOfConcurrentIslands(targetUUID, getWorld());
+        int max = target.getPermissionValue(
+                this.getIWM().getAddon(getWorld()).map(GameModeAddon::getPermissionPrefix).orElse("") + "island.number",
+                this.getIWM().getWorldSettings(getWorld()).getConcurrentIslands());
+        if (num >= max) {
+            user.sendMessage("commands.admin.team.setowner.errors.at-max", TextVariables.NAME, args.getFirst(),
+                    TextVariables.NUMBER, String.valueOf(num), "[max]", String.valueOf(max));
+            return false;
+        }
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.events.IslandBaseEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
@@ -91,6 +92,17 @@ public class IslandTeamSetownerCommand extends CompositeCommand {
         }
         if (!is.inTeam(targetUUID)) {
             user.sendMessage("commands.island.team.setowner.errors.target-is-not-member");
+            return false;
+        }
+        // Refuse if the recipient is already at their concurrent-islands cap.
+        // Without this check, ownership transfer bypasses the limit set in IslandCreateCommand (#2908).
+        User target = User.getInstance(targetUUID);
+        int num = getIslands().getNumberOfConcurrentIslands(targetUUID, getWorld());
+        int max = target.getPermissionValue(
+                getIWM().getAddon(getWorld()).map(GameModeAddon::getPermissionPrefix).orElse("") + "island.number",
+                getIWM().getWorldSettings(getWorld()).getConcurrentIslands());
+        if (num >= max) {
+            user.sendMessage("commands.island.team.setowner.errors.at-max");
             return false;
         }
         return true;

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -172,6 +172,10 @@ commands:
         confirmation: '<green>Are you sure you want to set [name] to be the owner of the
           [prefix_island] at [xyz]?</green>'
         success: '<aqua>[name]</aqua><green> is now the owner of this [prefix_island].</green>'
+        errors:
+          at-max: '<red>[name] already owns [number] [prefix_islands] - the maximum
+            allowed by settings or perms is [max]. Adjust their permission to allow
+            more.</red>'
         extra-islands: '<red>Warning: this player now owns [number] islands. This is
           more than allowed by settings or perms: [max].</red>'
       maxsize:

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
@@ -211,4 +211,19 @@ class AdminTeamSetownerCommandTest extends CommonTestSetup {
         // Add other verifications
         verify(user).sendMessage("commands.admin.team.setowner.success", TextVariables.NAME, "tastybento");
     }
+
+    /**
+     * Recipient already owns the maximum allowed concurrent islands - transfer must be refused.
+     */
+    @Test
+    void testCanExecuteTargetAtConcurrentIslandsCap() {
+        when(im.getIslandAt(any())).thenReturn(Optional.of(island));
+        when(island.getOwner()).thenReturn(notUUID);
+        when(Util.getUUID("tastybento")).thenReturn(uuid);
+        when(im.getNumberOfConcurrentIslands(eq(uuid), any())).thenReturn(1);
+
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        verify(user).sendMessage("commands.admin.team.setowner.errors.at-max", TextVariables.NAME, "tastybento",
+                TextVariables.NUMBER, "1", "[max]", "1");
+    }
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommandTest.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
+
 import org.eclipse.jdt.annotation.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -225,8 +227,9 @@ class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
     @Test
     void testExecuteUserStringListOfStringHasManyConcurrentAndPerm() {
         when(user.getPermissionValue(anyString(), anyInt())).thenReturn(40);
-        when(im.getNumberOfConcurrentIslands(any(), eq(world))).thenReturn(20);
         UUID target = UUID.randomUUID();
+        // Force the recipient to be treated as offline so getPermissionValue returns the world default (3).
+        mockedBukkit.when(() -> Bukkit.getPlayer(target)).thenReturn(null);
         when(pm.getUUID(anyString())).thenReturn(target);
         when(island.getMemberSet()).thenReturn(ImmutableSet.of(uuid, target));
         when(island.inTeam(any())).thenReturn(true);
@@ -237,12 +240,27 @@ class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
     }
 
     /**
+     * Recipient already owns the maximum allowed concurrent islands - transfer must be refused.
+     */
+    @Test
+    void testCanExecuteTargetAtConcurrentIslandsCap() {
+        UUID target = UUID.randomUUID();
+        mockedBukkit.when(() -> Bukkit.getPlayer(target)).thenReturn(null);
+        when(pm.getUUID(anyString())).thenReturn(target);
+        when(island.inTeam(any())).thenReturn(true);
+        when(im.getNumberOfConcurrentIslands(eq(target), any())).thenReturn(3);
+        assertFalse(its.canExecute(user, "", List.of("tastybento")));
+        verify(user).sendMessage("commands.island.team.setowner.errors.at-max");
+    }
+
+    /**
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamSetownerCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
     void testExecuteUserStringListOfStringSuccess() {
         when(im.inTeam(any(), any())).thenReturn(true);
         UUID target = UUID.randomUUID();
+        mockedBukkit.when(() -> Bukkit.getPlayer(target)).thenReturn(null);
         when(pm.getUUID(anyString())).thenReturn(target);
         when(island.inTeam(any())).thenReturn(true);
         when(im.getIsland(any(), any(User.class))).thenReturn(island);


### PR DESCRIPTION
## Summary
- Refuses ownership transfer (admin and user-facing) when the recipient is already at their `concurrent-islands` cap, instead of letting the transfer through and merely warning afterwards.
- Adds a parallel admin error message (`commands.admin.team.setowner.errors.at-max`) and wires up the existing user-facing `commands.island.team.setowner.errors.at-max` entry that was previously unused.

## Why
Setting `concurrent-islands: 1` (or any per-player `island.number.<n>` permission) only gated `IslandCreateCommand`. A player could be added as a member, then have the island handed to them via `/is team setowner` or `/bbox team setowner`, ending up with multiple owned islands regardless of the limit. `AdminTeamSetownerCommand` carried a post-transfer "warning" that the player now owns more than allowed, but it never actually blocked the action.

The fix moves the check into `canExecute` so the cap holds in both flows. An admin who really wants to push a recipient over the limit can raise their `island.number.<n>` permission first; the error message tells them exactly that.

## Test plan
- [x] `./gradlew test --tests AdminTeamSetownerCommandTest --tests IslandTeamSetownerCommandTest`
- [x] `./gradlew build -x test`
- [x] New `testCanExecuteTargetAtConcurrentIslandsCap` cases on both commands cover the refusal path.

Closes #2908.