### PR TITLE
feat(hooks): add CraftEngineHook.getItemId(item) lookup

### DIFF
--- a/src/main/java/world/bentobox/bentobox/hooks/CraftEngineHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/CraftEngineHook.java
@@ -100,4 +100,20 @@ public class CraftEngineHook extends Hook {
         }
         return Optional.ofNullable(customItem.buildItemStack());
     }
+
+    /**
+     * Returns the namespaced ID (e.g. {@code "mynamespace:my_block"}) of the CraftEngine custom item
+     * represented by the given ItemStack, or {@code null} if it is not a CraftEngine custom item.
+     * Useful for command handlers that need to look up the held item against custom-block configuration.
+     *
+     * @param item the ItemStack to check
+     * @return namespaced item ID or {@code null}
+     */
+    public static String getItemId(ItemStack item) {
+        if (item == null || !CraftEngineItems.isCustomItem(item)) {
+            return null;
+        }
+        Key id = CraftEngineItems.getCustomItemId(item);
+        return id == null ? null : id.asString();
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `CraftEngineHook.getItemId(ItemStack)` returning the namespaced ID of a held CraftEngine custom item, or `null` when the item is not a CraftEngine custom item.
- Mirrors the existing `getItemStack(id)` helper (added in 9d3715a69) so addons can map both directions without depending on CraftEngine directly.

## Why
Needed for the Level addon fix to issue [BentoBoxWorld/Level#428](https://github.com/BentoBoxWorld/Level/issues/428). The addon's `/is value hand` command and value-panel icon lookup both need to recognize a held CraftEngine item; without this helper they fall back to the vanilla material (PAPER) and report "no value".

## Test plan
- [x] `./gradlew compileJava` passes
- [ ] CI test suite green