### PR TITLE
fix: retry Vault hook after addons enable

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -206,6 +206,11 @@ public class BentoBox extends JavaPlugin implements Listener {
         // Enable addons
         addonsManager.enableAddons();
 
+        // Addons may register a Vault economy provider during their onEnable (e.g. InvSwitcher),
+        // after the early Vault hook already failed for lack of any economy. Retry now so getVault()
+        // reflects an economy an addon has since provided.
+        hookRegistrar.registerVaultHookIfNeeded();
+
         // Register default gamemode placeholders
         addonsManager.getGameModeAddons().forEach(placeholdersManager::registerDefaultPlaceholders);
 

--- a/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BentoBoxHookRegistrar.java
@@ -37,6 +37,22 @@ public class BentoBoxHookRegistrar {
     }
 
     /**
+     * Re-attempts the Vault economy hook after addons have been enabled.
+     * <p>
+     * BentoBox hooks Vault during {@link #registerEarlyHooks()}, before addons are enabled. An addon
+     * may register a Vault economy provider in its own {@code onEnable()} (e.g. InvSwitcher, which
+     * provides per-world balances), after that early attempt already failed for lack of any economy.
+     * A failed hook is discarded by {@link HooksManager}, so {@link BentoBox#getVault()} would stay
+     * empty even though an economy now exists. This gives the now-present economy a chance to be
+     * picked up. No-op if Vault is already hooked.
+     */
+    public void registerVaultHookIfNeeded() {
+        if (plugin.getVault().isEmpty()) {
+            hooksManager.registerHook(new VaultHook());
+        }
+    }
+
+    /**
      * Registers world-manager hooks (Multiverse variants) that load after BentoBox worlds.
      * Must be called after {@code islandWorldManager.registerWorldsToMultiverse()} is ready.
      */


### PR DESCRIPTION
## Problem

BentoBox registers its `VaultHook` during **early hooks** (`BentoBoxHookRegistrar.registerEarlyHooks()`), which runs *before* `addonsManager.enableAddons()`. At that point no economy provider may be registered with Bukkit's `ServicesManager` yet, so `VaultHook.hook()` returns `false`. `HooksManager.registerHook()` only stores hooks whose `hook()` **succeeds**, so a failed Vault hook is discarded entirely and `getVault()` returns empty.

This is a problem for addons that **provide** a Vault economy in their own `onEnable()` — e.g. [InvSwitcher](https://github.com/BentoBoxWorld/InvSwitcher), which registers a per-world `Economy` provider so each game world has its own balance. Because BentoBox already gave up on Vault, `getVault()` stays empty even though a perfectly good economy now exists, and economy-dependent addons such as **Bank** disable themselves with *"Vault is required"*.

## Fix

Re-attempt the Vault hook once, right after `enableAddons()`, via a new `BentoBoxHookRegistrar.registerVaultHookIfNeeded()` (no-op if Vault is already hooked). Any economy an addon registered during enable is now picked up.

This is a minimal, general safety net — it helps any addon that registers an economy in `onEnable`, not just InvSwitcher.

## Notes

- Addons that consult `getVault()` *during their own* `onEnable` (like Bank) still need to either enable after the economy provider or retry the hook themselves; a companion PR to Bank does the latter. This PR fixes the general BentoBox-side gap.
- Branched from `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)