### PR TITLE
feat: add admin range bonus management commands (removebonus + purgebonus)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 group = "world.bentobox" // From <groupId>
 
 // Base properties from <properties>
-val buildVersion = "3.17.0"
+val buildVersion = "3.17.1"
 val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommand.java
@@ -25,6 +25,7 @@ public class AdminRangeCommand extends CompositeCommand {
         new AdminRangeAddCommand(this);
         new AdminRangeRemoveCommand(this);
         new AdminRangeRemoveBonusCommand(this);
+        new AdminRangePurgeBonusCommand(this);
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeCommand.java
@@ -24,6 +24,7 @@ public class AdminRangeCommand extends CompositeCommand {
         new AdminRangeResetCommand(this);
         new AdminRangeAddCommand(this);
         new AdminRangeRemoveCommand(this);
+        new AdminRangeRemoveBonusCommand(this);
     }
 
     @Override

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommand.java
@@ -1,0 +1,134 @@
+package world.bentobox.bentobox.api.commands.admin.range;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.ConfirmableCommand;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.BonusRangeRecord;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Admin command to remove every bonus range carrying a given id from <b>all</b>
+ * islands in this gamemode's world.
+ * <p>
+ * Addons tag the bonus ranges they grant with their own name (the bonus
+ * {@code uniqueId}); for example the Upgrades addon stores them under the id
+ * {@code "Upgrades"}. When such an addon is removed, the bonus ranges it added
+ * remain on every island it ever touched. This command purges them in one go.
+ *
+ * @author tastybento
+ * @since 3.17.1
+ */
+public class AdminRangePurgeBonusCommand extends ConfirmableCommand {
+
+    private @Nullable String bonusId;
+
+    /**
+     * Admin command to remove a bonus range id from every island.
+     * @param parent - parent range command
+     */
+    public AdminRangePurgeBonusCommand(CompositeCommand parent) {
+        super(parent, "purgebonus");
+    }
+
+    @Override
+    public void setup() {
+        setPermission("admin.range.purgebonus");
+        setOnlyPlayer(false);
+        setParametersHelp("commands.admin.range.purgebonus.parameters");
+        setDescription("commands.admin.range.purgebonus.description");
+    }
+
+    @Override
+    public boolean canExecute(User user, String label, List<String> args) {
+        // A single bonus id is expected
+        if (args.size() != 1) {
+            showHelp(this, user);
+            return false;
+        }
+        bonusId = args.get(0);
+        // There must be at least one island carrying this bonus id
+        if (islandsWithBonus(bonusId).isEmpty()) {
+            user.sendMessage("commands.admin.range.purgebonus.none", "[id]", bonusId);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        Objects.requireNonNull(bonusId);
+        // Warn how many islands will be affected before the admin confirms
+        int count = islandsWithBonus(bonusId).size();
+        user.sendMessage("commands.admin.range.purgebonus.warning", "[id]", bonusId, TextVariables.NUMBER,
+                String.valueOf(count));
+        final String id = bonusId;
+        askConfirmation(user, () -> purge(user, id));
+        return true;
+    }
+
+    /**
+     * Removes the bonus range id from every island that carries it, firing a range
+     * change event per island whose effective protection range changed. Each island
+     * is persisted automatically via {@code setChanged()}.
+     *
+     * @param user the admin running the command
+     * @param id   the bonus range uniqueId to purge
+     */
+    void purge(User user, String id) {
+        int islandsChanged = 0;
+        for (Island island : islandsWithBonus(id)) {
+            int oldRange = island.getProtectionRange();
+            island.clearBonusRange(id);
+            int newRange = island.getProtectionRange();
+            if (oldRange != newRange) {
+                IslandEvent.builder()
+                        .island(island)
+                        .location(island.getCenter())
+                        .reason(IslandEvent.Reason.RANGE_CHANGE)
+                        .involvedPlayer(island.getOwner())
+                        .admin(true)
+                        .protectionRange(newRange, oldRange)
+                        .build();
+            }
+            islandsChanged++;
+        }
+        getPlugin().log("Purged bonus range '" + id + "' from " + islandsChanged + " island(s) in "
+                + getWorld().getName());
+        user.sendMessage("commands.admin.range.purgebonus.success", "[id]", id, TextVariables.NUMBER,
+                String.valueOf(islandsChanged));
+    }
+
+    /**
+     * @return the islands in this world that carry a bonus range with the given id.
+     *         Uses the island cache so the live, canonical instances are mutated.
+     */
+    private List<Island> islandsWithBonus(String id) {
+        return getIslands().getIslandCache().getIslands(getWorld()).stream()
+                .filter(i -> i.getBonusRangeRecord(id).isPresent()).toList();
+    }
+
+    @Override
+    public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
+        if (args.size() <= 1) {
+            String lastArg = !args.isEmpty() ? args.getLast() : "";
+            // Suggest the bonus ids that exist on currently-loaded islands in this world
+            Collection<Island> cached = getIslands().getIslandCache().getCachedIslands();
+            List<String> ids = cached.stream().filter(i -> getWorld().equals(i.getWorld()))
+                    .flatMap(i -> i.getBonusRanges().stream()).map(BonusRangeRecord::getUniqueId).distinct().sorted()
+                    .toList();
+            return Optional.of(Util.tabLimit(new ArrayList<>(ids), lastArg));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommand.java
@@ -3,13 +3,12 @@ package world.bentobox.bentobox.api.commands.admin.range;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
+import org.bukkit.Bukkit;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
-import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -25,13 +24,27 @@ import world.bentobox.bentobox.util.Util;
  * {@code uniqueId}); for example the Upgrades addon stores them under the id
  * {@code "Upgrades"}. When such an addon is removed, the bonus ranges it added
  * remain on every island it ever touched. This command purges them in one go.
+ * <p>
+ * Because a server can hold a large number of islands, the scan that finds the
+ * affected islands runs asynchronously (off the main thread). The admin is then
+ * shown the count and must re-run the command with {@code confirm} to apply it.
+ * The actual mutation and event firing happen back on the main thread, on the
+ * live cached island instances.
  *
  * @author tastybento
  * @since 3.17.1
  */
-public class AdminRangePurgeBonusCommand extends ConfirmableCommand {
+public class AdminRangePurgeBonusCommand extends CompositeCommand {
 
-    private @Nullable String bonusId;
+    /** True while an async scan is running, to prevent overlapping runs. */
+    volatile boolean inPurge;
+    /** True once a scan has found islands and is awaiting a {@code confirm}. */
+    boolean toBeConfirmed;
+    /** The bonus id the pending confirmation is for. */
+    @Nullable
+    String pendingId;
+    /** The unique ids of the islands the pending confirmation will purge. */
+    List<String> pendingIslandIds = List.of();
 
     /**
      * Admin command to remove a bonus range id from every island.
@@ -51,15 +64,14 @@ public class AdminRangePurgeBonusCommand extends ConfirmableCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
-        // A single bonus id is expected
-        if (args.size() != 1) {
-            showHelp(this, user);
+        if (inPurge) {
+            user.sendMessage("commands.admin.range.purgebonus.in-progress");
             return false;
         }
-        bonusId = args.get(0);
-        // There must be at least one island carrying this bonus id
-        if (islandsWithBonus(bonusId).isEmpty()) {
-            user.sendMessage("commands.admin.range.purgebonus.none", "[id]", bonusId);
+        // Expect "<id>" or "<id> confirm"
+        if (args.isEmpty() || args.size() > 2
+                || (args.size() == 2 && !args.get(1).equalsIgnoreCase("confirm"))) {
+            showHelp(this, user);
             return false;
         }
         return true;
@@ -67,27 +79,72 @@ public class AdminRangePurgeBonusCommand extends ConfirmableCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        Objects.requireNonNull(bonusId);
-        // Warn how many islands will be affected before the admin confirms
-        int count = islandsWithBonus(bonusId).size();
-        user.sendMessage("commands.admin.range.purgebonus.warning", "[id]", bonusId, TextVariables.NUMBER,
-                String.valueOf(count));
-        final String id = bonusId;
-        askConfirmation(user, () -> purge(user, id));
+        String id = args.get(0);
+        boolean confirm = args.size() == 2 && args.get(1).equalsIgnoreCase("confirm");
+        // Apply a pending purge if this is the matching confirmation
+        if (confirm && toBeConfirmed && id.equals(pendingId)) {
+            List<String> ids = pendingIslandIds;
+            toBeConfirmed = false;
+            pendingId = null;
+            pendingIslandIds = List.of();
+            applyPurge(user, id, ids);
+            return true;
+        }
+        // Otherwise (re)scan asynchronously and prompt for confirmation
+        inPurge = true;
+        getPlugin().getIslands().getIslandsASync().thenAccept(all -> {
+            List<String> ids = findIslandIds(all, id);
+            Bukkit.getScheduler().runTask(getPlugin(), () -> {
+                inPurge = false;
+                if (ids.isEmpty()) {
+                    user.sendMessage("commands.admin.range.purgebonus.none", "[id]", id);
+                    return;
+                }
+                pendingId = id;
+                pendingIslandIds = ids;
+                toBeConfirmed = true;
+                user.sendMessage("commands.admin.range.purgebonus.warning", "[id]", id, TextVariables.NUMBER,
+                        String.valueOf(ids.size()));
+                user.sendMessage("commands.admin.range.purgebonus.confirm");
+            });
+        }).exceptionally(ex -> {
+            getPlugin().logStacktrace(ex);
+            Bukkit.getScheduler().runTask(getPlugin(), () -> {
+                inPurge = false;
+                user.sendMessage("commands.admin.range.purgebonus.failed");
+            });
+            return null;
+        });
         return true;
     }
 
     /**
-     * Removes the bonus range id from every island that carries it, firing a range
-     * change event per island whose effective protection range changed. Each island
-     * is persisted automatically via {@code setChanged()}.
+     * @return the unique ids of the islands in this world that carry a bonus range
+     *         with the given id.
+     */
+    List<String> findIslandIds(Collection<Island> islands, String id) {
+        return islands.stream().filter(i -> getWorld().equals(i.getWorld()))
+                .filter(i -> i.getBonusRangeRecord(id).isPresent()).map(Island::getUniqueId).toList();
+    }
+
+    /**
+     * Removes the bonus range id from every still-matching island, firing a range
+     * change event per island whose effective protection range changed. Runs on the
+     * main thread and operates on the live cached island instances, which are
+     * persisted automatically via {@code setChanged()}.
      *
      * @param user the admin running the command
      * @param id   the bonus range uniqueId to purge
+     * @param ids  the unique ids of the islands found during the async scan
      */
-    void purge(User user, String id) {
-        int islandsChanged = 0;
-        for (Island island : islandsWithBonus(id)) {
+    void applyPurge(User user, String id, List<String> ids) {
+        int changed = 0;
+        for (String uid : ids) {
+            Island island = getIslands().getIslandById(uid).orElse(null);
+            // Re-check on the live instance in case it changed since the scan
+            if (island == null || island.getBonusRangeRecord(id).isEmpty()) {
+                continue;
+            }
             int oldRange = island.getProtectionRange();
             island.clearBonusRange(id);
             int newRange = island.getProtectionRange();
@@ -101,21 +158,12 @@ public class AdminRangePurgeBonusCommand extends ConfirmableCommand {
                         .protectionRange(newRange, oldRange)
                         .build();
             }
-            islandsChanged++;
+            changed++;
         }
-        getPlugin().log("Purged bonus range '" + id + "' from " + islandsChanged + " island(s) in "
+        getPlugin().log("Purged bonus range '" + id + "' from " + changed + " island(s) in "
                 + getWorld().getName());
         user.sendMessage("commands.admin.range.purgebonus.success", "[id]", id, TextVariables.NUMBER,
-                String.valueOf(islandsChanged));
-    }
-
-    /**
-     * @return the islands in this world that carry a bonus range with the given id.
-     *         Uses the island cache so the live, canonical instances are mutated.
-     */
-    private List<Island> islandsWithBonus(String id) {
-        return getIslands().getIslandCache().getIslands(getWorld()).stream()
-                .filter(i -> i.getBonusRangeRecord(id).isPresent()).toList();
+                String.valueOf(changed));
     }
 
     @Override
@@ -128,6 +176,8 @@ public class AdminRangePurgeBonusCommand extends ConfirmableCommand {
                     .flatMap(i -> i.getBonusRanges().stream()).map(BonusRangeRecord::getUniqueId).distinct().sorted()
                     .toList();
             return Optional.of(Util.tabLimit(new ArrayList<>(ids), lastArg));
+        } else if (args.size() == 2) {
+            return Optional.of(Util.tabLimit(new ArrayList<>(List.of("confirm")), args.getLast()));
         }
         return Optional.empty();
     }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveBonusCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveBonusCommand.java
@@ -1,0 +1,164 @@
+package world.bentobox.bentobox.api.commands.admin.range;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.ConfirmableCommand;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.BonusRangeRecord;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Admin command to remove bonus ranges from a player's island.
+ * <p>
+ * Bonus ranges are static values added to (or subtracted from) the protection
+ * range of an island. They are stored in the {@link Island} as
+ * {@link BonusRangeRecord}s and are typically granted by addons. Admins need a
+ * way to clear them - for example after the addon that granted them has been
+ * removed.
+ * <p>
+ * Usage: {@code /<admin> range removebonus <player> [id]}. With no id, every
+ * bonus range is removed. With an id, only the bonus ranges sharing that unique
+ * id are removed. The available ids are offered through tab completion so the
+ * admin does not have to guess them.
+ *
+ * @author tastybento
+ * @since 3.17.1
+ */
+public class AdminRangeRemoveBonusCommand extends ConfirmableCommand {
+
+    private Island targetIsland;
+    private @Nullable UUID targetUUID;
+    private @Nullable String bonusId;
+
+    /**
+     * Admin command to remove bonus ranges from a player's island.
+     * @param parent - parent range command
+     */
+    public AdminRangeRemoveBonusCommand(CompositeCommand parent) {
+        super(parent, "removebonus");
+    }
+
+    @Override
+    public void setup() {
+        setPermission("admin.range.removebonus");
+        setOnlyPlayer(false);
+        setParametersHelp("commands.admin.range.removebonus.parameters");
+        setDescription("commands.admin.range.removebonus.description");
+    }
+
+    @Override
+    public boolean canExecute(User user, String label, List<String> args) {
+        // Expect the player's name and an optional bonus id
+        if (args.isEmpty() || args.size() > 2) {
+            showHelp(this, user);
+            return false;
+        }
+        // Get target player
+        targetUUID = Util.getUUID(args.get(0));
+        if (targetUUID == null) {
+            user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
+            return false;
+        }
+        // Target must have an island in this world
+        targetIsland = getIslands().getIsland(getWorld(), targetUUID);
+        if (targetIsland == null) {
+            user.sendMessage("general.errors.player-has-no-island");
+            return false;
+        }
+        // Nothing to do if there are no bonus ranges at all
+        if (targetIsland.getBonusRanges().isEmpty()) {
+            user.sendMessage("commands.admin.range.removebonus.no-bonus");
+            return false;
+        }
+        // A specific bonus id was supplied - it must exist on this island
+        bonusId = args.size() == 2 ? args.get(1) : null;
+        if (bonusId != null && targetIsland.getBonusRangeRecord(bonusId).isEmpty()) {
+            user.sendMessage("commands.admin.range.removebonus.unknown-bonus", "[id]", bonusId);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        Objects.requireNonNull(targetIsland);
+        Objects.requireNonNull(targetUUID);
+        askConfirmation(user, () -> removeBonusRanges(user, args.get(0)));
+        return true;
+    }
+
+    /**
+     * Removes the bonus range(s) from the target island. If {@link #bonusId} is
+     * set, only that id's bonus ranges are removed, otherwise all of them are.
+     * Fires a range change event if the effective protection range changed and
+     * notifies the user. The island is persisted automatically via {@code setChanged()}.
+     *
+     * @param user the admin running the command
+     * @param name the target player's name (for the feedback message)
+     */
+    void removeBonusRanges(User user, String name) {
+        int oldRange = targetIsland.getProtectionRange();
+
+        int removed;
+        if (bonusId == null) {
+            // Remove every bonus range
+            removed = targetIsland.getBonusRanges().stream().mapToInt(BonusRangeRecord::getRange).sum();
+            targetIsland.clearAllBonusRanges();
+            user.sendMessage("commands.admin.range.removebonus.success", TextVariables.NUMBER,
+                    String.valueOf(removed), TextVariables.NAME, name);
+        } else {
+            // Remove only the bonus ranges for the given id
+            removed = targetIsland.getBonusRange(bonusId);
+            targetIsland.clearBonusRange(bonusId);
+            user.sendMessage("commands.admin.range.removebonus.success-id", "[id]", bonusId,
+                    TextVariables.NUMBER, String.valueOf(removed), TextVariables.NAME, name);
+        }
+
+        // The effective protection range may have changed - notify addons (not cancellable)
+        int newRange = targetIsland.getProtectionRange();
+        if (oldRange != newRange) {
+            IslandEvent.builder()
+                    .island(targetIsland)
+                    .location(targetIsland.getCenter())
+                    .reason(IslandEvent.Reason.RANGE_CHANGE)
+                    .involvedPlayer(targetUUID)
+                    .admin(true)
+                    .protectionRange(newRange, oldRange)
+                    .build();
+        }
+    }
+
+    @Override
+    public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
+        String lastArg = !args.isEmpty() ? args.getLast() : "";
+        if (args.size() <= 1) {
+            // Don't show every player on the server. Require at least the first letter
+            if (lastArg.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(Util.tabLimit(new ArrayList<>(Util.getOnlinePlayerList(user)), lastArg));
+        } else if (args.size() == 2) {
+            // Offer the bonus ids that exist on the target player's island
+            UUID uuid = Util.getUUID(args.get(0));
+            if (uuid != null) {
+                Island island = getIslands().getIsland(getWorld(), uuid);
+                if (island != null) {
+                    List<String> ids = island.getBonusRanges().stream().map(BonusRangeRecord::getUniqueId).distinct()
+                            .toList();
+                    return Optional.of(Util.tabLimit(new ArrayList<>(ids), lastArg));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -241,6 +241,13 @@ commands:
         success: >-
           <green>Úspěšně zmenšena chráněná oblast ostrova hráče </green><aqua>[name]</aqua><green>na </green><aqua></aqua>
           [total] <gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<hráč> [id]'
+        description: 'odebere bonusové rozsahy z ostrova (všechny nebo jeden podle id)'
+        no-bonus: '<red>Tento ostrov nemá žádné bonusové rozsahy k odebrání!</red>'
+        unknown-bonus: '<red>Na tomto ostrově neexistuje bonusový rozsah s id </red><aqua>[id]</aqua><red>!</red>'
+        success: '<green>Odebráno </green><aqua>[number]</aqua><green> z bonusového rozsahu ostrova hráče </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Odebrán bonusový rozsah </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) z ostrova hráče </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <Player>
       description: registrovat hráče na nevlastněný ostrov, na kterém se nacházíš

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -254,6 +254,9 @@ commands:
         none: '<red>Žádný ostrov nemá bonusový rozsah s id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Tímto odeberete bonusový rozsah </gold><aqua>[id]</aqua><gold> z </gold><aqua>[number]</aqua><gold> ostrovů.</gold>'
         success: '<green>Odebrán bonusový rozsah </green><aqua>[id]</aqua><green> z </green><aqua>[number]</aqua><green> ostrovů.</green>'
+        confirm: '<gold>Spusťte příkaz znovu s </gold><aqua>confirm</aqua><gold> pro potvrzení.</gold>'
+        in-progress: '<red>Čištění bonusových rozsahů již probíhá. Počkejte prosím.</red>'
+        failed: '<red>Skenování ostrovů selhalo. Zkontrolujte konzoli.</red>'
     register:
       parameters: <Player>
       description: registrovat hráče na nevlastněný ostrov, na kterém se nacházíš

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -248,6 +248,12 @@ commands:
         unknown-bonus: '<red>Na tomto ostrově neexistuje bonusový rozsah s id </red><aqua>[id]</aqua><red>!</red>'
         success: '<green>Odebráno </green><aqua>[number]</aqua><green> z bonusového rozsahu ostrova hráče </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Odebrán bonusový rozsah </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) z ostrova hráče </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'odebere bonusový rozsah s daným id ze všech ostrovů (např. po odebrání addonu, který jej přidal)'
+        none: '<red>Žádný ostrov nemá bonusový rozsah s id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Tímto odeberete bonusový rozsah </gold><aqua>[id]</aqua><gold> z </gold><aqua>[number]</aqua><gold> ostrovů.</gold>'
+        success: '<green>Odebrán bonusový rozsah </green><aqua>[id]</aqua><green> z </green><aqua>[number]</aqua><green> ostrovů.</green>'
     register:
       parameters: <Player>
       description: registrovat hráče na nevlastněný ostrov, na kterém se nacházíš

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -274,6 +274,9 @@ commands:
         none: '<red>Keine Insel hat einen Bonusbereich mit der id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Dies entfernt den Bonusbereich </gold><aqua>[id]</aqua><gold> von </gold><aqua>[number]</aqua><gold> Insel(n).</gold>'
         success: '<green>Bonusbereich </green><aqua>[id]</aqua><green> von </green><aqua>[number]</aqua><green> Insel(n) entfernt.</green>'
+        confirm: '<gold>Führe den Befehl erneut mit </gold><aqua>confirm</aqua><gold> aus, um fortzufahren.</gold>'
+        in-progress: '<red>Eine Bonusbereich-Bereinigung läuft bereits. Bitte warten.</red>'
+        failed: '<red>Inseln konnten nicht gescannt werden. Prüfe die Konsole.</red>'
     register:
       parameters: <spieler>
       description: Spieler auf freier Insel registrieren, auf der du dich befindest

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -261,6 +261,13 @@ commands:
         success: >-
           <green>Erfolgreich reduziert </green><aqua>[name]</aqua><green>'s geschützten Bereich der Insel</green>
           um<aqua>[total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<spieler> [id]'
+        description: 'entfernt Bonusbereiche von der Insel (alle oder einen per id)'
+        no-bonus: '<red>Diese Insel hat keine Bonusbereiche zum Entfernen!</red>'
+        unknown-bonus: '<red>Es gibt keinen Bonusbereich mit der id </red><aqua>[id]</aqua><red> auf dieser Insel!</red>'
+        success: '<green>Entfernt: </green><aqua>[number]</aqua><green> an Bonusbereich von der Insel von </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Bonusbereich </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) von der Insel von </green><aqua>[name]</aqua><green> entfernt.</green>'
     register:
       parameters: <spieler>
       description: Spieler auf freier Insel registrieren, auf der du dich befindest

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -268,6 +268,12 @@ commands:
         unknown-bonus: '<red>Es gibt keinen Bonusbereich mit der id </red><aqua>[id]</aqua><red> auf dieser Insel!</red>'
         success: '<green>Entfernt: </green><aqua>[number]</aqua><green> an Bonusbereich von der Insel von </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Bonusbereich </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) von der Insel von </green><aqua>[name]</aqua><green> entfernt.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'entfernt einen Bonusbereich mit dieser id von allen Inseln (z. B. nach dem Entfernen des Addons, das ihn hinzugefügt hat)'
+        none: '<red>Keine Insel hat einen Bonusbereich mit der id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Dies entfernt den Bonusbereich </gold><aqua>[id]</aqua><gold> von </gold><aqua>[number]</aqua><gold> Insel(n).</gold>'
+        success: '<green>Bonusbereich </green><aqua>[id]</aqua><green> von </green><aqua>[number]</aqua><green> Insel(n) entfernt.</green>'
     register:
       parameters: <spieler>
       description: Spieler auf freier Insel registrieren, auf der du dich befindest

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -221,6 +221,13 @@ commands:
         parameters: <player> <range> [[prefix_island] location]
         success: '<green>Successfully decreased </green><aqua>[name]</aqua><green>''s [prefix_island] protected
           range to </green><aqua>[total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>'
+      removebonus:
+        parameters: <player> [id]
+        description: removes bonus ranges from the [prefix_island] (all, or one by id)
+        no-bonus: '<red>This [prefix_island] has no bonus ranges to remove!</red>'
+        unknown-bonus: '<red>There is no bonus range with id </red><aqua>[id]</aqua><red> on this [prefix_island]!</red>'
+        success: '<green>Removed </green><aqua>[number]</aqua><green> of bonus range from </green><aqua>[name]</aqua><green>''s [prefix_island].</green>'
+        success-id: '<green>Removed bonus range </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) from </green><aqua>[name]</aqua><green>''s [prefix_island].</green>'
     register:
       parameters: <player>
       description: register player to unowned [prefix_island] you are on

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -234,6 +234,9 @@ commands:
         none: '<red>No [prefix_island] has a bonus range with id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>This will remove bonus range </gold><aqua>[id]</aqua><gold> from </gold><aqua>[number]</aqua><gold> island(s).</gold>'
         success: '<green>Removed bonus range </green><aqua>[id]</aqua><green> from </green><aqua>[number]</aqua><green> island(s).</green>'
+        confirm: '<gold>Run the command again with </gold><aqua>confirm</aqua><gold> to proceed.</gold>'
+        in-progress: '<red>A bonus range purge is already running. Please wait.</red>'
+        failed: '<red>Failed to scan islands. Check the console.</red>'
     register:
       parameters: <player>
       description: register player to unowned [prefix_island] you are on

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -228,6 +228,12 @@ commands:
         unknown-bonus: '<red>There is no bonus range with id </red><aqua>[id]</aqua><red> on this [prefix_island]!</red>'
         success: '<green>Removed </green><aqua>[number]</aqua><green> of bonus range from </green><aqua>[name]</aqua><green>''s [prefix_island].</green>'
         success-id: '<green>Removed bonus range </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) from </green><aqua>[name]</aqua><green>''s [prefix_island].</green>'
+      purgebonus:
+        parameters: <id>
+        description: removes a bonus range id from every [prefix_island] (e.g. after removing the addon that added it)
+        none: '<red>No [prefix_island] has a bonus range with id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>This will remove bonus range </gold><aqua>[id]</aqua><gold> from </gold><aqua>[number]</aqua><gold> island(s).</gold>'
+        success: '<green>Removed bonus range </green><aqua>[id]</aqua><green> from </green><aqua>[number]</aqua><green> island(s).</green>'
     register:
       parameters: <player>
       description: register player to unowned [prefix_island] you are on

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -260,6 +260,9 @@ commands:
         none: '<red>¡Ninguna isla tiene un rango de bonificación con la id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Esto eliminará el rango de bonificación </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> isla(s).</gold>'
         success: '<green>Rango de bonificación </green><aqua>[id]</aqua><green> eliminado de </green><aqua>[number]</aqua><green> isla(s).</green>'
+        confirm: '<gold>Vuelve a ejecutar el comando con </gold><aqua>confirm</aqua><gold> para continuar.</gold>'
+        in-progress: '<red>Ya hay una purga de rangos de bonificación en curso. Espera.</red>'
+        failed: '<red>No se pudieron escanear las islas. Revisa la consola.</red>'
     register:
       parameters: <jugador>
       description: registrar jugador en la isla sin dueño en la que estás

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -254,6 +254,12 @@ commands:
         unknown-bonus: '<red>¡No existe ningún rango de bonificación con la id </red><aqua>[id]</aqua><red> en esta isla!</red>'
         success: '<green>Se eliminaron </green><aqua>[number]</aqua><green> de rango de bonificación de la isla de </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Se eliminó el rango de bonificación </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) de la isla de </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'elimina un rango de bonificación con esa id de todas las islas (p. ej. tras eliminar el addon que lo añadió)'
+        none: '<red>¡Ninguna isla tiene un rango de bonificación con la id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Esto eliminará el rango de bonificación </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> isla(s).</gold>'
+        success: '<green>Rango de bonificación </green><aqua>[id]</aqua><green> eliminado de </green><aqua>[number]</aqua><green> isla(s).</green>'
     register:
       parameters: <jugador>
       description: registrar jugador en la isla sin dueño en la que estás

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -247,6 +247,13 @@ commands:
         success: >-
           <green>Disminuyó exitosamente </green><aqua>[name] </aqua><green>rango protegido de la isla a </green><aqua></aqua>
           [total] <gray>(</gray><aqua>- [number] </aqua><gray>) </gray><green>.</green>
+      removebonus:
+        parameters: '<jugador> [id]'
+        description: 'elimina rangos de bonificación de la isla (todos, o uno por id)'
+        no-bonus: '<red>¡Esta isla no tiene rangos de bonificación que eliminar!</red>'
+        unknown-bonus: '<red>¡No existe ningún rango de bonificación con la id </red><aqua>[id]</aqua><red> en esta isla!</red>'
+        success: '<green>Se eliminaron </green><aqua>[number]</aqua><green> de rango de bonificación de la isla de </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Se eliminó el rango de bonificación </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) de la isla de </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <jugador>
       description: registrar jugador en la isla sin dueño en la que estás

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -265,6 +265,13 @@ commands:
         success: >-
           <green>Diminution réussie de la zone de protection de l'île de </green><aqua>[name]</aqua>
           <green>à </green><aqua>[total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<joueur> [id]'
+        description: 'supprime les rayons bonus de l''île (tous, ou un seul par id)'
+        no-bonus: '<red>Cette île n''a aucun rayon bonus à supprimer !</red>'
+        unknown-bonus: '<red>Il n''existe aucun rayon bonus avec l''id </red><aqua>[id]</aqua><red> sur cette île !</red>'
+        success: '<green>Suppression de </green><aqua>[number]</aqua><green> de rayon bonus de l''île de </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Rayon bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) supprimé de l''île de </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <joueur>
       description: enregistrer le joueur sur une île sans propriétaire où vous êtes

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -278,6 +278,9 @@ commands:
         none: '<red>Aucune île n''a de rayon bonus avec l''id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Ceci supprimera le rayon bonus </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> île(s).</gold>'
         success: '<green>Rayon bonus </green><aqua>[id]</aqua><green> supprimé de </green><aqua>[number]</aqua><green> île(s).</green>'
+        confirm: '<gold>Relancez la commande avec </gold><aqua>confirm</aqua><gold> pour continuer.</gold>'
+        in-progress: '<red>Une purge des rayons bonus est déjà en cours. Veuillez patienter.</red>'
+        failed: '<red>Échec de l''analyse des îles. Consultez la console.</red>'
     register:
       parameters: <joueur>
       description: enregistrer le joueur sur une île sans propriétaire où vous êtes

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -272,6 +272,12 @@ commands:
         unknown-bonus: '<red>Il n''existe aucun rayon bonus avec l''id </red><aqua>[id]</aqua><red> sur cette île !</red>'
         success: '<green>Suppression de </green><aqua>[number]</aqua><green> de rayon bonus de l''île de </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Rayon bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) supprimé de l''île de </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'supprime un rayon bonus avec cet id de toutes les îles (par ex. après la suppression de l''addon qui l''a ajouté)'
+        none: '<red>Aucune île n''a de rayon bonus avec l''id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Ceci supprimera le rayon bonus </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> île(s).</gold>'
+        success: '<green>Rayon bonus </green><aqua>[id]</aqua><green> supprimé de </green><aqua>[number]</aqua><green> île(s).</green>'
     register:
       parameters: <joueur>
       description: enregistrer le joueur sur une île sans propriétaire où vous êtes

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -262,6 +262,9 @@ commands:
         none: '<red>Nijedan otok nema bonus raspon s id-om </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Ovo će ukloniti bonus raspon </gold><aqua>[id]</aqua><gold> s </gold><aqua>[number]</aqua><gold> otoka.</gold>'
         success: '<green>Uklonjen bonus raspon </green><aqua>[id]</aqua><green> s </green><aqua>[number]</aqua><green> otoka.</green>'
+        confirm: '<gold>Ponovno pokrenite naredbu s </gold><aqua>confirm</aqua><gold> za potvrdu.</gold>'
+        in-progress: '<red>Čišćenje bonus raspona već je u tijeku. Pričekajte.</red>'
+        failed: '<red>Skeniranje otoka nije uspjelo. Provjerite konzolu.</red>'
     register:
       parameters: <igrač>
       description: registrirajte igrača na nevlasnički otok na kojem se nalazite

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -249,6 +249,13 @@ commands:
         success: >-
           <green>Uspješno je smanjio </green><aqua>[name]</aqua><green>zaštićeni domet otoka na </green><aqua>[total]</aqua>
           <gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<igrač> [id]'
+        description: 'uklanja bonus raspone s otoka (sve ili jedan po id-u)'
+        no-bonus: '<red>Ovaj otok nema bonus raspone za uklanjanje!</red>'
+        unknown-bonus: '<red>Ne postoji bonus raspon s id-om </red><aqua>[id]</aqua><red> na ovom otoku!</red>'
+        success: '<green>Uklonjeno </green><aqua>[number]</aqua><green> bonus raspona s otoka igrača </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Uklonjen bonus raspon </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) s otoka igrača </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <igrač>
       description: registrirajte igrača na nevlasnički otok na kojem se nalazite

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -256,6 +256,12 @@ commands:
         unknown-bonus: '<red>Ne postoji bonus raspon s id-om </red><aqua>[id]</aqua><red> na ovom otoku!</red>'
         success: '<green>Uklonjeno </green><aqua>[number]</aqua><green> bonus raspona s otoka igrača </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Uklonjen bonus raspon </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) s otoka igrača </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'uklanja bonus raspon s danim id-om sa svih otoka (npr. nakon uklanjanja dodatka koji ga je dodao)'
+        none: '<red>Nijedan otok nema bonus raspon s id-om </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Ovo će ukloniti bonus raspon </gold><aqua>[id]</aqua><gold> s </gold><aqua>[number]</aqua><gold> otoka.</gold>'
+        success: '<green>Uklonjen bonus raspon </green><aqua>[id]</aqua><green> s </green><aqua>[number]</aqua><green> otoka.</green>'
     register:
       parameters: <igrač>
       description: registrirajte igrača na nevlasnički otok na kojem se nalazite

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -263,6 +263,13 @@ commands:
         success: >-
           <green>Sikeresen csökkentette </green><aqua>[name]</aqua><green>[prefix_island] védett tartományát </green><aqua></aqua>
           [total] <gray>-re (</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<játékos> [id]'
+        description: 'eltávolítja a bónusz hatótávolságokat a szigetről (mindet, vagy egyet id alapján)'
+        no-bonus: '<red>Ezen a szigeten nincs eltávolítható bónusz hatótávolság!</red>'
+        unknown-bonus: '<red>Nincs ilyen id-jű bónusz hatótávolság </red><aqua>[id]</aqua><red> ezen a szigeten!</red>'
+        success: '<green>Eltávolítva </green><aqua>[number]</aqua><green> bónusz hatótávolság </green><aqua>[name]</aqua><green> szigetéről.</green>'
+        success-id: '<green>Eltávolítva a(z) </green><aqua>[id]</aqua><green> bónusz hatótávolság (</green><aqua>[number]</aqua><green>) </green><aqua>[name]</aqua><green> szigetéről.</green>'
     register:
       parameters: <játékos>
       description: regisztrálj játékost egy ismeretlen szigetre, amelyen tartózkodsz

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -276,6 +276,9 @@ commands:
         none: '<red>Egyetlen szigetnek sincs </red><aqua>[id]</aqua><red> id-jű bónusz hatótávolsága!</red>'
         warning: '<gold>Ez eltávolítja a(z) </gold><aqua>[id]</aqua><gold> bónusz hatótávolságot </gold><aqua>[number]</aqua><gold> szigetről.</gold>'
         success: '<green>A(z) </green><aqua>[id]</aqua><green> bónusz hatótávolság eltávolítva </green><aqua>[number]</aqua><green> szigetről.</green>'
+        confirm: '<gold>Futtasd újra a parancsot a </gold><aqua>confirm</aqua><gold> kapcsolóval a megerősítéshez.</gold>'
+        in-progress: '<red>Egy bónusz hatótávolság tisztítás már fut. Kérlek várj.</red>'
+        failed: '<red>A szigetek beolvasása sikertelen. Ellenőrizd a konzolt.</red>'
     register:
       parameters: <játékos>
       description: regisztrálj játékost egy ismeretlen szigetre, amelyen tartózkodsz

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -270,6 +270,12 @@ commands:
         unknown-bonus: '<red>Nincs ilyen id-jű bónusz hatótávolság </red><aqua>[id]</aqua><red> ezen a szigeten!</red>'
         success: '<green>Eltávolítva </green><aqua>[number]</aqua><green> bónusz hatótávolság </green><aqua>[name]</aqua><green> szigetéről.</green>'
         success-id: '<green>Eltávolítva a(z) </green><aqua>[id]</aqua><green> bónusz hatótávolság (</green><aqua>[number]</aqua><green>) </green><aqua>[name]</aqua><green> szigetéről.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'eltávolít egy adott id-jű bónusz hatótávolságot az összes szigetről (pl. az azt hozzáadó kiegészítő eltávolítása után)'
+        none: '<red>Egyetlen szigetnek sincs </red><aqua>[id]</aqua><red> id-jű bónusz hatótávolsága!</red>'
+        warning: '<gold>Ez eltávolítja a(z) </gold><aqua>[id]</aqua><gold> bónusz hatótávolságot </gold><aqua>[number]</aqua><gold> szigetről.</gold>'
+        success: '<green>A(z) </green><aqua>[id]</aqua><green> bónusz hatótávolság eltávolítva </green><aqua>[number]</aqua><green> szigetről.</green>'
     register:
       parameters: <játékos>
       description: regisztrálj játékost egy ismeretlen szigetre, amelyen tartózkodsz

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -250,6 +250,13 @@ commands:
         success: >-
           <green>Berhasil menurunkan jangkauan perlindungan pulau </green><aqua>[name]</aqua><green></green>
           menjadi <aqua>[total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<pemain> [id]'
+        description: 'menghapus rentang bonus dari pulau (semua, atau satu berdasarkan id)'
+        no-bonus: '<red>Pulau ini tidak memiliki rentang bonus untuk dihapus!</red>'
+        unknown-bonus: '<red>Tidak ada rentang bonus dengan id </red><aqua>[id]</aqua><red> di pulau ini!</red>'
+        success: '<green>Menghapus </green><aqua>[number]</aqua><green> rentang bonus dari pulau </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Menghapus rentang bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) dari pulau </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <pemain>
       description: daftarkan pemain ke pulau tak berpemilik tempat Anda berada

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -257,6 +257,12 @@ commands:
         unknown-bonus: '<red>Tidak ada rentang bonus dengan id </red><aqua>[id]</aqua><red> di pulau ini!</red>'
         success: '<green>Menghapus </green><aqua>[number]</aqua><green> rentang bonus dari pulau </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Menghapus rentang bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) dari pulau </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'menghapus rentang bonus dengan id tersebut dari semua pulau (mis. setelah menghapus addon yang menambahkannya)'
+        none: '<red>Tidak ada pulau yang memiliki rentang bonus dengan id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Ini akan menghapus rentang bonus </gold><aqua>[id]</aqua><gold> dari </gold><aqua>[number]</aqua><gold> pulau.</gold>'
+        success: '<green>Rentang bonus </green><aqua>[id]</aqua><green> dihapus dari </green><aqua>[number]</aqua><green> pulau.</green>'
     register:
       parameters: <pemain>
       description: daftarkan pemain ke pulau tak berpemilik tempat Anda berada

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -263,6 +263,9 @@ commands:
         none: '<red>Tidak ada pulau yang memiliki rentang bonus dengan id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Ini akan menghapus rentang bonus </gold><aqua>[id]</aqua><gold> dari </gold><aqua>[number]</aqua><gold> pulau.</gold>'
         success: '<green>Rentang bonus </green><aqua>[id]</aqua><green> dihapus dari </green><aqua>[number]</aqua><green> pulau.</green>'
+        confirm: '<gold>Jalankan lagi perintah dengan </gold><aqua>confirm</aqua><gold> untuk melanjutkan.</gold>'
+        in-progress: '<red>Pembersihan rentang bonus sedang berjalan. Mohon tunggu.</red>'
+        failed: '<red>Gagal memindai pulau. Periksa konsol.</red>'
     register:
       parameters: <pemain>
       description: daftarkan pemain ke pulau tak berpemilik tempat Anda berada

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -269,6 +269,9 @@ commands:
         none: '<red>Nessuna isola ha un raggio bonus con id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Questo rimuoverà il raggio bonus </gold><aqua>[id]</aqua><gold> da </gold><aqua>[number]</aqua><gold> isola/e.</gold>'
         success: '<green>Raggio bonus </green><aqua>[id]</aqua><green> rimosso da </green><aqua>[number]</aqua><green> isola/e.</green>'
+        confirm: '<gold>Esegui di nuovo il comando con </gold><aqua>confirm</aqua><gold> per procedere.</gold>'
+        in-progress: '<red>È già in corso una rimozione dei raggi bonus. Attendi.</red>'
+        failed: '<red>Scansione delle isole non riuscita. Controlla la console.</red>'
     register:
       parameters: <giocatore>
       description: registra il giocatore nell'isola senza proprietario sulla quale sei

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -263,6 +263,12 @@ commands:
         unknown-bonus: '<red>Non esiste alcun raggio bonus con id </red><aqua>[id]</aqua><red> su quest''isola!</red>'
         success: '<green>Rimossi </green><aqua>[number]</aqua><green> di raggio bonus dall''isola di </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Raggio bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) rimosso dall''isola di </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'rimuove un raggio bonus con quell''id da tutte le isole (ad es. dopo aver rimosso l''addon che lo ha aggiunto)'
+        none: '<red>Nessuna isola ha un raggio bonus con id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Questo rimuoverà il raggio bonus </gold><aqua>[id]</aqua><gold> da </gold><aqua>[number]</aqua><gold> isola/e.</gold>'
+        success: '<green>Raggio bonus </green><aqua>[id]</aqua><green> rimosso da </green><aqua>[number]</aqua><green> isola/e.</green>'
     register:
       parameters: <giocatore>
       description: registra il giocatore nell'isola senza proprietario sulla quale sei

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -256,6 +256,13 @@ commands:
         success: >-
           <green>Diminuito  il raggio di protezione della isola di </green><aqua>[name]</aqua><green>al</green>
           raggio di <aqua>[total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<giocatore> [id]'
+        description: 'rimuove i raggi bonus dall''isola (tutti o uno per id)'
+        no-bonus: '<red>Quest''isola non ha raggi bonus da rimuovere!</red>'
+        unknown-bonus: '<red>Non esiste alcun raggio bonus con id </red><aqua>[id]</aqua><red> su quest''isola!</red>'
+        success: '<green>Rimossi </green><aqua>[number]</aqua><green> di raggio bonus dall''isola di </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Raggio bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) rimosso dall''isola di </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <giocatore>
       description: registra il giocatore nell'isola senza proprietario sulla quale sei

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -215,6 +215,13 @@ commands:
         description: 島の保護範囲を縮小します
         parameters: <プレーヤー> <範囲>
         success: '<green>[name]の島の保護範囲を[total]</green><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>に減らすことに成功しました。</green>'
+      removebonus:
+        parameters: '<player> [id]'
+        description: '島からボーナス範囲を削除します（すべて、またはidで1つ）'
+        no-bonus: '<red>この島には削除できるボーナス範囲がありません！</red>'
+        unknown-bonus: '<red>この島にid </red><aqua>[id]</aqua><red> のボーナス範囲はありません！</red>'
+        success: '<green></green><aqua>[name]</aqua><green>の島からボーナス範囲 </green><aqua>[number]</aqua><green> を削除しました。</green>'
+        success-id: '<green></green><aqua>[name]</aqua><green>の島からボーナス範囲 </green><aqua>[id]</aqua><green>（</green><aqua>[number]</aqua><green>）を削除しました。</green>'
     register:
       parameters: <プレーヤー>
       description: あなたがいる未所有の島にプレーヤーを登録する。

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -228,6 +228,9 @@ commands:
         none: '<red>id </red><aqua>[id]</aqua><red> のボーナス範囲を持つ島はありません！</red>'
         warning: '<gold>ボーナス範囲 </gold><aqua>[id]</aqua><gold> を </gold><aqua>[number]</aqua><gold> 個の島から削除します。</gold>'
         success: '<green>ボーナス範囲 </green><aqua>[id]</aqua><green> を </green><aqua>[number]</aqua><green> 個の島から削除しました。</green>'
+        confirm: '<gold>続行するには、コマンドに </gold><aqua>confirm</aqua><gold> を付けて再実行してください。</gold>'
+        in-progress: '<red>ボーナス範囲の削除がすでに実行中です。お待ちください。</red>'
+        failed: '<red>島のスキャンに失敗しました。コンソールを確認してください。</red>'
     register:
       parameters: <プレーヤー>
       description: あなたがいる未所有の島にプレーヤーを登録する。

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -222,6 +222,12 @@ commands:
         unknown-bonus: '<red>この島にid </red><aqua>[id]</aqua><red> のボーナス範囲はありません！</red>'
         success: '<green></green><aqua>[name]</aqua><green>の島からボーナス範囲 </green><aqua>[number]</aqua><green> を削除しました。</green>'
         success-id: '<green></green><aqua>[name]</aqua><green>の島からボーナス範囲 </green><aqua>[id]</aqua><green>（</green><aqua>[number]</aqua><green>）を削除しました。</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: '指定したidのボーナス範囲をすべての島から削除します（例：追加したアドオンを削除した後）'
+        none: '<red>id </red><aqua>[id]</aqua><red> のボーナス範囲を持つ島はありません！</red>'
+        warning: '<gold>ボーナス範囲 </gold><aqua>[id]</aqua><gold> を </gold><aqua>[number]</aqua><gold> 個の島から削除します。</gold>'
+        success: '<green>ボーナス範囲 </green><aqua>[id]</aqua><green> を </green><aqua>[number]</aqua><green> 個の島から削除しました。</green>'
     register:
       parameters: <プレーヤー>
       description: あなたがいる未所有の島にプレーヤーを登録する。

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -239,6 +239,12 @@ commands:
         unknown-bonus: '<red>이 섬에 id </red><aqua>[id]</aqua><red> 인 보너스 범위가 없습니다!</red>'
         success: '<green></green><aqua>[name]</aqua><green> 님의 섬에서 보너스 범위 </green><aqua>[number]</aqua><green> 을(를) 제거했습니다.</green>'
         success-id: '<green></green><aqua>[name]</aqua><green> 님의 섬에서 보너스 범위 </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) 을(를) 제거했습니다.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: '지정한 id의 보너스 범위를 모든 섬에서 제거합니다 (예: 추가한 애드온을 제거한 후)'
+        none: '<red>id </red><aqua>[id]</aqua><red> 인 보너스 범위를 가진 섬이 없습니다!</red>'
+        warning: '<gold>보너스 범위 </gold><aqua>[id]</aqua><gold> 을(를) </gold><aqua>[number]</aqua><gold> 개의 섬에서 제거합니다.</gold>'
+        success: '<green>보너스 범위 </green><aqua>[id]</aqua><green> 을(를) </green><aqua>[number]</aqua><green> 개의 섬에서 제거했습니다.</green>'
     register:
       parameters: <플레이어>
       description: 플레이어를 당신이 서있는 주인없는섬의 일원으로 추가합니다

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -232,6 +232,13 @@ commands:
         success: >-
           <green>성공적으로 </green><aqua>[name]</aqua><green>의 섬의 보호범위를 줄였습니다 </green><aqua>토탈 : [total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray></gray>
           )<green>.</green>
+      removebonus:
+        parameters: '<player> [id]'
+        description: '섬에서 보너스 범위를 제거합니다 (전체 또는 id로 하나)'
+        no-bonus: '<red>이 섬에는 제거할 보너스 범위가 없습니다!</red>'
+        unknown-bonus: '<red>이 섬에 id </red><aqua>[id]</aqua><red> 인 보너스 범위가 없습니다!</red>'
+        success: '<green></green><aqua>[name]</aqua><green> 님의 섬에서 보너스 범위 </green><aqua>[number]</aqua><green> 을(를) 제거했습니다.</green>'
+        success-id: '<green></green><aqua>[name]</aqua><green> 님의 섬에서 보너스 범위 </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) 을(를) 제거했습니다.</green>'
     register:
       parameters: <플레이어>
       description: 플레이어를 당신이 서있는 주인없는섬의 일원으로 추가합니다

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -245,6 +245,9 @@ commands:
         none: '<red>id </red><aqua>[id]</aqua><red> 인 보너스 범위를 가진 섬이 없습니다!</red>'
         warning: '<gold>보너스 범위 </gold><aqua>[id]</aqua><gold> 을(를) </gold><aqua>[number]</aqua><gold> 개의 섬에서 제거합니다.</gold>'
         success: '<green>보너스 범위 </green><aqua>[id]</aqua><green> 을(를) </green><aqua>[number]</aqua><green> 개의 섬에서 제거했습니다.</green>'
+        confirm: '<gold>계속하려면 </gold><aqua>confirm</aqua><gold> 을(를) 붙여 명령어를 다시 실행하세요.</gold>'
+        in-progress: '<red>보너스 범위 제거가 이미 실행 중입니다. 잠시 기다려 주세요.</red>'
+        failed: '<red>섬 검색에 실패했습니다. 콘솔을 확인하세요.</red>'
     register:
       parameters: <플레이어>
       description: 플레이어를 당신이 서있는 주인없는섬의 일원으로 추가합니다

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -257,6 +257,12 @@ commands:
         unknown-bonus: '<red>Šajā salā nav bonusa diapazona ar id </red><aqua>[id]</aqua><red>!</red>'
         success: '<green>Noņemti </green><aqua>[number]</aqua><green> bonusa diapazoni no </green><aqua>[name]</aqua><green> salas.</green>'
         success-id: '<green>Noņemts bonusa diapazons </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) no </green><aqua>[name]</aqua><green> salas.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'noņem bonusa diapazonu ar doto id no visām salām (piem., pēc papildinājuma, kas to pievienoja, noņemšanas)'
+        none: '<red>Nevienai salai nav bonusa diapazona ar id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Šis noņems bonusa diapazonu </gold><aqua>[id]</aqua><gold> no </gold><aqua>[number]</aqua><gold> salām.</gold>'
+        success: '<green>Bonusa diapazons </green><aqua>[id]</aqua><green> noņemts no </green><aqua>[number]</aqua><green> salām.</green>'
     register:
       parameters: <spēlētājs>
       description: >-

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -263,6 +263,9 @@ commands:
         none: '<red>Nevienai salai nav bonusa diapazona ar id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Šis noņems bonusa diapazonu </gold><aqua>[id]</aqua><gold> no </gold><aqua>[number]</aqua><gold> salām.</gold>'
         success: '<green>Bonusa diapazons </green><aqua>[id]</aqua><green> noņemts no </green><aqua>[number]</aqua><green> salām.</green>'
+        confirm: '<gold>Lai turpinātu, palaidiet komandu vēlreiz ar </gold><aqua>confirm</aqua><gold>.</gold>'
+        in-progress: '<red>Bonusa diapazonu tīrīšana jau notiek. Lūdzu, uzgaidiet.</red>'
+        failed: '<red>Neizdevās skenēt salas. Pārbaudiet konsoli.</red>'
     register:
       parameters: <spēlētājs>
       description: >-

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -250,6 +250,13 @@ commands:
         success: >-
           <green>Veiksmīgi samazināts </green><aqua>[name]</aqua><green>salas aizsardzības rādiuss līdz </green><aqua></aqua>
           [total] <gray>(</gray><aqua>+[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<spēlētājs> [id]'
+        description: 'noņem bonusa diapazonus no salas (visus vai vienu pēc id)'
+        no-bonus: '<red>Šai salai nav noņemamu bonusa diapazonu!</red>'
+        unknown-bonus: '<red>Šajā salā nav bonusa diapazona ar id </red><aqua>[id]</aqua><red>!</red>'
+        success: '<green>Noņemti </green><aqua>[number]</aqua><green> bonusa diapazoni no </green><aqua>[name]</aqua><green> salas.</green>'
+        success-id: '<green>Noņemts bonusa diapazons </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) no </green><aqua>[name]</aqua><green> salas.</green>'
     register:
       parameters: <spēlētājs>
       description: >-

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -264,6 +264,12 @@ commands:
         unknown-bonus: '<red>Er is geen bonusbereik met id </red><aqua>[id]</aqua><red> op dit eiland!</red>'
         success: '<green>Verwijderd: </green><aqua>[number]</aqua><green> aan bonusbereik van het eiland van </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Bonusbereik </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) verwijderd van het eiland van </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'verwijdert een bonusbereik met die id van alle eilanden (bijv. na het verwijderen van de addon die het toevoegde)'
+        none: '<red>Geen enkel eiland heeft een bonusbereik met id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Dit verwijdert bonusbereik </gold><aqua>[id]</aqua><gold> van </gold><aqua>[number]</aqua><gold> eiland(en).</gold>'
+        success: '<green>Bonusbereik </green><aqua>[id]</aqua><green> verwijderd van </green><aqua>[number]</aqua><green> eiland(en).</green>'
     register:
       parameters: <speler>
       description: registreer speler op het eiland waar je je bevindt

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -270,6 +270,9 @@ commands:
         none: '<red>Geen enkel eiland heeft een bonusbereik met id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Dit verwijdert bonusbereik </gold><aqua>[id]</aqua><gold> van </gold><aqua>[number]</aqua><gold> eiland(en).</gold>'
         success: '<green>Bonusbereik </green><aqua>[id]</aqua><green> verwijderd van </green><aqua>[number]</aqua><green> eiland(en).</green>'
+        confirm: '<gold>Voer de opdracht opnieuw uit met </gold><aqua>confirm</aqua><gold> om door te gaan.</gold>'
+        in-progress: '<red>Er loopt al een bonusbereik-opschoning. Even geduld.</red>'
+        failed: '<red>Kon eilanden niet scannen. Controleer de console.</red>'
     register:
       parameters: <speler>
       description: registreer speler op het eiland waar je je bevindt

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -257,6 +257,13 @@ commands:
         success: >-
           <green>Succesvol verkleind </green><aqua>[name] </aqua><green>'s beschermde eilandbereik naar </green><aqua></aqua>
           [total] <gray>(</gray><aqua>- [number]</aqua><gray>) </gray><green>.</green>
+      removebonus:
+        parameters: '<speler> [id]'
+        description: 'verwijdert bonusbereiken van het eiland (alle of één op id)'
+        no-bonus: '<red>Dit eiland heeft geen bonusbereiken om te verwijderen!</red>'
+        unknown-bonus: '<red>Er is geen bonusbereik met id </red><aqua>[id]</aqua><red> op dit eiland!</red>'
+        success: '<green>Verwijderd: </green><aqua>[number]</aqua><green> aan bonusbereik van het eiland van </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Bonusbereik </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) verwijderd van het eiland van </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <speler>
       description: registreer speler op het eiland waar je je bevindt

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -259,6 +259,12 @@ commands:
         unknown-bonus: '<red>Na tej wyspie nie ma zasięgu bonusowego o id </red><aqua>[id]</aqua><red>!</red>'
         success: '<green>Usunięto </green><aqua>[number]</aqua><green> zasięgu bonusowego z wyspy gracza </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Usunięto zasięg bonusowy </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) z wyspy gracza </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'usuwa zasięg bonusowy o danym id ze wszystkich wysp (np. po usunięciu dodatku, który go dodał)'
+        none: '<red>Żadna wyspa nie ma zasięgu bonusowego o id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>To usunie zasięg bonusowy </gold><aqua>[id]</aqua><gold> z </gold><aqua>[number]</aqua><gold> wysp.</gold>'
+        success: '<green>Usunięto zasięg bonusowy </green><aqua>[id]</aqua><green> z </green><aqua>[number]</aqua><green> wysp.</green>'
     register:
       parameters: <gracz>
       description: zarejestruj gracza na niezamieszkanej wyspie, na której jesteś

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -252,6 +252,13 @@ commands:
         success: >-
           <green>Pomyślnie pomniejszono obszar ochrony wyspy gracza </green><aqua>[name]</aqua><green>na</green>
           <aqua>[total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<gracz> [id]'
+        description: 'usuwa zasięgi bonusowe z wyspy (wszystkie lub jeden po id)'
+        no-bonus: '<red>Ta wyspa nie ma zasięgów bonusowych do usunięcia!</red>'
+        unknown-bonus: '<red>Na tej wyspie nie ma zasięgu bonusowego o id </red><aqua>[id]</aqua><red>!</red>'
+        success: '<green>Usunięto </green><aqua>[number]</aqua><green> zasięgu bonusowego z wyspy gracza </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Usunięto zasięg bonusowy </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) z wyspy gracza </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <gracz>
       description: zarejestruj gracza na niezamieszkanej wyspie, na której jesteś

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -265,6 +265,9 @@ commands:
         none: '<red>Żadna wyspa nie ma zasięgu bonusowego o id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>To usunie zasięg bonusowy </gold><aqua>[id]</aqua><gold> z </gold><aqua>[number]</aqua><gold> wysp.</gold>'
         success: '<green>Usunięto zasięg bonusowy </green><aqua>[id]</aqua><green> z </green><aqua>[number]</aqua><green> wysp.</green>'
+        confirm: '<gold>Uruchom polecenie ponownie z </gold><aqua>confirm</aqua><gold>, aby kontynuować.</gold>'
+        in-progress: '<red>Czyszczenie zasięgów bonusowych już trwa. Proszę czekać.</red>'
+        failed: '<red>Nie udało się przeskanować wysp. Sprawdź konsolę.</red>'
     register:
       parameters: <gracz>
       description: zarejestruj gracza na niezamieszkanej wyspie, na której jesteś

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -246,6 +246,13 @@ commands:
         success: >-
           <green>Raio de proteção da ilha de </green><aqua>[name]</aqua><green>reduzido para </green><aqua>[total] </aqua><gray></gray>
           (<aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<jogador> [id]'
+        description: 'remove os alcances bônus da ilha (todos ou um por id)'
+        no-bonus: '<red>Esta ilha não tem alcances bônus para remover!</red>'
+        unknown-bonus: '<red>Não existe nenhum alcance bônus com o id </red><aqua>[id]</aqua><red> nesta ilha!</red>'
+        success: '<green>Removido </green><aqua>[number]</aqua><green> de alcance bônus da ilha de </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Alcance bônus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) removido da ilha de </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <jogador>
       description: registrar jogador para a ilha sem dono em que você está

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -259,6 +259,9 @@ commands:
         none: '<red>Nenhuma ilha tem um alcance bônus com o id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Isto removerá o alcance bônus </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> ilha(s).</gold>'
         success: '<green>Alcance bônus </green><aqua>[id]</aqua><green> removido de </green><aqua>[number]</aqua><green> ilha(s).</green>'
+        confirm: '<gold>Execute o comando novamente com </gold><aqua>confirm</aqua><gold> para prosseguir.</gold>'
+        in-progress: '<red>Uma limpeza de alcances bônus já está em andamento. Aguarde.</red>'
+        failed: '<red>Falha ao escanear as ilhas. Verifique o console.</red>'
     register:
       parameters: <jogador>
       description: registrar jogador para a ilha sem dono em que você está

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -253,6 +253,12 @@ commands:
         unknown-bonus: '<red>Não existe nenhum alcance bônus com o id </red><aqua>[id]</aqua><red> nesta ilha!</red>'
         success: '<green>Removido </green><aqua>[number]</aqua><green> de alcance bônus da ilha de </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Alcance bônus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) removido da ilha de </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'remove um alcance bônus com esse id de todas as ilhas (ex.: após remover o addon que o adicionou)'
+        none: '<red>Nenhuma ilha tem um alcance bônus com o id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Isto removerá o alcance bônus </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> ilha(s).</gold>'
+        success: '<green>Alcance bônus </green><aqua>[id]</aqua><green> removido de </green><aqua>[number]</aqua><green> ilha(s).</green>'
     register:
       parameters: <jogador>
       description: registrar jogador para a ilha sem dono em que você está

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -253,6 +253,13 @@ commands:
         success: >-
           <green>Diminuido com sucesso </green><aqua>[name]</aqua><green>área de proteção para </green><aqua>[total]</aqua>
           <gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>
+      removebonus:
+        parameters: '<jogador> [id]'
+        description: 'remove os alcances bónus da ilha (todos ou um por id)'
+        no-bonus: '<red>Esta ilha não tem alcances bónus para remover!</red>'
+        unknown-bonus: '<red>Não existe nenhum alcance bónus com o id </red><aqua>[id]</aqua><red> nesta ilha!</red>'
+        success: '<green>Removido </green><aqua>[number]</aqua><green> de alcance bónus da ilha de </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Alcance bónus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) removido da ilha de </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <jogador>
       description: registrar jogador na ilha sem dono em que você está

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -266,6 +266,9 @@ commands:
         none: '<red>Nenhuma ilha tem um alcance bónus com o id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Isto irá remover o alcance bónus </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> ilha(s).</gold>'
         success: '<green>Alcance bónus </green><aqua>[id]</aqua><green> removido de </green><aqua>[number]</aqua><green> ilha(s).</green>'
+        confirm: '<gold>Execute o comando novamente com </gold><aqua>confirm</aqua><gold> para continuar.</gold>'
+        in-progress: '<red>Já está em curso uma limpeza de alcances bónus. Aguarde.</red>'
+        failed: '<red>Falha ao analisar as ilhas. Verifique a consola.</red>'
     register:
       parameters: <jogador>
       description: registrar jogador na ilha sem dono em que você está

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -260,6 +260,12 @@ commands:
         unknown-bonus: '<red>Não existe nenhum alcance bónus com o id </red><aqua>[id]</aqua><red> nesta ilha!</red>'
         success: '<green>Removido </green><aqua>[number]</aqua><green> de alcance bónus da ilha de </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Alcance bónus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) removido da ilha de </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'remove um alcance bónus com esse id de todas as ilhas (ex.: após remover o addon que o adicionou)'
+        none: '<red>Nenhuma ilha tem um alcance bónus com o id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Isto irá remover o alcance bónus </gold><aqua>[id]</aqua><gold> de </gold><aqua>[number]</aqua><gold> ilha(s).</gold>'
+        success: '<green>Alcance bónus </green><aqua>[id]</aqua><green> removido de </green><aqua>[number]</aqua><green> ilha(s).</green>'
     register:
       parameters: <jogador>
       description: registrar jogador na ilha sem dono em que você está

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -268,6 +268,9 @@ commands:
         none: '<red>Nicio insulă nu are o rază bonus cu id-ul </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Aceasta va elimina raza bonus </gold><aqua>[id]</aqua><gold> de pe </gold><aqua>[number]</aqua><gold> insulă(e).</gold>'
         success: '<green>Raza bonus </green><aqua>[id]</aqua><green> eliminată de pe </green><aqua>[number]</aqua><green> insulă(e).</green>'
+        confirm: '<gold>Rulează comanda din nou cu </gold><aqua>confirm</aqua><gold> pentru a continua.</gold>'
+        in-progress: '<red>O curățare a razelor bonus este deja în curs. Te rugăm să aștepți.</red>'
+        failed: '<red>Scanarea insulelor a eșuat. Verifică consola.</red>'
     register:
       parameters: <player>
       description: înregistrează jucătorul pe insula neproprietată pe care te afli

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -262,6 +262,12 @@ commands:
         unknown-bonus: '<red>Nu există nicio rază bonus cu id-ul </red><aqua>[id]</aqua><red> pe această insulă!</red>'
         success: '<green>Eliminat </green><aqua>[number]</aqua><green> din raza bonus de pe insula lui </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Raza bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) eliminată de pe insula lui </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'elimină o rază bonus cu acel id de pe toate insulele (de ex. după eliminarea addonului care a adăugat-o)'
+        none: '<red>Nicio insulă nu are o rază bonus cu id-ul </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Aceasta va elimina raza bonus </gold><aqua>[id]</aqua><gold> de pe </gold><aqua>[number]</aqua><gold> insulă(e).</gold>'
+        success: '<green>Raza bonus </green><aqua>[id]</aqua><green> eliminată de pe </green><aqua>[number]</aqua><green> insulă(e).</green>'
     register:
       parameters: <player>
       description: înregistrează jucătorul pe insula neproprietată pe care te afli

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -255,6 +255,13 @@ commands:
         success: >-
           <green>Scăderea cu succes a zonei protejate de </green><aqua>[name] </aqua><green>la </green><aqua>[total]</aqua>
           <gray>(</gray><aqua>- [number] </aqua><gray>) </gray><green>.</green>
+      removebonus:
+        parameters: '<jucător> [id]'
+        description: 'elimină razele bonus de pe insulă (toate sau una după id)'
+        no-bonus: '<red>Această insulă nu are raze bonus de eliminat!</red>'
+        unknown-bonus: '<red>Nu există nicio rază bonus cu id-ul </red><aqua>[id]</aqua><red> pe această insulă!</red>'
+        success: '<green>Eliminat </green><aqua>[number]</aqua><green> din raza bonus de pe insula lui </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Raza bonus </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) eliminată de pe insula lui </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <player>
       description: înregistrează jucătorul pe insula neproprietată pe care te afli

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -263,6 +263,9 @@ commands:
         none: '<red>Ни на одном острове нет бонусного радиуса с id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Это удалит бонусный радиус </gold><aqua>[id]</aqua><gold> с </gold><aqua>[number]</aqua><gold> остров(ов).</gold>'
         success: '<green>Бонусный радиус </green><aqua>[id]</aqua><green> удалён с </green><aqua>[number]</aqua><green> остров(ов).</green>'
+        confirm: '<gold>Запустите команду снова с </gold><aqua>confirm</aqua><gold>, чтобы продолжить.</gold>'
+        in-progress: '<red>Очистка бонусных радиусов уже выполняется. Пожалуйста, подождите.</red>'
+        failed: '<red>Не удалось просканировать острова. Проверьте консоль.</red>'
     register:
       parameters: <игрок>
       description: регистрирует игрока на острове без владельца, на котором вы находитесь

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -250,6 +250,13 @@ commands:
         parameters: <игрок> <радиус>
         success: <green>Радиус острова игрока <aqua>[name] </aqua>успешно уменьшен
           до </green> <aqua>[total] </aqua><gray>(<aqua>-[number]</aqua>)</gray>.</green>
+      removebonus:
+        parameters: '<игрок> [id]'
+        description: 'удаляет бонусные радиусы с острова (все или один по id)'
+        no-bonus: '<red>На этом острове нет бонусных радиусов для удаления!</red>'
+        unknown-bonus: '<red>На этом острове нет бонусного радиуса с id </red><aqua>[id]</aqua><red>!</red>'
+        success: '<green>Удалено </green><aqua>[number]</aqua><green> бонусного радиуса с острова игрока </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Бонусный радиус </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) удалён с острова игрока </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <игрок>
       description: регистрирует игрока на острове без владельца, на котором вы находитесь

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -257,6 +257,12 @@ commands:
         unknown-bonus: '<red>На этом острове нет бонусного радиуса с id </red><aqua>[id]</aqua><red>!</red>'
         success: '<green>Удалено </green><aqua>[number]</aqua><green> бонусного радиуса с острова игрока </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Бонусный радиус </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) удалён с острова игрока </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'удаляет бонусный радиус с указанным id со всех островов (например, после удаления аддона, который его добавил)'
+        none: '<red>Ни на одном острове нет бонусного радиуса с id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Это удалит бонусный радиус </gold><aqua>[id]</aqua><gold> с </gold><aqua>[number]</aqua><gold> остров(ов).</gold>'
+        success: '<green>Бонусный радиус </green><aqua>[id]</aqua><green> удалён с </green><aqua>[number]</aqua><green> остров(ов).</green>'
     register:
       parameters: <игрок>
       description: регистрирует игрока на острове без владельца, на котором вы находитесь

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -259,6 +259,9 @@ commands:
         none: '<red>Hiçbir adada </red><aqua>[id]</aqua><red> id''li bir bonus menzil yok!</red>'
         warning: '<gold>Bu işlem bonus menzil </gold><aqua>[id]</aqua><gold> öğesini </gold><aqua>[number]</aqua><gold> adadan kaldıracak.</gold>'
         success: '<green>Bonus menzil </green><aqua>[id]</aqua><green> </green><aqua>[number]</aqua><green> adadan kaldırıldı.</green>'
+        confirm: '<gold>Devam etmek için komutu </gold><aqua>confirm</aqua><gold> ile tekrar çalıştırın.</gold>'
+        in-progress: '<red>Zaten bir bonus menzil temizliği çalışıyor. Lütfen bekleyin.</red>'
+        failed: '<red>Adalar taranamadı. Konsolu kontrol edin.</red>'
     register:
       parameters: <player>
       description: Sahipsiz adalara oyuncu ver.

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -253,6 +253,12 @@ commands:
         unknown-bonus: '<red>Bu adada </red><aqua>[id]</aqua><red> id''li bir bonus menzil yok!</red>'
         success: '<green></green><aqua>[name]</aqua><green> adlı oyuncunun adasından </green><aqua>[number]</aqua><green> bonus menzil kaldırıldı.</green>'
         success-id: '<green></green><aqua>[name]</aqua><green> adlı oyuncunun adasından </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) bonus menzili kaldırıldı.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'belirtilen id''ye sahip bonus menzili tüm adalardan kaldırır (ör. onu ekleyen eklenti kaldırıldıktan sonra)'
+        none: '<red>Hiçbir adada </red><aqua>[id]</aqua><red> id''li bir bonus menzil yok!</red>'
+        warning: '<gold>Bu işlem bonus menzil </gold><aqua>[id]</aqua><gold> öğesini </gold><aqua>[number]</aqua><gold> adadan kaldıracak.</gold>'
+        success: '<green>Bonus menzil </green><aqua>[id]</aqua><green> </green><aqua>[number]</aqua><green> adadan kaldırıldı.</green>'
     register:
       parameters: <player>
       description: Sahipsiz adalara oyuncu ver.

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -246,6 +246,13 @@ commands:
         success: >-
           <light_purple>[name] </light_purple><gold>koruma alanı </gold><green>-[number] </green><gold>azaltıldı. </gold><gold>Toplam alan</gold>
           <dark_purple>[total]</dark_purple>
+      removebonus:
+        parameters: '<oyuncu> [id]'
+        description: 'adadan bonus menzilleri kaldırır (tümü veya id ile biri)'
+        no-bonus: '<red>Bu adada kaldırılacak bonus menzil yok!</red>'
+        unknown-bonus: '<red>Bu adada </red><aqua>[id]</aqua><red> id''li bir bonus menzil yok!</red>'
+        success: '<green></green><aqua>[name]</aqua><green> adlı oyuncunun adasından </green><aqua>[number]</aqua><green> bonus menzil kaldırıldı.</green>'
+        success-id: '<green></green><aqua>[name]</aqua><green> adlı oyuncunun adasından </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) bonus menzili kaldırıldı.</green>'
     register:
       parameters: <player>
       description: Sahipsiz adalara oyuncu ver.

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -237,6 +237,9 @@ commands:
         none: '<red>На жодному острові немає бонусного радіуса з id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Це видалить бонусний радіус </gold><aqua>[id]</aqua><gold> з </gold><aqua>[number]</aqua><gold> острова(ів).</gold>'
         success: '<green>Бонусний радіус </green><aqua>[id]</aqua><green> видалено з </green><aqua>[number]</aqua><green> острова(ів).</green>'
+        confirm: '<gold>Запустіть команду знову з </gold><aqua>confirm</aqua><gold>, щоб продовжити.</gold>'
+        in-progress: '<red>Очищення бонусних радіусів уже виконується. Будь ласка, зачекайте.</red>'
+        failed: '<red>Не вдалося просканувати острови. Перевірте консоль.</red>'
     register:
       parameters: <гравець>
       description: зареєструвати гравця на безхазяйному [prefix_island], на якому ви стоїте

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -224,6 +224,13 @@ commands:
         description: зменшити діапазон захисту [prefix_island]
         parameters: <гравець> <range> [[prefix_island] location]
         success: '<green>Успішно зменшено діапазон захисту [prefix_island] </green><aqua>[name]</aqua><green>до </green><aqua>[total] </aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>'
+      removebonus:
+        parameters: '<гравець> [id]'
+        description: 'видаляє бонусні радіуси з острова (усі або один за id)'
+        no-bonus: '<red>На цьому острові немає бонусних радіусів для видалення!</red>'
+        unknown-bonus: '<red>На цьому острові немає бонусного радіуса з id </red><aqua>[id]</aqua><red>!</red>'
+        success: '<green>Видалено </green><aqua>[number]</aqua><green> бонусного радіуса з острова гравця </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Бонусний радіус </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) видалено з острова гравця </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <гравець>
       description: зареєструвати гравця на безхазяйному [prefix_island], на якому ви стоїте

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -231,6 +231,12 @@ commands:
         unknown-bonus: '<red>На цьому острові немає бонусного радіуса з id </red><aqua>[id]</aqua><red>!</red>'
         success: '<green>Видалено </green><aqua>[number]</aqua><green> бонусного радіуса з острова гравця </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Бонусний радіус </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) видалено з острова гравця </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'видаляє бонусний радіус із вказаним id з усіх островів (наприклад, після видалення аддона, що його додав)'
+        none: '<red>На жодному острові немає бонусного радіуса з id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Це видалить бонусний радіус </gold><aqua>[id]</aqua><gold> з </gold><aqua>[number]</aqua><gold> острова(ів).</gold>'
+        success: '<green>Бонусний радіус </green><aqua>[id]</aqua><green> видалено з </green><aqua>[number]</aqua><green> острова(ів).</green>'
     register:
       parameters: <гравець>
       description: зареєструвати гравця на безхазяйному [prefix_island], на якому ви стоїте

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -262,6 +262,9 @@ commands:
         none: '<red>Không có đảo nào có phạm vi thưởng với id </red><aqua>[id]</aqua><red>!</red>'
         warning: '<gold>Thao tác này sẽ xóa phạm vi thưởng </gold><aqua>[id]</aqua><gold> khỏi </gold><aqua>[number]</aqua><gold> đảo.</gold>'
         success: '<green>Đã xóa phạm vi thưởng </green><aqua>[id]</aqua><green> khỏi </green><aqua>[number]</aqua><green> đảo.</green>'
+        confirm: '<gold>Chạy lại lệnh với </gold><aqua>confirm</aqua><gold> để tiếp tục.</gold>'
+        in-progress: '<red>Đã có một tiến trình xóa phạm vi thưởng đang chạy. Vui lòng đợi.</red>'
+        failed: '<red>Không thể quét các đảo. Kiểm tra bảng điều khiển.</red>'
     register:
       parameters: <người chơi>
       description: đăng kí người chơi vào đảo không chủ này

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -249,6 +249,13 @@ commands:
         success: >-
           <green>Đã giảm khu vực bảo vệ đảo của </green><aqua>[name]</aqua><green>xuống </green><aqua>[total] </aqua><gray>(</gray><aqua></aqua>
           -'[number]<gray>)</gray><green>.</green>'
+      removebonus:
+        parameters: '<người chơi> [id]'
+        description: 'xóa các phạm vi thưởng khỏi đảo (tất cả hoặc một theo id)'
+        no-bonus: '<red>Đảo này không có phạm vi thưởng nào để xóa!</red>'
+        unknown-bonus: '<red>Không có phạm vi thưởng nào với id </red><aqua>[id]</aqua><red> trên đảo này!</red>'
+        success: '<green>Đã xóa </green><aqua>[number]</aqua><green> phạm vi thưởng khỏi đảo của </green><aqua>[name]</aqua><green>.</green>'
+        success-id: '<green>Đã xóa phạm vi thưởng </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) khỏi đảo của </green><aqua>[name]</aqua><green>.</green>'
     register:
       parameters: <người chơi>
       description: đăng kí người chơi vào đảo không chủ này

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -256,6 +256,12 @@ commands:
         unknown-bonus: '<red>Không có phạm vi thưởng nào với id </red><aqua>[id]</aqua><red> trên đảo này!</red>'
         success: '<green>Đã xóa </green><aqua>[number]</aqua><green> phạm vi thưởng khỏi đảo của </green><aqua>[name]</aqua><green>.</green>'
         success-id: '<green>Đã xóa phạm vi thưởng </green><aqua>[id]</aqua><green> (</green><aqua>[number]</aqua><green>) khỏi đảo của </green><aqua>[name]</aqua><green>.</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: 'xóa một phạm vi thưởng có id đó khỏi tất cả các đảo (ví dụ: sau khi gỡ addon đã thêm nó)'
+        none: '<red>Không có đảo nào có phạm vi thưởng với id </red><aqua>[id]</aqua><red>!</red>'
+        warning: '<gold>Thao tác này sẽ xóa phạm vi thưởng </gold><aqua>[id]</aqua><gold> khỏi </gold><aqua>[number]</aqua><gold> đảo.</gold>'
+        success: '<green>Đã xóa phạm vi thưởng </green><aqua>[id]</aqua><green> khỏi </green><aqua>[number]</aqua><green> đảo.</green>'
     register:
       parameters: <người chơi>
       description: đăng kí người chơi vào đảo không chủ này

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -234,6 +234,9 @@ commands:
         none: '<red>没有任何岛屿拥有id为</red><aqua>[id]</aqua><red>的奖励范围!</red>'
         warning: '<gold>这将从</gold><aqua>[number]</aqua><gold>个岛屿移除奖励范围</gold><aqua>[id]</aqua><gold>.</gold>'
         success: '<green>已从</green><aqua>[number]</aqua><green>个岛屿移除奖励范围</green><aqua>[id]</aqua><green>.</green>'
+        confirm: '<gold>请附带</gold><aqua>confirm</aqua><gold>再次执行该命令以继续.</gold>'
+        in-progress: '<red>奖励范围清除已在进行中, 请稍候.</red>'
+        failed: '<red>扫描岛屿失败, 请检查控制台.</red>'
     register:
       parameters: <玩家>
       description: 将玩家认领到当前的无主岛屿

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -221,6 +221,13 @@ commands:
         description: 减少岛屿保护范围
         parameters: <player> <range> [island location]
         success: '<green>玩家</green><aqua>[name]</aqua><green>的岛屿保护范围已减少至</green><aqua>[total]</aqua><gray>(</gray><aqua>-[number]</aqua><gray>)</gray><green>.</green>'
+      removebonus:
+        parameters: '<player> [id]'
+        description: '移除岛屿的奖励范围（全部，或按id移除一个）'
+        no-bonus: '<red>该岛屿没有可移除的奖励范围!</red>'
+        unknown-bonus: '<red>该岛屿上不存在id为</red><aqua>[id]</aqua><red>的奖励范围!</red>'
+        success: '<green>已从</green><aqua>[name]</aqua><green>的岛屿移除</green><aqua>[number]</aqua><green>的奖励范围.</green>'
+        success-id: '<green>已从</green><aqua>[name]</aqua><green>的岛屿移除奖励范围</green><aqua>[id]</aqua><green>(</green><aqua>[number]</aqua><green>).</green>'
     register:
       parameters: <玩家>
       description: 将玩家认领到当前的无主岛屿

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -228,6 +228,12 @@ commands:
         unknown-bonus: '<red>该岛屿上不存在id为</red><aqua>[id]</aqua><red>的奖励范围!</red>'
         success: '<green>已从</green><aqua>[name]</aqua><green>的岛屿移除</green><aqua>[number]</aqua><green>的奖励范围.</green>'
         success-id: '<green>已从</green><aqua>[name]</aqua><green>的岛屿移除奖励范围</green><aqua>[id]</aqua><green>(</green><aqua>[number]</aqua><green>).</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: '从所有岛屿移除指定id的奖励范围（例如，在移除添加它的附属之后）'
+        none: '<red>没有任何岛屿拥有id为</red><aqua>[id]</aqua><red>的奖励范围!</red>'
+        warning: '<gold>这将从</gold><aqua>[number]</aqua><gold>个岛屿移除奖励范围</gold><aqua>[id]</aqua><gold>.</gold>'
+        success: '<green>已从</green><aqua>[number]</aqua><green>个岛屿移除奖励范围</green><aqua>[id]</aqua><green>.</green>'
     register:
       parameters: <玩家>
       description: 将玩家认领到当前的无主岛屿

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -222,6 +222,13 @@ commands:
         description: 減少島嶼保護範圍
         parameters: <player> <range>
         success: '<green>已將 </green><aqua>[name]</aqua><green>的島嶼保護範圍減少到 </green><aqua>[total] </aqua><gray>（</gray><aqua>+[number]</aqua><gray>）</gray><green>。</green>'
+      removebonus:
+        parameters: '<player> [id]'
+        description: '移除島嶼的獎勵範圍（全部，或按id移除一個）'
+        no-bonus: '<red>該島嶼沒有可移除的獎勵範圍!</red>'
+        unknown-bonus: '<red>該島嶼上不存在id為</red><aqua>[id]</aqua><red>的獎勵範圍!</red>'
+        success: '<green>已從</green><aqua>[name]</aqua><green>的島嶼移除</green><aqua>[number]</aqua><green>的獎勵範圍.</green>'
+        success-id: '<green>已從</green><aqua>[name]</aqua><green>的島嶼移除獎勵範圍</green><aqua>[id]</aqua><green>(</green><aqua>[number]</aqua><green>).</green>'
     register:
       parameters: <player>
       description: 將玩家註冊到您當前所在的無人島

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -229,6 +229,12 @@ commands:
         unknown-bonus: '<red>該島嶼上不存在id為</red><aqua>[id]</aqua><red>的獎勵範圍!</red>'
         success: '<green>已從</green><aqua>[name]</aqua><green>的島嶼移除</green><aqua>[number]</aqua><green>的獎勵範圍.</green>'
         success-id: '<green>已從</green><aqua>[name]</aqua><green>的島嶼移除獎勵範圍</green><aqua>[id]</aqua><green>(</green><aqua>[number]</aqua><green>).</green>'
+      purgebonus:
+        parameters: '<id>'
+        description: '從所有島嶼移除指定id的獎勵範圍（例如，在移除新增它的附加元件之後）'
+        none: '<red>沒有任何島嶼擁有id為</red><aqua>[id]</aqua><red>的獎勵範圍!</red>'
+        warning: '<gold>這將從</gold><aqua>[number]</aqua><gold>個島嶼移除獎勵範圍</gold><aqua>[id]</aqua><gold>.</gold>'
+        success: '<green>已從</green><aqua>[number]</aqua><green>個島嶼移除獎勵範圍</green><aqua>[id]</aqua><green>.</green>'
     register:
       parameters: <player>
       description: 將玩家註冊到您當前所在的無人島

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -235,6 +235,9 @@ commands:
         none: '<red>沒有任何島嶼擁有id為</red><aqua>[id]</aqua><red>的獎勵範圍!</red>'
         warning: '<gold>這將從</gold><aqua>[number]</aqua><gold>個島嶼移除獎勵範圍</gold><aqua>[id]</aqua><gold>.</gold>'
         success: '<green>已從</green><aqua>[number]</aqua><green>個島嶼移除獎勵範圍</green><aqua>[id]</aqua><green>.</green>'
+        confirm: '<gold>請附帶</gold><aqua>confirm</aqua><gold>再次執行該命令以繼續.</gold>'
+        in-progress: '<red>獎勵範圍清除已在進行中, 請稍候.</red>'
+        failed: '<red>掃描島嶼失敗, 請檢查主控台.</red>'
     register:
       parameters: <player>
       description: 將玩家註冊到您當前所在的無人島

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommandTest.java
@@ -1,0 +1,154 @@
+package world.bentobox.bentobox.api.commands.admin.range;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.BonusRangeRecord;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.CommandsManager;
+import world.bentobox.bentobox.managers.island.IslandCache;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Tests for {@link AdminRangePurgeBonusCommand}.
+ *
+ * @author tastybento
+ */
+class AdminRangePurgeBonusCommandTest extends CommonTestSetup {
+
+    @Mock
+    private CompositeCommand ac;
+    @Mock
+    private User user;
+    @Mock
+    private IslandCache islandCache;
+    @Mock
+    private Island island2;
+
+    private AdminRangePurgeBonusCommand command;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Util.setPlugin(plugin);
+
+        // Command manager
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+
+        // Settings - confirmation time of 0 seconds
+        Settings s = mock(Settings.class);
+        when(s.getConfirmationTime()).thenReturn(0);
+        when(plugin.getSettings()).thenReturn(s);
+
+        // Player
+        Player p = mock(Player.class);
+        when(user.isOp()).thenReturn(false);
+        User.setPlugin(plugin);
+        when(user.getUniqueId()).thenReturn(uuid);
+        when(user.getPlayer()).thenReturn(p);
+        when(user.getName()).thenReturn("tastybento");
+
+        // Parent command has no aliases and a known top label (needed for confirmation matching)
+        when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
+        when(ac.getWorld()).thenReturn(world);
+        when(ac.getTopLabel()).thenReturn("bsb");
+
+        // Island cache - two islands carry the "Upgrades" bonus, island2 also has "Other"
+        when(island.getWorld()).thenReturn(world);
+        when(island2.getWorld()).thenReturn(world);
+        when(island.getBonusRangeRecord("Upgrades")).thenReturn(Optional.of(new BonusRangeRecord("Upgrades", 50, "")));
+        when(island2.getBonusRangeRecord("Upgrades")).thenReturn(Optional.of(new BonusRangeRecord("Upgrades", 50, "")));
+        when(island.getBonusRangeRecord("Ghost")).thenReturn(Optional.empty());
+        when(island2.getBonusRangeRecord("Ghost")).thenReturn(Optional.empty());
+        when(island.getBonusRanges())
+                .thenReturn(new ArrayList<>(List.of(new BonusRangeRecord("Upgrades", 50, ""))));
+        when(island2.getBonusRanges())
+                .thenReturn(new ArrayList<>(List.of(new BonusRangeRecord("Upgrades", 50, ""),
+                        new BonusRangeRecord("Other", 10, ""))));
+
+        when(islandCache.getIslands(world)).thenReturn(List.of(island, island2));
+        when(islandCache.getCachedIslands()).thenReturn(List.of(island, island2));
+        when(im.getIslandCache()).thenReturn(islandCache);
+
+        command = new AdminRangePurgeBonusCommand(ac);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testCanExecuteWrongArgs() {
+        assertFalse(command.canExecute(user, "purgebonus", Collections.emptyList()));
+    }
+
+    @Test
+    void testCanExecuteNoMatchingIslands() {
+        assertFalse(command.canExecute(user, "purgebonus", List.of("Ghost")));
+        verify(user).sendMessage("commands.admin.range.purgebonus.none", "[id]", "Ghost");
+    }
+
+    @Test
+    void testCanExecuteSuccess() {
+        assertTrue(command.canExecute(user, "purgebonus", List.of("Upgrades")));
+    }
+
+    @Test
+    void testExecuteAsksConfirmationDoesNotPurgeYet() {
+        assertTrue(command.canExecute(user, "purgebonus", List.of("Upgrades")));
+        assertTrue(command.execute(user, "purgebonus", List.of("Upgrades")));
+        verify(island, never()).clearBonusRange(any());
+        verify(island2, never()).clearBonusRange(any());
+        verify(user).sendMessage("commands.admin.range.purgebonus.warning", "[id]", "Upgrades", "[number]", "2");
+    }
+
+    @Test
+    void testPurgeClearsMatchingIslands() {
+        assertTrue(command.canExecute(user, "purgebonus", List.of("Upgrades")));
+        command.purge(user, "Upgrades");
+        verify(island, times(1)).clearBonusRange("Upgrades");
+        verify(island2, times(1)).clearBonusRange("Upgrades");
+        verify(user).sendMessage("commands.admin.range.purgebonus.success", "[id]", "Upgrades", "[number]", "2");
+    }
+
+    @Test
+    void testTabCompleteListsBonusIds() {
+        List<String> ids = command.tabComplete(user, "purgebonus", List.of("")).orElse(Collections.emptyList());
+        assertTrue(ids.contains("Upgrades"));
+        assertTrue(ids.contains("Other"));
+    }
+
+    @Test
+    void testTabCompleteFiltersByPrefix() {
+        List<String> ids = command.tabComplete(user, "purgebonus", List.of("Up")).orElse(Collections.emptyList());
+        assertTrue(ids.contains("Upgrades"));
+        assertFalse(ids.contains("Other"));
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangePurgeBonusCommandTest.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.api.commands.admin.range;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -56,16 +57,13 @@ class AdminRangePurgeBonusCommandTest extends CommonTestSetup {
 
         Util.setPlugin(plugin);
 
-        // Command manager
         CommandsManager cm = mock(CommandsManager.class);
         when(plugin.getCommandsManager()).thenReturn(cm);
 
-        // Settings - confirmation time of 0 seconds
         Settings s = mock(Settings.class);
         when(s.getConfirmationTime()).thenReturn(0);
         when(plugin.getSettings()).thenReturn(s);
 
-        // Player
         Player p = mock(Player.class);
         when(user.isOp()).thenReturn(false);
         User.setPlugin(plugin);
@@ -73,14 +71,15 @@ class AdminRangePurgeBonusCommandTest extends CommonTestSetup {
         when(user.getPlayer()).thenReturn(p);
         when(user.getName()).thenReturn("tastybento");
 
-        // Parent command has no aliases and a known top label (needed for confirmation matching)
         when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
         when(ac.getWorld()).thenReturn(world);
         when(ac.getTopLabel()).thenReturn("bsb");
 
-        // Island cache - two islands carry the "Upgrades" bonus, island2 also has "Other"
+        // Two islands in this world carry the "Upgrades" bonus; island2 also has "Other"
         when(island.getWorld()).thenReturn(world);
         when(island2.getWorld()).thenReturn(world);
+        when(island.getUniqueId()).thenReturn("island1");
+        when(island2.getUniqueId()).thenReturn("island2");
         when(island.getBonusRangeRecord("Upgrades")).thenReturn(Optional.of(new BonusRangeRecord("Upgrades", 50, "")));
         when(island2.getBonusRangeRecord("Upgrades")).thenReturn(Optional.of(new BonusRangeRecord("Upgrades", 50, "")));
         when(island.getBonusRangeRecord("Ghost")).thenReturn(Optional.empty());
@@ -91,8 +90,9 @@ class AdminRangePurgeBonusCommandTest extends CommonTestSetup {
                 .thenReturn(new ArrayList<>(List.of(new BonusRangeRecord("Upgrades", 50, ""),
                         new BonusRangeRecord("Other", 10, ""))));
 
-        when(islandCache.getIslands(world)).thenReturn(List.of(island, island2));
         when(islandCache.getCachedIslands()).thenReturn(List.of(island, island2));
+        when(im.getIslandById("island1")).thenReturn(Optional.of(island));
+        when(im.getIslandById("island2")).thenReturn(Optional.of(island2));
         when(im.getIslandCache()).thenReturn(islandCache);
 
         command = new AdminRangePurgeBonusCommand(ac);
@@ -105,37 +105,68 @@ class AdminRangePurgeBonusCommandTest extends CommonTestSetup {
     }
 
     @Test
-    void testCanExecuteWrongArgs() {
+    void testCanExecuteNoArgs() {
         assertFalse(command.canExecute(user, "purgebonus", Collections.emptyList()));
     }
 
     @Test
-    void testCanExecuteNoMatchingIslands() {
-        assertFalse(command.canExecute(user, "purgebonus", List.of("Ghost")));
-        verify(user).sendMessage("commands.admin.range.purgebonus.none", "[id]", "Ghost");
+    void testCanExecuteTooManyArgs() {
+        assertFalse(command.canExecute(user, "purgebonus", List.of("Upgrades", "now", "extra")));
     }
 
     @Test
-    void testCanExecuteSuccess() {
+    void testCanExecuteBadSecondArg() {
+        assertFalse(command.canExecute(user, "purgebonus", List.of("Upgrades", "yes")));
+    }
+
+    @Test
+    void testCanExecuteValidId() {
         assertTrue(command.canExecute(user, "purgebonus", List.of("Upgrades")));
     }
 
     @Test
-    void testExecuteAsksConfirmationDoesNotPurgeYet() {
-        assertTrue(command.canExecute(user, "purgebonus", List.of("Upgrades")));
-        assertTrue(command.execute(user, "purgebonus", List.of("Upgrades")));
-        verify(island, never()).clearBonusRange(any());
-        verify(island2, never()).clearBonusRange(any());
-        verify(user).sendMessage("commands.admin.range.purgebonus.warning", "[id]", "Upgrades", "[number]", "2");
+    void testCanExecuteValidConfirm() {
+        assertTrue(command.canExecute(user, "purgebonus", List.of("Upgrades", "confirm")));
     }
 
     @Test
-    void testPurgeClearsMatchingIslands() {
-        assertTrue(command.canExecute(user, "purgebonus", List.of("Upgrades")));
-        command.purge(user, "Upgrades");
+    void testCanExecuteRejectedWhileInPurge() {
+        command.inPurge = true;
+        assertFalse(command.canExecute(user, "purgebonus", List.of("Upgrades")));
+        verify(user).sendMessage("commands.admin.range.purgebonus.in-progress");
+    }
+
+    @Test
+    void testFindIslandIds() {
+        List<String> ids = command.findIslandIds(List.of(island, island2), "Upgrades");
+        assertEquals(List.of("island1", "island2"), ids);
+        assertTrue(command.findIslandIds(List.of(island, island2), "Ghost").isEmpty());
+    }
+
+    @Test
+    void testConfirmAppliesPurge() {
+        // Arrange a pending confirmation as the async scan would have done
+        command.toBeConfirmed = true;
+        command.pendingId = "Upgrades";
+        command.pendingIslandIds = List.of("island1", "island2");
+
+        assertTrue(command.execute(user, "purgebonus", List.of("Upgrades", "confirm")));
+
         verify(island, times(1)).clearBonusRange("Upgrades");
         verify(island2, times(1)).clearBonusRange("Upgrades");
         verify(user).sendMessage("commands.admin.range.purgebonus.success", "[id]", "Upgrades", "[number]", "2");
+        // Pending state cleared
+        assertFalse(command.toBeConfirmed);
+    }
+
+    @Test
+    void testApplyPurgeSkipsIslandsNoLongerCarryingBonus() {
+        // island2 no longer has the bonus by the time we apply
+        when(island2.getBonusRangeRecord("Upgrades")).thenReturn(Optional.empty());
+        command.applyPurge(user, "Upgrades", List.of("island1", "island2"));
+        verify(island, times(1)).clearBonusRange("Upgrades");
+        verify(island2, never()).clearBonusRange("Upgrades");
+        verify(user).sendMessage("commands.admin.range.purgebonus.success", "[id]", "Upgrades", "[number]", "1");
     }
 
     @Test
@@ -150,5 +181,12 @@ class AdminRangePurgeBonusCommandTest extends CommonTestSetup {
         List<String> ids = command.tabComplete(user, "purgebonus", List.of("Up")).orElse(Collections.emptyList());
         assertTrue(ids.contains("Upgrades"));
         assertFalse(ids.contains("Other"));
+    }
+
+    @Test
+    void testTabCompleteSecondArgSuggestsConfirm() {
+        List<String> opts = command.tabComplete(user, "purgebonus", List.of("Upgrades", ""))
+                .orElse(Collections.emptyList());
+        assertTrue(opts.contains("confirm"));
     }
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveBonusCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/range/AdminRangeRemoveBonusCommandTest.java
@@ -1,0 +1,193 @@
+package world.bentobox.bentobox.api.commands.admin.range;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.BonusRangeRecord;
+import world.bentobox.bentobox.managers.CommandsManager;
+import world.bentobox.bentobox.managers.PlayersManager;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Tests for {@link AdminRangeRemoveBonusCommand}.
+ *
+ * @author tastybento
+ */
+class AdminRangeRemoveBonusCommandTest extends CommonTestSetup {
+
+    @Mock
+    private CompositeCommand ac;
+    @Mock
+    private User user;
+    @Mock
+    private PlayersManager pm;
+
+    private AdminRangeRemoveBonusCommand command;
+    private List<BonusRangeRecord> bonusRanges;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Util.setPlugin(plugin);
+
+        // Command manager
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+
+        // Settings - confirmation time of 0 seconds
+        Settings s = mock(Settings.class);
+        when(s.getConfirmationTime()).thenReturn(0);
+        when(plugin.getSettings()).thenReturn(s);
+
+        // Player
+        Player p = mock(Player.class);
+        when(user.isOp()).thenReturn(false);
+        User.setPlugin(plugin);
+        when(user.getUniqueId()).thenReturn(uuid);
+        when(user.getPlayer()).thenReturn(p);
+        when(user.getName()).thenReturn("tastybento");
+
+        // Players manager
+        when(pm.getUUID("tastybento")).thenReturn(uuid);
+        when(plugin.getPlayers()).thenReturn(pm);
+
+        // Parent command has no aliases and a known top label (needed for confirmation matching)
+        when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
+        when(ac.getWorld()).thenReturn(world);
+        when(ac.getTopLabel()).thenReturn("bsb");
+
+        // Island has a couple of bonus ranges to begin with
+        bonusRanges = new ArrayList<>();
+        BonusRangeRecord level = new BonusRangeRecord("Level", 50, "Reward");
+        bonusRanges.add(level);
+        bonusRanges.add(new BonusRangeRecord("Upgrades", 50, "Upgrade"));
+        when(island.getBonusRanges()).thenReturn(bonusRanges);
+        when(island.getBonusRangeRecord("Level")).thenReturn(Optional.of(level));
+        when(island.getBonusRangeRecord("Upgrades")).thenReturn(Optional.of(bonusRanges.get(1)));
+        when(island.getBonusRange("Level")).thenReturn(50);
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
+
+        command = new AdminRangeRemoveBonusCommand(ac);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testCanExecuteNoArgs() {
+        assertFalse(command.canExecute(user, "removebonus", Collections.emptyList()));
+    }
+
+    @Test
+    void testCanExecuteTooManyArgs() {
+        assertFalse(command.canExecute(user, "removebonus", List.of("tastybento", "Level", "extra")));
+    }
+
+    @Test
+    void testCanExecuteUnknownPlayer() {
+        when(pm.getUUID(any())).thenReturn(null);
+        assertFalse(command.canExecute(user, "removebonus", List.of("tastybento")));
+        verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
+    }
+
+    @Test
+    void testCanExecuteNoIsland() {
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
+        assertFalse(command.canExecute(user, "removebonus", List.of("tastybento")));
+        verify(user).sendMessage("general.errors.player-has-no-island");
+    }
+
+    @Test
+    void testCanExecuteNoBonus() {
+        bonusRanges.clear();
+        assertFalse(command.canExecute(user, "removebonus", List.of("tastybento")));
+        verify(user).sendMessage("commands.admin.range.removebonus.no-bonus");
+    }
+
+    @Test
+    void testCanExecuteUnknownBonusId() {
+        when(island.getBonusRangeRecord("Nope")).thenReturn(Optional.empty());
+        assertFalse(command.canExecute(user, "removebonus", List.of("tastybento", "Nope")));
+        verify(user).sendMessage("commands.admin.range.removebonus.unknown-bonus", "[id]", "Nope");
+    }
+
+    @Test
+    void testCanExecuteSuccessAll() {
+        assertTrue(command.canExecute(user, "removebonus", List.of("tastybento")));
+    }
+
+    @Test
+    void testCanExecuteSuccessId() {
+        assertTrue(command.canExecute(user, "removebonus", List.of("tastybento", "Level")));
+    }
+
+    @Test
+    void testExecuteAsksConfirmationDoesNotRemoveYet() {
+        assertTrue(command.canExecute(user, "removebonus", List.of("tastybento")));
+        assertTrue(command.execute(user, "removebonus", List.of("tastybento")));
+        // Nothing removed until confirmed
+        verify(island, never()).clearAllBonusRanges();
+        verify(island, never()).clearBonusRange(any());
+        verify(user).sendMessage("commands.confirmation.confirm", "[seconds]", "0");
+    }
+
+    @Test
+    void testRemoveAllBonusRanges() {
+        assertTrue(command.canExecute(user, "removebonus", List.of("tastybento")));
+        command.removeBonusRanges(user, "tastybento");
+        verify(island, times(1)).clearAllBonusRanges();
+        verify(island, never()).clearBonusRange(any());
+        verify(user).sendMessage("commands.admin.range.removebonus.success", "[number]", "100", "[name]",
+                "tastybento");
+    }
+
+    @Test
+    void testRemoveBonusRangeById() {
+        assertTrue(command.canExecute(user, "removebonus", List.of("tastybento", "Level")));
+        command.removeBonusRanges(user, "tastybento");
+        verify(island, times(1)).clearBonusRange("Level");
+        verify(island, never()).clearAllBonusRanges();
+        verify(user).sendMessage("commands.admin.range.removebonus.success-id", "[id]", "Level", "[number]", "50",
+                "[name]", "tastybento");
+    }
+
+    @Test
+    void testTabCompleteEmptyArgs() {
+        assertTrue(command.tabComplete(user, "removebonus", Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    void testTabCompleteBonusIds() {
+        List<String> ids = command.tabComplete(user, "removebonus", List.of("tastybento", "L"))
+                .orElse(Collections.emptyList());
+        assertTrue(ids.contains("Level"));
+    }
+}


### PR DESCRIPTION
## What

Adds two admin commands for managing the bonus ranges stored on islands. Bonus ranges are static values added to (or subtracted from) an island's protection range, stored as `BonusRangeRecord`s. Addons tag the ones they grant with their **own addon name** as the bonus `uniqueId` (e.g. the Upgrades addon uses `"Upgrades"`), so admins need a way to clear them — most importantly after the granting addon has been uninstalled.

## Commands

### `/<admin> range removebonus <player> [id]` (confirmable)
Operates on a single player's island.
- **No id** → removes *all* bonus ranges from that island.
- **With id** → removes only the bonus ranges for that unique id.
- Tab completion offers the island's existing bonus-range ids.

### `/<admin> range purgebonus <id>` → `… <id> confirm`
Removes the bonus id from **every island** in the gamemode's world — the "addon was uninstalled, purge its bonus everywhere" workflow.
- **Async**: the island scan runs off the main thread via `IslandsManager#getIslandsASync()`, so it won't freeze a large server. It reports the affected-island count, then you re-run with `confirm` to apply (reusing the scanned result — no second scan). An `inPurge` guard rejects overlapping runs.
- Mutation + `RANGE_CHANGE` event firing happen back on the main thread, on the live **cached** island instances (resolved by id), with a per-island re-check in case state changed since the scan.
- Tab completion lists the bonus ids on currently-loaded islands.

Both commands fire `IslandEvent` `RANGE_CHANGE` when an island's effective protection range actually changes. Persistence is via `setChanged()`, consistent with the existing `range add`/`reset` commands.

## Changes
- New `AdminRangeRemoveBonusCommand` and `AdminRangePurgeBonusCommand`, registered in `AdminRangeCommand`.
- Locale keys `commands.admin.range.{removebonus,purgebonus}.*` added to `en-US.yml` and translated into all 22 other bundled locales.
- Version bumped `3.17.0` → `3.17.1`.
- Test suites: `AdminRangeRemoveBonusCommandTest` (13) + `AdminRangePurgeBonusCommandTest` (12).

## Testing
`./gradlew build` passes — full test suite + all 23 locale files parse. New suites: 25/25 green.

> Non-English translations are best-effort and would benefit from native-speaker review; all preserve MiniMessage tags and placeholders exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)