### PR TITLE
Make admin team setowner console/automation friendly

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
@@ -40,30 +40,52 @@ public class AdminTeamSetownerCommand extends ConfirmableCommand {
         setPermission("mod.team.setowner");
         setParametersHelp("commands.admin.team.setowner.parameters");
         setDescription("commands.admin.team.setowner.description");
-        this.setOnlyPlayer(true);
+        // Not only-player: the island can be named explicitly (second arg) so this runs from the
+        // console too, which lets automation (e.g. Skript) transfer ownership.
+        this.setOnlyPlayer(false);
     }
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
-        // If args are not right, show help
-        if (args.size() != 1) {
+        // Syntax: <new owner> [current island owner]
+        if (args.isEmpty() || args.size() > 2) {
             showHelp(this, user);
             return false;
         }
 
-        // Get target
+        // Get the new owner
         targetUUID = Util.getUUID(args.getFirst());
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.getFirst());
             return false;
         }
-        // Check that user is on an island
-        Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());
-        if (opIsland.isEmpty()) {
-            user.sendMessage("commands.admin.team.setowner.must-be-on-island");
-            return false;
+
+        // Work out which island to transfer
+        if (args.size() == 2) {
+            // Island named by its current owner - location independent, so this works from the console
+            UUID islandOwnerUUID = Util.getUUID(args.get(1));
+            if (islandOwnerUUID == null) {
+                user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(1));
+                return false;
+            }
+            island = getIslands().getIsland(getWorld(), islandOwnerUUID);
+            if (island == null || !getIslands().hasIsland(getWorld(), islandOwnerUUID)) {
+                user.sendMessage("general.errors.player-has-no-island");
+                return false;
+            }
+        } else {
+            // No island named - use the one the player is standing on. This requires an in-game player.
+            if (!user.isPlayer()) {
+                user.sendMessage("commands.admin.team.setowner.specify-island");
+                return false;
+            }
+            Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());
+            if (opIsland.isEmpty()) {
+                user.sendMessage("commands.admin.team.setowner.must-be-on-island");
+                return false;
+            }
+            island = opIsland.get();
         }
