### PR TITLE
Add customisable member/prospect name & description locale keys (#3009)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
@@ -67,6 +67,10 @@ public class IslandTeamGUI {
 
     private static final String NAME = ".name";
     private static final String TIPS = "commands.island.team.gui.tips.";
+    /** Locale key for the (customisable) member button name. Placeholders: [name], [display_name]. */
+    private static final String MEMBER_NAME_REF = "commands.island.team.gui.buttons.member.name";
+    /** Locale key for the (customisable) member button rank line. Placeholder: [rank]. */
+    private static final String MEMBER_DESC_REF = "commands.island.team.gui.buttons.member.description";
 
     /** The user viewing the GUI */
     private final User user;
@@ -406,15 +410,18 @@ public class IslandTeamGUI {
                             + " " + user.getTranslation(ar.tooltip()))
                     .findFirst().ifPresent(desc::add);
         }
+        // Rank line, styled through a customisable locale key ([rank] placeholder), shown first
+        desc.addFirst(user.getTranslation(MEMBER_DESC_REF, TextVariables.RANK, user.getTranslation(rankRef)));
         if (member.isOnline()) {
-            desc.addFirst(user.getTranslation(rankRef));
-            return new PanelItemBuilder().icon(member.getName()).name(member.getDisplayName()).description(desc)
+            return new PanelItemBuilder().icon(member.getName())
+                    .name(user.getTranslation(MEMBER_NAME_REF, TextVariables.NAME, member.getName(), "[display_name]",
+                            member.getDisplayName()))
+                    .description(desc)
                     .clickHandler(
                             (panel, user, clickType, i) -> clickListener(panel, user, clickType, i, member, actions))
                     .build();
         } else {
-            // Offline player
-            desc.addFirst(user.getTranslation(rankRef));
+            // Offline player: the name keeps its last-seen status (see the member-layout locale keys)
             return new PanelItemBuilder().icon(member.getName())
                     .name(offlinePlayerStatus(Bukkit.getOfflinePlayer(member.getUniqueId()))).description(desc)
                     .clickHandler(

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
@@ -410,12 +410,14 @@ public class IslandTeamGUI {
                             + " " + user.getTranslation(ar.tooltip()))
                     .findFirst().ifPresent(desc::add);
         }
-        // Rank line, styled through a customisable locale key ([rank] placeholder), shown first
-        desc.addFirst(user.getTranslation(MEMBER_DESC_REF, TextVariables.RANK, user.getTranslation(rankRef)));
+        // Rank line, styled through a customisable locale key ([rank] placeholder), shown first.
+        // Fall back to the raw rank name if the key is absent (e.g. an older custom locale file).
+        String rankName = user.getTranslation(rankRef);
+        desc.addFirst(translateOr(MEMBER_DESC_REF, rankName, TextVariables.RANK, rankName));
         if (member.isOnline()) {
             return new PanelItemBuilder().icon(member.getName())
-                    .name(user.getTranslation(MEMBER_NAME_REF, TextVariables.NAME, member.getName(), "[display_name]",
-                            member.getDisplayName()))
+                    .name(translateOr(MEMBER_NAME_REF, member.getDisplayName(), TextVariables.NAME, member.getName(),
+                            TextVariables.DISPLAY_NAME, member.getDisplayName()))
                     .description(desc)
                     .clickHandler(
                             (panel, user, clickType, i) -> clickListener(panel, user, clickType, i, member, actions))
@@ -428,6 +430,22 @@ public class IslandTeamGUI {
                             (panel, user, clickType, i) -> clickListener(panel, user, clickType, i, member, actions))
                     .build();
         }
+    }
+
+    /**
+     * Translates {@code reference}, falling back to {@code fallback} when the key is
+     * missing from the locale. {@link User#getTranslation} echoes the reference back
+     * when a key is absent, so an older or customised locale file that lacks the new
+     * keys would otherwise show the raw key string in the GUI.
+     *
+     * @param reference the locale key
+     * @param fallback  value to use when the key is missing
+     * @param variables placeholder replacement pairs
+     * @return the translated (and substituted) string, or the fallback
+     */
+    private String translateOr(String reference, String fallback, String... variables) {
+        String translation = user.getTranslation(reference, variables);
+        return translation.equals(reference) ? fallback : translation;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUI.java
@@ -203,9 +203,13 @@ public class IslandTeamInviteGUI {
     }
 
     private PanelItem getProspect(Player player, ItemTemplateRecord template) {
-        // Customisable prospect name ([name] / [display_name] placeholders; defaults to the display name)
-        String name = user.getTranslation(PROSPECT_NAME_REF, TextVariables.NAME, player.getName(), "[display_name]",
-                player.getDisplayName());
+        // Customisable prospect name ([name] / [display_name] placeholders; defaults to the display name).
+        // getTranslation echoes the reference back when the key is missing, so fall back to the display name.
+        String name = user.getTranslation(PROSPECT_NAME_REF, TextVariables.NAME, player.getName(),
+                TextVariables.DISPLAY_NAME, player.getDisplayName());
+        if (name.equals(PROSPECT_NAME_REF)) {
+            name = player.getDisplayName();
+        }
         // Check if the prospect has already been invited
         if (this.itc.isInvited(player.getUniqueId())
                 && user.getUniqueId().equals(this.itc.getInvite(player.getUniqueId()).getInviter())) {
@@ -213,9 +217,10 @@ public class IslandTeamInviteGUI {
                     .description(user.getTranslation("commands.island.team.invite.gui.button.already-invited")).build();
         }
         List<String> desc = new ArrayList<>();
-        // Optional customisable description line, shown before the action tips when set (blank by default)
+        // Optional customisable description line, shown before the action tips when set (blank by default,
+        // and skipped when the key is missing so an older locale file does not leak the raw key).
         String descLine = user.getTranslation(PROSPECT_DESC_REF, TextVariables.NAME, player.getName(),
-                "[display_name]", player.getDisplayName());
+                TextVariables.DISPLAY_NAME, player.getDisplayName());
         if (!descLine.isBlank() && !descLine.equals(PROSPECT_DESC_REF)) {
             desc.add(descLine);
         }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUI.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.api.commands.island.team;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -32,6 +33,11 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 
 public class IslandTeamInviteGUI {
+
+    /** Locale key for the (customisable) prospect button name. Placeholders: [name], [display_name]. */
+    private static final String PROSPECT_NAME_REF = "commands.island.team.invite.gui.buttons.member.name";
+    /** Locale key for an optional (customisable) prospect description line. Placeholders: [name], [display_name]. */
+    private static final String PROSPECT_DESC_REF = "commands.island.team.invite.gui.buttons.member.description";
 
     private final IslandTeamInviteCommand itic;
     private final IslandTeamCommand itc;
@@ -197,16 +203,26 @@ public class IslandTeamInviteGUI {
     }
 
     private PanelItem getProspect(Player player, ItemTemplateRecord template) {
+        // Customisable prospect name ([name] / [display_name] placeholders; defaults to the display name)
+        String name = user.getTranslation(PROSPECT_NAME_REF, TextVariables.NAME, player.getName(), "[display_name]",
+                player.getDisplayName());
         // Check if the prospect has already been invited
         if (this.itc.isInvited(player.getUniqueId())
                 && user.getUniqueId().equals(this.itc.getInvite(player.getUniqueId()).getInviter())) {
-            return new PanelItemBuilder().icon(player.getName()).name(player.getDisplayName())
+            return new PanelItemBuilder().icon(player.getName()).name(name)
                     .description(user.getTranslation("commands.island.team.invite.gui.button.already-invited")).build();
         }
-        List<String> desc = template.actions().stream().map(ar -> user
+        List<String> desc = new ArrayList<>();
+        // Optional customisable description line, shown before the action tips when set (blank by default)
+        String descLine = user.getTranslation(PROSPECT_DESC_REF, TextVariables.NAME, player.getName(),
+                "[display_name]", player.getDisplayName());
+        if (!descLine.isBlank() && !descLine.equals(PROSPECT_DESC_REF)) {
+            desc.add(descLine);
+        }
+        template.actions().stream().map(ar -> user
                 .getTranslation("commands.island.team.invite.gui.tips." + ar.clickType().name() + ".name")
-                + " " + user.getTranslation(ar.tooltip())).toList();
-        return new PanelItemBuilder().icon(player.getName()).name(player.getDisplayName()).description(desc)
+                + " " + user.getTranslation(ar.tooltip())).forEach(desc::add);
+        return new PanelItemBuilder().icon(player.getName()).name(name).description(desc)
                 .clickHandler(
                         (panel, user, clickType, clickSlot) -> clickHandler(user, clickType, player,
                                 template.actions()))

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -796,6 +796,11 @@ commands:
               <green>Hráči musí být ve</green>
               <green>stejném světě jako ty,</green>
               <green>aby se zobrazili v seznamu.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Levý klik</aqua>'
@@ -901,6 +906,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift + levý klik</aqua>'
               trust: '<green>důvěřovat hráči</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Nemůžeš pozvat sám sebe!</red>'
           cooldown: '<red>Tohoto hráče nemůžeš pozvat dalších [number] sekund</red>'

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -847,6 +847,11 @@ commands:
               <green>Spieler müssen sich in</green>
               <green>deiner Welt befinden, um</green>
               <green>in der Liste angezeigt zu werden.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Linksklick</aqua>'
@@ -962,6 +967,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Umschalttaste Linksklick</aqua>'
               trust: '<green>einem Spieler vertrauen</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Du kannst dich nicht selbst einladen!</red>'
           cooldown: >-

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -763,6 +763,11 @@ commands:
               <green>Players must be in the</green>
               <green>same world as you to be</green>
               <green>shown in the list.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Left Click</aqua>'
@@ -862,6 +867,12 @@ commands:
             searching: |
               <aqua>Searching for</aqua>
               <red>[name]</red>
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
           enter-name: '<green>Enter name:</green>'
           tips:
             LEFT:

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -830,6 +830,11 @@ commands:
               <green>Los jugadores deben estar en el</green>
               <green>mismo mundo que tú para ser</green>
               <green>mostrados en la lista.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Clic Izquierdo</aqua>'
@@ -939,6 +944,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift Clic Izquierdo</aqua>'
               trust: '<green>para confiar en un jugador</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>No puedes invitarte!</red>'
           cooldown: '<red>No puedes invitar a esa persona por otros [number] segundos</red>'

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -853,6 +853,11 @@ commands:
               <green>Les joueurs doivent être dans le</green>
               <green>même monde que vous pour être</green>
               <green>affichés dans la liste.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Clic Gauche</aqua>'
@@ -958,6 +963,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift Clic Gauche</aqua>'
               trust: '<green>pour faire confiance à un joueur</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Vous ne pouvez pas vous inviter vous-même !</red>'
           cooldown: >-

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -806,6 +806,11 @@ commands:
               <green>Igrači moraju biti u</green>
               <green>istom svetu kao i vi da bi</green>
               <green>se prikazivali na listi.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Lijevi Klip</aqua>'
@@ -915,6 +920,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Pomakni lijevu tipku miša</aqua>'
               trust: '<green>za povjerenje igraču</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Ne možete pozvati sami sebe!</red>'
           cooldown: '<red>Ne možete pozvati tu osobu još [number] sekundi.</red>'

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -850,6 +850,11 @@ commands:
               hogy
 
               <green>megjelenjenek a listában.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Bal Kattintás</aqua>'
@@ -959,6 +964,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Balra átugrás kattintás</aqua>'
               trust: '<green>egy játékos megbízásához</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Nem hívhatod meg magad!</red>'
           cooldown: '<red>Nem hívhatja meg ezt a személyt további [number] másodpercig.</red>'

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -819,6 +819,11 @@ commands:
               <green>Pemain harus berada di</green>
               <green>dunia yang sama dengan Anda</green>
               <green>untuk ditampilkan di daftar.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Klik Kiri</aqua>'
@@ -928,6 +933,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Tekan Kiri Sambil Menahan Shift</aqua>'
               trust: '<green>untuk mempercayai pemain</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Anda tidak dapat mengundang diri sendiri!</red>'
           cooldown: >-

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -844,6 +844,11 @@ commands:
               <green>I giocatori devono essere nel</green>
               <green>stesso mondo di te per essere</green>
               <green>mostrati nella lista.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Clic Sinistro</aqua>'
@@ -949,6 +954,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Clicca sinistro mentre tieni premuto Shift</aqua>'
               trust: '<green>per fidarti di un giocatore</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Non puoi invitare te stesso!</red>'
           cooldown: '<red>Non potrai invitare quella persona per altri [number] secondi</red>'

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -735,6 +735,11 @@ commands:
               <green>プレイヤーはにいる必要があります</green>
               <green>あなたと同じ世界</green>
               <green>リストに示されています。</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>左クリック</aqua>'
@@ -836,6 +841,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>左クリックをシフトします</aqua>'
               trust: '<green>プレーヤーを信頼するために</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: 自分から誘うことはできない!
           cooldown: その人を別の [number]秒に招待することはできません

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -751,6 +751,11 @@ commands:
               <green>플레이어는 당신과 같은</green>
               <green>세상에 있어야</green>
               <green>목록에 표시됩니다.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>왼쪽 클릭</aqua>'
@@ -854,6 +859,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>왼쪽 Shift 클릭</aqua>'
               trust: '<green>플레이어를 신뢰하려면 [ ]를 입력하세요.</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>자기 자신을 초대할순 없습니다!</red>'
           cooldown: '<red>사람을 다시 초대하려면 [number] 초를 기다려야합니다</red>'

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -811,6 +811,11 @@ commands:
               <green>Spēlētājiem jābūt tajā</green>
               <green>pašā pasaulē kā jums, lai tiktu</green>
               <green>parādīti sarakstā.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Kreiso klikšķi</aqua>'
@@ -916,6 +921,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Nospiediet kreiso peli, turot uz sānu</aqua>'
               trust: '<green>, lai uzticētu spēlētāju</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Tu nevari ielūgt pats sevi!</red>'
           cooldown: '<red>Tu nevari sūtīt ielūgumu šim spēlētājam vēl [number] sekundes</red>'

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -849,6 +849,11 @@ commands:
               <green>Spelers moeten zich in de</green>
               <green>dezelfde wereld als jij bevinden</green>
               <green>om in de lijst te worden weergegeven.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Linker Klik</aqua>'
@@ -958,6 +963,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift Links Klikken</aqua>'
               trust: '<green>om een speler te vertrouwen</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Je kunt jezelf niet uitnodigen!</red>'
           cooldown: >-

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -820,6 +820,11 @@ commands:
               <green>Gracze muszą być w tej samej</green>
               <green>rzeczywistości co ty, aby</green>
               <green>być wyświetleni na liście.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Lewy Klik</aqua>'
@@ -925,6 +930,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Przesuń lewy przycisk myszy</aqua>'
               trust: '<green>, aby ufać graczowi</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Nie możesz zaprosić samego siebie!</red>'
           cooldown: '<red>Nie możesz zaprosić tej osoby przez [number] sekund.</red>'

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -814,6 +814,11 @@ commands:
               <green>Os jogadores devem estar no</green>
               <green>mesmo mundo que você para</green>
               <green>serem mostrados na lista.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Clique Esquerdo</aqua>'
@@ -921,6 +926,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift Clique Esquerdo</aqua>'
               trust: '<green>para confiar em um jogador</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Você não pode convidar a si mesmo!</red>'
           cooldown: >-

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -821,6 +821,11 @@ commands:
               <green>Os jogadores devem estar no</green>
               <green>mesmo mundo que você para</green>
               <green>serem mostrados na lista.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Clique Esquerdo</aqua>'
@@ -930,6 +935,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift Clique Esquerdo</aqua>'
               trust: '<green>para confiar em um jogador</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Você não pode se convidar!</red>'
           cooldown: '<red>Você não pode convidar essa pessoa por mais [number] segundos.</red>'

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -831,6 +831,11 @@ commands:
               <green>Jucătorii trebuie să fie în</green>
               și aceeași lume ca și tine să fii
               <green>arătat în listă.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Faceți clic stânga</aqua>'
@@ -946,6 +951,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift Click stânga</aqua>'
               trust: '<green>a avea încredere într-un jucător</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Nu vă puteți invita!</red>'
           cooldown: '<red>Nu puteți invita acea persoană pentru încă [number] de secunde.</red>'

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -802,6 +802,11 @@ commands:
               <green>Игроки должны находиться в</green>
               <green>том же мире, что и вы, чтобы</green>
               <green>отображаться в списке.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: <aqua>ЛКМ</aqua>
@@ -912,6 +917,12 @@ commands:
             SHIFT_LEFT:
               name: <aqua>Shift + ЛКМ</aqua>
               trust: <green>доверять игроку</green>
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: <red>Вы не можете пригласить самого себя!</red>
           cooldown: <red>Вы не можете пригласить этого игрока в течение [number] секунд.</red>

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -797,6 +797,11 @@ commands:
               <green>Oyuncuların listede gösterilebilmesi için</green>
               <green>seninle aynı dünyada olmaları</green>
               <green>gerekir.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Sol Tıkla</aqua>'
@@ -902,6 +907,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Sol Tıkla Kaydır</aqua>'
               trust: '<green>bir oyuncuya güvenmek için</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<dark_red>Kendine davet atamazsın!</dark_red>'
           cooldown: '<dark_red>Başkasına davet göndermek için [number] saniye bekle!</dark_red>'

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -736,6 +736,11 @@ commands:
               <green>Гравці мають бути</green>
               <green>в тому ж світі, що і ви,</green>
               <green>щоб з’явитися в списку.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>ЛКМ</aqua>'
@@ -847,6 +852,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift + ЛКМ</aqua>'
               trust: '<green>щоб зробити гравця довіреним</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Не можна запросити самого себе!</red>'
           cooldown: '<red>Ви не можете запрошувати цю людину ще [number] секунд.</red>'

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -801,6 +801,11 @@ commands:
               <green>Người chơi phải ở trong cùng</green>
               <green>thế giới với bạn để được</green>
               <green>hiển thị trong danh sách.</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>Nhấp Chuột Trái</aqua>'
@@ -906,6 +911,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Nhấn Shift + Click Trái</aqua>'
               trust: '<green>để tin tưởng một người chơi</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>Bạn không thể mời chính bạn!</red>'
           cooldown: '<red>Bạn không thể mời người đó trong [number] giây.</red>'

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -748,6 +748,11 @@ commands:
             description: |
               <green>玩家必须和你在一个世界(维度)</green>
               <green>才会显示在列表中</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>左键</aqua>'
@@ -855,6 +860,12 @@ commands:
               trust: |-
                 <green>将TA以</green><aqua>可信玩家</aqua><green>身份拉入团队</green>
                 <red>可信玩家拥有永久权限</red>
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>你不能邀请自己!</red>'
           cooldown: '<red>邀请冷却中, </red><aqua>[number]</aqua><red>秒后才能再次发出邀请.</red>'

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -747,6 +747,11 @@ commands:
               <green>玩家必須在</green>
               <green>和你相同的世界</green>
               <green>才會顯示在列表中。</green>
+          member:
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
+            name: '[display_name]'
+            # First line of a member's description (their rank). Placeholder: [rank].
+            description: '[rank]'
         tips:
           LEFT:
             name: '<aqua>左點擊</aqua>'
@@ -850,6 +855,12 @@ commands:
             SHIFT_LEFT:
               name: '<aqua>Shift+左鍵點擊</aqua>'
               trust: '<green>信任玩家</green>'
+          buttons:
+            member:
+              # Name shown on a prospect's head in the invite panel. Placeholders: [name], [display_name].
+              name: '[display_name]'
+              # Optional description line shown above the click tips. Placeholders: [name], [display_name].
+              description: ""
         errors:
           cannot-invite-self: '<red>您不能邀請您自己!</red>'
           cooldown: '<red>您必須在 [number] 秒後才能邀請這個人</red>'

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUIMemberTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUIMemberTest.java
@@ -2,11 +2,10 @@ package world.bentobox.bentobox.api.commands.island.team;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,8 +31,8 @@ import world.bentobox.bentobox.managers.CommandsManager;
 
 /**
  * Tests for the member button in {@link IslandTeamGUI}, verifying its name and
- * rank line come from customisable locale keys rather than being hardcoded.
- * See issue #3009.
+ * rank line come from customisable locale keys (with a fallback when the keys
+ * are missing). See issue #3009.
  *
  * <p>Panel slot layout derived from team_panel.yml: the first member button is
  * at row 2, column 2 → slot 10.
@@ -41,6 +40,8 @@ import world.bentobox.bentobox.managers.CommandsManager;
 class IslandTeamGUIMemberTest extends RanksManagerTestSetup {
 
     private static final int SLOT_FIRST_MEMBER = 10;
+    private static final String MEMBER_NAME_REF = "commands.island.team.gui.buttons.member.name";
+    private static final String MEMBER_DESC_REF = "commands.island.team.gui.buttons.member.description";
 
     @Mock
     private IslandTeamCommand itc;
@@ -91,7 +92,14 @@ class IslandTeamGUIMemberTest extends RanksManagerTestSetup {
 
         // The single member is the viewer, and is online
         when(mockPlayer.isOnline()).thenReturn(true);
-        when(mockPlayer.getDisplayName()).thenReturn("tastybento");
+        when(mockPlayer.getName()).thenReturn("tastybento");
+        when(mockPlayer.getDisplayName()).thenReturn("Bento");
+
+        // Concrete locale values so the panel renders real strings, and we can verify placeholder substitution.
+        when(rm.getRank(OWNER_RANK)).thenReturn("ranks.owner");
+        when(lm.get(any(), eq("ranks.owner"))).thenReturn("Owner");
+        when(lm.get(any(), eq(MEMBER_NAME_REF))).thenReturn("Member: [display_name]");
+        when(lm.get(any(), eq(MEMBER_DESC_REF))).thenReturn("Rank: [rank]");
 
         user = User.getInstance(mockPlayer);
 
@@ -110,34 +118,45 @@ class IslandTeamGUIMemberTest extends RanksManagerTestSetup {
 
     private void copyPanelYaml(String resource, File dest) throws IOException {
         try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
-            if (in != null) {
-                Files.copy(in, dest.toPath());
-            }
+            assertNotNull(in, "Missing test fixture on the classpath: " + resource);
+            Files.copy(in, dest.toPath());
         }
     }
 
-    @Test
-    void testMemberButtonName_comesFromCustomisableLocaleKey() {
+    private PanelItem buildMemberButton() {
         new IslandTeamGUI(plugin, itc, user, island).build();
-
         Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
         assertNotNull(panel);
         PanelItem item = panel.getItems().get(SLOT_FIRST_MEMBER);
         assertNotNull(item, "Expected a member button at slot " + SLOT_FIRST_MEMBER);
-        // Online member name now comes from the member.name locale key, not the hardcoded display name
-        assertEquals("commands.island.team.gui.buttons.member.name", item.getName());
+        return item;
     }
 
     @Test
-    void testMemberButtonDescription_rankLineComesFromCustomisableLocaleKey() {
-        new IslandTeamGUI(plugin, itc, user, island).build();
+    void testMemberButtonName_rendersFromLocaleKeyWithPlaceholder() {
+        // member.name = "Member: [display_name]" → [display_name] substituted with the member's display name
+        assertEquals("Member: Bento", buildMemberButton().getName());
+    }
 
-        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
-        assertNotNull(panel);
-        PanelItem item = panel.getItems().get(SLOT_FIRST_MEMBER);
-        assertNotNull(item, "Expected a member button at slot " + SLOT_FIRST_MEMBER);
-        assertFalse(item.getDescription().isEmpty(), "Member description should have a rank line");
-        // The rank line is routed through the customisable member.description key
-        assertEquals("commands.island.team.gui.buttons.member.description", item.getDescription().get(0));
+    @Test
+    void testMemberButtonDescription_rankLineRendersFromLocaleKeyWithPlaceholder() {
+        // member.description = "Rank: [rank]" → [rank] substituted with the resolved rank name
+        assertEquals("Rank: Owner", buildMemberButton().getDescription().get(0));
+    }
+
+    @Test
+    void testMemberButtonName_fallsBackToDisplayNameWhenKeyMissing() {
+        // Simulate an older/custom locale that lacks the key: getTranslation echoes the reference back
+        when(lm.get(any(), eq(MEMBER_NAME_REF))).thenReturn(MEMBER_NAME_REF);
+
+        assertEquals("Bento", buildMemberButton().getName());
+    }
+
+    @Test
+    void testMemberButtonDescription_fallsBackToRankNameWhenKeyMissing() {
+        // Simulate an older/custom locale that lacks the key: rank line falls back to the raw rank name
+        when(lm.get(any(), eq(MEMBER_DESC_REF))).thenReturn(MEMBER_DESC_REF);
+
+        assertEquals("Owner", buildMemberButton().getDescription().get(0));
     }
 }

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUIMemberTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUIMemberTest.java
@@ -1,0 +1,143 @@
+package world.bentobox.bentobox.api.commands.island.team;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.google.common.collect.ImmutableSet;
+
+import world.bentobox.bentobox.RanksManagerTestSetup;
+import world.bentobox.bentobox.api.panels.Panel;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.reader.TemplateReader;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.listeners.PanelListenerManager;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * Tests for the member button in {@link IslandTeamGUI}, verifying its name and
+ * rank line come from customisable locale keys rather than being hardcoded.
+ * See issue #3009.
+ *
+ * <p>Panel slot layout derived from team_panel.yml: the first member button is
+ * at row 2, column 2 → slot 10.
+ */
+class IslandTeamGUIMemberTest extends RanksManagerTestSetup {
+
+    private static final int SLOT_FIRST_MEMBER = 10;
+
+    @Mock
+    private IslandTeamCommand itc;
+    @Mock
+    private IslandTeamInviteCommand itic;
+    @Mock
+    private IslandTeamKickCommand kickCommand;
+    @Mock
+    private IslandTeamSetownerCommand setOwnerCommand;
+    @Mock
+    private IslandTeamLeaveCommand leaveCommand;
+
+    private User user;
+    private File dataFolder;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        dataFolder = new File("test-team-gui-member-" + uuid);
+        new File(dataFolder, "panels").mkdirs();
+        copyPanelYaml("panels/team_panel.yml", new File(dataFolder, "panels/team_panel.yml"));
+        when(plugin.getDataFolder()).thenReturn(dataFolder);
+
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+
+        when(itc.getWorld()).thenReturn(world);
+        when(itc.getLabel()).thenReturn("team");
+        when(itc.getInviteCommand()).thenReturn(itic);
+        when(itic.getPermission()).thenReturn("island.team.invite");
+        when(itc.getKickCommand()).thenReturn(kickCommand);
+        when(kickCommand.getPermission()).thenReturn("island.team.kick");
+        when(itc.getSetOwnerCommand()).thenReturn(setOwnerCommand);
+        when(setOwnerCommand.getPermission()).thenReturn("island.team.setowner");
+        when(itc.getLeaveCommand()).thenReturn(leaveCommand);
+        when(leaveCommand.getPermission()).thenReturn("island.team.leave");
+
+        when(im.getPrimaryIsland(world, uuid)).thenReturn(island);
+        when(im.getMaxMembers(any(), anyInt())).thenReturn(4);
+        // Status button member sets are empty; the member button set (rank above visitor -> 0) holds the viewer
+        when(island.getMemberSet()).thenReturn(ImmutableSet.of());
+        when(island.getMemberSet(anyInt())).thenReturn(ImmutableSet.of());
+        when(island.getMemberSet(anyInt(), anyBoolean())).thenReturn(ImmutableSet.of());
+        when(island.getMemberSet(0)).thenReturn(ImmutableSet.of(uuid));
+        when(island.getRank(any(User.class))).thenReturn(OWNER_RANK);
+
+        // The single member is the viewer, and is online
+        when(mockPlayer.isOnline()).thenReturn(true);
+        when(mockPlayer.getDisplayName()).thenReturn("tastybento");
+
+        user = User.getInstance(mockPlayer);
+
+        TemplateReader.clearPanels();
+        PanelListenerManager.getOpenPanels().clear();
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        deleteAll(dataFolder);
+        TemplateReader.clearPanels();
+        PanelListenerManager.getOpenPanels().clear();
+    }
+
+    private void copyPanelYaml(String resource, File dest) throws IOException {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
+            if (in != null) {
+                Files.copy(in, dest.toPath());
+            }
+        }
+    }
+
+    @Test
+    void testMemberButtonName_comesFromCustomisableLocaleKey() {
+        new IslandTeamGUI(plugin, itc, user, island).build();
+
+        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
+        assertNotNull(panel);
+        PanelItem item = panel.getItems().get(SLOT_FIRST_MEMBER);
+        assertNotNull(item, "Expected a member button at slot " + SLOT_FIRST_MEMBER);
+        // Online member name now comes from the member.name locale key, not the hardcoded display name
+        assertEquals("commands.island.team.gui.buttons.member.name", item.getName());
+    }
+
+    @Test
+    void testMemberButtonDescription_rankLineComesFromCustomisableLocaleKey() {
+        new IslandTeamGUI(plugin, itc, user, island).build();
+
+        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
+        assertNotNull(panel);
+        PanelItem item = panel.getItems().get(SLOT_FIRST_MEMBER);
+        assertNotNull(item, "Expected a member button at slot " + SLOT_FIRST_MEMBER);
+        assertFalse(item.getDescription().isEmpty(), "Member description should have a rank line");
+        // The rank line is routed through the customisable member.description key
+        assertEquals("commands.island.team.gui.buttons.member.description", item.getDescription().get(0));
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUITest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUITest.java
@@ -406,21 +406,38 @@ class IslandTeamInviteGUITest extends RanksManagerTestSetup {
     }
 
     @Test
-    void testProspectName_comesFromCustomisableLocaleKey() {
+    void testProspectName_rendersFromLocaleKeyWithPlaceholder() {
         setupSingleVisibleProspect("target", UUID.randomUUID());
+        // member.name = "Invite [display_name]" → placeholder substituted with the prospect's display name
+        when(lm.get(any(), eq("commands.island.team.invite.gui.buttons.member.name")))
+                .thenReturn("Invite [display_name]");
 
         gui.build(user);
 
         Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
         PanelItem item = panel.getItems().get(SLOT_FIRST_PROSPECT);
         assertNotNull(item);
-        // Name is now sourced from the member.name locale key rather than the hardcoded display name
-        assertEquals("commands.island.team.invite.gui.buttons.member.name", item.getName());
+        assertEquals("Invite target", item.getName());
+    }
+
+    @Test
+    void testProspectName_fallsBackToDisplayNameWhenKeyMissing() {
+        setupSingleVisibleProspect("target", UUID.randomUUID());
+        // Locale returns the reference for a missing key -> code must fall back to the display name
+
+        gui.build(user);
+
+        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
+        PanelItem item = panel.getItems().get(SLOT_FIRST_PROSPECT);
+        assertNotNull(item);
+        assertEquals("target", item.getName());
     }
 
     @Test
     void testProspectDescription_blankMemberDescriptionAddsNoStrayLine() {
         setupSingleVisibleProspect("target", UUID.randomUUID());
+        // Explicitly make the description key resolve to an empty string
+        when(lm.get(any(), eq("commands.island.team.invite.gui.buttons.member.description"))).thenReturn("");
 
         gui.build(user);
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUITest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteGUITest.java
@@ -406,6 +406,35 @@ class IslandTeamInviteGUITest extends RanksManagerTestSetup {
     }
 
     @Test
+    void testProspectName_comesFromCustomisableLocaleKey() {
+        setupSingleVisibleProspect("target", UUID.randomUUID());
+
+        gui.build(user);
+
+        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
+        PanelItem item = panel.getItems().get(SLOT_FIRST_PROSPECT);
+        assertNotNull(item);
+        // Name is now sourced from the member.name locale key rather than the hardcoded display name
+        assertEquals("commands.island.team.invite.gui.buttons.member.name", item.getName());
+    }
+
+    @Test
+    void testProspectDescription_blankMemberDescriptionAddsNoStrayLine() {
+        setupSingleVisibleProspect("target", UUID.randomUUID());
+
+        gui.build(user);
+
+        Panel panel = PanelListenerManager.getOpenPanels().get(uuid);
+        PanelItem item = panel.getItems().get(SLOT_FIRST_PROSPECT);
+        assertNotNull(item);
+        // Only the three action tips (invite/coop/trust) — no member.description line when it is blank
+        assertEquals(3, item.getDescription().size());
+        assertFalse(item.getDescription().stream()
+                .anyMatch(l -> l.contains("buttons.member.description")),
+                "A blank member.description key must not leak into the lore");
+    }
+
+    @Test
     void testProspectUnknownClickType_isIgnored() {
         setupSingleVisibleProspect("target", UUID.randomUUID());
 


### PR DESCRIPTION
## What

Makes the team member and invite-prospect button **name** and **description** customisable via locale, fixing #3009.

The `team_panel` `member_button` and `team_invite_panel` `prospect_button` templates referenced locale keys that **did not exist** and were **never read**:

- `commands.island.team.gui.buttons.member.{name,description}`
- `commands.island.team.invite.gui.buttons.member.{name,description}`

The button name and rank line were built entirely in code, so admins could not customise them, and the member's rank was always shown with no way to override it (as reported).

## Changes

- **`IslandTeamGUI.createMemberButton`** — the online member name now comes from `member.name` (`[name]` / `[display_name]` placeholders) and the rank line from `member.description` (`[rank]`). Offline members keep their last-seen status, which is already customisable via the existing `member-layout` keys.
- **`IslandTeamInviteGUI.getProspect`** — the prospect name now comes from `member.name`, and an optional `member.description` line is prepended when set (blank by default).
- Added the four keys to `en-US.yml` and **all 22 bundled locales**. The values are placeholder-only (`[display_name]`, `[rank]`, empty prospect description), so there is nothing language-specific to translate.
- Tests: `IslandTeamGUIMemberTest` (member name + rank line come from the locale keys) and two new prospect tests in `IslandTeamInviteGUITest`.

## Compatibility

Backwards compatible — the default key values reproduce the previous output exactly (`[display_name]` for the name, `[rank]` for the rank line, and an empty prospect description that adds no lore line). Existing installs see no visible change; admins can now edit the keys to customise.

Fixes #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLucPKxSBbG96WMVTFTuqB
