### PR TITLE
Refresh tabbed panels in place to stop settings-GUI click spam raising MSPT

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
@@ -145,7 +145,11 @@ public class Panel implements HeadRequester, InventoryHolder {
      * @since 3.19.0
      */
     protected boolean tryRefreshInPlace(String name, Map<Integer, PanelItem> items, int size) {
-        if (inventory == null || !Objects.equals(this.name, name) || inventory.getSize() != fixSize(size)) {
+        // Compute the target size from the *incoming* items (matching makePanel, which sets
+        // this.items before calling fixSize) so that an auto-sized (size==0) refresh whose new
+        // contents need a different inventory size correctly falls back to a full reopen.
+        if (inventory == null || !Objects.equals(this.name, name)
+                || inventory.getSize() != fixSize(size, items.size())) {
             return false;
         }
         this.items = items;
@@ -170,9 +174,13 @@ public class Panel implements HeadRequester, InventoryHolder {
     }
 
     private int fixSize(int size) {
+        return fixSize(size, items.size());
+    }
+
+    private int fixSize(int size, int itemCount) {
         // If size is undefined (0) then use the number of items
         if (size == 0) {
-            size = items.size();
+            size = itemCount;
         }
         if (size > 0) {
             // Make sure size is a multiple of 9 and is 54 max.

--- a/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/Panel.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.api.panels;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.bukkit.Bukkit;
@@ -117,6 +118,55 @@ public class Panel implements HeadRequester, InventoryHolder {
         this.user = user;
         if (user != null)
             this.open(user);
+    }
+
+    /**
+     * Attempts to refresh the panel's contents <b>in place</b>, updating the items of the
+     * already-open inventory instead of creating and re-opening a new one.
+     * <p>
+     * Re-opening an inventory ({@link Bukkit#createInventory} + {@code player.openInventory})
+     * fires the full {@code InventoryClose}/{@code InventoryOpen} event cascade across every
+     * plugin on the server and resends the entire window to the client. When a panel is only
+     * refreshing its contents (e.g. a tabbed panel cycling its display mode or paging) and the
+     * title and size are unchanged, that reopen is wasteful — spam-clicking such a panel can
+     * measurably raise MSPT. In that case we simply update the item in each slot, which sends
+     * only cheap per-slot packets.
+     * <p>
+     * This is only possible when an inventory already exists (the panel is open), the title
+     * ({@link #name}) is unchanged, and the computed size matches the current inventory. If any
+     * of those differ (notably a title change, which the client can only pick up on a reopen),
+     * the caller must fall back to {@link #makePanel}.
+     *
+     * @param name  the panel/title name for the refreshed panel
+     * @param items the new items keyed by slot
+     * @param size  the requested panel size (pre-{@link #fixSize})
+     * @return {@code true} if the panel was refreshed in place, {@code false} if the caller must
+     *         re-open the panel via {@link #makePanel}
+     * @since 3.19.0
+     */
+    protected boolean tryRefreshInPlace(String name, Map<Integer, PanelItem> items, int size) {
+        if (inventory == null || !Objects.equals(this.name, name) || inventory.getSize() != fixSize(size)) {
+            return false;
+        }
+        this.items = items;
+        int invSize = inventory.getSize();
+        for (int i = 0; i < invSize && i < 54; i++) {
+            PanelItem pi = items.get(i);
+            if (pi == null) {
+                inventory.setItem(i, null);
+            } else {
+                inventory.setItem(i, pi.getItem());
+                // Get player head async
+                if (pi.isPlayerHead()) {
+                    HeadGetter.getHead(pi, this);
+                }
+            }
+        }
+        // Mirror makePanel: run listener setup after the contents are updated
+        if (listener != null) {
+            listener.setup();
+        }
+        return true;
     }
 
     private int fixSize(int size) {

--- a/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
@@ -127,7 +127,8 @@ public class TabbedPanel extends Panel implements PanelListener {
                 // Previous page icon
                 items.put(46, new PanelItemBuilder().icon(Material.ARROW).name(tpb.getUser().getTranslation(PROTECTION_PANEL + "previous")).clickHandler((panel, user1, clickType, slot1) -> {
                     this.activePage--;
-                    this.refreshPanel();
+                    // PanelListenerManager refreshes the panel after every click handler,
+                    // so we must not refresh again here (that would rebuild the panel twice).
                     return true;
                 }).build());
             }
@@ -135,18 +136,26 @@ public class TabbedPanel extends Panel implements PanelListener {
                 // Next page icon
                 items.put(52, new PanelItemBuilder().icon(Material.ARROW).name(tpb.getUser().getTranslation(PROTECTION_PANEL + "next")).clickHandler((panel, user1, clickType, slot1) -> {
                     this.activePage++;
-                    this.refreshPanel();
+                    // PanelListenerManager refreshes the panel after every click handler,
+                    // so we must not refresh again here (that would rebuild the panel twice).
                     return true;
                 }).build());
             }
         } else {
             throw new InvalidParameterException("Unknown tab slot number " + activeTab);
         }
-        // Show it to the player — mark as refreshing so that the inventory close
-        // triggered by opening a new inventory is not treated as a true close.
-        this.refreshing = true;
-        this.makePanel(tab.getName(), items, tpb.getSize(), tpb.getUser(), this);
-        this.refreshing = false;
+        // Try to refresh the already-open inventory in place first. This avoids the expensive
+        // InventoryClose/Open packet-and-event cascade of a full reopen when only the contents
+        // change (e.g. cycling the settings display mode or paging within the same tab), which is
+        // what makes spam-clicking the panel raise MSPT. Falls back to a full reopen when the
+        // panel is opened for the first time or the tab (and therefore the title) changes.
+        if (!tryRefreshInPlace(tab.getName(), items, tpb.getSize())) {
+            // Mark as refreshing so that the inventory close triggered by opening a new
+            // inventory is not treated as a true close.
+            this.refreshing = true;
+            this.makePanel(tab.getName(), items, tpb.getSize(), tpb.getUser(), this);
+            this.refreshing = false;
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
+++ b/src/main/java/world/bentobox/bentobox/panels/settings/SettingsTab.java
@@ -286,7 +286,8 @@ public class SettingsTab implements Tab, ClickHandler {
         currentMode.put(user.getUniqueId(), currentMode.getOrDefault(user.getUniqueId(), Mode.BASIC).getNext());
         if (panel instanceof TabbedPanel tp) {
             tp.setActivePage(0);
-            tp.refreshPanel();
+            // Do not call refreshPanel() here: PanelListenerManager refreshes the panel after
+            // every click handler, so refreshing here as well would rebuild the panel twice.
             user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_OFF, 1F, 1F);
         }
         return true;

--- a/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
@@ -1,7 +1,9 @@
 package world.bentobox.bentobox.api.panels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -281,6 +283,67 @@ class PanelTest extends CommonTestSetup {
     void testGetName() {
         Panel p = new Panel(name, items, 10, null, listener);
         assertEquals(name, p.getName());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.panels.Panel#tryRefreshInPlace(String, Map, int)}.
+     * A same-title, same-size refresh must update the existing inventory in place: it must not
+     * create a new inventory nor re-open the panel (which would fire the InventoryClose/Open cascade).
+     */
+    @Test
+    void testTryRefreshInPlaceSuccess() {
+        ItemStack itemStack = mock(ItemStack.class);
+        PanelItem item = mock(PanelItem.class);
+        when(item.getItem()).thenReturn(itemStack);
+        // fixSize(10) == 18
+        when(inv.getSize()).thenReturn(18);
+
+        Panel p = new Panel(name, items, 10, user, listener);
+
+        Map<Integer, PanelItem> newItems = new HashMap<>();
+        newItems.put(0, item);
+
+        boolean result = p.tryRefreshInPlace(name, newItems, 10);
+
+        assertTrue(result);
+        // Items map is swapped for the new one
+        assertSame(newItems, p.getItems());
+        // The inventory was NOT re-created and the panel was NOT re-opened: exactly the single
+        // create/open from construction.
+        mockedBukkit.verify(() -> Bukkit.createInventory(eq(null), anyInt(),
+                any(net.kyori.adventure.text.Component.class)), times(1));
+        verify(player, times(1)).openInventory(any(Inventory.class));
+        // Slot 0 gets the new item; the remaining slots of the existing inventory are cleared
+        verify(inv).setItem(0, itemStack);
+        verify(inv).setItem(17, null);
+        // Listener setup runs again after the in-place refresh (once on construct, once on refresh)
+        verify(listener, times(2)).setup();
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.panels.Panel#tryRefreshInPlace(String, Map, int)}.
+     * A title change (e.g. switching tab in a tabbed panel) cannot be reflected in place, so the
+     * method must decline and let the caller re-open.
+     */
+    @Test
+    void testTryRefreshInPlaceNameChangeReturnsFalse() {
+        when(inv.getSize()).thenReturn(18);
+        Panel p = new Panel(name, items, 10, user, listener);
+
+        assertFalse(p.tryRefreshInPlace("a-different-title", items, 10));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.panels.Panel#tryRefreshInPlace(String, Map, int)}.
+     * A size change cannot be reflected in place, so the method must decline.
+     */
+    @Test
+    void testTryRefreshInPlaceSizeChangeReturnsFalse() {
+        when(inv.getSize()).thenReturn(18);
+        Panel p = new Panel(name, items, 10, user, listener);
+
+        // fixSize(19) == 27, which differs from the existing inventory size of 18
+        assertFalse(p.tryRefreshInPlace(name, items, 19));
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/panels/PanelTest.java
@@ -346,4 +346,32 @@ class PanelTest extends CommonTestSetup {
         assertFalse(p.tryRefreshInPlace(name, items, 19));
     }
 
+    /**
+     * Test method for {@link world.bentobox.bentobox.api.panels.Panel#tryRefreshInPlace(String, Map, int)}.
+     * With auto-size (size == 0) the target size must be derived from the <b>incoming</b> items,
+     * exactly like makePanel. If the refreshed contents would compute to a different inventory
+     * size, an in-place refresh cannot represent that and must decline - otherwise the new items
+     * would overflow the stale, smaller inventory.
+     */
+    @Test
+    void testTryRefreshInPlaceAutoSizeDifferentSizeReturnsFalse() {
+        ItemStack itemStack = mock(ItemStack.class);
+        PanelItem item = mock(PanelItem.class);
+        when(item.getItem()).thenReturn(itemStack);
+
+        // Built from 1 item with size == 0 -> fixSize(0) == 9
+        Map<Integer, PanelItem> oneItem = new HashMap<>();
+        oneItem.put(0, item);
+        when(inv.getSize()).thenReturn(9);
+        Panel p = new Panel(name, oneItem, 0, user, listener);
+
+        // Refreshed contents fill 10 slots -> fixSize(0) == 18, differing from the existing 9.
+        // Computed from the incoming items (not the old this.items), so this must decline.
+        Map<Integer, PanelItem> tenItems = new HashMap<>();
+        for (int i = 0; i < 10; i++) {
+            tenItems.put(i, item);
+        }
+        assertFalse(p.tryRefreshInPlace(name, tenItems, 0));
+    }
+
 }


### PR DESCRIPTION
## Problem

An admin reported an exploit on **3.19.0 build 277**: spam-clicking the Basic/Advanced/Expert mode icon in the `/is settings` GUI drives MSPT up / TPS down.

The 3.14.0 mitigations (250 ms per-panel click cooldown in `PanelListenerManager` + deferred island saves in `TabbedPanel`) reduced but did **not** eliminate the cost. Two costs survive the cooldown on every *allowed* click:

1. **Full inventory re-open per refresh.** `refreshPanel → openPanel → makePanel` does `Bukkit.createInventory()` + `player.openInventory()`, which fires the entire `InventoryClose`/`InventoryOpen` event cascade across **every plugin** on the server and resends the whole window to the client.
2. **Double rebuild per click.** `SettingsTab#onClick` and the page-arrow handlers call `refreshPanel()` themselves, and `PanelListenerManager` auto-refreshes again after every click handler — so each click rebuilds/reopens twice.

## Fix

- **`Panel#tryRefreshInPlace(name, items, size)`** — when the panel is already open and the title and size are unchanged (the mode-toggle / paging case), update the existing inventory's slots in place (cheap per-slot packets) instead of re-creating and re-opening it. `TabbedPanel#openPanel` uses it and only falls back to a full reopen on the first open or a real tab switch (title change, which the client can only pick up on a reopen).
- **Remove the redundant `refreshPanel()` calls** in `SettingsTab#onClick` and both `TabbedPanel` page-arrow handlers; the manager already refreshes once after each click handler. The flag-toggle listeners (`CycleClick`, etc.) already rely on that single auto-refresh.

Deferred-save handling is unchanged: in-place refreshes fire no close event, so island saves stay deferred until the panel is truly closed. `refreshing`-guarded reopen path is retained for tab switches.

Net effect: an allowed click now does one lightweight in-place item update instead of two full inventory reopens — the reopen event/packet cascade that drove the MSPT spike is gone, on top of the existing 250 ms throttle.

## Testing

- `./gradlew compileJava` clean.
- `panels.*`, `api.panels.*`, and `PanelListenerManagerTest` packages pass.
- Added `PanelTest` coverage: in-place success (asserts **no** additional `createInventory`/`openInventory`) plus title-change and size-change fallbacks. 20/20 pass.

## Compatibility

`tryRefreshInPlace` is a new `protected` method on `Panel`; no signatures changed and no methods removed — binary-compatible for addons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HQsJnVbYQme5cW7qjScbf