### PR TITLE
feat: per-world team disable + admin team disbandall (#2965)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommand.java
@@ -28,6 +28,10 @@ public class AdminTeamAddCommand extends CompositeCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
+        if (getIWM().isTeamsDisabled(getWorld())) {
+            user.sendMessage("commands.island.team.errors.teams-disabled");
+            return false;
+        }
         // If args are not right, show help
         if (args.size() != 2) {
             showHelp(this, user);

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamCommand.java
@@ -32,6 +32,7 @@ public class AdminTeamCommand extends CompositeCommand
 
         new AdminTeamAddCommand(this);
         new AdminTeamDisbandCommand(this);
+        new AdminTeamDisbandAllCommand(this);
 
         new AdminTeamKickCommand(this);
         new AdminTeamSetownerCommand(this);

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandAllCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandAllCommand.java
@@ -1,0 +1,74 @@
+package world.bentobox.bentobox.api.commands.admin.team;
+
+import java.util.List;
+import java.util.UUID;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.ConfirmableCommand;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
+import world.bentobox.bentobox.api.events.team.TeamEvent;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.RanksManager;
+
+/**
+ * Strips every member and sub-owner from every island in the current world. Trust and
+ * coop ranks are not touched. Pre-existing islands keep their owner.
+ * <p>
+ * Intended migration tool when toggling on
+ * {@link world.bentobox.bentobox.api.configuration.WorldSettings#isTeamsDisabled()}: legacy
+ * team membership cannot be cleaned up by users any more, so an admin runs this once.
+ *
+ * @since 3.16.0
+ */
+public class AdminTeamDisbandAllCommand extends ConfirmableCommand {
+
+    public AdminTeamDisbandAllCommand(CompositeCommand parent) {
+        super(parent, "disbandall");
+    }
+
+    @Override
+    public void setup() {
+        setPermission("mod.team.disbandall");
+        setDescription("commands.admin.team.disbandall.description");
+        setOnlyPlayer(false);
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        askConfirmation(user, user.getTranslation("commands.admin.team.disbandall.confirmation"),
+                () -> disbandAll(user));
+        return true;
+    }
+
+    private void disbandAll(User user) {
+        int islandsAffected = 0;
+        int playersRemoved = 0;
+        for (Island island : getIslands().getIslands(getWorld())) {
+            // Snapshot UUIDs first because removePlayer mutates the member map.
+            List<UUID> toRemove = island
+                    .getMemberSet(RanksManager.MEMBER_RANK, true)
+                    .stream()
+                    .filter(uuid -> island.getRank(uuid) < RanksManager.OWNER_RANK)
+                    .toList();
+            if (toRemove.isEmpty()) {
+                continue;
+            }
+            islandsAffected++;
+            for (UUID uuid : toRemove) {
+                int previousRank = island.getRank(uuid);
+                getIslands().removePlayer(island, uuid);
+                playersRemoved++;
+                TeamEvent.builder().island(island).reason(TeamEvent.Reason.KICK).involvedPlayer(uuid).admin(true)
+                        .build();
+                IslandEvent.builder().island(island).involvedPlayer(uuid).admin(true)
+                        .reason(IslandEvent.Reason.RANK_CHANGE)
+                        .rankChange(previousRank, RanksManager.VISITOR_RANK).build();
+            }
+        }
+        user.sendMessage("commands.admin.team.disbandall.success",
+                TextVariables.NUMBER, String.valueOf(playersRemoved),
+                "[islands]", String.valueOf(islandsAffected));
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -55,6 +55,13 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
         }
         TeamInvite invite = itc.getInvite(playerUUID);
         if (invite.getType().equals(Type.TEAM)) {
+            // Refuse team invitations when the team subsystem is disabled in this world.
+            // Trust/coop invites are still honoured below.
+            if (getIWM().isTeamsDisabled(getWorld())) {
+                user.sendMessage("commands.island.team.errors.teams-disabled");
+                itc.removeInvite(playerUUID);
+                return false;
+            }
             // Check rank to of inviter
             Island island = getIslands().getIsland(getWorld(), prospectiveOwnerUUID);
             String inviteUsage = getParent().getSubCommand("invite").map(CompositeCommand::getUsage).orElse("");

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
@@ -76,6 +76,10 @@ public class IslandTeamInviteCommand extends CompositeCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
+        if (getIWM().isTeamsDisabled(getWorld())) {
+            user.sendMessage("commands.island.team.errors.teams-disabled");
+            return false;
+        }
         UUID playerUUID = user.getUniqueId();
         IslandsManager islandsManager = getIslands();
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamKickCommand.java
@@ -36,6 +36,10 @@ public class IslandTeamKickCommand extends ConfirmableCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
+        if (getIWM().isTeamsDisabled(getWorld())) {
+            user.sendMessage("commands.island.team.errors.teams-disabled");
+            return false;
+        }
         if (!getIslands().inTeam(getWorld(), user.getUniqueId())) {
             user.sendMessage("general.errors.no-team");
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommand.java
@@ -28,6 +28,10 @@ public class IslandTeamLeaveCommand extends ConfirmableCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
+        if (getIWM().isTeamsDisabled(getWorld())) {
+            user.sendMessage("commands.island.team.errors.teams-disabled");
+            return false;
+        }
         if (!getIslands().inTeam(getWorld(), user.getUniqueId())) {
             user.sendMessage("general.errors.no-team");
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamPromoteCommand.java
@@ -75,6 +75,10 @@ public class IslandTeamPromoteCommand extends CompositeCommand {
      */
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
+        if (getIWM().isTeamsDisabled(getWorld())) {
+            user.sendMessage("commands.island.team.errors.teams-disabled");
+            return false;
+        }
         // If args are not right, show help
         if (args.size() != 1) {
             showHelp(this, user);

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
@@ -65,6 +65,10 @@ public class IslandTeamSetownerCommand extends CompositeCommand {
      */
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
+        if (getIWM().isTeamsDisabled(getWorld())) {
+            user.sendMessage("commands.island.team.errors.teams-disabled");
+            return false;
+        }
         // If args are not right, show help
         if (args.size() != 1) {
             showHelp(this, user);

--- a/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
+++ b/src/main/java/world/bentobox/bentobox/api/configuration/WorldSettings.java
@@ -663,4 +663,19 @@ public interface WorldSettings extends ConfigObject {
     default boolean isDisallowTeamMemberIslands() {
         return true;
     }
+
+    /**
+     * Whether the team subsystem (invite, accept, promote, demote, setowner, kick, leave, admin team add)
+     * is disabled in this world. When {@code true}, every {@code island team *} sub-command except
+     * {@code trust}, {@code coop}, {@code untrust} and {@code uncoop} refuses to run, and members can
+     * no longer be assigned to islands. Trusted and coop relationships are unaffected.
+     * <p>
+     * Use the admin {@code team disbandall} command to strip pre-existing members from islands when
+     * flipping this on.
+     * @return true if the team subsystem should be disabled for this world; defaults to {@code false}.
+     * @since 3.16.0
+     */
+    default boolean isTeamsDisabled() {
+        return false;
+    }
 }

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -497,6 +497,17 @@ public class IslandWorldManager {
     }
 
     /**
+     * Whether the team subsystem is disabled in this world.
+     * @param world - world
+     * @return true if teams are disabled in this world
+     * @since 3.16.0
+     * @see WorldSettings#isTeamsDisabled()
+     */
+    public boolean isTeamsDisabled(@NonNull World world) {
+        return gameModes.containsKey(world) && gameModes.get(world).getWorldSettings().isTeamsDisabled();
+    }
+
+    /**
      * Get max coop size for this world
      * @param world - world
      * @return max coop size or zero if world is not a game world

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -145,6 +145,10 @@ commands:
         use-disband-owner: '<red>Not owner! Use disband [owner].</red>'
         disbanded: '<red>Admin disbanded your team!</red>'
         success: '<aqua>[name]</aqua><green>''s team has been disbanded.</green>'
+      disbandall:
+        description: strip every member and sub-owner from every [prefix_island] in this world
+        confirmation: '<red>This will remove every member and sub-owner from every [prefix_island] in this world. Trusted and coop players will not be affected. Type the confirmation command to proceed.</red>'
+        success: '<green>Removed </green><aqua>[number]</aqua><green> members from </green><aqua>[islands]</aqua><green> [prefix_islands].</green>'
       fix:
         description: scans and fixes cross [prefix_island] membership in database
         scanning: Scanning database...
@@ -722,6 +726,8 @@ commands:
       success: '<green>Successfully reset your [prefix_island] name.</green>'
     team:
       description: manage your team
+      errors:
+        teams-disabled: '<red>Teams are disabled in this world. Use trust or coop instead.</red>'
       gui:
         titles:
           team-panel: Team Management

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamAddCommandTest.java
@@ -251,6 +251,23 @@ class AdminTeamAddCommandTest extends CommonTestSetup {
     }
 
     /**
+     * Refuses to add a player when the team subsystem is disabled in the world.
+     */
+    @Test
+    void testExecuteTeamsDisabled() {
+        when(iwm.isTeamsDisabled(any())).thenReturn(true);
+        AdminTeamAddCommand itl = new AdminTeamAddCommand(ac);
+        String[] name = { "tastybento", "poslovich" };
+
+        when(pm.getUUID("tastybento")).thenReturn(uuid);
+        when(pm.getUUID("poslovich")).thenReturn(notUUID);
+
+        assertFalse(itl.execute(user, itl.getLabel(), Arrays.asList(name)));
+        verify(user).sendMessage("commands.island.team.errors.teams-disabled");
+        verify(im, org.mockito.Mockito.never()).setJoinTeam(any(), any());
+    }
+
+    /**
      * Test method for
      * {@link world.bentobox.bentobox.api.commands.admin.team.AdminTeamAddCommand#execute(User, String, List)}.
      */

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandAllCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamDisbandAllCommandTest.java
@@ -1,0 +1,187 @@
+package world.bentobox.bentobox.api.commands.admin.team;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import java.util.Collection;
+
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.collect.ImmutableSet;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.TestWorldSettings;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.configuration.WorldSettings;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.CommandsManager;
+import world.bentobox.bentobox.managers.LocalesManager;
+import world.bentobox.bentobox.managers.PlaceholdersManager;
+import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.managers.RanksManager;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Tests for {@link AdminTeamDisbandAllCommand}.
+ */
+class AdminTeamDisbandAllCommandTest extends CommonTestSetup {
+
+    @Mock
+    private CompositeCommand ac;
+    @Mock
+    private User user;
+    @Mock
+    private PlayersManager pm;
+    @Mock
+    private BukkitScheduler scheduler;
+
+    private UUID ownerUUID;
+    private UUID memberUUID;
+    private UUID subOwnerUUID;
+    private UUID trustedUUID;
+    private UUID coopUUID;
+
+    private AdminTeamDisbandAllCommand cmd;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        Util.setPlugin(plugin);
+
+        Settings settings = new Settings();
+        when(plugin.getSettings()).thenReturn(settings);
+
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+
+        when(user.isOp()).thenReturn(false);
+        when(user.getUniqueId()).thenReturn(uuid);
+        when(user.getPlayer()).thenReturn(mockPlayer);
+        when(user.getName()).thenReturn("admin");
+        when(user.getTranslation(any()))
+                .thenAnswer((Answer<String>) i -> i.getArgument(0, String.class));
+
+        when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
+        when(ac.getTopLabel()).thenReturn("bsbadmin");
+        when(ac.getWorld()).thenReturn(world);
+
+        when(plugin.getPlayers()).thenReturn(pm);
+
+        LocalesManager lm = mock(LocalesManager.class);
+        when(lm.get(any(), any())).thenReturn("mock translation");
+        when(plugin.getLocalesManager()).thenReturn(lm);
+        PlaceholdersManager phm = mock(PlaceholdersManager.class);
+        when(plugin.getPlaceholdersManager()).thenReturn(phm);
+        when(phm.replacePlaceholders(any(), any())).thenReturn("mock translation");
+
+        when(iwm.getFriendlyName(any())).thenReturn("BSkyBlock");
+        @NonNull WorldSettings ws = new TestWorldSettings();
+        when(iwm.getWorldSettings(any())).thenReturn(ws);
+        when(iwm.getAddon(any())).thenReturn(Optional.empty());
+
+        // Scheduler — capture and run runnables on demand for confirmation flow.
+        mockedBukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+        when(scheduler.runTaskLater(any(), any(Runnable.class), any(Long.class))).thenReturn(mock(BukkitTask.class));
+
+        // Owner + ranks setup
+        ownerUUID = uuid;
+        memberUUID = UUID.randomUUID();
+        subOwnerUUID = UUID.randomUUID();
+        trustedUUID = UUID.randomUUID();
+        coopUUID = UUID.randomUUID();
+
+        when(island.getOwner()).thenReturn(ownerUUID);
+        when(island.getCenter()).thenReturn(location);
+        when(location.toVector()).thenReturn(new Vector(0, 0, 0));
+        // Members set with rank >= MEMBER_RANK and includeAboveRanks=true: owner, sub-owner, member.
+        // Stub the generic form last-wins so it covers the call site (RanksManager.MEMBER_RANK, true).
+        when(island.getMemberSet(anyInt(), anyBoolean()))
+                .thenReturn(ImmutableSet.of(ownerUUID, subOwnerUUID, memberUUID));
+        when(island.getRank(ownerUUID)).thenReturn(RanksManager.OWNER_RANK);
+        when(island.getRank(subOwnerUUID)).thenReturn(RanksManager.SUB_OWNER_RANK);
+        when(island.getRank(memberUUID)).thenReturn(RanksManager.MEMBER_RANK);
+        when(island.getRank(trustedUUID)).thenReturn(RanksManager.TRUSTED_RANK);
+        when(island.getRank(coopUUID)).thenReturn(RanksManager.COOP_RANK);
+
+        Collection<Island> islandsInWorld = List.of(island);
+        doReturn(islandsInWorld).when(im).getIslands(world);
+
+        cmd = new AdminTeamDisbandAllCommand(ac);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * First execute should ask for confirmation; nothing should be removed yet.
+     */
+    @Test
+    void testExecutePromptsConfirmation() {
+        assertTrue(cmd.execute(user, cmd.getLabel(), List.of()));
+        verify(im, never()).removePlayer(any(Island.class), any(UUID.class));
+        verify(user).sendMessage(eq("commands.confirmation.confirm"), eq("[seconds]"),
+                any(String.class));
+    }
+
+    /**
+     * Second execute (after confirmation) should remove members and sub-owners but not the owner,
+     * trusted, or coop ranks.
+     */
+    @Test
+    void testExecuteRemovesMembersAndSubOwnersOnly() {
+        // Prime confirmation
+        assertTrue(cmd.execute(user, cmd.getLabel(), List.of()));
+        // Capture the disband runnable scheduled by askConfirmation when it fires the second time.
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        // Confirm
+        assertTrue(cmd.execute(user, cmd.getLabel(), List.of()));
+        verify(scheduler).runTask(any(), runnableCaptor.capture());
+        // Run the captured disband-all action.
+        runnableCaptor.getValue().run();
+
+        // Owner is preserved.
+        verify(im, never()).removePlayer(island, ownerUUID);
+        // Trust/coop are not in the >= MEMBER_RANK set, so should never be touched.
+        verify(im, never()).removePlayer(island, trustedUUID);
+        verify(im, never()).removePlayer(island, coopUUID);
+        // Members and sub-owners are removed.
+        verify(im).removePlayer(island, memberUUID);
+        verify(im).removePlayer(island, subOwnerUUID);
+        // TeamEvent + IslandEvent are each fired per removed player; the builders also dispatch
+        // a deprecated copy each, so 3 callEvent invocations per player × 2 players = 6.
+        verify(pim, times(6)).callEvent(any());
+        verify(user).sendMessage(eq("commands.admin.team.disbandall.success"), any(), any(),
+                any(), any());
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
@@ -169,6 +169,16 @@ class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
     }
 
     /**
+     * Refuses to run when teams are disabled in the world.
+     */
+    @Test
+    void testCanExecuteTeamsDisabled() {
+        when(iwm.isTeamsDisabled(any())).thenReturn(true);
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("target")));
+        verify(user).sendMessage("commands.island.team.errors.teams-disabled");
+    }
+
+    /**
      * Test method for {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#canExecute(User, String, java.util.List)}.
      */
     @Test


### PR DESCRIPTION
## Summary
- Adds `WorldSettings#isTeamsDisabled()` (default `false`) and `IslandWorldManager#isTeamsDisabled(World)` so game modes can switch off the team subsystem per world. When enabled, `island team invite/accept/kick/leave/promote/demote/setowner` and `admin team add` refuse with `commands.island.team.errors.teams-disabled`. Trust/coop/untrust/uncoop are intentionally unaffected.
- Adds `admin team disbandall` to strip every member and sub-owner from every island in the world (trusted/coop players preserved), for cleaning up pre-existing teams when flipping the flag on.
- Locale entries for the new error and disbandall command, plus tests for `AdminTeamAddCommand`, `IslandTeamInviteCommand`, and the new `AdminTeamDisbandAllCommand`.

Closes #2965.

## Test plan
- [x] `./gradlew test --tests "world.bentobox.bentobox.api.commands.admin.team.*" --tests "world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommandTest"`
- [ ] In a game mode that sets `isTeamsDisabled() == true`, verify `/is team invite` and admin `team add` are refused with the new message
- [ ] Verify `trust`, `coop`, `untrust`, `uncoop` still work in that world
- [ ] Run `admin team disbandall`, confirm with the printed token, and verify members/sub-owners are removed while trusted/coop relationships survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)