### PR TITLE
fix: don't count transferred island against limit in setowner (#2996)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
@@ -69,9 +69,14 @@ public class AdminTeamSetownerCommand extends ConfirmableCommand {
             user.sendMessage("commands.admin.team.setowner.already-owner", TextVariables.NAME, args.getFirst());
             return false;
         }
-        // Refuse if the recipient is already at their concurrent-islands cap (#2908).
+        // Refuse if the recipient would exceed their concurrent-islands cap by gaining this island (#2908).
+        // If the target is already a member of this island it is already counted, so discount it -
+        // otherwise a member whose only island is this one is wrongly blocked at the limit (#2996).
         User target = User.getInstance(targetUUID);
         int num = this.getIslands().getNumberOfConcurrentIslands(targetUUID, getWorld());
+        if (island.inTeam(targetUUID)) {
+            num--;
+        }
         int max = target.getPermissionValue(
                 this.getIWM().getAddon(getWorld()).map(GameModeAddon::getPermissionPrefix).orElse("") + "island.number",
                 this.getIWM().getWorldSettings(getWorld()).getConcurrentIslands());

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommand.java
@@ -98,10 +98,13 @@ public class IslandTeamSetownerCommand extends CompositeCommand {
             user.sendMessage("commands.island.team.setowner.errors.target-is-not-member");
             return false;
         }
-        // Refuse if the recipient is already at their concurrent-islands cap.
+        // Refuse if the recipient would exceed their concurrent-islands cap by gaining this island.
         // Without this check, ownership transfer bypasses the limit set in IslandCreateCommand (#2908).
+        // The target is already a member of this island, so it is already included in their
+        // concurrent-island count - discount it, otherwise a member whose only island is this one is
+        // wrongly blocked once the limit is reached (#2996).
         User target = User.getInstance(targetUUID);
-        int num = getIslands().getNumberOfConcurrentIslands(targetUUID, getWorld());
+        int num = getIslands().getNumberOfConcurrentIslands(targetUUID, getWorld()) - 1;
         int max = target.getPermissionValue(
                 getIWM().getAddon(getWorld()).map(GameModeAddon::getPermissionPrefix).orElse("") + "island.number",
                 getIWM().getWorldSettings(getWorld()).getConcurrentIslands());

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamSetownerCommandTest.java
@@ -240,7 +240,9 @@ class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
     }
 
     /**
-     * Recipient already owns the maximum allowed concurrent islands - transfer must be refused.
+     * Recipient already owns the maximum allowed concurrent islands besides the one being
+     * transferred - transfer must be refused. The target is a member of the island being
+     * transferred (so it is already counted), plus owns {@code max} other islands (#2996).
      */
     @Test
     void testCanExecuteTargetAtConcurrentIslandsCap() {
@@ -248,9 +250,32 @@ class IslandTeamSetownerCommandTest extends RanksManagerTestSetup {
         mockedBukkit.when(() -> Bukkit.getPlayer(target)).thenReturn(null);
         when(pm.getUUID(anyString())).thenReturn(target);
         when(island.inTeam(any())).thenReturn(true);
-        when(im.getNumberOfConcurrentIslands(eq(target), any())).thenReturn(3);
+        // max is 3; target is a member of this island (counted) plus owns 3 others = 4 total
+        when(im.getNumberOfConcurrentIslands(eq(target), any())).thenReturn(4);
         assertFalse(its.canExecute(user, "", List.of("tastybento")));
         verify(user).sendMessage("commands.island.team.setowner.errors.at-max");
+    }
+
+    /**
+     * Transferring ownership to a member whose only island is the one being transferred must be
+     * allowed even when the concurrent-island limit has been reached. The island is already
+     * counted in the target's concurrent total because they are a member of it, so the transfer
+     * does not give them a new island (#2996).
+     */
+    @Test
+    void testCanExecuteTargetIsMemberOfOnlyThisIslandAtLimit() {
+        // World limit of 1 island
+        WorldSettings ws = mock(WorldSettings.class);
+        when(ws.getConcurrentIslands()).thenReturn(1);
+        when(iwm.getWorldSettings(world)).thenReturn(ws);
+        UUID target = UUID.randomUUID();
+        // Offline so getPermissionValue returns the world default (1)
+        mockedBukkit.when(() -> Bukkit.getPlayer(target)).thenReturn(null);
+        when(pm.getUUID(anyString())).thenReturn(target);
+        when(island.inTeam(any())).thenReturn(true);
+        // The target's only island is the one being transferred (already counted as a member)
+        when(im.getNumberOfConcurrentIslands(eq(target), any())).thenReturn(1);
+        assertTrue(its.canExecute(user, "", List.of("tastybento")));
     }
 
     /**


### PR DESCRIPTION
Fixes #2996

## Problem

`/is team setowner <player>` refused the transfer with *"The specified player has reached the maximum number of islands allowed on the server."* when the concurrent-island limit was reached — even though the target is **already a member** of the island being transferred and gains no new island. With a limit of 1, a member whose only island is this one always hit the cap.

This blocks mobile players, who have no left/right-click and cannot use the `/is team` GUI, so `setowner` is their only way to transfer ownership.

## Cause

`IslandsManager#getNumberOfConcurrentIslands` counts every island the player **owns or is a member of**. Since `IslandTeamSetownerCommand` requires the target to already be a team member, the island being transferred is already included in `num`, so `num >= max` fires one island too early.

## Fix

Discount the island being transferred from the count before the cap check:

- **`IslandTeamSetownerCommand`** — the target is always a member at this point (enforced earlier), so `num` is decremented unconditionally.
- **`AdminTeamSetownerCommand`** — the target may not be a member (admin stands on any island), so it is decremented only when `island.inTeam(targetUUID)`.

The transfer is now rejected only when the target has `max` **other** islands, preserving the limit added in #2908.

## Tests

- Adds `testCanExecuteTargetIsMemberOfOnlyThisIslandAtLimit` — a member whose only island is the one being transferred, at a limit of 1, can now receive ownership. (Fails before the fix, passes after.)
- Updates `testCanExecuteTargetAtConcurrentIslandsCap` so the target owns `max` *other* islands plus this one, confirming the cap still blocks genuine over-limit transfers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)