### PR TITLE
Add FISHING protection flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 
 - The Gradle build uses the Paper `userdev` plugin and Shadow plugin to produce a fat/shaded JAR at `build/libs/BentoBox-{version}.jar`.
 - `plugin.yml` and `config.yml` are filtered for the `${version}` placeholder at build time; locale files are copied without filtering.
+- Locale translations are produced with Claude, not GitLocalize. When a key is added to `en-US.yml`, translate it into every other `src/main/resources/locales/*.yml` file in the same PR, preserving each file's existing style (e.g. the MiniMessage-tagged names in `zh-CN.yml` / `zh-HK.yml`).
 - Java preview features are enabled for both compilation and test execution.
 - Local builds produce version `{buildVersion}-LOCAL-SNAPSHOT` (current: `3.18.1-LOCAL-SNAPSHOT`); CI builds append `-b{BUILD_NUMBER}-SNAPSHOT`; `origin/master` builds produce the bare version. The authoritative version is `buildVersion` in `build.gradle.kts`.
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/FishingListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/FishingListener.java
@@ -1,0 +1,31 @@
+package world.bentobox.bentobox.listeners.flags.protection;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerFishEvent;
+
+import world.bentobox.bentobox.api.flags.FlagListener;
+import world.bentobox.bentobox.lists.Flags;
+
+/**
+ * Handles fishing with a fishing rod ({@link Flags#FISHING}).
+ * Both casting and catching fish are checked at the hook's location, so fishing
+ * in protected water from outside the protected area is also blocked.
+ * Hooking entities is not handled here - that is covered by the hurting and PVP flags.
+ * @author tastybento
+ * @since 3.19.0
+ */
+public class FishingListener extends FlagListener {
+
+    /**
+     * Check when a player casts a rod or catches a fish
+     * @param e - event
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onFishing(PlayerFishEvent e) {
+        if ((e.getState() == PlayerFishEvent.State.FISHING || e.getState() == PlayerFishEvent.State.CAUGHT_FISH)
+                && !checkIsland(e, e.getPlayer(), e.getHook().getLocation(), Flags.FISHING)) {
+            e.getHook().remove();
+        }
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/lists/Flags.java
+++ b/src/main/java/world/bentobox/bentobox/lists/Flags.java
@@ -26,6 +26,7 @@ import world.bentobox.bentobox.listeners.flags.protection.ElytraListener;
 import world.bentobox.bentobox.listeners.flags.protection.EntityInteractListener;
 import world.bentobox.bentobox.listeners.flags.protection.ExplosionListener;
 import world.bentobox.bentobox.listeners.flags.protection.FireListener;
+import world.bentobox.bentobox.listeners.flags.protection.FishingListener;
 import world.bentobox.bentobox.listeners.flags.protection.HurtingListener;
 import world.bentobox.bentobox.listeners.flags.protection.InventoryListener;
 import world.bentobox.bentobox.listeners.flags.protection.ItemDropPickUpListener;
@@ -219,6 +220,17 @@ public final class Flags {
      * @since 1.21
      */
     public static final Flag AXOLOTL_SCOOPING = new Flag.Builder("AXOLOTL_SCOOPING", Material.AXOLOTL_BUCKET).build();
+
+    // Fishing
+    /**
+     * Prevents players from fishing with a fishing rod.
+     * Defaults to {@link RanksManager#VISITOR_RANK} so fishing stays allowed unless an admin
+     * or island owner restricts it.
+     * @since 3.19.0
+     * @see FishingListener
+     */
+    public static final Flag FISHING = new Flag.Builder("FISHING", Material.FISHING_ROD)
+            .defaultRank(RanksManager.VISITOR_RANK).listener(new FishingListener()).build();
 
     // Chorus Fruit and Enderpearls
     public static final Flag CHORUS_FRUIT = new Flag.Builder("CHORUS_FRUIT", Material.CHORUS_FRUIT).listener(new TeleportationListener()).build();

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -1341,6 +1341,10 @@ protection:
       description: |-
         <green>Přepnout, zda se může oheň šířit</green>
         <green>na sousedící bloky nebo ne.</green>
+    FISHING:
+      name: Rybaření
+      description: Povolit rybaření udicí
+      hint: Rybaření zakázáno
     FISH_SCOOPING:
       name: Rybobraní
       description: Povolit rybobraní použitím kbelíku

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -1408,6 +1408,10 @@ protection:
       description: |-
         <green>Umschalten, ob Feuer sich</green>
         <green>auf nahe gelegene Blöcke ausbreiten kann oder nicht.</green>
+    FISHING:
+      name: Angeln
+      description: Erlaubt das Angeln mit einer Angel
+      hint: Angeln deaktiviert
     FISH_SCOOPING:
       name: Fische fangen
       description: Erlaubt das Fangen von Fischen mit einem Eimer

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1330,6 +1330,10 @@ protection:
       description: |-
         <green>Toggle whether fire can spread</green>
         <green>to nearby blocks or not.</green>
+    FISHING:
+      name: Fishing
+      description: Allow fishing with a fishing rod
+      hint: Fishing disabled
     FISH_SCOOPING:
       name: Fish Scooping
       description: Allow scooping of fishes using a bucket

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -1379,6 +1379,10 @@ protection:
       description: |-
         <green>Modificar si el fuego puede exparcirse</green>
         <green>a bloques cercanos o no.</green>
+    FISHING:
+      name: Pesca
+      description: Permitir pescar con una caña de pescar
+      hint: Pesca deshabilitada
     FISH_SCOOPING:
       name: Recolección de pescado
       description: Permitir Recolección de pescado usando un balde

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -1399,6 +1399,10 @@ protection:
       description: |-
         <green>Basculer si le feu peut se propager</green>
         <green>aux blocs voisins ou non.</green>
+    FISHING:
+      name: Pêche
+      description: Autoriser la pêche avec une canne à pêche
+      hint: Pêche désactivée
     FISH_SCOOPING:
       name: Pêche à la source
       description: Autoriser la capture de poissons avec un seau

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -1365,6 +1365,10 @@ protection:
       description: |-
         <green>Uključivanje/isključivanje može li se vatra proširiti</green>
         <green>u obližnje blokove ili ne.</green>
+    FISHING:
+      name: Pecanje
+      description: Omogućuje pecanje štapom za pecanje
+      hint: Pecanje onemogućeno
     FISH_SCOOPING:
       name: Grabljenje ribe
       description: Omogućuje vađenje ribe pomoću kante

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -1410,6 +1410,10 @@ protection:
       description: |-
         <green>Kapcsolja be, hogy a tűz továbbterjedhet-e</green>
         <green>a közeli blokkokra vagy sem.</green>
+    FISHING:
+      name: Horgászat
+      description: Engedélyezi a horgászbottal való horgászatot
+      hint: Horgászat letiltva
     FISH_SCOOPING:
       name: Hal befogás vödörrel
       description: Engedje meg a halak vödörrel való befogását

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -1383,6 +1383,10 @@ protection:
       description: |-
         <green>Beralih apakah api dapat menyebar</green>
         <green>ke blok terdekat atau tidak.</green>
+    FISHING:
+      name: Memancing
+      description: Izinkan memancing menggunakan pancing
+      hint: Memancing dinonaktifkan
     FISH_SCOOPING:
       name: Menyendoki Ikan
       description: Biarkan menyendok ikan menggunakan ember

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -1387,6 +1387,10 @@ protection:
       description: |-
         <green>Scegli se il fuoco può espandersi</green>
         <green>ai blocchi vicini oppure no.</green>
+    FISHING:
+      name: Pesca
+      description: Permetti la pesca con una canna da pesca
+      hint: Pesca disabilitata
     FISH_SCOOPING:
       name: Raccolta di pesci
       description: Permetti la raccolta dei pesci utilizzando un secchio

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -1259,6 +1259,10 @@ protection:
     FIRE_SPREAD:
       name: 延焼
       description: 火の広がりをトグル
+    FISHING:
+      name: 釣り
+      description: 釣り竿での釣りを許可
+      hint: 釣り無効
     FISH_SCOOPING:
       name: 魚すくい
       description: バケツを使用して魚をすくい取る

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -1286,6 +1286,10 @@ protection:
       description: |-
         <green>불이 가까운 블럭으로</green>
         <green>번질것인지 설정.</green>
+    FISHING:
+      name: 낚시
+      description: 낚싯대로 낚시하는 것을 허용합니다
+      hint: 낚시 비활성화
     FISH_SCOOPING:
       name: 물고기 양동이
       description: 양동이를 사용하여 물고기를 떠 다닐 수 있습니다

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -1364,6 +1364,10 @@ protection:
         <green>Pārslēdz vai uguns var</green>
         <green>izplatīties uz blakusesošajiem</green>
         <green>blokiem.</green>
+    FISHING:
+      name: Makšķerēšana
+      description: Atļauj makšķerēšanu ar makšķeri
+      hint: Makšķerēšana nav atļauta
     FISH_SCOOPING:
       name: Zivju iesmelšana
       description: Pārslēdz iespēju zivis iesmelt spaiņos

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -1410,6 +1410,10 @@ protection:
       description: |-
         <green>Omschakelen of vuur zich kan verspreiden</green>
         <green>naar nabijgelegen blokken of niet.</green>
+    FISHING:
+      name: Vissen
+      description: Sta vissen met een hengel toe
+      hint: Vissen is uitgeschakeld
     FISH_SCOOPING:
       name: Vis scheppen
       description: Sta het scheppen van vissen toe met een emmer

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -1359,6 +1359,10 @@ protection:
     FIRE_SPREAD:
       name: Rozprzestrzenianie ognia
       description: Przełącz rozprzestrzenianie
+    FISHING:
+      name: Wędkowanie
+      description: Zezwól na wędkowanie za pomocą wędki
+      hint: Wędkowanie jest wyłączone
     FISH_SCOOPING:
       name: Zbieranie ryb wiadrem
       description: Zezwól na zbieranie ryb za pomocą wiadra

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -1369,6 +1369,10 @@ protection:
       description: |-
         <green>Alternar se o fogo pode espalhar</green>
         <green>para blocos próximos ou não.</green>
+    FISHING:
+      name: Pesca
+      description: Permitir a pesca com uma vara de pescar
+      hint: Pesca desabilitada
     FISH_SCOOPING:
       name: Coleta de peixes
       description: Permitir a coleta de peixes usando um balde

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -1381,6 +1381,10 @@ protection:
       description: |-
         <green>Alternar se o fogo pode se espalhar</green>
         <green>para blocos próximos ou não.</green>
+    FISHING:
+      name: Pesca
+      description: Permitir pescar com uma cana de pesca
+      hint: Pesca desativada
     FISH_SCOOPING:
       name: Escavação de peixe
       description: Permitir escavar peixes usando um balde

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -1395,6 +1395,10 @@ protection:
       description: |-
         <green>Comutați dacă focul se poate răspândi</green>
         <green>la blocurile din apropiere sau nu.</green>
+    FISHING:
+      name: Pescuit
+      description: Permiteți pescuitul cu o undiță
+      hint: Pescuitul este dezactivat
     FISH_SCOOPING:
       name: Scooping de pește
       description: Permiteți scoaterea peștilor folosind o găleată

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -1411,6 +1411,10 @@ protection:
       description: |-
         <green>Переключает распространение огня</green>
         <green>на близлежащие блоки</green>
+    FISHING:
+      name: Рыбалка
+      description: Разрешает рыбалку удочкой
+      hint: Рыбалка запрещена
     FISH_SCOOPING:
       name: Сбор рыбы
       description: Переключает сбор рыбы ведром

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -1324,6 +1324,10 @@ protection:
       description: |-
         <green>Ateşin yanındaki bloklara</green>
         <green>saçılmasını ayarlar.</green>
+    FISHING:
+      name: Balık tutma
+      description: Olta ile balık tutmaya izin ver
+      hint: Balık tutma kapalı
     FISH_SCOOPING:
       name: Kovayla balık tutma.
       description: Kovayla balık almasını değiş.

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -1289,6 +1289,10 @@ protection:
       description: |-
         <green>Перемикає, чи може вогонь</green>
         <green>поширюватися на сусідні блоки.</green>
+    FISHING:
+      name: Риболовля
+      description: Дозволити риболовлю вудкою
+      hint: Риболовлю вимкнено
     FISH_SCOOPING:
       name: Вилов риб
       description: Дозволити вилов риб відром

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -1353,6 +1353,10 @@ protection:
       description: |-
         <green>Bật/Tắt việc lửa có thể</green>
         <green>lan ra các khối bên cạnh.</green>
+    FISHING:
+      name: Câu cá
+      description: Cho phép câu cá bằng cần câu
+      hint: Đã tắt câu cá
     FISH_SCOOPING:
       name: Bắt cá
       description: Cho phép bắt cá bằng xô

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -1270,6 +1270,10 @@ protection:
     FIRE_SPREAD:
       name: '<aqua><bold>火势蔓延</bold></aqua>'
       description: '<green>允许</green><color:#FAFAD2>或</color:#FAFAD2><red>禁止</red><color:#FAFAD2>火势蔓延到附近的方块</color:#FAFAD2>'
+    FISHING:
+      name: '<aqua><bold>钓鱼</bold></aqua>'
+      description: '<green>允许</green><color:#FAFAD2>或</color:#FAFAD2><red>禁止</red><color:#FAFAD2>使用钓鱼竿钓鱼</color:#FAFAD2>'
+      hint: 禁止钓鱼
     FISH_SCOOPING:
       name: '<aqua><bold>捕捞鱼</bold></aqua>'
       description: '<green>允许</green><color:#FAFAD2>或</color:#FAFAD2><red>禁止</red><color:#FAFAD2>用水桶捕捞鱼</color:#FAFAD2>'

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -1273,6 +1273,10 @@ protection:
     FIRE_SPREAD:
       name: 火焰蔓延
       description: 切換火焰能否蔓延
+    FISHING:
+      name: '<green><bold>釣魚</bold></green>'
+      description: 允許/禁止 使用魚竿釣魚
+      hint: '<red>已被禁止釣魚</red>'
     FISH_SCOOPING:
       name: '<green><bold>捕魚</bold></green>'
       description: 允許/禁止 用水桶捕魚

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/FishingListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/FishingListenerTest.java
@@ -1,0 +1,113 @@
+package world.bentobox.bentobox.listeners.flags.protection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.entity.FishHook;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.bentobox.CommonTestSetup;
+
+/**
+ * @author tastybento
+ */
+class FishingListenerTest extends CommonTestSetup {
+
+    private FishingListener fl;
+    private FishHook hook;
+
+    /**
+     */
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        // Default is that everything is allowed
+        when(island.isAllowed(any(), any())).thenReturn(true);
+
+        hook = mock(FishHook.class);
+        when(hook.getLocation()).thenReturn(location);
+
+        // Listener
+        fl = new FishingListener();
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.FishingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
+     */
+    @Test
+    void testOnCastAllowed() {
+        PlayerFishEvent e = new PlayerFishEvent(mockPlayer, null, hook, PlayerFishEvent.State.FISHING);
+        fl.onFishing(e);
+        assertFalse(e.isCancelled());
+        verify(hook, never()).remove();
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.FishingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
+     */
+    @Test
+    void testOnCastNotAllowed() {
+        when(island.isAllowed(any(), any())).thenReturn(false);
+        PlayerFishEvent e = new PlayerFishEvent(mockPlayer, null, hook, PlayerFishEvent.State.FISHING);
+        fl.onFishing(e);
+        assertTrue(e.isCancelled());
+        verify(hook).remove();
+        verify(notifier).notify(any(), eq("protection.protected"));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.FishingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
+     */
+    @Test
+    void testOnCaughtFishAllowed() {
+        PlayerFishEvent e = new PlayerFishEvent(mockPlayer, null, hook, PlayerFishEvent.State.CAUGHT_FISH);
+        fl.onFishing(e);
+        assertFalse(e.isCancelled());
+        verify(hook, never()).remove();
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.flags.protection.FishingListener#onFishing(org.bukkit.event.player.PlayerFishEvent)}.
+     */
+    @Test
+    void testOnCaughtFishNotAllowed() {
+        when(island.isAllowed(any(), any())).thenReturn(false);
+        PlayerFishEvent e = new PlayerFishEvent(mockPlayer, null, hook, PlayerFishEvent.State.CAUGHT_FISH);
+        fl.onFishing(e);
+        assertTrue(e.isCancelled());
+        verify(hook).remove();
+        verify(notifier).notify(any(), eq("protection.protected"));
+    }
+
+    /**
+     * Reeling in with no catch should never be blocked, even when fishing is not allowed.
+     */
+    @Test
+    void testOnReelInNotAllowedIgnored() {
+        when(island.isAllowed(any(), any())).thenReturn(false);
+        PlayerFishEvent e = new PlayerFishEvent(mockPlayer, null, hook, PlayerFishEvent.State.REEL_IN);
+        fl.onFishing(e);
+        assertFalse(e.isCancelled());
+        verify(hook, never()).remove();
+        verify(notifier, never()).notify(any(), anyString());
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/managers/FlagsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/FlagsManagerTest.java
@@ -34,7 +34,7 @@ class FlagsManagerTest extends CommonTestSetup {
     /**
      * Update this value if the number of registered listeners changes
      */
-    private static final int NUMBER_OF_LISTENERS = 59;
+    private static final int NUMBER_OF_LISTENERS = 60;
 
     @Override
     @BeforeEach


### PR DESCRIPTION
## Summary
Adds a `FISHING` protection flag so admins and island owners can prevent fishing outside island boundaries, as requested in #1687 (needed for Boxed).

- New `FishingListener` handles `PlayerFishEvent` for the `FISHING` (cast) and `CAUGHT_FISH` states, checking the **hook's location** — so fishing into a protected area from outside is blocked, and a blocked cast removes the bobber.
- Hooking entities is intentionally not handled here; that remains covered by the hurting flags and PVP flags in `HurtingListener`/`PVPListener`.
- The flag defaults to visitor rank, so behavior on existing servers is unchanged until an admin or owner raises the required rank.
- Locale entry added to `en-US.yml`; unit tests added for allowed/blocked cast, allowed/blocked catch, and ignored states.

Fixes #1687

## Test plan
- `./gradlew test` — full suite passes (3,230 tests), including new `FishingListenerTest` and updated `FlagsManagerTest` listener count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSNDntyLgy2861v5QckCVR