### PR TITLE
Style offline member name via the member.name locale key (#3009 follow-up)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
@@ -71,6 +71,10 @@ public class IslandTeamGUI {
     private static final String MEMBER_NAME_REF = "commands.island.team.gui.buttons.member.name";
     /** Locale key for the (customisable) member button rank line. Placeholder: [rank]. */
     private static final String MEMBER_DESC_REF = "commands.island.team.gui.buttons.member.description";
+    /** Locale key for the (customisable) suffix appended to an offline member's name. Placeholder: [last_seen]. */
+    private static final String MEMBER_LAST_SEEN_REF = "commands.island.team.gui.buttons.member.last-seen";
+    /** Placeholder replaced with the formatted last-seen suffix in the member button name. */
+    private static final String LAST_SEEN = "[last_seen]";
 
     /** The user viewing the GUI */
     private final User user;
@@ -433,22 +437,36 @@ public class IslandTeamGUI {
         // Fall back to the raw rank name if the key is absent (e.g. an older custom locale file).
         String rankName = user.getTranslation(rankRef);
         desc.addFirst(translateOr(MEMBER_DESC_REF, rankName, TextVariables.RANK, rankName));
-        if (member.isOnline()) {
-            return new PanelItemBuilder().icon(member.getName())
-                    .name(translateOr(MEMBER_NAME_REF, member.getDisplayName(), TextVariables.NAME, member.getName(),
-                            TextVariables.DISPLAY_NAME, member.getDisplayName()))
-                    .description(desc)
-                    .clickHandler(
-                            (panel, user, clickType, i) -> clickListener(panel, user, clickType, i, member, actions))
-                    .build();
-        } else {
-            // Offline player: the name keeps its last-seen status (see the member-layout locale keys)
-            return new PanelItemBuilder().icon(member.getName())
-                    .name(offlinePlayerStatus(Bukkit.getOfflinePlayer(member.getUniqueId()))).description(desc)
-                    .clickHandler(
-                            (panel, user, clickType, i) -> clickListener(panel, user, clickType, i, member, actions))
-                    .build();
+        // The name is styled through the same customisable member.name key whether the member is
+        // online or offline, so admins get one consistent format. Offline members (member rank or
+        // above) get a last-seen suffix via the [last_seen] placeholder; online members and
+        // trusted-or-below members get an empty suffix.
+        String lastSeenSuffix = lastSeenSuffix(is, member);
+        return new PanelItemBuilder().icon(member.getName())
+                .name(translateOr(MEMBER_NAME_REF, member.getDisplayName() + lastSeenSuffix, TextVariables.NAME,
+                        member.getName(), TextVariables.DISPLAY_NAME, member.getDisplayName(), LAST_SEEN,
+                        lastSeenSuffix))
+                .description(desc)
+                .clickHandler(
+                        (panel, user, clickType, i) -> clickListener(panel, user, clickType, i, member, actions))
+                .build();
+    }
+
+    /**
+     * Builds the last-seen suffix shown after an offline member's name in the team GUI. Returns an
+     * empty string for online members and for members ranked trusted or below (who have no last-seen
+     * status), otherwise the formatted, customisable {@link #MEMBER_LAST_SEEN_REF} suffix.
+     *
+     * @param is     the island being viewed
+     * @param member the member whose button is being built
+     * @return the suffix to append to the member's name, or an empty string
+     */
+    private String lastSeenSuffix(Island is, User member) {
+        if (member.isOnline() || !is.getMemberSet(RanksManager.MEMBER_RANK, true).contains(member.getUniqueId())) {
+            return "";
         }
+        String lastSeen = lastSeen(Bukkit.getOfflinePlayer(member.getUniqueId()));
+        return translateOr(MEMBER_LAST_SEEN_REF, "", LAST_SEEN, lastSeen);
     }
 
     /**

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -797,10 +797,12 @@ commands:
               <green>stejném světě jako ty,</green>
               <green>aby se zobrazili v seznamu.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Levý klik</aqua>'

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -848,10 +848,12 @@ commands:
               <green>deiner Welt befinden, um</green>
               <green>in der Liste angezeigt zu werden.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Linksklick</aqua>'

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -764,10 +764,12 @@ commands:
               <green>same world as you to be</green>
               <green>shown in the list.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Left Click</aqua>'

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -831,10 +831,12 @@ commands:
               <green>mismo mundo que tú para ser</green>
               <green>mostrados en la lista.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Clic Izquierdo</aqua>'

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -854,10 +854,12 @@ commands:
               <green>même monde que vous pour être</green>
               <green>affichés dans la liste.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Clic Gauche</aqua>'

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -807,10 +807,12 @@ commands:
               <green>istom svetu kao i vi da bi</green>
               <green>se prikazivali na listi.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Lijevi Klip</aqua>'

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -851,10 +851,12 @@ commands:
 
               <green>megjelenjenek a listában.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Bal Kattintás</aqua>'

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -820,10 +820,12 @@ commands:
               <green>dunia yang sama dengan Anda</green>
               <green>untuk ditampilkan di daftar.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Klik Kiri</aqua>'

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -845,10 +845,12 @@ commands:
               <green>stesso mondo di te per essere</green>
               <green>mostrati nella lista.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Clic Sinistro</aqua>'

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -736,10 +736,12 @@ commands:
               <green>あなたと同じ世界</green>
               <green>リストに示されています。</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>左クリック</aqua>'

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -752,10 +752,12 @@ commands:
               <green>세상에 있어야</green>
               <green>목록에 표시됩니다.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>왼쪽 클릭</aqua>'

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -812,10 +812,12 @@ commands:
               <green>pašā pasaulē kā jums, lai tiktu</green>
               <green>parādīti sarakstā.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Kreiso klikšķi</aqua>'

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -850,10 +850,12 @@ commands:
               <green>dezelfde wereld als jij bevinden</green>
               <green>om in de lijst te worden weergegeven.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Linker Klik</aqua>'

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -821,10 +821,12 @@ commands:
               <green>rzeczywistości co ty, aby</green>
               <green>być wyświetleni na liście.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Lewy Klik</aqua>'

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -815,10 +815,12 @@ commands:
               <green>mesmo mundo que você para</green>
               <green>serem mostrados na lista.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Clique Esquerdo</aqua>'

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -822,10 +822,12 @@ commands:
               <green>mesmo mundo que você para</green>
               <green>serem mostrados na lista.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Clique Esquerdo</aqua>'

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -832,10 +832,12 @@ commands:
               și aceeași lume ca și tine să fii
               <green>arătat în listă.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Faceți clic stânga</aqua>'

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -803,10 +803,12 @@ commands:
               <green>том же мире, что и вы, чтобы</green>
               <green>отображаться в списке.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: <aqua>ЛКМ</aqua>

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -798,10 +798,12 @@ commands:
               <green>seninle aynı dünyada olmaları</green>
               <green>gerekir.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Sol Tıkla</aqua>'

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -737,10 +737,12 @@ commands:
               <green>в тому ж світі, що і ви,</green>
               <green>щоб з’явитися в списку.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>ЛКМ</aqua>'

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -802,10 +802,12 @@ commands:
               <green>thế giới với bạn để được</green>
               <green>hiển thị trong danh sách.</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>Nhấp Chuột Trái</aqua>'

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -749,10 +749,12 @@ commands:
               <green>玩家必须和你在一个世界(维度)</green>
               <green>才会显示在列表中</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>左键</aqua>'

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -748,10 +748,12 @@ commands:
               <green>和你相同的世界</green>
               <green>才會顯示在列表中。</green>
           member:
-            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name].
-            name: '[display_name]'
+            # Name shown on a member's head in the team panel. Placeholders: [name], [display_name], [last_seen].
+            name: '[display_name][last_seen]'
             # First line of a member's description (their rank). Placeholder: [rank].
             description: '[rank]'
+            # Suffix appended to an offline member's name. Placeholder: [last_seen]. Blank for online members.
+            last-seen: ' <gray>([last_seen])</gray>'
         tips:
           LEFT:
             name: '<aqua>左點擊</aqua>'

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUIMemberTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUIMemberTest.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,8 @@ class IslandTeamGUIMemberTest extends RanksManagerTestSetup {
     private static final int SLOT_FIRST_MEMBER = 10;
     private static final String MEMBER_NAME_REF = "commands.island.team.gui.buttons.member.name";
     private static final String MEMBER_DESC_REF = "commands.island.team.gui.buttons.member.description";
+    private static final String MEMBER_LAST_SEEN_REF = "commands.island.team.gui.buttons.member.last-seen";
+    private static final String LAST_SEEN_LAYOUT_REF = "commands.island.team.info.last-seen.layout";
 
     @Mock
     private IslandTeamCommand itc;
@@ -158,5 +162,37 @@ class IslandTeamGUIMemberTest extends RanksManagerTestSetup {
         when(lm.get(any(), eq(MEMBER_DESC_REF))).thenReturn(MEMBER_DESC_REF);
 
         assertEquals("Owner", buildMemberButton().getDescription().get(0));
+    }
+
+    @Test
+    void testMemberButtonName_offlineMemberUsesSameNameKeyWithLastSeenSuffix() {
+        // The offline member's name must come from the same customisable member.name key (issue #3011
+        // follow-up), with the last-seen status supplied through the [last_seen] placeholder.
+        when(mockPlayer.isOnline()).thenReturn(false);
+        // Member rank or above -> a last-seen status is shown
+        when(island.getMemberSet(MEMBER_RANK, true)).thenReturn(ImmutableSet.of(uuid));
+
+        OfflinePlayer offline = mock(OfflinePlayer.class);
+        when(offline.getUniqueId()).thenReturn(uuid);
+        when(offline.getName()).thenReturn("tastybento");
+        when(offline.getLastSeen()).thenReturn(System.currentTimeMillis());
+        mockedBukkit.when(() -> Bukkit.getOfflinePlayer(uuid)).thenReturn(offline);
+
+        when(lm.get(any(), eq(MEMBER_NAME_REF))).thenReturn("Member: [display_name][last_seen]");
+        when(lm.get(any(), eq(MEMBER_LAST_SEEN_REF))).thenReturn(" ([last_seen])");
+        when(lm.get(any(), eq(LAST_SEEN_LAYOUT_REF))).thenReturn("recently");
+
+        assertEquals("Member: Bento (recently)", buildMemberButton().getName());
+    }
+
+    @Test
+    void testMemberButtonName_offlineTrustedMemberHasNoLastSeenSuffix() {
+        // Trusted or below -> no last-seen status, so the [last_seen] suffix is empty
+        when(mockPlayer.isOnline()).thenReturn(false);
+        when(island.getMemberSet(MEMBER_RANK, true)).thenReturn(ImmutableSet.of());
+
+        when(lm.get(any(), eq(MEMBER_NAME_REF))).thenReturn("Member: [display_name][last_seen]");
+
+        assertEquals("Member: Bento", buildMemberButton().getName());
     }
 }


### PR DESCRIPTION
## What

Follow-up to #3011, from admin testing feedback: an **offline** member's head name in the team panel did not follow the new customisable `member.name` format, so it looked inconsistent with online members.

The offline name was still built from `commands.island.team.info.member-layout.{offline,offline-not-last-seen}` — keys that belong to the `/team info` **text** command — so any styling an admin applied to `member.name` was ignored for offline members.

## Changes

- **`IslandTeamGUI.createMemberButton`** — online and offline members now share the same `member.name` key. The last-seen status is supplied through a new `[last_seen]` placeholder rather than a separate key.
- New helper `lastSeenSuffix(...)` returns:
  - an empty string for **online** members,
  - an empty string for members ranked **trusted or below** (who have no last-seen status),
  - the formatted, customisable `member.last-seen` suffix otherwise.
- Added the `commands.island.team.gui.buttons.member.last-seen` key and updated `member.name` (`[display_name][last_seen]`) in `en-US.yml` and **all 22 bundled locales**.
- Tests: two new offline-member cases in `IslandTeamGUIMemberTest` (last-seen suffix present for member+; absent for trusted-or-below).

## Compatibility

Backwards compatible. The default `member.name` (`[display_name][last_seen]`) and `member.last-seen` (` <gray>([last_seen])</gray>`) reproduce the previous offline appearance, while admins can now restyle online and offline names uniformly through one key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1rthQ8P46vu7hmbCbLdwZ