### PR TITLE
BlueMap: survive reloads + config toggles and marker customization

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -199,6 +199,18 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "dynmap.island-areas", since = "3.17.1")
     private boolean dynmapIslandAreas = true;
 
+    /* BLUEMAP */
+    @ConfigComment("Toggle whether BentoBox shows a marker (pin) on BlueMap at the center of every island.")
+    @ConfigComment("Set to false if you manage your own island markers and don't want BentoBox's layer.")
+    @ConfigComment("/!\\ Restart the server or use /bbox reload after changing this for it to take effect.")
+    @ConfigEntry(path = "bluemap.island-markers", since = "3.18.1")
+    private boolean bluemapIslandMarkers = true;
+
+    @ConfigComment("Toggle whether BentoBox draws the protected area border box of every island on BlueMap.")
+    @ConfigComment("/!\\ Restart the server or use /bbox reload after changing this for it to take effect.")
+    @ConfigEntry(path = "bluemap.island-areas", since = "3.18.1")
+    private boolean bluemapIslandAreas = true;
+
     /*
      * Logs
      */
@@ -1032,6 +1044,46 @@ public class Settings implements ConfigObject {
      */
     public void setDynmapIslandAreas(boolean dynmapIslandAreas) {
         this.dynmapIslandAreas = dynmapIslandAreas;
+    }
+
+    /**
+     * Whether BentoBox shows a marker (pin) on BlueMap at the center of every island.
+     *
+     * @return true if island markers should be shown
+     * @since 3.18.1
+     */
+    public boolean isBluemapIslandMarkers() {
+        return bluemapIslandMarkers;
+    }
+
+    /**
+     * Sets whether BentoBox shows a marker (pin) on BlueMap at the center of every island.
+     *
+     * @param bluemapIslandMarkers whether island markers should be shown
+     * @since 3.18.1
+     */
+    public void setBluemapIslandMarkers(boolean bluemapIslandMarkers) {
+        this.bluemapIslandMarkers = bluemapIslandMarkers;
+    }
+
+    /**
+     * Whether BentoBox draws the protected area border box of every island on BlueMap.
+     *
+     * @return true if island area boxes should be drawn
+     * @since 3.18.1
+     */
+    public boolean isBluemapIslandAreas() {
+        return bluemapIslandAreas;
+    }
+
+    /**
+     * Sets whether BentoBox draws the protected area border box of every island on BlueMap.
+     *
+     * @param bluemapIslandAreas whether island area boxes should be drawn
+     * @since 3.18.1
+     */
+    public void setBluemapIslandAreas(boolean bluemapIslandAreas) {
+        this.bluemapIslandAreas = bluemapIslandAreas;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -211,6 +211,39 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "bluemap.island-areas", since = "3.18.1")
     private boolean bluemapIslandAreas = true;
 
+    @ConfigComment("Path to a custom icon for the island POI marker, relative to BlueMap's web root")
+    @ConfigComment("(e.g. \"assets/island.png\" or \"assets/island.svg\"). Leave blank to use BlueMap's")
+    @ConfigComment("default POI icon.")
+    @ConfigEntry(path = "bluemap.marker-icon", since = "3.18.1")
+    private String bluemapMarkerIcon = "";
+
+    @ConfigComment("Pixel anchor of the custom icon - the point of the image that sits on the island")
+    @ConfigComment("location. Ignored when marker-icon is blank.")
+    @ConfigEntry(path = "bluemap.marker-icon-anchor-x", since = "3.18.1")
+    private int bluemapMarkerIconAnchorX = 25;
+    @ConfigEntry(path = "bluemap.marker-icon-anchor-y", since = "3.18.1")
+    private int bluemapMarkerIconAnchorY = 45;
+
+    @ConfigComment("Distance range (in blocks) within which the island POI marker is visible on the map.")
+    @ConfigComment("Raise min-distance to hide markers when zoomed far out; lower max-distance to hide them")
+    @ConfigComment("when zoomed in. The default range effectively means \"always visible\".")
+    @ConfigEntry(path = "bluemap.marker-min-distance", since = "3.18.1")
+    private double bluemapMarkerMinDistance = 0.0;
+    @ConfigEntry(path = "bluemap.marker-max-distance", since = "3.18.1")
+    private double bluemapMarkerMaxDistance = 10000000.0;
+
+    @ConfigComment("Colour and styling of the protected-area rectangle. Colours are hex strings.")
+    @ConfigEntry(path = "bluemap.area-line-color", since = "3.18.1")
+    private String bluemapAreaLineColor = "#3388FF";
+    @ConfigEntry(path = "bluemap.area-fill-color", since = "3.18.1")
+    private String bluemapAreaFillColor = "#3388FF";
+    @ConfigComment("Fill opacity, 0.0 (transparent) to 1.0 (opaque).")
+    @ConfigEntry(path = "bluemap.area-fill-opacity", since = "3.18.1")
+    private double bluemapAreaFillOpacity = 0.15;
+    @ConfigComment("Border line width in pixels.")
+    @ConfigEntry(path = "bluemap.area-line-width", since = "3.18.1")
+    private int bluemapAreaLineWidth = 2;
+
     /*
      * Logs
      */
@@ -1084,6 +1117,153 @@ public class Settings implements ConfigObject {
      */
     public void setBluemapIslandAreas(boolean bluemapIslandAreas) {
         this.bluemapIslandAreas = bluemapIslandAreas;
+    }
+
+    /**
+     * Path to a custom icon for the island POI marker, relative to BlueMap's web root. Blank
+     * means use BlueMap's default POI icon.
+     * @return the icon path, possibly blank
+     * @since 3.18.1
+     */
+    public String getBluemapMarkerIcon() {
+        return bluemapMarkerIcon;
+    }
+
+    /**
+     * Sets the custom icon path for the island POI marker.
+     * @param bluemapMarkerIcon icon path relative to BlueMap's web root, or blank for default
+     * @since 3.18.1
+     */
+    public void setBluemapMarkerIcon(String bluemapMarkerIcon) {
+        this.bluemapMarkerIcon = bluemapMarkerIcon;
+    }
+
+    /**
+     * @return the X pixel anchor of the custom island marker icon
+     * @since 3.18.1
+     */
+    public int getBluemapMarkerIconAnchorX() {
+        return bluemapMarkerIconAnchorX;
+    }
+
+    /**
+     * @param bluemapMarkerIconAnchorX the X pixel anchor of the custom island marker icon
+     * @since 3.18.1
+     */
+    public void setBluemapMarkerIconAnchorX(int bluemapMarkerIconAnchorX) {
+        this.bluemapMarkerIconAnchorX = bluemapMarkerIconAnchorX;
+    }
+
+    /**
+     * @return the Y pixel anchor of the custom island marker icon
+     * @since 3.18.1
+     */
+    public int getBluemapMarkerIconAnchorY() {
+        return bluemapMarkerIconAnchorY;
+    }
+
+    /**
+     * @param bluemapMarkerIconAnchorY the Y pixel anchor of the custom island marker icon
+     * @since 3.18.1
+     */
+    public void setBluemapMarkerIconAnchorY(int bluemapMarkerIconAnchorY) {
+        this.bluemapMarkerIconAnchorY = bluemapMarkerIconAnchorY;
+    }
+
+    /**
+     * @return the minimum distance (blocks) at which the island POI marker is visible
+     * @since 3.18.1
+     */
+    public double getBluemapMarkerMinDistance() {
+        return bluemapMarkerMinDistance;
+    }
+
+    /**
+     * @param bluemapMarkerMinDistance the minimum distance (blocks) at which the marker is visible
+     * @since 3.18.1
+     */
+    public void setBluemapMarkerMinDistance(double bluemapMarkerMinDistance) {
+        this.bluemapMarkerMinDistance = bluemapMarkerMinDistance;
+    }
+
+    /**
+     * @return the maximum distance (blocks) at which the island POI marker is visible
+     * @since 3.18.1
+     */
+    public double getBluemapMarkerMaxDistance() {
+        return bluemapMarkerMaxDistance;
+    }
+
+    /**
+     * @param bluemapMarkerMaxDistance the maximum distance (blocks) at which the marker is visible
+     * @since 3.18.1
+     */
+    public void setBluemapMarkerMaxDistance(double bluemapMarkerMaxDistance) {
+        this.bluemapMarkerMaxDistance = bluemapMarkerMaxDistance;
+    }
+
+    /**
+     * @return the protected-area rectangle border colour as a hex string
+     * @since 3.18.1
+     */
+    public String getBluemapAreaLineColor() {
+        return bluemapAreaLineColor;
+    }
+
+    /**
+     * @param bluemapAreaLineColor the protected-area rectangle border colour as a hex string
+     * @since 3.18.1
+     */
+    public void setBluemapAreaLineColor(String bluemapAreaLineColor) {
+        this.bluemapAreaLineColor = bluemapAreaLineColor;
+    }
+
+    /**
+     * @return the protected-area rectangle fill colour as a hex string
+     * @since 3.18.1
+     */
+    public String getBluemapAreaFillColor() {
+        return bluemapAreaFillColor;
+    }
+
+    /**
+     * @param bluemapAreaFillColor the protected-area rectangle fill colour as a hex string
+     * @since 3.18.1
+     */
+    public void setBluemapAreaFillColor(String bluemapAreaFillColor) {
+        this.bluemapAreaFillColor = bluemapAreaFillColor;
+    }
+
+    /**
+     * @return the protected-area rectangle fill opacity, 0.0 to 1.0
+     * @since 3.18.1
+     */
+    public double getBluemapAreaFillOpacity() {
+        return bluemapAreaFillOpacity;
+    }
+
+    /**
+     * @param bluemapAreaFillOpacity the protected-area rectangle fill opacity, 0.0 to 1.0
+     * @since 3.18.1
+     */
+    public void setBluemapAreaFillOpacity(double bluemapAreaFillOpacity) {
+        this.bluemapAreaFillOpacity = bluemapAreaFillOpacity;
+    }
+
+    /**
+     * @return the protected-area rectangle border line width in pixels
+     * @since 3.18.1
+     */
+    public int getBluemapAreaLineWidth() {
+        return bluemapAreaLineWidth;
+    }
+
+    /**
+     * @param bluemapAreaLineWidth the protected-area rectangle border line width in pixels
+     * @since 3.18.1
+     */
+    public void setBluemapAreaLineWidth(int bluemapAreaLineWidth) {
+        this.bluemapAreaLineWidth = bluemapAreaLineWidth;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
@@ -1,7 +1,9 @@
 package world.bentobox.bentobox.hooks;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -50,16 +52,47 @@ public class BlueMapHook extends MapHook implements Listener {
 
     @Override
     public boolean hook() {
-        if (BlueMapAPI.getInstance().isPresent()) {
-            api = BlueMapAPI.getInstance().get();
-        } else {
-            return false;
-        }
+        // Register with BlueMap's own lifecycle instead of grabbing the API once. BlueMap
+        // invokes the onEnable callback immediately if its API is already loaded, and again
+        // every time BlueMap (re)loads - crucially, after a "/bluemap reload", which discards
+        // BlueMap's maps and their marker sets. Re-populating from the callback means our
+        // island markers survive a reload instead of vanishing until the next server restart.
+        // A one-shot getInstance() in hook() was also racy at startup: if BlueMap had not
+        // finished loading yet, the hook silently produced no markers.
+        BlueMapAPI.onEnable(loadedApi -> {
+            this.api = loadedApi;
+            populateAll();
+        });
+        BlueMapAPI.onDisable(disabledApi -> this.api = null);
         // Listen for island events and BentoBoxReadyEvent to populate island markers
         // after islands are loaded (map hooks register before addons enable, so islands
         // are not yet loaded at hook time)
         Bukkit.getPluginManager().registerEvents(this, plugin);
         return true;
+    }
+
+    /**
+     * (Re)creates and attaches every known marker set to BlueMap. Called whenever BlueMap's
+     * API becomes available (including after a reload) and once islands have loaded. Safe to
+     * call repeatedly - marker creation is idempotent.
+     */
+    private void populateAll() {
+        if (api == null) {
+            return;
+        }
+        // Rebuild island markers for every game mode and re-attach the sets to their worlds
+        Set<String> gameModeNames = new HashSet<>();
+        plugin.getAddonsManager().getGameModeAddons().forEach(addon -> {
+            gameModeNames.add(addon.getWorldSettings().getFriendlyName());
+            registerGameMode(addon);
+        });
+        // Re-attach any addon-created marker sets (created via createMarkerSet) to all maps,
+        // since a BlueMap reload drops them from the freshly built maps too
+        markerSets.forEach((id, markerSet) -> {
+            if (!gameModeNames.contains(id)) {
+                api.getMaps().forEach(map -> map.getMarkerSets().put(id, markerSet));
+            }
+        });
     }
 
     /**
@@ -269,8 +302,10 @@ public class BlueMapHook extends MapHook implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onBentoBoxReady(BentoBoxReadyEvent e) {
-        // Now that islands are loaded, populate markers for all game modes
-        plugin.getAddonsManager().getGameModeAddons().forEach(this::registerGameMode);
+        // Islands are now loaded. If BlueMap enabled before this point its onEnable callback
+        // ran against an empty island cache, so populate again now. No-op if BlueMap's API is
+        // not yet available - its onEnable callback will populate once it is.
+        populateAll();
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
@@ -142,21 +142,25 @@ public class BlueMapHook extends MapHook implements Listener {
         String id = island.getUniqueId();
 
         // Point marker at island center for the label/icon
-        POIMarker marker = POIMarker.builder().label(label).listed(true).defaultIcon()
-                .position(island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ())
-                .build();
-        markerSet.put(id, marker);
+        if (plugin.getSettings().isBluemapIslandMarkers()) {
+            POIMarker marker = POIMarker.builder().label(label).listed(true).defaultIcon()
+                    .position(island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ())
+                    .build();
+            markerSet.put(id, marker);
+        }
         // Shape marker showing the protected island border
-        ShapeMarker area = ShapeMarker.builder()
-                .label(label)
-                .shape(Shape.createRect(island.getMinProtectedX(), island.getMinProtectedZ(),
-                        island.getMaxProtectedX(), island.getMaxProtectedZ()),
-                        (float) island.getCenter().getY())
-                .lineColor(new de.bluecolored.bluemap.api.math.Color(51, 136, 255))
-                .fillColor(new de.bluecolored.bluemap.api.math.Color(51, 136, 255, 0.15f))
-                .lineWidth(2)
-                .build();
-        markerSet.put(id + "_area", area);
+        if (plugin.getSettings().isBluemapIslandAreas()) {
+            ShapeMarker area = ShapeMarker.builder()
+                    .label(label)
+                    .shape(Shape.createRect(island.getMinProtectedX(), island.getMinProtectedZ(),
+                            island.getMaxProtectedX(), island.getMaxProtectedZ()),
+                            (float) island.getCenter().getY())
+                    .lineColor(new de.bluecolored.bluemap.api.math.Color(51, 136, 255))
+                    .fillColor(new de.bluecolored.bluemap.api.math.Color(51, 136, 255, 0.15f))
+                    .lineWidth(2)
+                    .build();
+            markerSet.put(id + "_area", area);
+        }
     }
 
     private String getIslandLabel(Island island) {

--- a/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
+++ b/src/main/java/world/bentobox/bentobox/hooks/BlueMapHook.java
@@ -21,6 +21,7 @@ import de.bluecolored.bluemap.api.markers.POIMarker;
 import de.bluecolored.bluemap.api.markers.ShapeMarker;
 import de.bluecolored.bluemap.api.math.Shape;
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.BentoBoxReadyEvent;
 import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
@@ -138,29 +139,65 @@ public class BlueMapHook extends MapHook implements Listener {
     }
 
     private void setMarker(MarkerSet markerSet, Island island) {
+        Settings settings = plugin.getSettings();
         String label = getIslandLabel(island);
         String id = island.getUniqueId();
 
         // Point marker at island center for the label/icon
-        if (plugin.getSettings().isBluemapIslandMarkers()) {
-            POIMarker marker = POIMarker.builder().label(label).listed(true).defaultIcon()
+        if (settings.isBluemapIslandMarkers()) {
+            POIMarker.Builder builder = POIMarker.builder().label(label).listed(true)
                     .position(island.getCenter().getX(), island.getCenter().getY(), island.getCenter().getZ())
-                    .build();
-            markerSet.put(id, marker);
+                    .minDistance(settings.getBluemapMarkerMinDistance())
+                    .maxDistance(settings.getBluemapMarkerMaxDistance());
+            String icon = settings.getBluemapMarkerIcon();
+            if (icon != null && !icon.isBlank()) {
+                builder.icon(icon, settings.getBluemapMarkerIconAnchorX(), settings.getBluemapMarkerIconAnchorY());
+            } else {
+                builder.defaultIcon();
+            }
+            markerSet.put(id, builder.build());
         }
         // Shape marker showing the protected island border
-        if (plugin.getSettings().isBluemapIslandAreas()) {
+        if (settings.isBluemapIslandAreas()) {
             ShapeMarker area = ShapeMarker.builder()
                     .label(label)
                     .shape(Shape.createRect(island.getMinProtectedX(), island.getMinProtectedZ(),
                             island.getMaxProtectedX(), island.getMaxProtectedZ()),
                             (float) island.getCenter().getY())
-                    .lineColor(new de.bluecolored.bluemap.api.math.Color(51, 136, 255))
-                    .fillColor(new de.bluecolored.bluemap.api.math.Color(51, 136, 255, 0.15f))
-                    .lineWidth(2)
+                    .lineColor(parseHexColor(settings.getBluemapAreaLineColor(), 1.0f))
+                    .fillColor(parseHexColor(settings.getBluemapAreaFillColor(),
+                            (float) settings.getBluemapAreaFillOpacity()))
+                    .lineWidth(settings.getBluemapAreaLineWidth())
                     .build();
             markerSet.put(id + "_area", area);
         }
+    }
+
+    /**
+     * Parses a {@code #RRGGBB} (or {@code RRGGBB}) hex string into a BlueMap colour with the
+     * given alpha. Falls back to the default island blue (51, 136, 255) if the string is null
+     * or malformed, so a bad config value never stops markers from rendering.
+     * @param hex hex colour string
+     * @param alpha alpha channel, 0.0 to 1.0
+     * @return the parsed colour
+     */
+    private de.bluecolored.bluemap.api.math.Color parseHexColor(String hex, float alpha) {
+        if (hex != null) {
+            String h = hex.startsWith("#") ? hex.substring(1) : hex;
+            if (h.length() == 6) {
+                try {
+                    int r = Integer.parseInt(h.substring(0, 2), 16);
+                    int g = Integer.parseInt(h.substring(2, 4), 16);
+                    int b = Integer.parseInt(h.substring(4, 6), 16);
+                    return new de.bluecolored.bluemap.api.math.Color(r, g, b, alpha);
+                } catch (NumberFormatException e) {
+                    plugin.logError("Invalid BlueMap colour in config: '" + hex + "'. Using default.");
+                }
+            } else {
+                plugin.logError("Invalid BlueMap colour in config: '" + hex + "'. Expected #RRGGBB. Using default.");
+            }
+        }
+        return new de.bluecolored.bluemap.api.math.Color(51, 136, 255, alpha);
     }
 
     private String getIslandLabel(Island island) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -127,6 +127,16 @@ dynmap:
   # /!\ Restart the server or use /bbox reload after changing this for it to take effect.
   # Added since 3.17.1.
   island-areas: true
+bluemap:
+  # Toggle whether BentoBox shows a marker (pin) on BlueMap at the center of every island.
+  # Set to false if you manage your own island markers and don't want BentoBox's layer.
+  # /!\ Restart the server or use /bbox reload after changing this for it to take effect.
+  # Added since 3.18.1.
+  island-markers: true
+  # Toggle whether BentoBox draws the protected area border box of every island on BlueMap.
+  # /!\ Restart the server or use /bbox reload after changing this for it to take effect.
+  # Added since 3.18.1.
+  island-areas: true
 logs:
   # Toggle whether superflat chunks regeneration should be logged in the server logs or not.
   # It can be spammy if there are a lot of superflat chunks to regenerate.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -137,6 +137,25 @@ bluemap:
   # /!\ Restart the server or use /bbox reload after changing this for it to take effect.
   # Added since 3.18.1.
   island-areas: true
+  # Path to a custom icon for the island POI marker, relative to BlueMap's web root
+  # (e.g. "assets/island.png" or "assets/island.svg"). Leave blank to use BlueMap's default POI icon.
+  # Added since 3.18.1.
+  marker-icon: ''
+  # Pixel anchor of the custom icon - the point of the image that sits on the island location.
+  # Ignored when marker-icon is blank.
+  marker-icon-anchor-x: 25
+  marker-icon-anchor-y: 45
+  # Distance range (in blocks) within which the island POI marker is visible on the map.
+  # The defaults effectively mean "always visible".
+  marker-min-distance: 0.0
+  marker-max-distance: 10000000.0
+  # Colour and styling of the protected-area rectangle. Colours are hex strings, e.g. '#3388FF'.
+  area-line-color: '#3388FF'
+  area-fill-color: '#3388FF'
+  # Fill opacity, 0.0 (transparent) to 1.0 (opaque).
+  area-fill-opacity: 0.15
+  # Border line width in pixels.
+  area-line-width: 2
 logs:
   # Toggle whether superflat chunks regeneration should be logged in the server logs or not.
   # It can be spammy if there are a lot of superflat chunks to regenerate.

--- a/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
+++ b/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
@@ -250,6 +250,30 @@ class BlueMapHookTest extends CommonTestSetup {
     }
 
     @Test
+    void testIslandMarkersDisabledNoPointMarker() {
+        plugin.getSettings().setBluemapIslandMarkers(false);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertNotNull(ms);
+        // No POI pin, but the area shape is still drawn
+        assertNull(ms.get(uuid.toString()));
+        assertNotNull(ms.get(uuid.toString() + "_area"));
+    }
+
+    @Test
+    void testIslandAreasDisabledNoAreaMarker() {
+        plugin.getSettings().setBluemapIslandAreas(false);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        MarkerSet ms = mapMarkerSets.get("BSkyBlock");
+        assertNotNull(ms);
+        // POI pin still placed, but no area shape
+        assertNotNull(ms.get(uuid.toString()));
+        assertNull(ms.get(uuid.toString() + "_area"));
+    }
+
+    @Test
     void testRegisterGameModeUnownedIslandIgnored() {
         Island unowned = mock(Island.class);
         when(unowned.getOwner()).thenReturn(null);

--- a/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
+++ b/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -69,15 +71,25 @@ class BlueMapHookTest extends CommonTestSetup {
     private MockedStatic<BlueMapAPI> mockedBlueMapAPI;
     private BlueMapHook hook;
     private Map<String, MarkerSet> mapMarkerSets;
+    private Consumer<BlueMapAPI> onEnableConsumer;
+    private Consumer<BlueMapAPI> onDisableConsumer;
 
     @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();
 
-        // BlueMapAPI static mock
+        // BlueMapAPI static mock. hook() registers onEnable/onDisable callbacks rather than
+        // calling getInstance(); capture them so tests can simulate BlueMap (re)loading.
         mockedBlueMapAPI = Mockito.mockStatic(BlueMapAPI.class);
-        mockedBlueMapAPI.when(BlueMapAPI::getInstance).thenReturn(Optional.of(blueMapAPI));
+        mockedBlueMapAPI.when(() -> BlueMapAPI.onEnable(any())).thenAnswer(inv -> {
+            onEnableConsumer = inv.getArgument(0);
+            return null;
+        });
+        mockedBlueMapAPI.when(() -> BlueMapAPI.onDisable(any())).thenAnswer(inv -> {
+            onDisableConsumer = inv.getArgument(0);
+            return null;
+        });
 
         // BlueMap world/map chain
         mapMarkerSets = new HashMap<>();
@@ -123,12 +135,25 @@ class BlueMapHookTest extends CommonTestSetup {
     }
 
     /**
-     * Calls hook() then fires BentoBoxReadyEvent to trigger island marker population,
+     * Calls hook(), simulates BlueMap becoming available, then fires BentoBoxReadyEvent,
      * mirroring the real startup sequence.
      */
     private void hookAndReady() {
         hook.hook();
+        simulateBlueMapEnable();
         hook.onBentoBoxReady(mock(BentoBoxReadyEvent.class));
+    }
+
+    /** Simulates BlueMap's API becoming available (initial load or after a reload). */
+    private void simulateBlueMapEnable() {
+        onEnableConsumer.accept(blueMapAPI);
+    }
+
+    /** Simulates BlueMap tearing down its API (as happens at the start of a reload). */
+    private void simulateBlueMapDisable() {
+        if (onDisableConsumer != null) {
+            onDisableConsumer.accept(blueMapAPI);
+        }
     }
 
     @AfterEach
@@ -146,9 +171,12 @@ class BlueMapHookTest extends CommonTestSetup {
     }
 
     @Test
-    void testHookFailsWhenBlueMapNotPresent() {
-        mockedBlueMapAPI.when(BlueMapAPI::getInstance).thenReturn(Optional.empty());
-        assertFalse(hook.hook());
+    void testHookRegistersLifecycleCallbacks() {
+        // hook() succeeds by registering with BlueMap's lifecycle; it no longer fails just
+        // because BlueMap's API is not loaded at hook time (that was the startup race).
+        assertTrue(hook.hook());
+        mockedBlueMapAPI.verify(() -> BlueMapAPI.onEnable(any()));
+        mockedBlueMapAPI.verify(() -> BlueMapAPI.onDisable(any()));
     }
 
     @Test
@@ -160,7 +188,32 @@ class BlueMapHookTest extends CommonTestSetup {
     @Test
     void testBentoBoxReadyCallsRegisterGameMode() {
         hookAndReady();
-        verify(im).getIslands(overWorld);
+        verify(im, atLeastOnce()).getIslands(overWorld);
+    }
+
+    /**
+     * Regression test for the reported bug: island markers disappeared after "/bluemap reload"
+     * and did not return until a full server restart. A reload discards BlueMap's maps (and
+     * their marker sets) and re-enables the API with fresh, empty maps. The hook must re-attach
+     * its markers via the onEnable callback.
+     */
+    @Test
+    void testMarkersSurviveBlueMapReload() {
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        assertNotNull(mapMarkerSets.get("BSkyBlock"));
+
+        // Simulate /bluemap reload: BlueMap disables, then re-enables with a brand new,
+        // empty marker-set map on the freshly rebuilt map.
+        Map<String, MarkerSet> freshMapSets = new HashMap<>();
+        when(blueMapMap.getMarkerSets()).thenReturn(freshMapSets);
+        simulateBlueMapDisable();
+        simulateBlueMapEnable();
+
+        // The island marker set and its markers must be re-attached to the new map.
+        assertTrue(freshMapSets.containsKey("BSkyBlock"));
+        assertNotNull(freshMapSets.get("BSkyBlock").get(uuid.toString()));
+        assertNotNull(freshMapSets.get("BSkyBlock").get(uuid.toString() + "_area"));
     }
 
     // ---- getPluginName() / getFailureCause() ----
@@ -400,6 +453,7 @@ class BlueMapHookTest extends CommonTestSetup {
     @Test
     void testGetBlueMapAPI() {
         hook.hook();
+        simulateBlueMapEnable();
         assertEquals(blueMapAPI, hook.getBlueMapAPI());
     }
 
@@ -423,6 +477,7 @@ class BlueMapHookTest extends CommonTestSetup {
     void testCreateMarkerSet() {
         when(blueMapAPI.getMaps()).thenReturn(List.of(blueMapMap));
         hook.hook();
+        simulateBlueMapEnable();
         hook.createMarkerSet("warps.markers", "Warps");
         // Should be attached to the BlueMap map
         assertTrue(mapMarkerSets.containsKey("warps.markers"));

--- a/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
+++ b/src/test/java/world/bentobox/bentobox/hooks/BlueMapHookTest.java
@@ -35,6 +35,7 @@ import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.BlueMapWorld;
 import de.bluecolored.bluemap.api.markers.MarkerSet;
+import de.bluecolored.bluemap.api.markers.POIMarker;
 import de.bluecolored.bluemap.api.markers.ShapeMarker;
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -271,6 +272,60 @@ class BlueMapHookTest extends CommonTestSetup {
         // POI pin still placed, but no area shape
         assertNotNull(ms.get(uuid.toString()));
         assertNull(ms.get(uuid.toString() + "_area"));
+    }
+
+    @Test
+    void testCustomMarkerIconApplied() {
+        plugin.getSettings().setBluemapMarkerIcon("assets/island.png");
+        plugin.getSettings().setBluemapMarkerIconAnchorX(30);
+        plugin.getSettings().setBluemapMarkerIconAnchorY(60);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        POIMarker pin = (POIMarker) mapMarkerSets.get("BSkyBlock").get(uuid.toString());
+        assertEquals("assets/island.png", pin.getIconAddress());
+        assertEquals(30, pin.getAnchor().getX());
+        assertEquals(60, pin.getAnchor().getY());
+    }
+
+    @Test
+    void testMarkerDistanceRangeApplied() {
+        plugin.getSettings().setBluemapMarkerMinDistance(15.0);
+        plugin.getSettings().setBluemapMarkerMaxDistance(5000.0);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        POIMarker pin = (POIMarker) mapMarkerSets.get("BSkyBlock").get(uuid.toString());
+        assertEquals(15.0, pin.getMinDistance());
+        assertEquals(5000.0, pin.getMaxDistance());
+    }
+
+    @Test
+    void testAreaStyleCustomised() {
+        plugin.getSettings().setBluemapAreaLineColor("#FF0000");
+        plugin.getSettings().setBluemapAreaFillColor("#00FF00");
+        plugin.getSettings().setBluemapAreaFillOpacity(0.5);
+        plugin.getSettings().setBluemapAreaLineWidth(4);
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        ShapeMarker area = (ShapeMarker) mapMarkerSets.get("BSkyBlock").get(uuid.toString() + "_area");
+        assertEquals(255, area.getLineColor().getRed());
+        assertEquals(0, area.getLineColor().getGreen());
+        assertEquals(0, area.getLineColor().getBlue());
+        assertEquals(0, area.getFillColor().getRed());
+        assertEquals(255, area.getFillColor().getGreen());
+        assertEquals(0.5f, area.getFillColor().getAlpha());
+        assertEquals(4, area.getLineWidth());
+    }
+
+    @Test
+    void testMalformedAreaColorFallsBackToDefault() {
+        plugin.getSettings().setBluemapAreaLineColor("not-a-colour");
+        when(im.getIslands(overWorld)).thenReturn(List.of(island));
+        hookAndReady();
+        ShapeMarker area = (ShapeMarker) mapMarkerSets.get("BSkyBlock").get(uuid.toString() + "_area");
+        // Falls back to the default island blue (51, 136, 255) instead of throwing
+        assertEquals(51, area.getLineColor().getRed());
+        assertEquals(136, area.getLineColor().getGreen());
+        assertEquals(255, area.getLineColor().getBlue());
     }
 
     @Test


### PR DESCRIPTION
## Problem

An admin running BlueMap with a OneBlock world reported the BentoBox island layer (owner pins + blue protected-area rectangles) behaving erratically:

- **First boot:** no BentoBox markers appeared.
- **After a server restart:** markers suddenly showed up.
- **After `/bluemap reload`:** markers vanished and did not return until the next full server restart.

They also asked whether the layer can be **toggled** and **customized** (they run their own markers on the main worlds, à la FancyWaystones).

## 1. Root-cause fix — markers now survive `/bluemap reload`

`BlueMapHook` grabbed the BlueMap API **once** via `BlueMapAPI.getInstance()` in `hook()` and only populated markers on `BentoBoxReadyEvent` (fired once at startup).

- A `/bluemap reload` rebuilds **fresh** `BlueMapMap` objects with empty marker-set maps; the sets BentoBox had `put()` into the old maps were discarded and never re-added — hence the vanish-until-restart.
- The one-shot `getInstance()` was also racy at boot: if BlueMap had not finished loading when BentoBox hooked, `getInstance()` was empty and no markers were created.

Fix: register with BlueMap's own lifecycle instead.
- `BlueMapAPI.onEnable(...)` fires immediately if the API is already loaded, and **again on every reload** — the callback stores the API and re-populates all markers.
- `BlueMapAPI.onDisable(...)` clears the stale reference.
- (Re)population is in `populateAll()`, called from both the `onEnable` callback and `BentoBoxReadyEvent` (works regardless of load order); it also re-attaches addon-created marker sets, which a reload drops too.

## 2. Config toggles

BlueMap previously had **no** config knobs. Dynmap gained `dynmap.island-markers` / `dynmap.island-areas` in 3.17.1; this mirrors them so admins running their own markers can turn BentoBox's layer off:

```yaml
bluemap:
  island-markers: true   # the owner pins
  island-areas: true     # the protected-area rectangles
```

(The marker set is also `toggleable(true)`, so viewers can switch the layer on/off client-side in BlueMap's UI.)

## 3. Marker customization

Exposes the `POIMarker` / `ShapeMarker` options an admin would want, mirroring how FancyWaystones configures BlueMap:

```yaml
bluemap:
  marker-icon: ''                 # custom icon path relative to BlueMap web root (blank = default POI icon)
  marker-icon-anchor-x: 25        # icon anchor
  marker-icon-anchor-y: 45
  marker-min-distance: 0.0        # POI visibility range (blocks)
  marker-max-distance: 10000000.0
  area-line-color: '#3388FF'      # protected-area rectangle styling
  area-fill-color: '#3388FF'
  area-fill-opacity: 0.15
  area-line-width: 2
```

Hex colours are parsed with a safe fallback to the default island blue, so a malformed value logs an error rather than dropping the marker.

_Not included:_ a templated `detail` popup (e.g. owner + members HTML) — that needs placeholder substitution and is left as a possible follow-up.

## Tests

- `testMarkersSurviveBlueMapReload` — disable → re-enable with fresh empty maps; asserts the set + pin + area are re-attached (the core regression).
- `testHookRegistersLifecycleCallbacks` — `onEnable`/`onDisable` registered.
- `testIslandMarkersDisabledNoPointMarker` / `testIslandAreasDisabledNoAreaMarker` — toggles.
- `testCustomMarkerIconApplied`, `testMarkerDistanceRangeApplied`, `testAreaStyleCustomised`, `testMalformedAreaColorFallsBackToDefault` — customization.
- Existing tests updated to drive markers through the simulated BlueMap-enable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1rthQ8P46vu7hmbCbLdwZ