-        island = opIsland.get();
         previousOwnerUUID = island.getOwner();
         if (targetUUID.equals(previousOwnerUUID)) {
             user.sendMessage("commands.admin.team.setowner.already-owner", TextVariables.NAME, args.getFirst());
@@ -92,6 +114,12 @@ public class AdminTeamSetownerCommand extends ConfirmableCommand {
     public boolean execute(User user, String label, List<String> args) {
         Objects.requireNonNull(island);
         Objects.requireNonNull(targetUUID);
+
+        // The console (e.g. Skript automation) cannot answer a confirmation prompt, so transfer at once.
+        if (!user.isPlayer()) {
+            changeOwner(user);
+            return true;
+        }
 
         this.askConfirmation(user, user.getTranslation("commands.admin.team.setowner.confirmation", TextVariables.NAME,
                 args.getFirst(), TextVariables.XYZ, Util.xyz(island.getCenter().toVector())), () -> changeOwner(user));
@@ -142,8 +170,12 @@ public class AdminTeamSetownerCommand extends ConfirmableCommand {
 
     @Override
     public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
-        String lastArg = !args.isEmpty() ? args.getLast() : "";
-        List<String> options = Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
-        return Optional.of(Util.tabLimit(options, lastArg));
+        // args[0] = label, [1] = new owner, [2] = current island owner
+        if (args.size() == 2 || args.size() == 3) {
+            String lastArg = !args.isEmpty() ? args.getLast() : "";
+            List<String> options = Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
+            return Optional.of(Util.tabLimit(options, lastArg));
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommand.java
@@ -69,7 +69,10 @@ public class AdminTeamSetownerCommand extends ConfirmableCommand {
                 return false;
             }
             island = getIslands().getIsland(getWorld(), islandOwnerUUID);
-            if (island == null || !getIslands().hasIsland(getWorld(), islandOwnerUUID)) {
+            // getIsland() returns the player's active/primary island, which may be a team island
+            // they only belong to. Require that they actually own it, so we never transfer the
+            // wrong island out from under its real owner.
+            if (island == null || !islandOwnerUUID.equals(island.getOwner())) {
                 user.sendMessage("general.errors.player-has-no-island");
                 return false;
             }
@@ -170,12 +173,9 @@ public class AdminTeamSetownerCommand extends ConfirmableCommand {
 
     @Override
     public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
-        // args[0] = label, [1] = new owner, [2] = current island owner
-        if (args.size() == 2 || args.size() == 3) {
-            String lastArg = !args.isEmpty() ? args.getLast() : "";
-            List<String> options = Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
-            return Optional.of(Util.tabLimit(options, lastArg));
-        }
-        return Optional.empty();
+        // Both positions - the new owner and the current island owner - are player names
+        String lastArg = !args.isEmpty() ? args.getLast() : "";
+        List<String> options = Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
+        return Optional.of(Util.tabLimit(options, lastArg));
     }
 }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -168,10 +168,13 @@ commands:
         admin-kicked: '<red>The admin kicked you from the team.</red>'
         success: '<aqua>[name] </aqua><green>has been kicked from </green><aqua>[owner]</aqua><green>''s [prefix_island].</green>'
       setowner:
-        parameters: <player>
-        description: transfers [prefix_island] ownership to the player
+        parameters: <player> [island owner]
+        description: transfers [prefix_island] ownership to the player. Name the current island
+          owner to run it from the console
         already-owner: '<red>[name] is already the owner of this [prefix_island]!</red>'
         must-be-on-island: '<red>You must be on the [prefix_island] to set the owner</red>'
+        specify-island: '<red>Stand on the [prefix_island] and run this in-game, or name the
+          island''s current owner: </red><yellow>setowner <player> <island owner></yellow>'
         confirmation: '<green>Are you sure you want to set [name] to be the owner of the
           [prefix_island] at [xyz]?</green>'
         success: '<aqua>[name]</aqua><green> is now the owner of this [prefix_island].</green>'

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
@@ -72,6 +72,7 @@ class AdminTeamSetownerCommandTest extends CommonTestSetup {
         User.getInstance(mockPlayer);
         // Sometimes use Mockito.withSettings().verboseLogging()
         when(user.isOp()).thenReturn(false);
+        when(user.isPlayer()).thenReturn(true);
         when(user.getUniqueId()).thenReturn(uuid);
         when(user.getPlayer()).thenReturn(mockPlayer);
         when(user.getName()).thenReturn("tastybento");
@@ -141,7 +142,8 @@ class AdminTeamSetownerCommandTest extends CommonTestSetup {
     void testSetup() {
         assertEquals("commands.admin.team.setowner.description", itl.getDescription());
         assertEquals("commands.admin.team.setowner.parameters", itl.getParameters());
-        assertTrue(itl.isOnlyPlayer());
+        // No longer only-player: the console can name the island explicitly
+        assertFalse(itl.isOnlyPlayer());
         assertEquals("mod.team.setowner", itl.getPermission());
     }
 
@@ -210,6 +212,62 @@ class AdminTeamSetownerCommandTest extends CommonTestSetup {
         itl.changeOwner(user);
         // Add other verifications
         verify(user).sendMessage("commands.admin.team.setowner.success", TextVariables.NAME, "tastybento");
+    }
+
+    /**
+     * The console names the island's current owner explicitly - no location and no confirmation.
+     */
+    @Test
+    void testExecuteConsoleWithIslandOwnerArg() {
+        when(user.isPlayer()).thenReturn(false);
+        when(Util.getUUID("tastybento")).thenReturn(uuid);
+        when(Util.getUUID("victim")).thenReturn(notUUID);
+        when(im.getIsland(any(), eq(notUUID))).thenReturn(island);
+        when(im.hasIsland(any(), eq(notUUID))).thenReturn(true);
+        when(island.getOwner()).thenReturn(notUUID);
+
+        List<String> args = List.of("tastybento", "victim");
+        assertTrue(itl.canExecute(user, itl.getLabel(), args));
+        assertTrue(itl.execute(user, itl.getLabel(), args));
+        // No confirmation prompt for the console - the transfer happens immediately
+        verify(user).sendMessage("commands.admin.team.setowner.success", TextVariables.NAME, "tastybento");
+    }
+
+    /**
+     * The console must name the island - it cannot rely on a standing location.
+     */
+    @Test
+    void testCanExecuteConsoleNoIslandArg() {
+        when(user.isPlayer()).thenReturn(false);
+        when(Util.getUUID("tastybento")).thenReturn(uuid);
+
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
+        verify(user).sendMessage("commands.admin.team.setowner.specify-island");
+    }
+
+    /**
+     * Named island owner is unknown.
+     */
+    @Test
+    void testCanExecuteUnknownIslandOwner() {
+        when(Util.getUUID("tastybento")).thenReturn(uuid);
+        when(Util.getUUID("ghost")).thenReturn(null);
+
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "ghost")));
+        verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "ghost");
+    }
+
+    /**
+     * Named island owner has no island.
+     */
+    @Test
+    void testCanExecuteIslandOwnerHasNoIsland() {
+        when(Util.getUUID("tastybento")).thenReturn(uuid);
+        when(Util.getUUID("victim")).thenReturn(notUUID);
+        when(im.getIsland(any(), eq(notUUID))).thenReturn(null);
+
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "victim")));
+        verify(user).sendMessage("general.errors.player-has-no-island");
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/team/AdminTeamSetownerCommandTest.java
@@ -223,7 +223,6 @@ class AdminTeamSetownerCommandTest extends CommonTestSetup {
         when(Util.getUUID("tastybento")).thenReturn(uuid);
         when(Util.getUUID("victim")).thenReturn(notUUID);
         when(im.getIsland(any(), eq(notUUID))).thenReturn(island);
-        when(im.hasIsland(any(), eq(notUUID))).thenReturn(true);
         when(island.getOwner()).thenReturn(notUUID);
 
         List<String> args = List.of("tastybento", "victim");
@@ -267,6 +266,21 @@ class AdminTeamSetownerCommandTest extends CommonTestSetup {
         when(im.getIsland(any(), eq(notUUID))).thenReturn(null);
 
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "victim")));
+        verify(user).sendMessage("general.errors.player-has-no-island");
+    }
+
+    /**
+     * The named player's active island is a team island they do not own - must not be transferred.
+     */
+    @Test
+    void testCanExecuteIslandOwnerNotActualOwner() {
+        when(Util.getUUID("tastybento")).thenReturn(uuid);
+        when(Util.getUUID("member")).thenReturn(notUUID);
+        // getIsland() resolves an island owned by someone else (a team island the player belongs to)
+        when(im.getIsland(any(), eq(notUUID))).thenReturn(island);
+        when(island.getOwner()).thenReturn(UUID.randomUUID());
+
+        assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento", "member")));
         verify(user).sendMessage("general.errors.player-has-no-island");
     }
 


