### PR TITLE
Recover islands pending deletion: register, undelete, and stand-on delete

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -38,8 +38,8 @@ public class AdminDeleteCommand extends ConfirmableCommand {
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
         if (args.isEmpty()) {
-            this.showHelp(this, user);
-            return false;
+            // No player named - delete the island the admin is standing on
+            return canExecuteStandingOn(user);
         }
         // Convert name to a UUID
         targetUUID = Util.getUUID(args.getFirst());
@@ -90,6 +90,41 @@ public class AdminDeleteCommand extends ConfirmableCommand {
             // This is the only island they have so, no need to specify it
             island = null;
         }
+        return true;
+    }
+
+    /**
+     * Handles the no-argument form: delete the island the admin is standing on.
+     * Sets {@link #island} and {@link #targetUUID} on success so
+     * {@link #execute(User, String, List)} deletes just that island after
+     * confirmation.
+     *
+     * @param user the admin running the command
+     * @return true if there is a deletable island here, false otherwise
+     */
+    private boolean canExecuteStandingOn(User user) {
+        // Location-based deletion only makes sense for an in-game player
+        if (!user.isPlayer()) {
+            this.showHelp(this, user);
+            return false;
+        }
+        if (!getWorld().equals(user.getWorld())) {
+            user.sendMessage("general.errors.wrong-world");
+            return false;
+        }
+        Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());
+        if (opIsland.isEmpty()) {
+            user.sendMessage("general.errors.not-on-island");
+            return false;
+        }
+        island = opIsland.get();
+        // Do not orphan a team - its members have to be kicked first
+        if (island.hasTeam()) {
+            user.sendMessage("commands.admin.delete.cannot-delete-owner");
+            return false;
+        }
+        // The involved player for the deletion event is the island owner, if any
+        targetUUID = island.getOwner();
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -130,18 +130,22 @@ public class AdminDeleteCommand extends ConfirmableCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
+        // Snapshot the resolved target so the deferred confirmation acts on it even
+        // if canExecute re-runs (e.g. the admin moves) before it is confirmed.
+        final Island targetIsland = this.island;
+        final UUID target = this.targetUUID;
         // Confirm
-        if (island == null) {
+        if (targetIsland == null) {
             // Delete the player entirely
-            askConfirmation(user, () -> deletePlayer(user));
+            askConfirmation(user, () -> deletePlayer(user, target));
         } else {
             // Just delete the player's island
-            askConfirmation(user, () -> deleteIsland(user, island));
+            askConfirmation(user, () -> deleteIsland(user, targetIsland, target));
         }
         return true;
     }
 
