### PR TITLE
Fix #1752: Item frames and paintings in blueprints

### DIFF
--- a/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntity.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntity.java
@@ -3,11 +3,13 @@ package world.bentobox.bentobox.blueprints.dataobjects;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bukkit.Art;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.Rotation;
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
@@ -22,11 +24,13 @@ import org.bukkit.entity.Display.Billboard;
 import org.bukkit.entity.Display.Brightness;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Hanging;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Horse.Style;
 import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.ItemDisplay.ItemDisplayTransform;
 import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Painting;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.entity.TextDisplay.TextAlignment;
@@ -167,7 +171,19 @@ public class BlueprintEntity {
      */
     @Expose
     private ItemFrameRec itemFrame;
-    
+    /**
+     * Facing direction for hanging entities (item frames, paintings)
+     * @since 3.18.1
+     */
+    @Expose
+    private BlockFace facing;
+    /**
+     * Painting art registry key, e.g. {@code minecraft:wanderer}
+     * @since 3.18.1
+     */
+    @Expose
+    private String paintingArt;
+
     /**
      * Serializes an entity to a Blueprint Entity
      * @param entity entity to serialize
@@ -211,6 +227,12 @@ public class BlueprintEntity {
         }
         if (entity instanceof ItemFrame frame) {
             this.setItemFrame(new ItemFrameRec(frame.getItem(), frame.getRotation(), frame.isFixed(), frame.isVisible(), frame.getItemDropChance()));
+        }
+        if (entity instanceof Hanging hanging) {
+            this.setFacing(hanging.getFacing());
+        }
+        if (entity instanceof Painting painting && painting.getArt() != null) {
+            this.setPaintingArt(painting.getArt().getKey().toString());
         }
     }
 
@@ -256,8 +278,16 @@ public class BlueprintEntity {
         e.setInvulnerable(isInvulnerable());
         e.setFireTicks(getFireTicks());
 
+        // Hanging entities (item frames, paintings) must face the way they were copied,
+        // otherwise they attach to an arbitrary face or pop off
+        if (facing != null && e instanceof Hanging hanging) {
+            hanging.setFacingDirection(facing, true);
+        }
         if (e instanceof ItemFrame frame) {
             setFrame(frame);
+        }
+        if (e instanceof Painting painting) {
+            setPainting(painting);
         }
         if (e instanceof Villager villager) {
             setVillager(villager);
@@ -303,10 +333,21 @@ public class BlueprintEntity {
             return;
         }
         frame.setItem(itemFrame.item());
-        frame.setVisible(itemFrame.isVisible);
-        frame.setFixed(frame.isFixed());
+        frame.setVisible(itemFrame.isVisible());
+        frame.setFixed(itemFrame.isFixed());
         frame.setRotation(itemFrame.rotation());
         frame.setItemDropChance(itemFrame.dropChance());
+    }
+
+    private void setPainting(Painting painting) {
+        if (paintingArt == null) {
+            return;
+        }
+        NamespacedKey key = NamespacedKey.fromString(paintingArt);
+        Art art = key == null ? null : Registry.ART.get(key);
+        if (art != null) {
+            painting.setArt(art, true);
+        }
     }
 
     /**
@@ -727,5 +768,36 @@ public class BlueprintEntity {
         this.itemFrame = itemFrame;
     }
 
+    /**
+     * @return the facing direction of a hanging entity, or null if not a hanging entity
+     * @since 3.18.1
+     */
+    public BlockFace getFacing() {
+        return facing;
+    }
+
+    /**
+     * @param facing the facing direction to set
+     * @since 3.18.1
+     */
+    public void setFacing(BlockFace facing) {
+        this.facing = facing;
+    }
+
+    /**
+     * @return the painting art registry key, or null if not a painting
+     * @since 3.18.1
+     */
+    public String getPaintingArt() {
+        return paintingArt;
+    }
+
+    /**
+     * @param paintingArt the painting art registry key to set
+     * @since 3.18.1
+     */
+    public void setPaintingArt(String paintingArt) {
+        this.paintingArt = paintingArt;
+    }
 
 }

--- a/src/main/java/world/bentobox/bentobox/util/DefaultPasteUtil.java
+++ b/src/main/java/world/bentobox/bentobox/util/DefaultPasteUtil.java
@@ -224,7 +224,15 @@ public class DefaultPasteUtil {
             // Nothing
             return false;
         }
-        Entity e = location.getWorld().spawnEntity(location, k.getType());
+        Entity e;
+        try {
+            e = location.getWorld().spawnEntity(location, k.getType());
+        } catch (IllegalArgumentException ex) {
+            // Hanging entities (item frames, paintings) cannot spawn without a block to attach to
+            plugin.logWarning("Could not paste entity " + k.getType() + " at "
+                    + Util.xyz(location.toVector()) + ": " + ex.getMessage());
+            return false;
+        }
         applyCustomName(e, k, island);
         k.configureEntity(e);
 