### PR DESCRIPTION
## What

Adds an optional second argument to `admin team setowner` naming the island's current owner:

```
/[gamemode] admin team setowner <newOwner> [islandOwner]
```

## Why

Previously `admin team setowner` was `setOnlyPlayer(true)`, acted only on the island the executor was **standing on**, and required a **confirmation** prompt. That made it impossible to drive from the console — and therefore from automation such as Skript (e.g. a "capture the island by killing the owner" game mode).

## How it behaves

- **`setowner <newOwner>`** — unchanged. In-game admin, targets the island they're standing on, asks for confirmation.
- **`setowner <newOwner> <islandOwner>`** — new. Names the island by its current owner, so it's location-independent and **runs from the console**. Console execution **skips the confirmation** prompt (the console can't answer one).

The named form resolves the owner's **primary/active** island via `IslandsManager.getIsland(world, uuid)`. Behaviour left unchanged:
- **Concurrent-island cap** still applies — a recipient at their `island.number` limit is refused with `at-max`. Servers wanting capture-style transfers raise the limit.
- **Old owner** is still demoted to Member (not removed).

## Changes

- `AdminTeamSetownerCommand`: `setOnlyPlayer(false)`; two-arg island resolution by owner name; skip confirmation for non-player senders; tab-complete both name positions.
- `en-US.yml`: updated `parameters`/`description`; new `specify-island` message (shown if the console runs the one-arg form).
- `AdminTeamSetownerCommandTest`: added coverage for the console/two-arg paths (success, missing island arg, unknown island owner, owner-has-no-island); `testSetup` now asserts `isOnlyPlayer()` is false.

## Testing

`./gradlew test --tests "*.AdminTeamSetownerCommandTest"` — 12 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)