### PR TITLE
Defer on-join player resets until after team-accept teleport

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommand.java
@@ -177,23 +177,28 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
             user.sendMessage("commands.island.team.invite.errors.island-is-full");
             return;
         }
-        if (getIWM().getWorldSettings(getWorld()).isDisallowTeamMemberIslands()) {
+        boolean disallowTeamMemberIslands = getIWM().getWorldSettings(getWorld()).isDisallowTeamMemberIslands();
+        if (disallowTeamMemberIslands) {
             // Remove the player's other islands
             getIslands().removePlayer(getWorld(), user.getUniqueId());
-            // Remove money inventory etc. for leaving
-            cleanPlayer(user);
-        } else {
-            // Apply on-join resets since the player is joining a team island
-            cleanJoiningPlayer(user);
         }
         // Add the player as a team member of the new island
         getIslands().setJoinTeam(teamIsland, user.getUniqueId());
         // Move player to team's island
         getIslands().setPrimaryIsland(user.getUniqueId(), teamIsland);
         getIslands().homeTeleportAsync(getWorld(), user.getPlayer()).thenRun(() -> {
-            if (getIWM().getWorldSettings(getWorld()).isDisallowTeamMemberIslands()) {
+            // Apply on-join (and, where applicable, on-leave) resets after the player has
+            // been teleported to the island world. Running these before the teleport would
+            // clear the player's inventory etc. while they are still in their previous world,
+            // which other plugins (e.g. InvSwitcher) may then save as that world's state.
+            if (disallowTeamMemberIslands) {
+                // Remove money inventory etc. for leaving
+                cleanPlayer(user);
                 // Delete the old islands
                 islands.forEach(island -> getIslands().deleteIsland(island, true, user.getUniqueId()));
+            } else {
+                // Apply on-join resets since the player is joining a team island
+                cleanJoiningPlayer(user);
             }
             // Put player back into normal mode
             user.setGameMode(getIWM().getDefaultGameMode(getWorld()));
@@ -203,8 +208,7 @@ public class IslandTeamInviteAcceptCommand extends ConfirmableCommand {
             Util.runCommands(user, ownerName, getIWM().getOnJoinCommands(getWorld()), "join");
 
         });
-        if (getIWM().getWorldSettings(getWorld()).isDisallowTeamMemberIslands()
-                && getIWM().isTeamJoinDeathReset(getWorld())) {
+        if (disallowTeamMemberIslands && getIWM().isTeamJoinDeathReset(getWorld())) {
             // Reset deaths
             getPlayers().setDeaths(getWorld(), user.getUniqueId(), 0);
         }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteAcceptCommandTest.java
@@ -396,6 +396,56 @@ class IslandTeamInviteAcceptCommandTest extends RanksManagerTestSetup {
     }
 
     /**
+     * Regression test for the InvSwitcher interaction bug: inventory/XP resets configured by
+     * on-join.reset.* must run AFTER the player has been teleported to the island world, not
+     * before. Running them earlier clears the inventory while the player is still standing in
+     * their previous world, where another plugin (e.g. InvSwitcher) may then save the empty
+     * state as that world's stored inventory and overwrite the player's real items.
+     */
+    @Test
+    void testAcceptTeamInvite_inventoryClearWaitsForTeleport() {
+        // Set up world settings with isOnJoinResetInventory = true (the trigger condition)
+        when(itc.getWorld()).thenReturn(world);
+        when(iwm.isOnJoinResetInventory(any())).thenReturn(true);
+        when(iwm.isOnJoinResetXP(any())).thenReturn(true);
+        when(iwm.getOnJoinCommands(any())).thenReturn(Collections.emptyList());
+
+        // Set up team island
+        String islandId = UUID.randomUUID().toString();
+        when(invite.getIslandID()).thenReturn(islandId);
+        when(invite.getInviter()).thenReturn(notUUID);
+        Island teamIsland = mock(Island.class);
+        when(teamIsland.getOwner()).thenReturn(notUUID);
+        when(teamIsland.getMemberSet(anyInt(), anyBoolean())).thenReturn(ImmutableSet.of());
+        when(im.getIslandById(islandId)).thenReturn(Optional.of(teamIsland));
+        when(im.getMaxMembers(any(), anyInt())).thenReturn(4);
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(Collections.emptyList());
+
+        // Teleport future is deliberately *not* completed yet so we can observe the order
+        CompletableFuture<Boolean> pendingTeleport = new CompletableFuture<>();
+        when(im.homeTeleportAsync(any(World.class), any(Player.class))).thenReturn(pendingTeleport);
+
+        // Execute
+        c.acceptTeamInvite(user, invite);
+
+        // Before the teleport completes, none of the resets must have run.
+        // Previously these were called synchronously before homeTeleportAsync, which let
+        // them clear the player's inventory while they were still in their old world.
+        verify(inv, never()).clear();
+        verify(mockPlayer, never()).setLevel(0);
+        verify(mockPlayer, never()).setExp(0F);
+        verify(mockPlayer, never()).setTotalExperience(0);
+
+        // Complete the teleport — now the on-join resets are allowed to run
+        pendingTeleport.complete(true);
+
+        verify(inv).clear();
+        verify(mockPlayer).setLevel(0);
+        verify(mockPlayer).setExp(0F);
+        verify(mockPlayer).setTotalExperience(0);
+    }
+
+    /**
      * Test that XP is NOT reset when isOnJoinResetXP is false and isDisallowTeamMemberIslands is false.
      */
     @Test


### PR DESCRIPTION
## Summary
- Move `cleanPlayer` / `cleanJoiningPlayer` from before `homeTeleportAsync` to inside the `.thenRun(...)` callback in `IslandTeamInviteAcceptCommand.acceptTeamInvite`, so the inventory / XP / health / hunger / money resets configured by `island.reset.on-join.*` (and on-leave) run **after** the player has been teleported to the island world, not before.
- Adds a regression test that uses an uncompleted `CompletableFuture` to assert no resets fire until the teleport completes.

## The bug

Reported via [InvSwitcher](https://github.com/BentoBoxWorld/InvSwitcher): a player standing in a non-BentoBox world with items, who accepts an invite into an AOneBlock or Boxed team island, returns to find their non-BentoBox-world inventory empty. The pattern only shows up in those two game modes because they're the ones that ship (Boxed 3.3.0) or commonly default (AOneBlock, via the Java field default `true`) with `island.reset.on-join.inventory: true`. BSkyBlock / AcidIsland / CaveBlock / Poseidon / StrangerRealms ship with `false` and don't trigger it.

### Root cause

1. Player stands in non-BB world `world` with real items.
2. `/island team accept` calls `cleanJoiningPlayer(user)` synchronously — `player.getInventory().clear()` runs **while the player is still in the non-BB world**.
3. `homeTeleportAsync` then teleports them to the island. The teleport eventually fires `PlayerChangedWorldEvent`.
4. InvSwitcher's `PlayerListener.onWorldEnter` sees `from = world`, calls `storeInventory(player, world)`, and persists the now-empty inventory under that world's storage key.
5. When the player later returns to a non-BB world, InvSwitcher loads the empty inventory it just saved. Their items are gone.

### Fix

Defer the player-data resets until the teleport completes. This way `PlayerChangedWorldEvent` fires (and InvSwitcher saves the still-intact non-BB inventory) before any `clear()` happens; the resets then run in the island world, which is the semantically correct place for on-join resets. The `getIslands().removePlayer(...)` call is logical island-state housekeeping and stays before the teleport; `deleteIsland(...)` was already inside `thenRun` and is now grouped with `cleanPlayer` there for consistency.

## Test plan

- [x] `./gradlew test --tests 'IslandTeamInviteAcceptCommandTest'` — green, including the three pre-existing XP-reset tests that still verify resets occur (the mocked `CompletableFuture.completedFuture(true)` causes `thenRun` to fire synchronously).
- [x] `./gradlew test` — full suite green.
- [x] New `testAcceptTeamInvite_inventoryClearWaitsForTeleport` uses an uncompleted future to assert `inv.clear()` / `setLevel(0)` / `setExp(0F)` / `setTotalExperience(0)` are **not** called before the teleport completes, then completes the future and asserts they **are** called after.
- [ ] Manual reproduction with InvSwitcher 1.17.1, AOneBlock 1.25.0, Boxed 3.3.0 (both with `on-join.inventory: true`): player joins a team while standing in `world`, returns to `world` after, items should remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)