### PR TITLE
Fix multi-line lore/text losing colour after the first line

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 group = "world.bentobox" // From <groupId>
 
 // Base properties from <properties>
-val buildVersion = "3.18.0"
+val buildVersion = "3.18.1"
 val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -1433,7 +1433,7 @@ public class Util {
         String content = getComponentContent(component);
         if (!content.isEmpty()) {
             emitStyleTransition(sb, effective, state);
-            sb.append(content);
+            appendContentWithNewlineStyleCarry(sb, content, state);
         }
         for (Component child : component.children()) {
             appendComponentLegacy(sb, child, effective, state);
@@ -1529,6 +1529,65 @@ public class Util {
             state.obfuscated = true;
         }
         state.isFresh = false;
+    }
+
+    /**
+     * Appends text content to the legacy output, re-emitting the currently active color and
+     * decorations after every newline. Legacy lore/text is split on {@code \n} downstream (each
+     * line becomes a separate tooltip line), and a color/format code only applies until the end of
+     * its line — so without re-stating the active style, every line after the first would render in
+     * the default color. Vanilla clears decorations when a color code is emitted, so the color is
+     * written first, then any active decorations.
+     *
+     * @param sb output buffer
+     * @param content text that may contain newlines
+     * @param state the currently active emitted style
+     */
+    private static void appendContentWithNewlineStyleCarry(StringBuilder sb, String content, EmittedState state) {
+        if (content.indexOf('\n') < 0) {
+            sb.append(content);
+            return;
+        }
+
+        String active = activeStyleCodes(state);
+        int start = 0;
+        int idx;
+        while ((idx = content.indexOf('\n', start)) >= 0) {
+            sb.append(content, start, idx).append('\n');
+            sb.append(active);
+            start = idx + 1;
+        }
+        sb.append(content, start, content.length());
+    }
+
+    /**
+     * Builds the legacy code sequence that restates the currently active style (color followed by
+     * any active decorations), so it can be re-applied at the start of a new line.
+     *
+     * @param state the currently active emitted style
+     * @return the legacy §-code sequence, or an empty string if nothing is active
+     */
+    private static String activeStyleCodes(EmittedState state) {
+        StringBuilder codes = new StringBuilder();
+        if (state.color != null) {
+            codes.append(legacyColorCode(state.color));
+        }
+        if (state.bold) {
+            codes.append(COLOR_CHAR).append('l');
+        }
+        if (state.italic) {
+            codes.append(COLOR_CHAR).append('o');
+        }
+        if (state.underlined) {
+            codes.append(COLOR_CHAR).append('n');
+        }
+        if (state.strikethrough) {
+            codes.append(COLOR_CHAR).append('m');
+        }
+        if (state.obfuscated) {
+            codes.append(COLOR_CHAR).append('k');
+        }
+        return codes.toString();
     }
 
     private static String legacyColorCode(TextColor color) {

--- a/src/test/java/world/bentobox/bentobox/util/LegacyToMiniMessageTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/LegacyToMiniMessageTest.java
@@ -359,7 +359,7 @@ class LegacyToMiniMessageTest extends CommonTestSetup {
         String[] lines = legacy.split("\n", -1);
         assertEquals(2, lines.length, "expected two lines: " + legacy);
         for (String line : lines) {
-            assertTrue(line.startsWith("§6§l"),
+            assertTrue(line.startsWith("\u00A76\u00A7l"),
                     "each line should restate gold then bold: " + line);
         }
     }

--- a/src/test/java/world/bentobox/bentobox/util/LegacyToMiniMessageTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/LegacyToMiniMessageTest.java
@@ -327,4 +327,40 @@ class LegacyToMiniMessageTest extends CommonTestSetup {
         assertNotNull(color, "Expected a colour");
         assertEquals(0x238af0, color.value());
     }
+
+    /**
+     * Multi-line text is split on '\n' downstream (each line becomes a separate lore/tooltip line),
+     * and a colour code only applies to the end of its line. componentToLegacy must therefore
+     * re-state the active colour after every newline, or every line after the first renders in the
+     * default colour. This is the "second line loses its colour" GUI bug.
+     */
+    @Test
+    void testColourCarriesAcrossNewlines() {
+        Component comp = Util.parseMiniMessage("<gray>Displays a list of\nfree challenges");
+        String legacy = Util.componentToLegacy(comp);
+
+        String[] lines = legacy.split("\n", -1);
+        assertEquals(2, lines.length, "expected two lines: " + legacy);
+        for (String line : lines) {
+            assertTrue(line.startsWith("§7"),
+                    "each line should start with the gray colour code: " + line);
+        }
+    }
+
+    /**
+     * Both the colour and any active decorations must be re-stated after a newline, with the colour
+     * emitted first (a colour code clears decorations in vanilla), then the decorations.
+     */
+    @Test
+    void testColourAndBoldCarryAcrossNewlines() {
+        Component comp = Util.parseMiniMessage("<gold><bold>Line one\nLine two");
+        String legacy = Util.componentToLegacy(comp);
+
+        String[] lines = legacy.split("\n", -1);
+        assertEquals(2, lines.length, "expected two lines: " + legacy);
+        for (String line : lines) {
+            assertTrue(line.startsWith("§6§l"),
+                    "each line should restate gold then bold: " + line);
+        }
+    }
 }

--- a/src/test/java/world/bentobox/bentobox/util/LegacyToMiniMessageTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/LegacyToMiniMessageTest.java
@@ -342,7 +342,7 @@ class LegacyToMiniMessageTest extends CommonTestSetup {
         String[] lines = legacy.split("\n", -1);
         assertEquals(2, lines.length, "expected two lines: " + legacy);
         for (String line : lines) {
-            assertTrue(line.startsWith("§7"),
+            assertTrue(line.startsWith("\u00A77"),
                     "each line should start with the gray colour code: " + line);
         }
     }


### PR DESCRIPTION
## Problem

Multi-line names and lore lose their formatting after the first line — the second and subsequent lines render in the default (purple) colour, even when each source line specifies a colour. This affects GUI tooltips across all addons (reported on Challenges).

## Root cause

`Util.componentToLegacy` walks the component tree and emits a style transition **once per text node**, then appends the node's content verbatim. When a text node's content spans newlines, the colour/format code is written only before the first line. Downstream, legacy lore/text is split on `\n` (each line becomes a separate tooltip line) and a legacy colour code only applies to the end of its line — so every line after the first renders uncoloured.

Concretely, `<gray>line1\nline2` serialised to `§7line1\nline2`; after the `\n`-split the second line had no colour code left.

## Fix

When appended text spans newlines, re-emit the active style after each `\n`: colour first (a colour code clears decorations in vanilla), then any active decorations. So `<gray>a\nb` now serialises to `§7a\n§7b`, and each split line keeps its colour. Multi-decoration state (e.g. gold + bold) is restated in the correct order too.

## Tests

Adds to `LegacyToMiniMessageTest`:
- `testColourCarriesAcrossNewlines` — each line of a two-line gray string starts with `§7`.
- `testColourAndBoldCarryAcrossNewlines` — each line restates `§6§l` (colour then bold).

`LegacyToMiniMessageTest` and `UtilTest` pass.

Bumps version to **3.18.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)