-    private void deleteIsland(User user, Island oldIsland) {
+    private void deleteIsland(User user, Island oldIsland, UUID targetUUID) {
         // Fire island preclear event
         IslandEvent.builder().involvedPlayer(user.getUniqueId()).reason(Reason.PRECLEAR).island(oldIsland)
                 .oldIsland(oldIsland).location(oldIsland.getCenter()).build();
@@ -155,10 +159,10 @@ public class AdminDeleteCommand extends ConfirmableCommand {
         getIslands().deleteIsland(oldIsland, true, targetUUID);
     }
 
-    private void deletePlayer(User user) {
+    private void deletePlayer(User user, UUID targetUUID) {
         // Delete player and island
         for (Island oldIsland : getIslands().getIslands(getWorld(), targetUUID)) {
-            deleteIsland(user, oldIsland);
+            deleteIsland(user, oldIsland, targetUUID);
         }
         // Check if player is online and on the island
         assert targetUUID != null;

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommand.java
@@ -21,6 +21,8 @@ import world.bentobox.bentobox.util.Util;
 
 public class AdminDeleteCommand extends ConfirmableCommand {
 
+    private static final String CANNOT_DELETE_OWNER = "commands.admin.delete.cannot-delete-owner";
+
     private @Nullable UUID targetUUID;
     private Island island;
 
@@ -57,7 +59,7 @@ public class AdminDeleteCommand extends ConfirmableCommand {
             // Check if player is owner of any islands
             if (getIslands().getIslands(getWorld(), targetUUID).stream().filter(Island::hasTeam)
                     .anyMatch(is -> targetUUID.equals(is.getOwner()))) {
-                user.sendMessage("commands.admin.delete.cannot-delete-owner");
+                user.sendMessage(CANNOT_DELETE_OWNER);
                 return false;
             }
             // This is a delete everything request
@@ -83,7 +85,7 @@ public class AdminDeleteCommand extends ConfirmableCommand {
 
         // Team members should be kicked before deleting otherwise the whole team will become weird
         if (island.hasTeam() && targetUUID.equals(island.getOwner())) {
-            user.sendMessage("commands.admin.delete.cannot-delete-owner");
+            user.sendMessage(CANNOT_DELETE_OWNER);
             return false;
         }
         if (names.size() == 1) {
@@ -120,7 +122,7 @@ public class AdminDeleteCommand extends ConfirmableCommand {
         island = opIsland.get();
         // Do not orphan a team - its members have to be kicked first
         if (island.hasTeam()) {
-            user.sendMessage("commands.admin.delete.cannot-delete-owner");
+            user.sendMessage(CANNOT_DELETE_OWNER);
             return false;
         }
         // The involved player for the deletion event is the island owner, if any

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
@@ -22,7 +22,6 @@ import world.bentobox.bentobox.util.Util;
 public class AdminRegisterCommand extends ConfirmableCommand {
 
     private Island island;
-    private Location closestIsland;
     private @Nullable UUID targetUUID;
 
     public AdminRegisterCommand(CompositeCommand parent) {
@@ -56,7 +55,7 @@ public class AdminRegisterCommand extends ConfirmableCommand {
             return false;
         }
         // Check if this spot is being deleted
-        closestIsland = Util.getClosestIsland(user.getLocation());
+        Location closestIsland = Util.getClosestIsland(user.getLocation());
         boolean inDeletion = getPlugin().getIslandDeletionManager().inDeletion(closestIsland);
         // Check if island is owned
         Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
@@ -55,12 +55,9 @@ public class AdminRegisterCommand extends ConfirmableCommand {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.getFirst());
             return false;
         }
-        // Check if this spot is still being deleted
+        // Check if this spot is being deleted
         closestIsland = Util.getClosestIsland(user.getLocation());
-        if (getPlugin().getIslandDeletionManager().inDeletion(closestIsland)) {
-            user.sendMessage("commands.admin.register.in-deletion");
-            return false;
-        }
+        boolean inDeletion = getPlugin().getIslandDeletionManager().inDeletion(closestIsland);
         // Check if island is owned
         Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());
         if (opIsland.isEmpty()) {
@@ -72,6 +69,12 @@ public class AdminRegisterCommand extends ConfirmableCommand {
         island = opIsland.get();
         if (targetUUID.equals(island.getOwner())) {
             user.sendMessage("commands.admin.register.already-owned");
+            return false;
+        }
+        // Island is pending deletion - registering it will cancel the deletion, so confirm first
+        if (inDeletion) {
+            askConfirmation(user, user.getTranslation("commands.admin.register.in-deletion"),
+                    () -> register(user, args.getFirst()));
             return false;
         }
         // Check if island is spawn
@@ -129,8 +132,9 @@ public class AdminRegisterCommand extends ConfirmableCommand {
         if (island.isSpawn()) {
             getIslands().clearSpawn(island.getWorld());
         }
-        // Remove deletion status if it has been assigned.
-        island.setDeleted(false);
+        // Remove deletion status if it has been assigned so the island is not
+        // reaped by the region-file purge and stays owned by the new player.
+        getIslands().undeleteIsland(island);
         user.sendMessage("commands.admin.register.registered-island", TextVariables.XYZ,
                 Util.xyz(island.getCenter().toVector()), TextVariables.NAME, targetName);
         user.sendMessage("general.success");

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommand.java
@@ -61,9 +61,13 @@ public class AdminRegisterCommand extends ConfirmableCommand {
         // Check if island is owned
         Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());
         if (opIsland.isEmpty()) {
-            // Reserve spot
+            // Reserve spot. Capture the context now so the deferred confirmation
+            // acts on the same target/location even if the admin moves first.
+            final UUID uuid = targetUUID;
+            final Location loc = closestIsland;
+            final String name = args.getFirst();
             this.askConfirmation(user, user.getTranslation("commands.admin.register.no-island-here"),
-                    () -> reserve(user, args.getFirst()));
+                    () -> reserve(user, uuid, loc, name));
             return false;
         }
         island = opIsland.get();
@@ -73,32 +77,48 @@ public class AdminRegisterCommand extends ConfirmableCommand {
         }
         // Island is pending deletion - registering it will cancel the deletion, so confirm first
         if (inDeletion) {
-            askConfirmation(user, user.getTranslation("commands.admin.register.in-deletion"),
-                    () -> register(user, args.getFirst()));
+            confirmRegister(user, "commands.admin.register.in-deletion", args.getFirst());
             return false;
         }
         // Check if island is spawn
         if (island.isSpawn()) {
-            askConfirmation(user, user.getTranslation("commands.admin.register.island-is-spawn"),
-                    () -> register(user, args.getFirst()));
+            confirmRegister(user, "commands.admin.register.island-is-spawn", args.getFirst());
             return false;
         }
 
         return true;
     }
 
+    /**
+     * Ask the user to confirm registering the island they are on. The target and
+     * island are captured now so the deferred action stays stable even if
+     * {@link #canExecute(User, String, List)} re-runs before confirmation.
+     *
+     * @param user user doing the registering
+     * @param messageKey confirmation prompt translation key
+     * @param targetName name of the target player
+     */
+    private void confirmRegister(User user, String messageKey, String targetName) {
+        final UUID uuid = targetUUID;
+        final Island targetIsland = island;
+        askConfirmation(user, user.getTranslation(messageKey),
+                () -> register(user, uuid, targetIsland, targetName));
+    }
+
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        register(user, args.getFirst());
+        register(user, targetUUID, island, args.getFirst());
         return true;
     }
 
     /**
      * Reserve a spot for a target
      * @param user user doing the reserving
+     * @param targetUUID UUID of the target player
+     * @param closestIsland location to reserve
      * @param targetName target name
      */
-    void reserve(User user, String targetName) {
+    void reserve(User user, UUID targetUUID, Location closestIsland, String targetName) {
         Objects.requireNonNull(closestIsland);
         Objects.requireNonNull(targetUUID);
         // Island does not exist - this is a reservation
@@ -121,10 +141,11 @@ public class AdminRegisterCommand extends ConfirmableCommand {
     /**
      * Register the island to a target
      * @param user user doing the registering
+     * @param targetUUID UUID of the target player
+     * @param island island to register
      * @param targetName name of target
      */
-    void register(User user, String targetName) {
-        Objects.requireNonNull(closestIsland);
+    void register(User user, UUID targetUUID, Island island, String targetName) {
         Objects.requireNonNull(targetUUID);
         Objects.requireNonNull(island);
         // Island exists

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommand.java
@@ -1,0 +1,79 @@
+package world.bentobox.bentobox.api.commands.admin;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.bukkit.Location;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Removes the pending-deletion status from the island the admin is standing on
+ * and leaves it unowned. Only works on islands that are actually queued for
+ * deletion (soft-deleted, awaiting the region-file purge).
+ *
+ * <p>Shares its restore logic with {@link AdminRegisterCommand} via
+ * {@link world.bentobox.bentobox.managers.IslandsManager#undeleteIsland(Island)};
+ * the difference is that register assigns the island to a player whereas this
+ * command leaves it unowned.
+ *
+ * @author tastybento
+ * @since 3.6.4
+ */
+public class AdminUndeleteCommand extends CompositeCommand {
+
+    private Island island;
+
+    public AdminUndeleteCommand(CompositeCommand parent) {
+        super(parent, "undelete");
+    }
+
+    @Override
+    public void setup() {
+        setPermission("admin.undelete");
+        setOnlyPlayer(true);
+        setDescription("commands.admin.undelete.description");
+    }
+
+    @Override
+    public boolean canExecute(User user, String label, List<String> args) {
+        // No arguments expected
+        if (!args.isEmpty()) {
+            showHelp(this, user);
+            return false;
+        }
+        // Check world
+        if (!getWorld().equals(user.getWorld())) {
+            user.sendMessage("general.errors.wrong-world");
+            return false;
+        }
+        // The island must be at this location and be pending deletion
+        Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());
+        if (opIsland.isEmpty() || !opIsland.get().isDeletable()) {
+            user.sendMessage("commands.admin.undelete.not-in-deletion");
+            return false;
+        }
+        island = opIsland.get();
+        return true;
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        Objects.requireNonNull(island);
+        // Make sure the island is unowned
+        island.setOwner(null);
+        // Clear the pending-deletion status so the region purge skips it
+        getIslands().undeleteIsland(island);
+        Location center = island.getCenter();
+        user.sendMessage("commands.admin.undelete.undeleted-island", TextVariables.XYZ,
+                Util.xyz(center.toVector()));
+        user.sendMessage("general.success");
+        return true;
+    }
+
+}

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommand.java
@@ -35,24 +35,23 @@ public class AdminUndeleteCommand extends CompositeCommand {
 
     @Override
     public void setup() {
-        setPermission("admin.undelete");
         setOnlyPlayer(true);
         setDescription("commands.admin.undelete.description");
+        setPermission("admin.undelete");
     }
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
-        // No arguments expected
-        if (!args.isEmpty()) {
-            showHelp(this, user);
-            return false;
-        }
-        // Check world
+        // Location-based command: right world, no arguments, standing on the island
         if (!getWorld().equals(user.getWorld())) {
             user.sendMessage("general.errors.wrong-world");
             return false;
         }
-        // The island must be at this location and be pending deletion
+        if (!args.isEmpty()) {
+            showHelp(this, user);
+            return false;
+        }
+        // The island here must exist and be pending deletion
         Optional<Island> opIsland = getIslands().getIslandAt(user.getLocation());
         if (opIsland.isEmpty() || !opIsland.get().isDeletable()) {
             user.sendMessage("commands.admin.undelete.not-in-deletion");

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/DefaultAdminCommand.java
@@ -72,6 +72,7 @@ public abstract class DefaultAdminCommand extends CompositeCommand {
         // Register/unregister islands
         new AdminRegisterCommand(this);
         new AdminUnregisterCommand(this);
+        new AdminUndeleteCommand(this);
         // Range
         new AdminRangeCommand(this);
         // Resets

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -309,7 +309,26 @@ public class IslandsManager {
             IslandEvent.builder().deletedIslandInfo(new IslandDeletion(island)).reason(Reason.DELETED).build();
         }
     }
-    
+
+    /**
+     * Removes an island from the pending-deletion queue.
+     *
+     * <p>Clears the soft-delete flags set by
+     * {@link #deleteIsland(Island, boolean, UUID)} so the island is no longer
+     * reaped by the region-file purge ({@code PurgeRegionsService} /
+     * {@code HousekeepingManager}), then persists the change. Ownership is left
+     * untouched - the island stays unowned unless the caller assigns an owner
+     * separately.
+     *
+     * @param island the island to remove from the deletion queue, not null
+     * @since 3.6.4
+     */
+    public void undeleteIsland(@NonNull Island island) {
+        island.setDeleted(false);
+        island.setDeletable(false);
+        saveIsland(island);
+    }
+
     /**
      * Hard-deletes an island: fires the pre-delete event, kicks members,
      * nulls the owner, evicts the island from the cache, and removes the

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -264,11 +264,16 @@ commands:
       reserved-island: '<green>Ostrov [xyz] rezervován pro hráče.</green>'
       already-owned: '<red>Ostrov je již vlastněn jiným hráčem!</red>'
       no-island-here: '<red>Zde není žádný ostrov. Potvrď jeho vytvoření.</red>'
-      in-deletion: '<red>Tento ostrov bude smazán. Opakuj později.</red>'
+      in-deletion: '<gold>Tento ostrov čeká na smazání. Jeho registrace smazání zruší.
+        Pro potvrzení zadej příkaz znovu.</gold>'
       cannot-make-island: >-
         <red>Pardon, sem nelze umístit ostrov. Podívej se do konzole pro přípané</red>
         chyby.
       island-is-spawn: '<gold>Ostrov je spawn. Jsi si jistý? Potvrď opětovným zadáním příkazu.</gold>'
+    undelete:
+      description: odebere status čekání na smazání z [prefix_island] bez vlastníka, na kterém stojíš
+      not-in-deletion: '<red>Tento [prefix_island] nečeká na smazání.</red>'
+      undeleted-island: '<green>Odebrán status smazání z [prefix_island] na [xyz]. Nyní je bez vlastníka.</green>'
     unregister:
       parameters: <vlastník> [x,y,z]
       description: odregistrovat vlastníka z ostrova, ale zachovat bloky ostrova
@@ -559,8 +564,8 @@ commands:
     world:
       description: Spravovat nastavení světa
     delete:
-      parameters: <Player>
-      description: odstraní ostrov hráče
+      parameters: '[Player]'
+      description: 'odstraní ostrov hráče, nebo ostrov, na kterém stojíš, pokud není zadán hráč'
       cannot-delete-owner: >-
         <red>Všichni členové ostrova musí být vykopnuti z ostrova, než jej bude</red>
         možné smazat.

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -284,13 +284,18 @@ commands:
       reserved-island: '<green>Reservierte Insel bei [xyz] für Spieler.</green>'
       already-owned: '<red>Die Insel ist bereits im Besitz eines anderen Spielers!</red>'
       no-island-here: '<red>Es gibt hier keine Insel. Bestätige um eine zu erstellen.</red>'
-      in-deletion: '<red>Dieser Inselbereich wird derzeit gelöscht. Probier es später.</red>'
+      in-deletion: '<gold>Diese Insel wird gelöscht. Durch das Registrieren wird die
+        Löschung abgebrochen. Gib den Befehl zur Bestätigung erneut ein.</gold>'
       cannot-make-island: >-
         <red>Hier kann keine Insel platziert werden, sorry. Für mögliche Fehler</red>
         siehe Konsole.
       island-is-spawn: >-
         <gold>Die Insel ist der Spawn. Bist du sicher? Gib den Befehl zur</gold>
         Bestätigung noch einmal ein.
+    undelete:
+      description: entfernt den ausstehenden Löschstatus von [prefix_island] ohne Besitzer, auf der du stehst
+      not-in-deletion: '<red>Diese [prefix_island] wartet nicht auf Löschung.</red>'
+      undeleted-island: '<green>Löschstatus von [prefix_island] bei [xyz] entfernt. Sie ist jetzt ohne Besitzer.</green>'
     unregister:
       parameters: <inhaber> [x,y,z]
       description: Besitzer von Insel entfernen, aber Inselblöcke behalten
@@ -593,8 +598,8 @@ commands:
     world:
       description: Welteinstellungen verwalten
     delete:
-      parameters: <spieler>
-      description: Löscht die Insel eines Spielers
+      parameters: '[spieler]'
+      description: 'Löscht die Insel eines Spielers oder die Insel, auf der du stehst, wenn kein Spieler angegeben ist'
       cannot-delete-owner: >-
         <red>Alle Inselmitglieder müssen vor dem Löschen von der Insel gekickt</red>
         werden.

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -247,12 +247,18 @@ commands:
       reserved-island: '<green>Reserved [prefix_island] at [xyz] for [name].</green>'
       already-owned: '<red>[prefix_island] is already owned by another player!</red>'
       no-island-here: '<red>There is no [prefix_island] here. Confirm to make one.</red>'
-      in-deletion: '<red>This [prefix_island] space is currently being deleted. Try
-        later.</red>'
+      in-deletion: '<gold>This [prefix_island] is pending deletion. Registering it will
+        cancel the deletion. Enter command again to confirm.</gold>'
       cannot-make-island: '<red>[prefix_an-island] cannot be placed here, sorry. See
         console for possible errors.</red>'
       island-is-spawn: '<gold>[prefix_island] is spawn. Are you sure? Enter command again
         to confirm.</gold>'
+    undelete:
+      description: remove the pending deletion status from the unowned [prefix_island]
+        you are on
+      not-in-deletion: '<red>This [prefix_island] is not pending deletion.</red>'
+      undeleted-island: '<green>Removed the deletion status from the [prefix_island]
+        at [xyz]. It is now unowned.</green>'
     unregister:
       parameters: <owner> [x,y,z]
       description: unregister owner from [prefix_island], but keep [prefix_island]
@@ -532,8 +538,9 @@ commands:
     world:
       description: Manage world settings
     delete:
-      parameters: <player>
-      description: deletes a player's [prefix_island]
+      parameters: '[player]'
+      description: deletes a player's [prefix_island], or the [prefix_island] you are
+        standing on if no player is given
       cannot-delete-owner: '<red>All [prefix_island] members have to be kicked from
         the [prefix_island] before deleting it.</red>'
       deleted-island: '<green>[prefix_Island] at </green><yellow>[xyz] </yellow><green>has been successfully deleted.</green>'

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -270,15 +270,18 @@ commands:
       reserved-island: '<green>Isla reservada en [xyz] para jugador.</green>'
       already-owned: '<red>La isla ya es propiedad de otro jugador!</red>'
       no-island-here: '<red>No hay isla aquí. Confirmar para hacer uno.</red>'
-      in-deletion: >-
-        <red>Este espacio de la isla se está eliminando actualmente. Intenta más</red>
-        tarde.
+      in-deletion: '<gold>Esta isla está pendiente de eliminación. Registrarla cancelará
+        la eliminación. Introduce el comando de nuevo para confirmar.</gold>'
       cannot-make-island: >-
         <red>Una isla no puede ser colocada aquí, lo siento. Ver consola para</red>
         posibles errores.
       island-is-spawn: >-
         <gold>La isla está spawneada. ¿Estás seguro? Ingrese el comando nuevamente</gold>
         para confirmar.
+    undelete:
+      description: elimina el estado de eliminación pendiente de la [prefix_island] sin dueño en la que estás
+      not-in-deletion: '<red>Esta [prefix_island] no está pendiente de eliminación.</red>'
+      undeleted-island: '<green>Se eliminó el estado de eliminación de la [prefix_island] en [xyz]. Ahora no tiene dueño.</green>'
     unregister:
       parameters: <dueño> [x,y,z]
       description: Desregistrar propietario de isla, pero mantener bloques de islas
@@ -582,8 +585,8 @@ commands:
     world:
       description: Administrar la configuración del mundo
     delete:
-      parameters: <jugador>
-      description: elimina la isla de un jugador
+      parameters: '[jugador]'
+      description: 'elimina la isla de un jugador, o la isla en la que estás si no se indica un jugador'
       cannot-delete-owner: >-
         <red>Todos los miembros de la isla deben ser expulsados ​​de la isla antes</red>
         de eliminarla.

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -288,13 +288,18 @@ commands:
       reserved-island: '<green>l''île à [xyz] est réservée pour le joueur </green><aqua>[name] </aqua><green>.</green>'
       already-owned: '<red>Cette île appartient déjà à un autre joueur!</red>'
       no-island-here: '<red>Il n''y a pas d''île ici. Confirmez pour en faire une.</red>'
-      in-deletion: '<red>Cette île est en cours de suppression. Essayer plus tard.</red>'
+      in-deletion: '<gold>Cette île est en attente de suppression. L''enregistrer annulera
+        la suppression. Entrez à nouveau la commande pour confirmer.</gold>'
       cannot-make-island: >-
         <red>Une île ne peut pas être placée ici, désolé. Voir la console pour les</red>
         erreurs possibles.
       island-is-spawn: >-
         <gold>L'île est un spawn. Êtes-vous sûr? Entrez à nouveau la commande pour</gold>
         confirmer.
+    undelete:
+      description: supprime le statut de suppression en attente de [prefix_island] sans propriétaire sur laquelle vous êtes
+      not-in-deletion: '<red>Cette [prefix_island] n''est pas en attente de suppression.</red>'
+      undeleted-island: '<green>Statut de suppression retiré de [prefix_island] à [xyz]. Elle est maintenant sans propriétaire.</green>'
     unregister:
       parameters: <owner> [x,y,z]
       description: >-
@@ -601,8 +606,8 @@ commands:
     world:
       description: Gérer les paramètres du monde
     delete:
-      parameters: <joueur>
-      description: supprimer l'île d'un joueur
+      parameters: '[joueur]'
+      description: 'supprimer l''île d''un joueur, ou l''île sur laquelle vous vous trouvez si aucun joueur n''est indiqué'
       cannot-delete-owner: >-
         <red>Tous les membres de l'île doivent être expulsés avant de la</red>
         supprimer.

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -272,11 +272,16 @@ commands:
       reserved-island: '<green>Rezervirani otok na [xyz] za [name].</green>'
       already-owned: '<red>Island je već u vlasništvu drugog igrača!</red>'
       no-island-here: '<red>Ovdje nema otoka. Potvrdite da napravite jedan.</red>'
-      in-deletion: '<red>Ovaj otočni prostor trenutno se briše. Pokušaj kasnije.</red>'
+      in-deletion: '<gold>Ovaj otok čeka na brisanje. Njegova registracija otkazat će
+        brisanje. Ponovno unesite naredbu za potvrdu.</gold>'
       cannot-make-island: >-
         <red>Ovdje se ne može smjestiti otok, nažalost. Pogledajte konzolu za</red>
         moguće pogreške.
       island-is-spawn: '<gold>Otok je spawn. Jeste li sigurni? Ponovno unesite naredbu za potvrdu.</gold>'
+    undelete:
+      description: uklanja status čekanja na brisanje s [prefix_island] bez vlasnika na kojem stojiš
+      not-in-deletion: '<red>Ovaj [prefix_island] ne čeka na brisanje.</red>'
+      undeleted-island: '<green>Uklonjen status brisanja s [prefix_island] na [xyz]. Sada je bez vlasnika.</green>'
     unregister:
       parameters: <vlasnik> [x,y,z]
       description: odjaviti vlasnika s otoka, ali zadržati otočne blokove
@@ -567,8 +572,8 @@ commands:
     world:
       description: Upravljanje svjetskim postavkama
     delete:
-      parameters: <igrač>
-      description: briše igračev otok
+      parameters: '[igrač]'
+      description: 'briše igračev otok ili otok na kojem stojiš ako igrač nije naveden'
       cannot-delete-owner: '<red>Svi članovi otoka moraju biti izbačeni s otoka prije brisanja.</red>'
       deleted-island: '<green>Otok na </green><yellow>[xyz] </yellow><green>je uspješno izbrisan.</green>'
     deletehomes:

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -286,13 +286,18 @@ commands:
       reserved-island: '<green>fenntartott [prefix_island] a [xyz] címen a [name] számára.</green>'
       already-owned: 'Az <red>Island már egy másik játékos tulajdona!</red>'
       no-island-here: '<red>Itt nincs [prefix_island]. Erősítse meg, hogy készítsen egyet.</red>'
-      in-deletion: '<red>Ez a szigetterület jelenleg törlés alatt áll. Próbáld később.</red>'
+      in-deletion: '<gold>Ez a sziget törlésre vár. A regisztrálása megszakítja a törlést.
+        Írd be újra a parancsot a megerősítéshez.</gold>'
       cannot-make-island: >-
         <red>[prefix_Island] nem helyezhető ide, sajnálom. Lásd a konzolt a lehetséges</red>
         hibákért.
       island-is-spawn: >-
         <gold>A [prefix_island] spawn. biztos vagy ebben? A megerősítéshez írja be újra a</gold>
         parancsot.
+    undelete:
+      description: eltávolítja a függőben lévő törlési státuszt a tulajdonos nélküli [prefix_island] szigetről, amelyen állsz
+      not-in-deletion: '<red>Ez a [prefix_island] nem vár törlésre.</red>'
+      undeleted-island: '<green>A törlési státusz eltávolítva a [prefix_island] szigetről itt: [xyz]. Most már tulajdonos nélküli.</green>'
     unregister:
       parameters: <tulajdonos> [x,y,z]
       description: >-
@@ -601,8 +606,8 @@ commands:
     world:
       description: Világbeállítások kezelése
     delete:
-      parameters: <játékos>
-      description: törli a játékos szigetét
+      parameters: '[játékos]'
+      description: 'törli a játékos szigetét, vagy a szigetet, amelyen állsz, ha nincs játékos megadva'
       cannot-delete-owner: '<red>A [prefix_island] összes tagját ki kell rúgni a szigetről, mielőtt törli.</red>'
       deleted-island: '<green>[prefix_island] itt: </green><yellow>[xyz] </yellow><green>sikeresen törölve.</green>'
     deletehomes:

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -273,13 +273,18 @@ commands:
       reserved-island: '<green>Pulau yang dilindungi di [xyz] untuk [name].</green>'
       already-owned: '<red>Pulau sudah dimiliki oleh pemain lain!</red>'
       no-island-here: '<red>Tidak ada pulau di sini. Konfirmasikan untuk membuatnya.</red>'
-      in-deletion: '<red>Ruang pulau ini sedang dihapus. Coba nanti.</red>'
+      in-deletion: '<gold>Pulau ini menunggu untuk dihapus. Mendaftarkannya akan membatalkan
+        penghapusan. Masukkan perintah lagi untuk mengonfirmasi.</gold>'
       cannot-make-island: >-
         <red>Sebuah pulau tidak dapat ditempatkan di sini, maaf. Lihat konsol</red>
         untuk kemungkinan kesalahan.
       island-is-spawn: >-
         <gold>Pulau muncul. Apa kamu yakin? Masukkan perintah lagi untuk</gold>
         mengonfirmasi.
+    undelete:
+      description: menghapus status penghapusan tertunda dari [prefix_island] tanpa pemilik tempat kamu berada
+      not-in-deletion: '<red>[prefix_island] ini tidak menunggu untuk dihapus.</red>'
+      undeleted-island: '<green>Status penghapusan dihapus dari [prefix_island] di [xyz]. Sekarang tanpa pemilik.</green>'
     unregister:
       parameters: <pemilik> [x,y,z]
       description: batalkan pendaftaran pemilik dari pulau, tetapi pertahankan blok pulau
@@ -578,8 +583,8 @@ commands:
     world:
       description: Kelola pengaturan dunia
     delete:
-      parameters: <pemain>
-      description: menghapus pulau pemain
+      parameters: '[pemain]'
+      description: 'menghapus pulau pemain, atau pulau tempat kamu berdiri jika tidak ada pemain yang diberikan'
       cannot-delete-owner: >-
         <red>Semua anggota pulau harus dikeluarkan dari pulau sebelum</red>
         menghapusnya.

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -279,11 +279,16 @@ commands:
       reserved-island: '<green>Riservata la isola in  [xyz] per un giocatore.</green>'
       already-owned: '<red>L''isola è già posseduta da un''altro giocatore!</red>'
       no-island-here: '<red>Non ci sono isole qua. Conferma il comando per crearne una.</red>'
-      in-deletion: '<red>Lo spazio di quest''isola sta venendo eliminato. Prova più tardi.</red>'
+      in-deletion: '<gold>Quest''isola è in attesa di eliminazione. Registrarla annullerà
+        l''eliminazione. Inserisci di nuovo il comando per confermare.</gold>'
       cannot-make-island: >-
         <red>Qui non possono essere piazzate isole. Guarda la console per</red>
         controllare possibili errori.
       island-is-spawn: '<gold>La isola è uno spawn. Sei sicuro? Rifai il comando per confermare.</gold>'
+    undelete:
+      description: rimuove lo stato di eliminazione in sospeso dall'[prefix_island] senza proprietario su cui ti trovi
+      not-in-deletion: '<red>Quest''[prefix_island] non è in attesa di eliminazione.</red>'
+      undeleted-island: '<green>Stato di eliminazione rimosso dall''[prefix_island] a [xyz]. Ora è senza proprietario.</green>'
     unregister:
       parameters: <proprietario> [x,y,z]
       description: dissocia un proprietario dall'isola, ma mantenendo i blocchi dell'isola
@@ -594,8 +599,8 @@ commands:
     world:
       description: Gestisci le impostazioni del mondo
     delete:
-      parameters: <player>
-      description: elimina l'isola di un giocatore
+      parameters: '[player]'
+      description: 'elimina l''isola di un giocatore, o l''isola su cui ti trovi se non viene indicato un giocatore'
       cannot-delete-owner: >-
         <red>Tutti i membri di un'isola devono essere cacciati, prima di eliminare</red>
         l'isola.

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -238,9 +238,13 @@ commands:
       reserved-island: '<green>プレイヤー用に[xyz]に島を予約しました。</green>'
       already-owned: '<red>島はすでに他のプレイヤーが所有している!</red>'
       no-island-here: '<red>ここには島はない1つを確認します。</red>'
-      in-deletion: '<red>この島のスペースは現在削除中です。後で試してください。</red>'
+      in-deletion: '<gold>この島は削除待ちです。登録すると削除が取り消されます。確認するにはコマンドをもう一度入力してください。</gold>'
       cannot-make-island: '<red>島はここに配置できません。申し訳ありません。考えられるエラーについては、コンソールをご覧ください。</red>'
       island-is-spawn: '<gold>島が生成されます。本気ですか？もう一度コマンドを入力して確認します。</gold>'
+    undelete:
+      description: あなたがいる所有者のいない[prefix_island]から保留中の削除ステータスを解除します
+      not-in-deletion: '<red>この[prefix_island]は削除待ちではありません。</red>'
+      undeleted-island: '<green>[xyz]の[prefix_island]から削除ステータスを解除しました。現在は所有者がいません。</green>'
     unregister:
       parameters: <所有者> [x,y,z]
       description: 島から所有者を登録解除するが、島のブロックを維持する
@@ -511,8 +515,8 @@ commands:
     world:
       description: 世界の設定を管理する
     delete:
-      parameters: <プレイヤー>
-      description: プレイヤーの島を削除します。
+      parameters: '[プレイヤー]'
+      description: 'プレイヤーの島を削除します。プレイヤーが指定されていない場合は、あなたがいる島を削除します。'
       cannot-delete-owner: '<red>すべての島のメンバーは、それを削除する前に島から追い出される必要があります。</red>'
       deleted-island: '<dark_green>[xyz] の島は正常に削除されました。</dark_green>'
     deletehomes:

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -255,9 +255,13 @@ commands:
       reserved-island: '<green>[xyz] 에 있는섬을 [name]에게 예약걸었습니다.</green>'
       already-owned: '<red>이섬은 이미 주인이 있습니다!</red>'
       no-island-here: '<red>그곳에는 섬이 없습니다. 명령어를 한번더 입력하여 하나 만듭니다.</red>'
-      in-deletion: '<red>섬 공간이 삭제되었습니다 잠시후 다시 시도해보세요</red>'
+      in-deletion: '<gold>이 섬은 삭제 대기 중입니다. 등록하면 삭제가 취소됩니다. 확인하려면 명령어를 다시 입력하세요.</gold>'
       cannot-make-island: '<red>섬은 이곳에 만들수 없습니다. 죄송합니다. 콘솔을 참고해주세요.</red>'
       island-is-spawn: '<gold>섬이 생성되었습니다. 정말로 하시겠습니까? 명령어를 한번더 입력해주세요.</gold>'
+    undelete:
+      description: 당신이 있는 소유자 없는 [prefix_island]에서 삭제 대기 상태를 제거합니다
+      not-in-deletion: '<red>이 [prefix_island]은(는) 삭제 대기 중이 아닙니다.</red>'
+      undeleted-island: '<green>[xyz]의 [prefix_island]에서 삭제 상태를 제거했습니다. 이제 소유자가 없습니다.</green>'
     unregister:
       parameters: <주인> [x,y,z]
       description: 섬을 주인없는 섬으로 만들지만 섬은 유지됩니다
@@ -527,8 +531,8 @@ commands:
     world:
       description: 월드 설정
     delete:
-      parameters: <player>
-      description: 플레이어의 섬을 삭제합니다
+      parameters: '[player]'
+      description: '플레이어의 섬을 삭제합니다. 플레이어를 지정하지 않으면 당신이 서 있는 섬을 삭제합니다'
       cannot-delete-owner: '<red>섬을 삭제하기 전에 모든 섬원을 추방해야합니다.</red>'
       deleted-island: '<yellow>[xyz] </yellow><green>에 있던 섬을 삭제했습니다</green>'
     deletehomes:

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -275,13 +275,18 @@ commands:
       reserved-island: '<green>Sala ir rezērvēta [xyz] priekš spēlētāja.</green>'
       already-owned: '<red>Sala jau pieder citam spēlētājam!</red>'
       no-island-here: '<red>Šeit neatrodas neviena sala! Apstiprini, lai izveidotu.</red>'
-      in-deletion: '<red>Šī salas pozīcija šobrīt tiek dzēsta. Mēģini vēlāk.</red>'
+      in-deletion: '<gold>Šī sala gaida dzēšanu. Tās reģistrēšana atcels dzēšanu. Ievadi
+        komandu vēlreiz, lai apstiprinātu.</gold>'
       cannot-make-island: >-
         <red>Atvaino, bet neizdevās izveidot šeit salu. Iespējams konsulē ir kļūdas</red>
         paziņojumi.
       island-is-spawn: >-
         <gold>Šī ir sākuma sala. Vai tiešām vēlies turpināt? Ievadi komandu</gold>
         vēlreiz, lai apstiprinātu.
+    undelete:
+      description: noņem gaidošo dzēšanas statusu no [prefix_island] bez īpašnieka, uz kuras tu stāvi
+      not-in-deletion: '<red>Šī [prefix_island] negaida dzēšanu.</red>'
+      undeleted-island: '<green>Dzēšanas statuss noņemts no [prefix_island] pie [xyz]. Tagad tā ir bez īpašnieka.</green>'
     unregister:
       parameters: <īpašnieks> [x,y,z]
       description: atreģistrē īpašnieku no salas paturot salas blokus
@@ -574,8 +579,8 @@ commands:
     world:
       description: Pārvaldīt pasaules iestatījumus
     delete:
-      parameters: <spēlētājs>
-      description: izdzēš spēlētāja salu
+      parameters: '[spēlētājs]'
+      description: 'izdzēš spēlētāja salu vai salu, uz kuras tu stāvi, ja spēlētājs nav norādīts'
       cannot-delete-owner: >-
         <red>Visi spēlētāja komandas biedriem ir jābūt izmestiem no komandas pirms</red>
         salas dzēšanas.

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -280,13 +280,19 @@ commands:
       reserved-island: '<green>gereserveerd eiland op [xyz] voor [name].</green>'
       already-owned: '<red>Eiland is al eigendom van een andere speler!</red>'
       no-island-here: '<red>Er is hier geen eiland. Bevestig om er een te maken.</red>'
-      in-deletion: '<red>Deze eilandruimte wordt momenteel verwijderd. Probeer later.</red>'
+      in-deletion: '<gold>Dit eiland staat op de nominatie om verwijderd te worden. Door
+        het te registreren wordt de verwijdering geannuleerd. Voer het commando nogmaals
+        in om te bevestigen.</gold>'
       cannot-make-island: >-
         <red>Hier kan geen eiland worden geplaatst, sorry. Zie console voor</red>
         mogelijke fouten.
       island-is-spawn: >-
         <gold>Eiland wordt uitgezet. Weet je het zeker? Voer de opdracht nogmaals</gold>
         in om te bevestigen.
+    undelete:
+      description: verwijdert de aanstaande verwijderstatus van [prefix_island] zonder eigenaar waar je op staat
+      not-in-deletion: '<red>Dit [prefix_island] staat niet op de nominatie om verwijderd te worden.</red>'
+      undeleted-island: '<green>Verwijderstatus verwijderd van [prefix_island] op [xyz]. Het heeft nu geen eigenaar.</green>'
     unregister:
       parameters: <eigenaar> [x,y,z]
       description: >-
@@ -599,8 +605,8 @@ commands:
     world:
       description: Beheer wereldinstellingen
     delete:
-      parameters: <speler>
-      description: verwijdert het eiland van een speler
+      parameters: '[speler]'
+      description: 'verwijdert het eiland van een speler, of het eiland waar je op staat als er geen speler is opgegeven'
       cannot-delete-owner: >-
         <red>Alle eilandleden moeten van het eiland worden verwijderd voordat ze</red>
         het kunnen verwijderen.

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -275,11 +275,16 @@ commands:
       reserved-island: '<green>Zarezerwowano wyspę na [xyz] dla gracza.</green>'
       already-owned: '<red>Wyspa jest już własnością innego gracza!</red>'
       no-island-here: '<red>Tu nie ma wyspy. Potwierdź, aby ją utworzyć.</red>'
-      in-deletion: '<red>Ta wyspa jest w trakcie usuwania. Spróbuj później.</red>'
+      in-deletion: '<gold>Ta wyspa oczekuje na usunięcie. Zarejestrowanie jej anuluje
+        usuwanie. Wpisz komendę ponownie, aby potwierdzić.</gold>'
       cannot-make-island: >-
         <red>Niestety nie można tu umieścić wyspy. Zobacz konsolę dla możliwych</red>
         błędów.
       island-is-spawn: '<gold>Ta wyspa jest wyspą spawnu. Jesteś pewny? Wpisz ponownie tę komendę.</gold>'
+    undelete:
+      description: usuwa oczekujący status usunięcia z [prefix_island] bez właściciela, na której stoisz
+      not-in-deletion: '<red>Ta [prefix_island] nie oczekuje na usunięcie.</red>'
+      undeleted-island: '<green>Usunięto status usunięcia z [prefix_island] na [xyz]. Jest teraz bez właściciela.</green>'
     unregister:
       parameters: <właściciel> [x,y,z]
       description: wyrejestruj właściciela z wyspy, ale zachowaj bloki wyspy
@@ -574,8 +579,8 @@ commands:
     world:
       description: Zarządzaj ustawieniami świata
     delete:
-      parameters: <gracz>
-      description: usuwa wyspę gracza
+      parameters: '[gracz]'
+      description: 'usuwa wyspę gracza lub wyspę, na której stoisz, jeśli nie podano gracza'
       cannot-delete-owner: >-
         <red>Wszyscy członkowie wyspy muszą zostać wyrzuceni z wyspy przed jej</red>
         usunięciem.

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -269,13 +269,18 @@ commands:
       reserved-island: '<green>A ilha em [xyz] foi reservada para [name].</green>'
       already-owned: '<red>Essa ilha já é posse de outro jogador!</red>'
       no-island-here: '<red>Não há uma ilha aqui. Confirme para criar uma.</red>'
-      in-deletion: '<red>Esse espaço de ilha está sendo excluído no momento. Tente mais tarde.</red>'
+      in-deletion: '<gold>Esta ilha está pendente de exclusão. Registrá-la cancelará
+        a exclusão. Digite o comando novamente para confirmar.</gold>'
       cannot-make-island: >-
         <red>Uma ilha não pôde ser colocada aqui, desculpe. Veja o console para</red>
         possíveis erros.
       island-is-spawn: >-
         <gold>Essa ilha é o spawn. Você tem certeza? Digite o comando novamente</gold>
         para confirmar.
+    undelete:
+      description: remove o status de exclusão pendente da [prefix_island] sem dono em que você está
+      not-in-deletion: '<red>Esta [prefix_island] não está pendente de exclusão.</red>'
+      undeleted-island: '<green>Status de exclusão removido da [prefix_island] em [xyz]. Agora está sem dono.</green>'
     unregister:
       parameters: <dono> [x,y,z]
       description: desregistrar dono da ilha, mas manter os blocos
@@ -572,8 +577,8 @@ commands:
     world:
       description: Gerenciar opções de mundo
     delete:
-      parameters: <jogador>
-      description: excluir a ilha de um jogador
+      parameters: '[jogador]'
+      description: 'exclui a ilha de um jogador, ou a ilha em que você está se nenhum jogador for informado'
       cannot-delete-owner: '<red>Todos os membros da ilha devem ser expulsos antes de excluí-la.</red>'
       deleted-island: '<green>A ilha em </green><yellow>[xyz] </yellow><green>foi excluída com sucesso.</green>'
     deletehomes:

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -276,13 +276,18 @@ commands:
       reserved-island: '<green>Ilha reservada em [xyz] para [name].</green>'
       already-owned: '<red>Ilha já pertence a outro jogador!</red>'
       no-island-here: '<red>Não há ilha aqui. Confirme para criar uma.</red>'
-      in-deletion: '<red>Este espaço na ilha está sendo excluído no momento. Tente depois.</red>'
+      in-deletion: '<gold>Esta ilha está pendente de exclusão. Registá-la cancelará a
+        exclusão. Introduza o comando novamente para confirmar.</gold>'
       cannot-make-island: >-
         <red>Uma ilha não pode ser colocada aqui, desculpe. Veja o console para</red>
         possíveis erros.
       island-is-spawn: >-
         <gold>Ilha é spawn. Você tem certeza? Digite o comando novamente para</gold>
         confirmar.
+    undelete:
+      description: remove o estado de exclusão pendente da [prefix_island] sem dono onde estás
+      not-in-deletion: '<red>Esta [prefix_island] não está pendente de exclusão.</red>'
+      undeleted-island: '<green>Estado de exclusão removido da [prefix_island] em [xyz]. Agora está sem dono.</green>'
     unregister:
       parameters: <proprietário> [x,y,z]
       description: Remover o registro de dono da ilha, mas manter os blocos da ilha
@@ -579,8 +584,8 @@ commands:
     world:
       description: Gerenciar configurações mundiais
     delete:
-      parameters: <jogador>
-      description: exclui a ilha de um jogador
+      parameters: '[jogador]'
+      description: 'exclui a ilha de um jogador, ou a ilha onde estás se nenhum jogador for indicado'
       cannot-delete-owner: >-
         <red>Todos os membros da ilha devem ser expulsos da ilha antes de</red>
         excluí-la.

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -278,13 +278,18 @@ commands:
       reserved-island: '<italic>insulă rezervată la [xyz] pentru [name].</italic>'
       already-owned: '<red>Island este deja deținut de un alt jucător!</red>'
       no-island-here: '<red>Nu există insulă aici. Confirmați să faceți una.</red>'
-      in-deletion: '<red>Acest spațiu insular este în prezent șters. Încercați mai târziu.</red>'
+      in-deletion: '<gold>Această insulă așteaptă să fie ștearsă. Înregistrarea ei va
+        anula ștergerea. Introdu comanda din nou pentru a confirma.</gold>'
       cannot-make-island: >-
         <red>O insulă nu poate fi plasată aici, îmi pare rău. Consultați consola</red>
         pentru eventuale erori.
       island-is-spawn: >-
         <gold>Insula este spawn. Ești sigur? Introduceți din nou comanda pentru</gold>
         a confirma.
+    undelete:
+      description: elimină starea de ștergere în așteptare de pe [prefix_island] fără proprietar pe care te afli
+      not-in-deletion: '<red>Această [prefix_island] nu este în așteptarea ștergerii.</red>'
+      undeleted-island: '<green>Starea de ștergere a fost eliminată de pe [prefix_island] la [xyz]. Acum este fără proprietar.</green>'
     unregister:
       parameters: <proprietar> [x,y,z]
       description: >-
@@ -585,8 +590,8 @@ commands:
     world:
       description: Gestionați setările lumii
     delete:
-      parameters: <player>
-      description: șterge insula unui jucător
+      parameters: '[player]'
+      description: 'șterge insula unui jucător sau insula pe care te afli dacă nu este specificat niciun jucător'
       cannot-delete-owner: >-
         <red>Toți membrii insulei trebuie expulzați din insulă înainte de ao</red>
         șterge.

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -274,12 +274,16 @@ commands:
       reserved-island: <green>Остров на координатах [xyz] зарезервирован для [name].</green>
       already-owned: <red>Остров уже принадлежит другому игроку!</red>
       no-island-here: <red>Здесь нет острова. Подтвердите для создания острова.</red>
-      in-deletion: <red>Это пространство для острова уже было удалено. Попробуйте
-        позднее.</red>
+      in-deletion: '<gold>Этот остров ожидает удаления. Его регистрация отменит удаление.
+        Введите команду ещё раз для подтверждения.</gold>'
       cannot-make-island: <red>Остров не может быть размещён здесь, извините. Посмотрите
         в консоль за возможными ошибками.</red>
       island-is-spawn: <gold>Остров является спавном. Вы уверены? Введите команду
         снова для подтверждения.</gold>
+    undelete:
+      description: снимает статус ожидания удаления с [prefix_island] без владельца, на котором вы стоите
+      not-in-deletion: '<red>Этот [prefix_island] не ожидает удаления.</red>'
+      undeleted-island: '<green>Статус удаления снят с [prefix_island] на [xyz]. Теперь он без владельца.</green>'
     unregister:
       parameters: <владелец> [x,y,z]
       description: разрегистрирует остров, но сохраняет блоки на острове
@@ -571,8 +575,8 @@ commands:
     world:
       description: управление настройками мира
     delete:
-      parameters: <игрок>
-      description: удаление острова игрока
+      parameters: '[игрок]'
+      description: 'удаление острова игрока или острова, на котором вы стоите, если игрок не указан'
       cannot-delete-owner: <red>Все участники острова будут изгнаны перед удалением.</red>
       deleted-island: <green>Остров на координатах <yellow>[xyz] </yellow>успешно
         удален.</green>

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -269,13 +269,18 @@ commands:
       reserved-island: '<dark_purple>[xyz] </dark_purple><blue>koordinatlarındaki ada oyuncuya ayrıldı.</blue>'
       already-owned: '<dark_red>Bu ada zaten sahipli!</dark_red>'
       no-island-here: '<dark_red>Burda ada yok. Olusturmak icin kabul et!</dark_red>'
-      in-deletion: '<dark_red>Ada şuanda siliniyor daha sonra tekrar dene!</dark_red>'
+      in-deletion: '<gold>Bu ada silinmeyi bekliyor. Kaydetmek silmeyi iptal eder. Onaylamak
+        için komutu tekrar gir.</gold>'
       cannot-make-island: >-
         <dark_purple>Buraya ada yerleştirilemiyor. Lütfen detaylı bilgi için konsola</dark_purple>
         bakınız!
       island-is-spawn: >-
         <gold>Başlangıç adası, buna emin misiniz ?Kabul etmek için komutu tekrar</gold>
         girin!
+    undelete:
+      description: üzerinde bulunduğun sahipsiz [prefix_island] üzerindeki bekleyen silme durumunu kaldırır
+      not-in-deletion: '<red>Bu [prefix_island] silinmeyi beklemiyor.</red>'
+      undeleted-island: '<green>[xyz] konumundaki [prefix_island] üzerindeki silme durumu kaldırıldı. Artık sahipsiz.</green>'
     unregister:
       parameters: <sahip> [x,y,z]
       description: Oyuncuyu adadan siler ama ada silinmez.
@@ -566,8 +571,8 @@ commands:
     world:
       description: Dünya ayarlarını yönet"
     delete:
-      parameters: <oyuncu>
-      description: Oyuncunun adasını siler.
+      parameters: '[oyuncu]'
+      description: 'Oyuncunun adasını siler veya oyuncu belirtilmezse üzerinde bulunduğun adayı siler.'
       cannot-delete-owner: '<dark_red>Silmeden önce adadaki herkesi at.</dark_red>'
       deleted-island: '<yellow>[xyz] </yellow><aqua>kordinatlarındaki ada başarıyla silindi</aqua>'
     deletehomes:

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -247,9 +247,14 @@ commands:
       reserved-island: '<green>Зарезервовано [prefix_island] за [xyz] для [name].</green>'
       already-owned: '<red>[prefix_island] уже належить іншому гравцю!</red>'
       no-island-here: '<red>Тут немає [prefix_island]. Підтвердіть, щоб створити.</red>'
-      in-deletion: '<red>Цей простір [prefix_island] зараз видаляється. Спробуйте пізніше.</red>'
+      in-deletion: '<gold>Цей [prefix_island] очікує на видалення. Його реєстрація скасує
+        видалення. Введіть команду ще раз для підтвердження.</gold>'
       cannot-make-island: '<red>[prefix_an-island] не може бути створено тут. Див. консоль на помилки.</red>'
       island-is-spawn: '<gold>[prefix_island] — це спавн. Ви впевнені? Виконайте команду ще раз для підтвердження.</gold>'
+    undelete:
+      description: знімає статус очікування видалення з [prefix_island] без власника, на якому ви стоїте
+      not-in-deletion: '<red>Цей [prefix_island] не очікує на видалення.</red>'
+      undeleted-island: '<green>Статус видалення знято з [prefix_island] на [xyz]. Тепер він без власника.</green>'
     unregister:
       parameters: <owner> [x,y,z]
       description: зняти реєстрацію власника з [prefix_island], але залишити блоки [prefix_island]
@@ -518,8 +523,8 @@ commands:
     world:
       description: Керування налаштуваннями світу
     delete:
-      parameters: <гравець>
-      description: видалити [prefix_island] гравця
+      parameters: '[гравець]'
+      description: 'видалити [prefix_island] гравця або [prefix_island], на якому ви стоїте, якщо гравця не вказано'
       cannot-delete-owner: '<red>Усі учасники [prefix_island] мають бути вигнані до видалення.</red>'
       deleted-island: '<green>[prefix_Island] за </green><yellow>[xyz] </yellow><green>успішно видалено.</green>'
     deletehomes:

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -272,9 +272,14 @@ commands:
       reserved-island: '<green>Để dành đảo ở [xyz] cho [name].</green>'
       already-owned: '<red>Đảo đã có chủ!</red>'
       no-island-here: '<red>Không có đảo ở đây. Xác nhận để tạo.</red>'
-      in-deletion: '<red>Không gian đảo này đang được xóa. Thử lại.</red>'
+      in-deletion: '<gold>Hòn đảo này đang chờ bị xóa. Việc đăng ký sẽ hủy việc xóa. Nhập
+        lại lệnh để xác nhận.</gold>'
       cannot-make-island: '<red>Đảo không thể đặt ở đây. Xem bảng điều khiển để xem lỗi tiềm ẩn.</red>'
       island-is-spawn: '<gold>Đảo là điểm triệu hồi. Bạn chắc chứ? Nhập lần nữa để xác nhận.</gold>'
+    undelete:
+      description: xóa trạng thái chờ xóa khỏi [prefix_island] không có chủ mà bạn đang đứng trên đó
+      not-in-deletion: '<red>[prefix_island] này không đang chờ bị xóa.</red>'
+      undeleted-island: '<green>Đã xóa trạng thái xóa khỏi [prefix_island] tại [xyz]. Bây giờ nó không có chủ.</green>'
     unregister:
       parameters: <chủ> [x,y,z]
       description: hủy đăng kí chủ đảo khỏi đảo này. nhưng giữ lại tài nguyên đảo
@@ -565,8 +570,8 @@ commands:
     world:
       description: Quản lý cài đặt thế giới
     delete:
-      parameters: <người chơi>
-      description: xóa đảo của người chơi
+      parameters: '[người chơi]'
+      description: 'xóa đảo của người chơi, hoặc đảo bạn đang đứng nếu không có người chơi nào được cung cấp'
       cannot-delete-owner: >-
         <red>Tất cả thành viên đảo phải bị đuổi khỏi đảo trước khi xóa.</red>
       deleted-island: '<green>Đảo tại </green><yellow>[xyz] </yellow><green>đã được xóa thành công.</green>'

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -244,11 +244,15 @@ commands:
       reserved-island: '<green>已为玩家</green><aqua>[name]</aqua><green>预留了位于</green><aqua>[xyz]</aqua><green>的岛屿.</green>'
       already-owned: '<red>当前岛屿已有所属!</red>'
       no-island-here: '<red>当前位置没有岛屿, 是否要创建一个?</red>'
-      in-deletion: '<red>当前位置对应的岛屿正在删除中, 请稍后再试.</red>'
+      in-deletion: '<gold>该岛屿正在等待删除. 注册它将取消删除. 再次输入命令以确认.</gold>'
       cannot-make-island: '<red>当前位置无法创建岛屿, 请查看控制台查看可能的错误.</red>'
       island-is-spawn: |-
         <red>当前岛屿是出生点岛屿, 确定要让玩家认领这个岛屿吗?</red>
         <gold>请再次输入命令以确认.</gold>
+    undelete:
+      description: 移除你所在的无主[prefix_island]的待删除状态
+      not-in-deletion: '<red>这个[prefix_island]没有等待删除.</red>'
+      undeleted-island: '<green>已移除[xyz]处[prefix_island]的删除状态. 现在它无主.</green>'
     unregister:
       parameters: <拥有者> [x,y,z]
       description: 设置为无主岛屿并保留岛屿建筑
@@ -526,8 +530,8 @@ commands:
     world:
       description: 管理世界设置
     delete:
-      parameters: <玩家>
-      description: 删除玩家的岛屿
+      parameters: '[玩家]'
+      description: '删除玩家的岛屿，如果未指定玩家则删除你所站的岛屿'
       cannot-delete-owner: '<red>删除岛屿之前, 必须将所有团队成员踢出队伍.</red>'
       deleted-island: '<green>位于</green><yellow>[xyz]</yellow><green>的岛屿已成功删除.</green>'
     deletehomes:

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -245,11 +245,15 @@ commands:
       reserved-island: '<green>已為 [name] 保留位於 [xyz] 的[prefix_island]。</green>'
       already-owned: '<red>該島嶼不是無人島!</red>'
       no-island-here: '<red>這個地方沒有島嶼。確認來創建一個。</red>'
-      in-deletion: '<red>這個島嶼空間正在被刪除。 請稍後再試</red>'
+      in-deletion: '<gold>這個島嶼正在等待刪除。 註冊它將取消刪除。 再次輸入指令以確認。</gold>'
       cannot-make-island: '<red>抱歉，不能在這裡創建島嶼。 請參閱控制台以獲取詳細信息。</red>'
       island-is-spawn: |-
         <red>所處位置為出生點島嶼， 您確定要將玩家注冊到這個島嶼上？</red>
         <gold>請再次輸入命令以確認。</gold>
+    undelete:
+      description: 移除你所在的無主[prefix_island]的待刪除狀態
+      not-in-deletion: '<red>這個[prefix_island]沒有等待刪除。</red>'
+      undeleted-island: '<green>已移除[xyz]處[prefix_island]的刪除狀態。 現在它無主。</green>'
     unregister:
       parameters: <owner> [x,y,z]
       description: 將島主註銷但保留方塊
@@ -524,8 +528,8 @@ commands:
     world:
       description: 管理世界設置
     delete:
-      parameters: <player>
-      description: 刪除玩家的島嶼
+      parameters: '[player]'
+      description: '刪除玩家的島嶼，如果未指定玩家則刪除你所站的島嶼'
       cannot-delete-owner: '<red>刪除之前必須將所有島嶼成員都踢出島嶼。</red>'
       deleted-island: '<green>位於 </green><yellow>[xyz] </yellow><green>的島嶼已經被成功刪除。</green>'
     deletehomes:

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
@@ -334,7 +334,7 @@ class AdminDeleteCommandTest extends CommonTestSetup {
         itl.execute(user, itl.getLabel(), Collections.emptyList());
         itl.execute(user, itl.getLabel(), Collections.emptyList());
         // Only the island stood on is deleted, with its owner as the involved player
-        verify(im).deleteIsland(eq(island), eq(true), eq(notUUID));
+        verify(im).deleteIsland(island, true, notUUID);
         verify(im, never()).removePlayer(eq(world), any(UUID.class));
     }
 

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminDeleteCommandTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -243,6 +244,98 @@ class AdminDeleteCommandTest extends CommonTestSetup {
 
         verify(im).deleteIsland(eq(island), eq(true), eq(notUUID));
         verify(im, never()).hardDeleteIsland(any());
+    }
+
+    /**
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)}.
+     * No argument and the console cannot stand on an island - show help.
+     */
+    @Test
+    void testNoArgConsoleShowsHelp() {
+        when(user.isPlayer()).thenReturn(false);
+        AdminDeleteCommand itl = new AdminDeleteCommand(ac);
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
+        verify(user, never()).sendMessage("general.errors.not-on-island");
+    }
+
+    /**
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)}.
+     * No argument, standing in the wrong world.
+     */
+    @Test
+    void testNoArgWrongWorld() {
+        when(user.isPlayer()).thenReturn(true);
+        when(user.getWorld()).thenReturn(mock(org.bukkit.World.class));
+        AdminDeleteCommand itl = new AdminDeleteCommand(ac);
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
+        verify(user).sendMessage("general.errors.wrong-world");
+    }
+
+    /**
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)}.
+     * No argument, not standing on an island.
+     */
+    @Test
+    void testNoArgNotOnIsland() {
+        when(user.isPlayer()).thenReturn(true);
+        when(user.getWorld()).thenReturn(world);
+        when(user.getLocation()).thenReturn(location);
+        when(im.getIslandAt(location)).thenReturn(Optional.empty());
+        AdminDeleteCommand itl = new AdminDeleteCommand(ac);
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
+        verify(user).sendMessage("general.errors.not-on-island");
+    }
+
+    /**
+     * Test method for {@link AdminDeleteCommand#canExecute(User, String, java.util.List)}.
+     * No argument, standing on an island that still has a team - refuse.
+     */
+    @Test
+    void testNoArgIslandHasTeam() {
+        when(user.isPlayer()).thenReturn(true);
+        when(user.getWorld()).thenReturn(world);
+        when(user.getLocation()).thenReturn(location);
+        when(island.hasTeam()).thenReturn(true);
+        when(im.getIslandAt(location)).thenReturn(Optional.of(island));
+        AdminDeleteCommand itl = new AdminDeleteCommand(ac);
+        assertFalse(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
+        verify(user).sendMessage("commands.admin.delete.cannot-delete-owner");
+    }
+
+    /**
+     * Test method for {@link AdminDeleteCommand#execute(User, String, java.util.List)}.
+     * No argument, standing on a teamless island - soft-delete it after confirmation.
+     */
+    @Test
+    void testNoArgDeletesIslandStandingOn() {
+        when(user.isPlayer()).thenReturn(true);
+        when(user.getWorld()).thenReturn(world);
+        when(user.getLocation()).thenReturn(location);
+        when(island.hasTeam()).thenReturn(false);
+        when(island.getOwner()).thenReturn(notUUID);
+        when(island.getCenter()).thenReturn(location);
+        when(island.getWorld()).thenReturn(world);
+        when(location.toVector()).thenReturn(new Vector(1, 2, 3));
+        when(im.getIslandAt(location)).thenReturn(Optional.of(island));
+
+        // Scheduler that runs the confirmation runnable immediately
+        BukkitScheduler scheduler = mock(BukkitScheduler.class);
+        BukkitTask task = mock(BukkitTask.class);
+        when(scheduler.runTaskLater(any(), any(Runnable.class), any(Long.class))).thenReturn(task);
+        when(scheduler.runTask(any(), any(Runnable.class))).thenAnswer(inv -> {
+            inv.<Runnable>getArgument(1).run();
+            return task;
+        });
+        mockedBukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+
+        AdminDeleteCommand itl = new AdminDeleteCommand(ac);
+        assertTrue(itl.canExecute(user, itl.getLabel(), Collections.emptyList()));
+        // First execute asks for confirmation, second confirms and runs it
+        itl.execute(user, itl.getLabel(), Collections.emptyList());
+        itl.execute(user, itl.getLabel(), Collections.emptyList());
+        // Only the island stood on is deleted, with its owner as the involved player
+        verify(im).deleteIsland(eq(island), eq(true), eq(notUUID));
+        verify(im, never()).removePlayer(eq(world), any(UUID.class));
     }
 
     private AdminDeleteCommand setupForDeletion() {

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -202,6 +202,7 @@ class AdminRegisterCommandTest extends CommonTestSetup {
 
     /**
      * Test method for {@link AdminRegisterCommand#canExecute(org.bukkit.command.CommandSender, String, String[])}.
+     * An island pending deletion can be registered after confirmation.
      */
     @Test
     void testCanExecuteInDeletionIsland() {
@@ -211,14 +212,26 @@ class AdminRegisterCommandTest extends CommonTestSetup {
         when(pm.getUUID(any())).thenReturn(notUUID);
         Location loc = mock(Location.class);
 
-        // Island has owner
-        when(island.getOwner()).thenReturn(uuid);
+        // Island is orphaned (owner cleared by the soft-delete)
+        when(island.getOwner()).thenReturn(null);
         Optional<Island> opi = Optional.of(island);
         when(im.getIslandAt(any())).thenReturn(opi);
         when(user.getLocation()).thenReturn(loc);
 
+        // canExecute defers to a confirmation rather than registering immediately
         assertFalse(itl.canExecute(user, itl.getLabel(), List.of("tastybento")));
-        verify(user).sendMessage("commands.admin.register.in-deletion");
+        verify(user).getTranslation("commands.admin.register.in-deletion");
+    }
+
+    /**
+     * Test method for {@link AdminRegisterCommand#register(User, String)}.
+     * Registering an island clears its deletion status so the region purge skips it.
+     */
+    @Test
+    void testRegisterClearsDeletionStatus() {
+        testCanExecuteSuccess();
+        itl.register(user, "tastybento");
+        verify(im).undeleteIsland(island);
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminRegisterCommandTest.java
@@ -230,7 +230,7 @@ class AdminRegisterCommandTest extends CommonTestSetup {
     @Test
     void testRegisterClearsDeletionStatus() {
         testCanExecuteSuccess();
-        itl.register(user, "tastybento");
+        itl.register(user, uuid, island, "tastybento");
         verify(im).undeleteIsland(island);
     }
 
@@ -257,7 +257,7 @@ class AdminRegisterCommandTest extends CommonTestSetup {
     void testRegister() {
         testCanExecuteSuccess();
         when(island.isSpawn()).thenReturn(true);
-        itl.register(user, "tastybento");
+        itl.register(user, uuid, island, "tastybento");
         verify(im).setOwner(user, uuid, island, RanksManager.VISITOR_RANK);
         verify(im).clearSpawn(world);
         verify(user).sendMessage("commands.admin.register.registered-island", TextVariables.XYZ, "123,123,432", TextVariables.NAME,
@@ -272,7 +272,7 @@ class AdminRegisterCommandTest extends CommonTestSetup {
     void testReserveCannotMakeIsland() {
         when(im.createIsland(any(), eq(uuid))).thenReturn(null);
         testCanExecuteNoIsland();
-        itl.reserve(user, "tastybento");
+        itl.reserve(user, uuid, location, "tastybento");
         verify(im).createIsland(any(), eq(uuid));
         verify(user).sendMessage("commands.admin.register.cannot-make-island");
     }
@@ -283,7 +283,7 @@ class AdminRegisterCommandTest extends CommonTestSetup {
     @Test
     void testReserveCanMakeIsland() {
         testCanExecuteNoIsland();
-        itl.reserve(user, "tastybento");
+        itl.reserve(user, uuid, location, "tastybento");
         verify(im).createIsland(any(), eq(uuid));
         verify(user, never()).sendMessage("commands.admin.register.cannot-make-island");
         verify(block).setType(Material.BEDROCK);

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommandTest.java
@@ -27,7 +27,6 @@ import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
-import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.CommandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.util.Util;

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminUndeleteCommandTest.java
@@ -1,0 +1,140 @@
+package world.bentobox.bentobox.api.commands.admin;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import org.bukkit.World;
+import org.bukkit.util.Vector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.CommandsManager;
+import world.bentobox.bentobox.managers.LocalesManager;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Tests for {@link AdminUndeleteCommand}.
+ *
+ * @author tastybento
+ */
+class AdminUndeleteCommandTest extends CommonTestSetup {
+
+    @Mock
+    private CompositeCommand ac;
+    @Mock
+    private User user;
+
+    private AdminUndeleteCommand cmd;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        Util.setPlugin(plugin);
+
+        Settings settings = new Settings();
+        when(plugin.getSettings()).thenReturn(settings);
+        when(ac.getWorld()).thenReturn(world);
+
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+
+        // Player
+        when(user.getWorld()).thenReturn(world);
+        when(user.getLocation()).thenReturn(location);
+        when(user.isPlayer()).thenReturn(true);
+        when(user.getTranslation(anyString()))
+                .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+        User.getInstance(mockPlayer);
+        User.setPlugin(plugin);
+
+        // Parent command has no aliases
+        when(ac.getSubCommandAliases()).thenReturn(new HashMap<>());
+
+        // Locales
+        LocalesManager lm = mock(LocalesManager.class);
+        when(lm.get(any(), any())).thenReturn("mock translation");
+        when(plugin.getLocalesManager()).thenReturn(lm);
+
+        // Island - by default it is pending deletion
+        when(island.getWorld()).thenReturn(world);
+        when(island.getCenter()).thenReturn(location);
+        when(island.isDeletable()).thenReturn(true);
+        when(location.toVector()).thenReturn(new Vector(1, 2, 3));
+        when(im.getIslandAt(any())).thenReturn(Optional.of(island));
+
+        // DUT
+        cmd = new AdminUndeleteCommand(ac);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testCanExecuteTooManyArgs() {
+        assertFalse(cmd.canExecute(user, cmd.getLabel(), List.of("extra")));
+        // Shows help
+    }
+
+    @Test
+    void testCanExecuteWrongWorld() {
+        when(user.getWorld()).thenReturn(mock(World.class));
+        assertFalse(cmd.canExecute(user, cmd.getLabel(), new ArrayList<>()));
+        verify(user).sendMessage("general.errors.wrong-world");
+    }
+
+    @Test
+    void testCanExecuteNoIsland() {
+        when(im.getIslandAt(any())).thenReturn(Optional.empty());
+        assertFalse(cmd.canExecute(user, cmd.getLabel(), new ArrayList<>()));
+        verify(user).sendMessage("commands.admin.undelete.not-in-deletion");
+    }
+
+    @Test
+    void testCanExecuteIslandNotDeletable() {
+        when(island.isDeletable()).thenReturn(false);
+        assertFalse(cmd.canExecute(user, cmd.getLabel(), new ArrayList<>()));
+        verify(user).sendMessage("commands.admin.undelete.not-in-deletion");
+    }
+
+    @Test
+    void testCanExecuteSuccess() {
+        assertTrue(cmd.canExecute(user, cmd.getLabel(), new ArrayList<>()));
+        verify(user, never()).sendMessage(anyString());
+    }
+
+    @Test
+    void testExecute() {
+        // Set up the island reference via canExecute
+        assertTrue(cmd.canExecute(user, cmd.getLabel(), new ArrayList<>()));
+        assertTrue(cmd.execute(user, cmd.getLabel(), new ArrayList<>()));
+        // Island is unowned and no longer pending deletion
+        verify(island).setOwner(null);
+        verify(im).undeleteIsland(island);
+        verify(user).sendMessage("commands.admin.undelete.undeleted-island", TextVariables.XYZ, "1,2,3");
+        verify(user).sendMessage("general.success");
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/IslandsManagerTest.java
@@ -473,6 +473,20 @@ class IslandsManagerTest extends CommonTestSetup {
 
     /**
      * Test method for
+     * {@link world.bentobox.bentobox.managers.IslandsManager#undeleteIsland(world.bentobox.bentobox.database.objects.Island)}.
+     */
+    @Test
+    void testUndeleteIslandClearsFlags() {
+        Island island = islandsManager.createIsland(location, UUID.randomUUID());
+        island.setDeleted(true);
+        island.setDeletable(true);
+        islandsManager.undeleteIsland(island);
+        assertFalse(island.isDeleted());
+        assertFalse(island.isDeletable());
+    }
+
+    /**
+     * Test method for
      * {@link world.bentobox.bentobox.managers.IslandsManager#getIslandCount()}.
      */
     @Test


### PR DESCRIPTION
## What

Lets admins recover islands that are **soft-deleted** (marked `deletable`, owner cleared, awaiting the region-file purge by `PurgeRegionsService` / `HousekeepingManager`), and adds a location-based delete.

### `/admin register <player>` on an island pending deletion
Previously hard-blocked with `commands.admin.register.in-deletion` ("Try later."). Now that message becomes a **confirmation prompt** — confirming registers the island to the player and cancels its deletion. Register delegates the flag-clearing to the new shared manager method.

### `/admin undelete` (new command)
Clears the pending-deletion status of the island you are **standing on** and leaves it **unowned**. Only works on islands actually pending deletion (`isDeletable()`); otherwise `commands.admin.undelete.not-in-deletion`.

### `/admin delete` with no player argument (new mode)
Soft-deletes the island you are **standing on**, after confirmation. Guards: not-a-player (shows help), wrong world, not on an island, and refuses if the island still has a team (would orphan members). Naming a player still works exactly as before.

## How

Shared restore logic lives in **`IslandsManager.undeleteIsland(Island)`** (symmetric with `deleteIsland`) — clears `deleted`/`deletable`, persists, leaves ownership alone. Both `AdminRegisterCommand` and `AdminUndeleteCommand` call it, so there is no duplicated flag-clearing.

## Locales

- `commands.admin.register.in-deletion` reworded to a confirmation (all bundled locales).
- New `commands.admin.undelete.{description,not-in-deletion,undeleted-island}` translated into all bundled locales.
- `commands.admin.delete.{parameters,description}` updated (player now optional) across all locales. The no-arg delete reuses existing `general.errors.*` keys — no new error keys.

## Tests

- New `AdminUndeleteCommandTest` (wrong-world, no-island, not-deletable, success, execute).
- New `IslandsManagerTest.testUndeleteIslandClearsFlags`.
- `AdminRegisterCommandTest`: in-deletion path now confirms; verifies delegation to `undeleteIsland`.
- `AdminDeleteCommandTest`: console-help, wrong-world, not-on-island, has-team, and full stand-on soft-delete via the confirmation flow.

Full suite green.

## Notes for reviewers

- **Spawn islands are not specially guarded** in the no-arg delete — standing on spawn and running `/admin delete` would soft-delete spawn after confirmation. Happy to add an `isSpawn()` guard if preferred.
- Undelete has no confirmation (safe, reversible, explicitly invoked); register's in-deletion path confirms because it also assigns ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)