--- a/src/test/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntityTest.java
+++ b/src/test/java/world/bentobox/bentobox/blueprints/dataobjects/BlueprintEntityTest.java
@@ -5,24 +5,32 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bukkit.Art;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
+import org.bukkit.Rotation;
 import org.bukkit.World;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.ChestedHorse;
 import org.bukkit.entity.Cow;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Horse.Style;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Painting;
 import org.bukkit.entity.Sheep;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Villager.Profession;
@@ -58,6 +66,10 @@ class BlueprintEntityTest extends CommonTestSetup {
     private Display display;
     @Mock
     private World mockWorld;
+    @Mock
+    private ItemFrame itemFrame;
+    @Mock
+    private Painting painting;
 
     private BlueprintEntity blueprint;
 
@@ -85,6 +97,8 @@ class BlueprintEntityTest extends CommonTestSetup {
         when(horse.getStyle()).thenReturn(Horse.Style.WHITE_DOTS);
         when(horse.getLocation()).thenReturn(location);
         when(cow.getLocation()).thenReturn(location);
+        when(itemFrame.getLocation()).thenReturn(location);
+        when(painting.getLocation()).thenReturn(location);
 
         blueprint = new BlueprintEntity();
         when(display.getType()).thenReturn(EntityType.PLAYER);
@@ -285,6 +299,97 @@ class BlueprintEntityTest extends CommonTestSetup {
     void testFireTicks() {
         blueprint.setFireTicks(20);
         assertEquals(20, blueprint.getFireTicks());
+    }
+
+    @Test
+    void testSerializeItemFrame() {
+        ItemStack item = new ItemStack(Material.DIAMOND);
+        when(itemFrame.getType()).thenReturn(EntityType.ITEM_FRAME);
+        when(itemFrame.getItem()).thenReturn(item);
+        when(itemFrame.getRotation()).thenReturn(Rotation.CLOCKWISE);
+        when(itemFrame.isFixed()).thenReturn(true);
+        when(itemFrame.isVisible()).thenReturn(false);
+        when(itemFrame.getItemDropChance()).thenReturn(0.5F);
+        when(itemFrame.getFacing()).thenReturn(BlockFace.EAST);
+
+        BlueprintEntity localBlueprint = new BlueprintEntity(itemFrame);
+
+        assertEquals(BlockFace.EAST, localBlueprint.getFacing());
+        assertNotNull(localBlueprint.getItemFrame());
+        assertEquals(item, localBlueprint.getItemFrame().item());
+        assertEquals(Rotation.CLOCKWISE, localBlueprint.getItemFrame().rotation());
+        assertTrue(localBlueprint.getItemFrame().isFixed());
+        assertFalse(localBlueprint.getItemFrame().isVisible());
+        assertEquals(0.5F, localBlueprint.getItemFrame().dropChance());
+    }
+
+    @Test
+    void testConfigureEntityWithItemFrame() {
+        ItemStack item = new ItemStack(Material.DIAMOND);
+        BlueprintEntity localBlueprint = new BlueprintEntity();
+        localBlueprint.setType(EntityType.ITEM_FRAME);
+        localBlueprint.setFacing(BlockFace.SOUTH);
+        localBlueprint.setItemFrame(new BlueprintEntity.ItemFrameRec(item, Rotation.FLIPPED, true, false, 0.25F));
+
+        localBlueprint.configureEntity(itemFrame);
+
+        verify(itemFrame).setFacingDirection(BlockFace.SOUTH, true);
+        verify(itemFrame).setItem(item);
+        verify(itemFrame).setRotation(Rotation.FLIPPED);
+        verify(itemFrame).setFixed(true);
+        verify(itemFrame).setVisible(false);
+        verify(itemFrame).setItemDropChance(0.25F);
+    }
+
+    @Test
+    void testConfigureEntityWithItemFrameNoStoredData() {
+        BlueprintEntity localBlueprint = new BlueprintEntity();
+        localBlueprint.setType(EntityType.ITEM_FRAME);
+
+        localBlueprint.configureEntity(itemFrame);
+
+        // No facing or frame record stored (e.g. legacy blueprint) - nothing applied
+        verify(itemFrame, never()).setFacingDirection(any(), anyBoolean());
+        verify(itemFrame, never()).setItem(any());
+    }
+
+    @Test
+    void testSerializePainting() {
+        Art art = Registry.ART.get(NamespacedKey.minecraft("wanderer"));
+        assertNotNull(art);
+        when(painting.getType()).thenReturn(EntityType.PAINTING);
+        when(painting.getFacing()).thenReturn(BlockFace.NORTH);
+        when(painting.getArt()).thenReturn(art);
+
+        BlueprintEntity localBlueprint = new BlueprintEntity(painting);
+
+        assertEquals(BlockFace.NORTH, localBlueprint.getFacing());
+        assertEquals("minecraft:wanderer", localBlueprint.getPaintingArt());
+    }
+
+    @Test
+    void testConfigureEntityWithPainting() {
+        Art art = Registry.ART.get(NamespacedKey.minecraft("wanderer"));
+        BlueprintEntity localBlueprint = new BlueprintEntity();
+        localBlueprint.setType(EntityType.PAINTING);
+        localBlueprint.setFacing(BlockFace.WEST);
+        localBlueprint.setPaintingArt("minecraft:wanderer");
+
+        localBlueprint.configureEntity(painting);
+
+        verify(painting).setFacingDirection(BlockFace.WEST, true);
+        verify(painting).setArt(art, true);
+    }
+
+    @Test
+    void testConfigureEntityWithPaintingUnknownArt() {
+        BlueprintEntity localBlueprint = new BlueprintEntity();
+        localBlueprint.setType(EntityType.PAINTING);
+        localBlueprint.setPaintingArt("minecraft:does_not_exist");
+
+        localBlueprint.configureEntity(painting);
+
+        verify(painting, never()).setArt(any(), anyBoolean());
     }
 
     @Test

--- a/src/test/java/world/bentobox/bentobox/util/DefaultPasteUtilTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/DefaultPasteUtilTest.java
@@ -429,6 +429,22 @@ class DefaultPasteUtilTest extends CommonTestSetup {
     }
 
     @Test
+    void testSpawnBlueprintEntitySpawnFailureLogsWarningAndReturnsFalse() {
+        // Hanging entities (item frames, paintings) throw IllegalArgumentException when they
+        // have nothing to attach to - this must not propagate and kill the rest of the batch
+        when(blueprintEntity.getType()).thenReturn(EntityType.ITEM_FRAME);
+        when(world.spawnEntity(any(), any(EntityType.class)))
+                .thenThrow(new IllegalArgumentException("Cannot spawn hanging entity"));
+        mockedUtil.when(() -> Util.xyz(any())).thenReturn("1,2,3");
+
+        boolean result = DefaultPasteUtil.spawnBlueprintEntity(blueprintEntity, location, island);
+
+        assertFalse(result);
+        verify(plugin).logWarning(anyString());
+        verify(blueprintEntity, never()).configureEntity(any());
+    }
+
+    @Test
     void testSpawnBlueprintEntityNoHooksForMythicMobsFallsThrough() {
         // getMythicMobsRecord is non-null but MythicMobs hook is absent → Bukkit spawn
         BlueprintEntity.MythicMobRecord mythicMobRecord =


### PR DESCRIPTION
Fixes #1752

## Problem

Item frames survived the blueprint **copy** since 3.2.6 (`ItemFrameRec`), but the round trip was still broken:

1. **Facing direction was never stored.** On paste, `spawnEntity` picks an arbitrary surviving face for hanging entities, so frames ended up facing the wrong way or popping off.
2. **Self-assignment bug** in `BlueprintEntity.setFrame()`: `frame.setFixed(frame.isFixed())` meant the stored `isFixed` value was never applied.
3. **Paintings** lost both their facing and their artwork entirely.
4. A hanging entity with nothing to attach to threw `IllegalArgumentException` out of `spawnBlueprintEntity`, silently dropping the remaining entities for that block.

## Changes

- `BlueprintEntity`: store `BlockFace facing` for any `Hanging` entity and re-apply it with `setFacingDirection(facing, true)` on paste, before the frame/painting contents are set.
- `BlueprintEntity`: store the painting `Art` registry key (`paintingArt`) and restore it via `Registry.ART` with force. Unknown keys (blueprint from a newer server) are skipped safely.
- Fix the `setFixed` self-assignment.
- `DefaultPasteUtil.spawnBlueprintEntity`: catch `IllegalArgumentException` from the spawn, log a warning with the entity type and location, and continue with the rest of the batch.

Both new blueprint fields are nullable `@Expose` additions — existing blueprint files load unchanged.

## Tests

- `BlueprintEntityTest`: item frame serialization round trip, `configureEntity` applies facing/item/rotation/**fixed** (regression), legacy-blueprint no-op path, painting art round trip, unknown-art safety.
- `DefaultPasteUtilTest`: spawn failure logs a warning, returns false, and does not propagate.

Full `./gradlew build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLucPKxSBbG96WMVTFTuqB