### PR TITLE
Pin MockBukkit to v4.110.0 (fix flaky SNAPSHOT resolution)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,14 @@ version = finalRevision
 val javaVersion = "21"
 val junitVersion = "5.10.2"
 val mockitoVersion = "5.11.0"
-val mockBukkitVersion = "v1.21-SNAPSHOT"
+// Pin to a concrete JitPack tag rather than the v1.21-SNAPSHOT pointer.
+// SNAPSHOT resolution on JitPack is flaky — it sometimes advertises a
+// timestamped version in maven-metadata.xml whose corresponding .pom 404s,
+// breaking dependency resolution mid-build. Newer tags (>= v4.111) also
+// currently fail to build on JitPack because the project requires a Java 25
+// toolchain that JitPack's default image doesn't have. v4.110.0 is the most
+// recent tag with both POM and JAR available on JitPack.
+val mockBukkitVersion = "v4.110.0"
 val mongodbVersion = "3.12.12"
 val mariadbVersion = "3.0.5"
 val mysqlVersion = "8.0.27"

--- a/src/test/java/world/bentobox/bentobox/database/objects/IslandTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/objects/IslandTest.java
@@ -798,6 +798,15 @@ class IslandTest extends CommonTestSetup {
 
     @Test
     void testSetRange() {
+        // setRange only allows values that disagree with the gamemode's configured
+        // distance-between-islands when the gamemode opts out via
+        // isEnforceEqualRanges()==false. That's the path StrangerRealms uses to grow
+        // claims with team size. Without the opt-out, setRange refuses mismatched
+        // values to prevent silent database corruption (see testSetRangeRefused...).
+        GameModeAddon optOutAddon = mock(GameModeAddon.class);
+        when(optOutAddon.isEnforceEqualRanges()).thenReturn(false);
+        when(iwm.getAddon(any())).thenReturn(Optional.of(optOutAddon));
+
         island.setRange(200);
         assertEquals(200, island.getRange());
     }


### PR DESCRIPTION
## Problem

`develop` currently can't compile tests on a clean CI runner:

```
Could not find MockBukkit-v1.21-SNAPSHOT.jar
  (com.github.MockBukkit:MockBukkit:v1.21-SNAPSHOT:v4.110.0-g1a072c3-1)
```

Direct probing of JitPack:

```bash
$ curl -sIL https://jitpack.io/com/github/MockBukkit/MockBukkit/v1.21-SNAPSHOT/MockBukkit-v1.21-v4.110.0-g1a072c3-1.jar
HTTP/2 200          ← jar exists
$ curl -sIL https://jitpack.io/com/github/MockBukkit/MockBukkit/v1.21-SNAPSHOT/MockBukkit-v1.21-v4.110.0-g1a072c3-1.pom
HTTP/2 404          ← but the POM doesn't
```

JitPack's `maven-metadata.xml` advertises the timestamped version, the jar is reachable, but the corresponding POM 404s. Gradle requires the POM for dependency resolution, so the build aborts.

Triggering a JitPack rebuild for a newer tag (e.g. `v4.113.1`) also fails — MockBukkit recently moved to a Java 25 toolchain and JitPack's default build image only has Java 21:

```
Cannot find a Java installation on your machine (Linux amd64) matching:
  {languageVersion=25, vendor=any vendor, …}
Toolchain download repositories have not been configured.
```

## Fix

Pin to the most recent tag that's actually serving on JitPack: **`v4.110.0`** (May 5 2026). Both `.pom` and `.jar` return 200, and this is the version the SNAPSHOT pointer was already trying to resolve to under the covers.

The pin trades the (mostly notional) benefit of automatic snapshot updates for build stability. When JitPack starts publishing newer tags successfully — or when this project moves off JitPack — we can bump.

## Also: testSetRange update

`IslandTest.testSetRange` was asserting that `island.setRange(200)` succeeded when the configured distance was 100 — which is exactly the corruption pattern `Island.setRange` now refuses (introduced in #2980). Updated the test to simulate an addon that opts out of equal-range enforcement (`isEnforceEqualRanges() == false`), which is the legitimate use case (claim resizing in StrangerRealms-style addons). The new `testSetRange*` tests added in #2980 cover the enforce-true and unregistered-world paths.

## Test plan

- [x] `./gradlew compileTestJava --refresh-dependencies` — clean
- [x] `./gradlew test` — full suite green
- [x] `./gradlew test --tests "world.bentobox.bentobox.database.objects.IslandTest"` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)