### PR TITLE
Add CraftEngineHook.getItemStack(id) lookup

### DIFF
--- a/src/main/java/world/bentobox/bentobox/hooks/CraftEngineHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/CraftEngineHook.java
@@ -1,11 +1,16 @@
 package world.bentobox.bentobox.hooks;
 
+import java.util.Optional;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
 
 import net.momirealms.craftengine.bukkit.api.CraftEngineBlocks;
+import net.momirealms.craftengine.bukkit.api.CraftEngineItems;
 import net.momirealms.craftengine.core.block.ImmutableBlockState;
+import net.momirealms.craftengine.core.item.CustomItem;
 import net.momirealms.craftengine.core.util.Key;
 import world.bentobox.bentobox.api.hooks.Hook;
 
@@ -76,5 +81,23 @@ public class CraftEngineHook extends Hook {
      */
     public static boolean placeBlock(Location location, String blockId) {
         return CraftEngineBlocks.place(location, Key.of(blockId), false);
+    }
+
+    /**
+     * Returns an {@link ItemStack} for the CraftEngine custom item with the given namespaced ID.
+     * Useful for rendering the correct icon (texture / model data) and display name in panels and GUIs.
+     *
+     * @param id namespaced ID (e.g. {@code "mynamespace:my_block"})
+     * @return an Optional containing the registered custom item's ItemStack, or empty if not registered
+     */
+    public static Optional<ItemStack> getItemStack(String id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        CustomItem<ItemStack> customItem = CraftEngineItems.byId(Key.of(id));
+        if (customItem == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(customItem.buildItemStack());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Optional<ItemStack> CraftEngineHook.getItemStack(String id)` so addons can resolve a CraftEngine custom-item ID to a real `ItemStack` (with the correct texture / model data) without depending on CraftEngine directly
- Mirrors the existing `OraxenHook.getOptionalItemById` and `ItemsAdderHook.getItemStack` shape so addon code can branch by hook uniformly

## Why
The Level addon (and others) need to render custom blocks in GUIs. Oraxen and ItemsAdder both expose hook methods that return an `ItemStack`; CraftEngine did not, so panels fell back to `Material.PAPER`. See BentoBoxWorld/Level#426.

## Implementation
Calls `CraftEngineItems.byId(Key.of(id))` and, if the item is registered, returns `customItem.buildItemStack()` (the parameterless default on `BuildableItem`, which uses the empty build context).

## Test plan
- [x] `./gradlew test` — full suite passes
- [x] `./gradlew compileJava` — compiles cleanly against `craft-engine-bukkit:0.0.67`
- [ ] Manual: Level addon's `/is value` panel renders CraftEngine custom blocks with the correct icon and display name

🤖 Generated with [Claude Code](https://claude.com/claude-code)