### PR TITLE
Add config toggles for Dynmap island markers and area boxes

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -187,6 +187,18 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "panel.ticks-between-calls", since = "1.16.0", needsRestart = true)
     private long ticksBetweenCalls = 10;
 
+    /* DYNMAP */
+    @ConfigComment("Toggle whether BentoBox shows a marker (house icon) on Dynmap at the center of every island.")
+    @ConfigComment("On worlds with many tightly-packed islands these icons can flood the map. Set to false to hide them.")
+    @ConfigComment("/!\\ Restart the server or use /bbox reload after changing this for it to take effect.")
+    @ConfigEntry(path = "dynmap.island-markers", since = "3.17.1")
+    private boolean dynmapIslandMarkers = true;
+
+    @ConfigComment("Toggle whether BentoBox draws the protected area border box of every island on Dynmap.")
+    @ConfigComment("/!\\ Restart the server or use /bbox reload after changing this for it to take effect.")
+    @ConfigEntry(path = "dynmap.island-areas", since = "3.17.1")
+    private boolean dynmapIslandAreas = true;
+
     /*
      * Logs
      */
@@ -980,6 +992,46 @@ public class Settings implements ConfigObject {
      */
     public void setTicksBetweenCalls(long ticksBetweenCalls) {
         this.ticksBetweenCalls = ticksBetweenCalls;
+    }
+
+    /**
+     * Whether BentoBox shows a marker (house icon) on Dynmap at the center of every island.
+     *
+     * @return true if island markers should be shown
+     * @since 3.17.1
+     */
+    public boolean isDynmapIslandMarkers() {
+        return dynmapIslandMarkers;
+    }
+
+    /**
+     * Sets whether BentoBox shows a marker (house icon) on Dynmap at the center of every island.
+     *
+     * @param dynmapIslandMarkers whether island markers should be shown
+     * @since 3.17.1
+     */
+    public void setDynmapIslandMarkers(boolean dynmapIslandMarkers) {
+        this.dynmapIslandMarkers = dynmapIslandMarkers;
+    }
+
+    /**
+     * Whether BentoBox draws the protected area border box of every island on Dynmap.
+     *
+     * @return true if island area boxes should be drawn
+     * @since 3.17.1
+     */
+    public boolean isDynmapIslandAreas() {
+        return dynmapIslandAreas;
+    }
+
+    /**
+     * Sets whether BentoBox draws the protected area border box of every island on Dynmap.
+     *
+     * @param dynmapIslandAreas whether island area boxes should be drawn
+     * @since 3.17.1
+     */
+    public void setDynmapIslandAreas(boolean dynmapIslandAreas) {
+        this.dynmapIslandAreas = dynmapIslandAreas;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/hooks/DynmapHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/DynmapHook.java
@@ -121,20 +121,24 @@ public class DynmapHook extends MapHook implements Listener {
             existingArea.deleteMarker();
         }
         // Point marker at island center for the label/icon
-        markerSet.createMarker(id, label, worldName,
-                island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ(),
-                markerAPI.getMarkerIcon("default"), true);
+        if (plugin.getSettings().isDynmapIslandMarkers()) {
+            markerSet.createMarker(id, label, worldName,
+                    island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ(),
+                    markerAPI.getMarkerIcon("default"), true);
+        }
         // Area marker showing the protected island border
-        double[] xCorners = { island.getMinProtectedX(), island.getMaxProtectedX(),
-                island.getMaxProtectedX(), island.getMinProtectedX() };
-        double[] zCorners = { island.getMinProtectedZ(), island.getMinProtectedZ(),
-                island.getMaxProtectedZ(), island.getMaxProtectedZ() };
-        AreaMarker area = markerSet.createAreaMarker(id + "_area", label, false, worldName,
-                xCorners, zCorners, true);
-        if (area != null) {
-            area.setRangeY(w.getMaxHeight(), w.getMinHeight());
-            area.setLineStyle(2, 0.8, 0x3388FF);
-            area.setFillStyle(0.15, 0x3388FF);
+        if (plugin.getSettings().isDynmapIslandAreas()) {
+            double[] xCorners = { island.getMinProtectedX(), island.getMaxProtectedX(),
+                    island.getMaxProtectedX(), island.getMinProtectedX() };
+            double[] zCorners = { island.getMinProtectedZ(), island.getMinProtectedZ(),
+                    island.getMaxProtectedZ(), island.getMaxProtectedZ() };
+            AreaMarker area = markerSet.createAreaMarker(id + "_area", label, false, worldName,
+                    xCorners, zCorners, true);
+            if (area != null) {
+                area.setRangeY(w.getMaxHeight(), w.getMinHeight());
+                area.setLineStyle(2, 0.8, 0x3388FF);
+                area.setFillStyle(0.15, 0x3388FF);
+            }
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -117,6 +117,16 @@ panel:
   # Added since 1.16.0.
   # /!\ In order to apply the changes made to this option, you must restart your server. Reloading BentoBox or the server won't work.
   ticks-between-calls: 10
+dynmap:
+  # Toggle whether BentoBox shows a marker (house icon) on Dynmap at the center of every island.
+  # On worlds with many tightly-packed islands these icons can flood the map. Set to false to hide them.
+  # /!\ Restart the server or use /bbox reload after changing this for it to take effect.
+  # Added since 3.17.1.
+  island-markers: true
+  # Toggle whether BentoBox draws the protected area border box of every island on Dynmap.
+  # /!\ Restart the server or use /bbox reload after changing this for it to take effect.
+  # Added since 3.17.1.
+  island-areas: true
 logs:
   # Toggle whether superflat chunks regeneration should be logged in the server logs or not.
   # It can be spammy if there are a lot of superflat chunks to regenerate.

--- a/src/test/java/world/bentobox/bentobox/hooks/DynmapHookTest.java
+++ b/src/test/java/world/bentobox/bentobox/hooks/DynmapHookTest.java
@@ -211,6 +211,30 @@ class DynmapHookTest extends CommonTestSetup {
     }
 
     @Test
+    void testIslandMarkersDisabledNoPointMarker() {
+        plugin.getSettings().setDynmapIslandMarkers(false);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        // No house icon, but the area box is still drawn
+        verify(markerSet, never()).createMarker(anyString(), anyString(), anyString(),
+                anyDouble(), anyDouble(), anyDouble(), any(MarkerIcon.class), anyBoolean());
+        verify(markerSet).createAreaMarker(eq(uuid.toString() + "_area"), eq("tastybento"), eq(false),
+                eq("bskyblock_world"), any(double[].class), any(double[].class), eq(true));
+    }
+
+    @Test
+    void testIslandAreasDisabledNoAreaMarker() {
+        plugin.getSettings().setDynmapIslandAreas(false);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        // House icon still placed, but no area box
+        verify(markerSet).createMarker(eq(uuid.toString()), eq("tastybento"),
+                eq("bskyblock_world"), eq(0.0), eq(64.0), eq(0.0), eq(defaultIcon), eq(true));
+        verify(markerSet, never()).createAreaMarker(anyString(), anyString(), anyBoolean(), anyString(),
+                any(double[].class), any(double[].class), anyBoolean());
+    }
+
+    @Test
     void testAreaMarkerYRangeSetToWorldHeight() {
         when(im.getIslands(overWorld)).thenReturn(List.of(island));
         hookAndReady();


### PR DESCRIPTION
## Background

BentoBox's Dynmap integration draws, for **every** island:

1. A **house icon marker** at the island center (the "Iles" markers in the layers control), and
2. A **protected-area border box** outlining the island.

On worlds with many tightly-packed islands, these can flood the Dynmap view. Until now the only ways to hide them were per-viewer (untick the layer) or via Dynmap commands (`/dmarker updateset … hide:true`, `/dmarker deleteset …`) — and the latter isn't permanent because BentoBox re-creates and re-populates the set on restart and on island create/reset/rename/delete events.

## Change

Adds a new `dynmap` config section with two toggles:

```yaml
dynmap:
  # Toggle whether BentoBox shows a marker (house icon) on Dynmap at the center of every island.
  island-markers: true
  # Toggle whether BentoBox draws the protected area border box of every island on Dynmap.
  island-areas: true
```

`DynmapHook` now checks each setting before creating the corresponding marker. Both default to `true`, so existing behaviour is unchanged. Changes take effect after a server restart or `/bbox reload`.

## Tests

Added two tests to `DynmapHookTest`:
- `testIslandMarkersDisabledNoPointMarker` — no point marker created, area box still drawn
- `testIslandAreasDisabledNoAreaMarker` — house icon still placed, no area box

🤖 Generated with [Claude Code](https://claude.com/claude-code)