### PR TITLE
Make team_panel button icons configurable via the template (#3008)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
@@ -136,7 +136,7 @@ public class IslandTeamGUI {
             return this.getBlankBorder();
         }
         PanelItemBuilder builder = new PanelItemBuilder();
-        builder.icon(Material.PLAYER_HEAD);
+        applyIcon(builder, template, Material.PLAYER_HEAD);
         builder.name(user.getTranslation("commands.island.team.gui.buttons.invite.name"));
         builder.description(user.getTranslation("commands.island.team.gui.buttons.invite.description"));
         builder.clickHandler((panel, user, clickType, clickSlot) -> {
@@ -160,7 +160,7 @@ public class IslandTeamGUI {
         }
         PanelItemBuilder builder = new PanelItemBuilder();
         builder.name(user.getTranslation("commands.island.team.gui.buttons.rank-filter.name"));
-        builder.icon(Material.AMETHYST_SHARD);
+        applyIcon(builder, template, Material.AMETHYST_SHARD);
         // Create description
         createDescription(builder);
         createClickHandler(builder, template.actions());
@@ -333,8 +333,27 @@ public class IslandTeamGUI {
             return getBlankBorder();
         }
 
-        return builder.icon(user.getName()).name(user.getTranslation("commands.island.team.gui.buttons.status.name"))
+        // Use the template icon if the admin has set one, otherwise show the viewer's head.
+        if (template.icon() != null) {
+            builder.icon(template.icon().clone());
+        } else {
+            builder.icon(user.getName());
+        }
+        return builder.name(user.getTranslation("commands.island.team.gui.buttons.status.name"))
                 .description(showMembers()).build();
+    }
+
+    /**
+     * Applies the icon for a button. If the panel template defines an {@code icon:}
+     * for this button it is used (allowing server admins to customise it via
+     * {@code team_panel.yml}); otherwise the supplied default material is used.
+     *
+     * @param builder  the panel item builder
+     * @param template the template record for this button
+     * @param fallback the default material to use when the template has no icon
+     */
+    private void applyIcon(PanelItemBuilder builder, ItemTemplateRecord template, Material fallback) {
+        builder.icon(template.icon() != null ? template.icon().clone() : new ItemStack(fallback));
     }
 
     private PanelItem getBlankBorder() {

--- a/src/main/resources/panels/team_panel.yml
+++ b/src/main/resources/panels/team_panel.yml
@@ -27,8 +27,9 @@ team_panel:
         # The data section is a key-value list of data relavent for this button. It is interpreted by the code implemented the panel.
         # The convention is to specify the type and the panel tab that will open if pressed. These are Enums in the code.
         # Icon shown for this button. If omitted, the viewer's own player head is used.
-        # Set this to any material (e.g. PAPER, BOOK) to override it.
-        #icon: PLAYER_HEAD
+        # Set this to any material (e.g. PAPER, BOOK) to override it. Note: a
+        # material here replaces the viewer head with a plain, unowned icon.
+        #icon: PAPER
         data:
           type: STATUS
         # Actions cover what happens if the button is clicked or the mouse is moved over it. There can be multiple actions possible for different

--- a/src/main/resources/panels/team_panel.yml
+++ b/src/main/resources/panels/team_panel.yml
@@ -26,6 +26,9 @@ team_panel:
       1:
         # The data section is a key-value list of data relavent for this button. It is interpreted by the code implemented the panel.
         # The convention is to specify the type and the panel tab that will open if pressed. These are Enums in the code.
+        # Icon shown for this button. If omitted, the viewer's own player head is used.
+        # Set this to any material (e.g. PAPER, BOOK) to override it.
+        #icon: PLAYER_HEAD
         data:
           type: STATUS
         # Actions cover what happens if the button is clicked or the mouse is moved over it. There can be multiple actions possible for different
@@ -39,6 +42,9 @@ team_panel:
             tooltip: commands.island.team.gui.tips.click-to-view
       3:
         # Rank filter
+        # Icon shown for this button. If omitted, AMETHYST_SHARD is used.
+        # Set this to any material (e.g. HOPPER) to override it.
+        icon: AMETHYST_SHARD
         data:
           type: RANK
           name: commands.island.team.gui.buttons.rank-filter
@@ -63,6 +69,9 @@ team_panel:
             tooltip: commands.island.team.gui.tips.SHIFT_RIGHT.reject
       7:
         # Invite button
+        # Icon shown for this button. If omitted, PLAYER_HEAD is used.
+        # Set this to any material to override it.
+        icon: PLAYER_HEAD
         data:
           type: INVITE
           name: commands.island.team.gui.buttons.invite

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUITest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUITest.java
@@ -99,9 +99,8 @@ class IslandTeamGUITest extends RanksManagerTestSetup {
 
     private void copyPanelYaml(String resource, File dest) throws IOException {
         try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
-            if (in != null) {
-                Files.copy(in, dest.toPath());
-            }
+            assertNotNull(in, "Missing test fixture on the classpath: " + resource);
+            Files.copy(in, dest.toPath());
         }
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUITest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUITest.java
@@ -1,0 +1,145 @@
+package world.bentobox.bentobox.api.commands.island.team;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.google.common.collect.ImmutableSet;
+
+import world.bentobox.bentobox.RanksManagerTestSetup;
+import world.bentobox.bentobox.api.panels.Panel;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.reader.TemplateReader;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.listeners.PanelListenerManager;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * Tests for {@link IslandTeamGUI}, focused on the icons being sourced from the
+ * panel template (team_panel.yml) rather than hardcoded. See issue #3008.
+ *
+ * <p>Panel slot layout derived from team_panel.yml:
+ * <pre>
+ *   Row 0 (nav):  slot 0=STATUS, slot 2=RANK filter, slot 4=INVITED, slot 6=INVITE
+ * </pre>
+ */
+class IslandTeamGUITest extends RanksManagerTestSetup {
+
+    private static final int SLOT_RANK = 2;
+
+    @Mock
+    private IslandTeamCommand itc;
+    @Mock
+    private IslandTeamInviteCommand itic;
+
+    private User user;
+    private File dataFolder;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        dataFolder = new File("test-team-gui-" + uuid);
+        new File(dataFolder, "panels").mkdirs();
+        copyPanelYaml("panels/team_panel.yml", new File(dataFolder, "panels/team_panel.yml"));
+        when(plugin.getDataFolder()).thenReturn(dataFolder);
+
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+
+        // Make createItemStack throw so ItemParser.parse() falls through to parseOld(),
+        // which resolves plain material names (e.g. AMETHYST_SHARD, HOPPER) via Material.valueOf.
+        when(itemFactory.createItemStack(anyString())).thenThrow(new IllegalArgumentException("test"));
+
+        when(itc.getPlugin()).thenReturn(plugin);
+        when(itc.getWorld()).thenReturn(world);
+        when(itc.getLabel()).thenReturn("team");
+        when(itc.getInviteCommand()).thenReturn(itic);
+        when(itic.getPermission()).thenReturn("island.team.invite");
+
+        // Island with no members so the member/status buttons resolve to blanks without NPE
+        when(im.getPrimaryIsland(world, uuid)).thenReturn(island);
+        when(island.getMemberSet()).thenReturn(ImmutableSet.of());
+        when(island.getMemberSet(anyInt())).thenReturn(ImmutableSet.of());
+        when(island.getMemberSet(anyInt(), anyBoolean())).thenReturn(ImmutableSet.of());
+        when(island.getRank(any(User.class))).thenReturn(OWNER_RANK);
+        when(im.getMaxMembers(any(), anyInt())).thenReturn(4);
+
+        user = User.getInstance(mockPlayer);
+
+        TemplateReader.clearPanels();
+        PanelListenerManager.getOpenPanels().clear();
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        deleteAll(dataFolder);
+        TemplateReader.clearPanels();
+        PanelListenerManager.getOpenPanels().clear();
+    }
+
+    private void copyPanelYaml(String resource, File dest) throws IOException {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
+            if (in != null) {
+                Files.copy(in, dest.toPath());
+            }
+        }
+    }
+
+    /**
+     * The shipped template sets the rank filter icon to AMETHYST_SHARD, so the
+     * built button must use that material rather than an internally hardcoded one.
+     */
+    @Test
+    void testRankFilterIcon_comesFromTemplate() {
+        new IslandTeamGUI(plugin, itc, user, island).build();
+
+        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
+        assertNotNull(panel);
+        PanelItem item = panel.getItems().get(SLOT_RANK);
+        assertNotNull(item, "Expected rank filter button at slot " + SLOT_RANK);
+        assertEquals(Material.AMETHYST_SHARD, item.getItem().getType());
+    }
+
+    /**
+     * When an admin overrides the rank filter icon in team_panel.yml (e.g. to a
+     * HOPPER), the override must be honoured rather than ignored. This is the
+     * core of issue #3008.
+     */
+    @Test
+    void testRankFilterIcon_templateOverrideIsRespected() throws IOException {
+        // Rewrite the panel's rank filter icon to HOPPER
+        File panelFile = new File(dataFolder, "panels/team_panel.yml");
+        String yaml = Files.readString(panelFile.toPath()).replace("icon: AMETHYST_SHARD", "icon: HOPPER");
+        Files.writeString(panelFile.toPath(), yaml);
+        TemplateReader.clearPanels();
+
+        new IslandTeamGUI(plugin, itc, user, island).build();
+
+        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
+        assertNotNull(panel);
+        PanelItem item = panel.getItems().get(SLOT_RANK);
+        assertNotNull(item, "Expected rank filter button at slot " + SLOT_RANK);
+        assertEquals(Material.HOPPER, item.getItem().getType(),
+                "Rank filter icon should come from the template, allowing admin override");
+    }
+}


### PR DESCRIPTION
## What

Makes the team management panel (`team_panel.yml`) button icons configurable, fixing #3008.

The **STATUS**, **RANK filter** and **INVITE** buttons in `IslandTeamGUI` hardcoded their icons (`AMETHYST_SHARD`, `PLAYER_HEAD`, viewer head) and ignored any `icon:` set in the template, so admins could not customise them — e.g. changing the rank filter to a `HOPPER` had no effect.

## Changes

- Added an `applyIcon()` helper that uses the template's `icon:` when present and falls back to the previous hardcoded material otherwise.
- Rank filter and invite buttons now honour the template icon.
- Status button honours a template icon if set, otherwise keeps the viewer's player head.
- Exposed the icons in the shipped `team_panel.yml` with explanatory comments so they are discoverable.
- Added `IslandTeamGUITest` covering the default icon and an admin override (`HOPPER`).

## Compatibility

Backwards compatible — existing installs keep the same icons (shipped template values match the old hardcoded ones, and the fallback preserves behaviour when no icon is set). Player-head buttons that are inherently per-player (member heads) are unchanged.

Fixes #3008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLucPKxSBbG96WMVTFTuqB
