### PR TITLE
build: scope vendor repos to fix flaky dependency resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -196,15 +196,44 @@ repositories {
     maven("https://repo.onarandombox.com/multiverse-releases") { name = "Multiverse-Releases" }
     maven("https://repo.onarandombox.com/multiverse-snapshots") { name = "Multiverse-Snapshots" }
     maven("https://mvn.lumine.io/repository/maven-public/") { name = "Lumine-Releases" } // Mythic mobs
-    maven("https://repo.clojars.org/") { name = "Clojars" }
-    maven("https://repo.fancyplugins.de/releases") { name = "FancyPlugins-Releases" }
-    maven("https://repo.pyr.lol/snapshots") { name = "Pyr-Snapshots" }
     maven("https://maven.devs.beer/") { name = "MatteoDev" }
-    maven("https://repo.mikeprimm.com/") { name = "Dynmap" }
     maven("https://repo.oraxen.com/releases") { name = "Oraxen" } // Custom items plugin
-    maven("https://repo.momirealms.net/releases/") { name = "MomiRealms" } // CraftEngine custom block plugin
     maven("https://repo.codemc.org/repository/bentoboxworld/") { name = "BentoBoxWorld-Repo" }
     maven("https://repo.extendedclip.com/releases/") { name = "Placeholder-API-Releases" }
+
+    // Vendor-specific repositories scoped to the exact groups they host.
+    // Without exclusiveContent, Gradle queries every repo in order for every
+    // artifact; a fragile host (e.g. fancyplugins returning HTTP 520) that is
+    // queried for a group it does NOT host aborts resolution before the real
+    // repo is reached. Scoping guarantees each group resolves only from its
+    // authoritative source and these hosts are never queried for anything else.
+    exclusiveContent {
+        forRepository { maven("https://repo.mikeprimm.com/") { name = "Dynmap" } }
+        filter { includeGroup("us.dynmap") }
+    }
+    exclusiveContent {
+        forRepository { maven("https://repo.momirealms.net/releases/") { name = "MomiRealms" } } // CraftEngine custom block plugin
+        filter { includeGroup("net.momirealms") }
+    }
+    exclusiveContent {
+        // FancyNpcs/FancyHolograms moved off repo.fancyplugins.de (now offline)
+        // to repo.fancyinnovations.com per the FancyInnovations API docs.
+        forRepository { maven("https://repo.fancyinnovations.com/releases") { name = "FancyInnovations-Releases" } }
+        filter { includeGroup("de.oliver") }
+    }
+    exclusiveContent {
+        forRepository { maven("https://repo.pyr.lol/snapshots") { name = "Pyr-Snapshots" } }
+        filter { includeGroup("lol.pyr") }
+    }
+    // MultiLib (com.github.puregero:multilib) is published to Clojars per the
+    // MultiLib docs (github.com/MultiPaper/MultiLib). Its com.github.* group is
+    // claimed by jitpack, which 404s it, so scope the group exclusively to
+    // Clojars: MultiLib resolves from Clojars instead of falling through to a
+    // jitpack 404, and Clojars is never queried for the vendor groups above.
+    exclusiveContent {
+        forRepository { maven("https://repo.clojars.org/") { name = "Clojars" } }
+        filter { includeGroup("com.github.puregero") }
+    }
 }
 
 


### PR DESCRIPTION
## Problem

CI intermittently fails in `:compileJava` with:

```
Could not resolve us.dynmap:DynmapCoreAPI:3.4
```

The root cause is **repository query order**, not missing artifacts. Gradle queries every repository in declaration order for each artifact until one answers. When resolving `us.dynmap:*` it reaches `repo.clojars.org` and `repo.fancyplugins.de` **before** the authoritative Dynmap repo — and `repo.fancyplugins.de` returning **HTTP 520** (a 5xx = hard error) aborts resolution before `repo.mikeprimm.com` is ever reached. (`clojars` 404s are benign; the 520 is fatal.)

Fixing that unmasked two further latent breakages that the early abort had been hiding:
- **`de.oliver` (FancyNpcs/FancyHolograms)** — `repo.fancyplugins.de` is now **offline**; the repo migrated to `repo.fancyinnovations.com`.
- **`com.github.puregero:multilib`** — its `com.github.*` group is claimed by jitpack (which 404s it); the artifact is actually published to **Clojars**.

## Fix

Scope every vendor group to its authoritative repo with `exclusiveContent`, so fragile hosts are never queried for groups they don't host and one host's outage can't cascade into unrelated groups:

| Group | Source |
|---|---|
| `us.dynmap` | repo.mikeprimm.com |
| `net.momirealms` | repo.momirealms.net |
| `lol.pyr` | repo.pyr.lol |
| `de.oliver` | **repo.fancyinnovations.com** (migrated from offline repo.fancyplugins.de) |
| `com.github.puregero` (MultiLib) | **Clojars** (was falling through to a jitpack 404) |

No dependency versions were changed.

## Verification

`./gradlew dependencies --configuration compileClasspath --refresh-dependencies` (cold cache) → `BUILD SUCCESSFUL`, **zero `FAILED`** entries. All eight previously-failing coordinates (`DynmapCoreAPI`, `dynmap-api`, `craft-engine-bukkit/core`, `FancyNpcs`, `FancyHolograms`, `znpcsplus-api`, `multilib`) resolve.

## Merge order

Please merge this **before** #2999 — it fixes the CI dependency resolution that #2999's build depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153KLwL66bB31pTc4BtsTMd