### PR TITLE
Add Dialogs API and wire it into confirmations, go picker, team invites & first-join (#3021)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -344,6 +344,13 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "island.confirmation.invites", since = "1.8.0")
     private boolean inviteConfirmation = false;
 
+    @ConfigComment("Show sensitive-command confirmations as a modal [Confirm]/[Cancel] dialog")
+    @ConfigComment("instead of asking the player to type the command again. Requires a server")
+    @ConfigComment("that supports dialogs (Minecraft 26+); older servers always use the type-again")
+    @ConfigComment("prompt regardless of this setting.")
+    @ConfigEntry(path = "island.confirmation.use-dialog", since = "3.21.0")
+    private boolean useDialogConfirmation = true;
+
     @ConfigComment("Sets the minimum length an island custom name is required to have.")
     @ConfigEntry(path = "island.name.min-length")
     private int nameMinLength = 4;
@@ -920,6 +927,22 @@ public class Settings implements ConfigObject {
      */
     public void setInviteConfirmation(boolean inviteConfirmation) {
         this.inviteConfirmation = inviteConfirmation;
+    }
+
+    /**
+     * @return whether sensitive-command confirmations should use a modal dialog
+     * @since 3.21.0
+     */
+    public boolean isUseDialogConfirmation() {
+        return useDialogConfirmation;
+    }
+
+    /**
+     * @param useDialogConfirmation whether to use a modal dialog for confirmations
+     * @since 3.21.0
+     */
+    public void setUseDialogConfirmation(boolean useDialogConfirmation) {
+        this.useDialogConfirmation = useDialogConfirmation;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -344,12 +344,30 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "island.confirmation.invites", since = "1.8.0")
     private boolean inviteConfirmation = false;
 
+    @ConfigComment("Modal dialog options. Dialogs are the 'menu they can't click away' shown to")
+    @ConfigComment("players for high-friction flows. They require a server that supports dialogs")
+    @ConfigComment("(Minecraft 26+); on older servers every option below falls back automatically")
+    @ConfigComment("to the classic chat/command behaviour regardless of the setting.")
     @ConfigComment("Show sensitive-command confirmations as a modal [Confirm]/[Cancel] dialog")
-    @ConfigComment("instead of asking the player to type the command again. Requires a server")
-    @ConfigComment("that supports dialogs (Minecraft 26+); older servers always use the type-again")
-    @ConfigComment("prompt regardless of this setting.")
-    @ConfigEntry(path = "island.confirmation.use-dialog", since = "3.21.0")
-    private boolean useDialogConfirmation = true;
+    @ConfigComment("instead of asking the player to type the command again.")
+    @ConfigEntry(path = "island.dialogs.confirmations", since = "3.21.0")
+    private boolean dialogConfirmations = true;
+
+    @ConfigComment("Auto-open an [Accept]/[Decline] dialog when a player receives a team invite,")
+    @ConfigComment("instead of relying on them to type the accept/reject command.")
+    @ConfigEntry(path = "island.dialogs.team-invites", since = "3.21.0")
+    private boolean dialogTeamInvites = true;
+
+    @ConfigComment("Show a button-per-destination picker when a player runs the island go/home")
+    @ConfigComment("command with no name and has more than one island or home to choose from.")
+    @ConfigEntry(path = "island.dialogs.go-picker", since = "3.21.0")
+    private boolean dialogGoPicker = true;
+
+    @ConfigComment("Show a non-dismissable 'choose your game' dialog to brand new players when")
+    @ConfigComment("more than one game mode is installed. Off by default: it is intrusive and")
+    @ConfigComment("clicking a game runs that game mode's command for the player.")
+    @ConfigEntry(path = "island.dialogs.game-mode-selection", since = "3.21.0")
+    private boolean dialogGameModeSelection = false;
 
     @ConfigComment("Sets the minimum length an island custom name is required to have.")
     @ConfigEntry(path = "island.name.min-length")
@@ -933,16 +951,64 @@ public class Settings implements ConfigObject {
      * @return whether sensitive-command confirmations should use a modal dialog
      * @since 3.21.0
      */
-    public boolean isUseDialogConfirmation() {
-        return useDialogConfirmation;
+    public boolean isDialogConfirmations() {
+        return dialogConfirmations;
     }
 
     /**
-     * @param useDialogConfirmation whether to use a modal dialog for confirmations
+     * @param dialogConfirmations whether to use a modal dialog for confirmations
      * @since 3.21.0
      */
-    public void setUseDialogConfirmation(boolean useDialogConfirmation) {
-        this.useDialogConfirmation = useDialogConfirmation;
+    public void setDialogConfirmations(boolean dialogConfirmations) {
+        this.dialogConfirmations = dialogConfirmations;
+    }
+
+    /**
+     * @return whether team invites should auto-open an accept/decline dialog
+     * @since 3.21.0
+     */
+    public boolean isDialogTeamInvites() {
+        return dialogTeamInvites;
+    }
+
+    /**
+     * @param dialogTeamInvites whether team invites should open a dialog
+     * @since 3.21.0
+     */
+    public void setDialogTeamInvites(boolean dialogTeamInvites) {
+        this.dialogTeamInvites = dialogTeamInvites;
+    }
+
+    /**
+     * @return whether the island go/home command shows a destination picker dialog
+     * @since 3.21.0
+     */
+    public boolean isDialogGoPicker() {
+        return dialogGoPicker;
+    }
+
+    /**
+     * @param dialogGoPicker whether the go/home command shows a picker dialog
+     * @since 3.21.0
+     */
+    public void setDialogGoPicker(boolean dialogGoPicker) {
+        this.dialogGoPicker = dialogGoPicker;
+    }
+
+    /**
+     * @return whether brand new players see a game-mode selection dialog
+     * @since 3.21.0
+     */
+    public boolean isDialogGameModeSelection() {
+        return dialogGameModeSelection;
+    }
+
+    /**
+     * @param dialogGameModeSelection whether new players see a game-mode dialog
+     * @since 3.21.0
+     */
+    public void setDialogGameModeSelection(boolean dialogGameModeSelection) {
+        this.dialogGameModeSelection = dialogGameModeSelection;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/ConfirmableCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/ConfirmableCommand.java
@@ -7,7 +7,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitTask;
 
 import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.dialogs.BBDialog;
+import world.bentobox.bentobox.api.dialogs.DialogBuilder;
+import world.bentobox.bentobox.api.dialogs.DialogButton;
+import world.bentobox.bentobox.api.dialogs.Dialogs;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
 
 /**
  * An extension of {@link CompositeCommand} that adds a confirmation step for
@@ -96,6 +101,11 @@ public abstract class ConfirmableCommand extends CompositeCommand {
      * @param confirmed The action to execute upon successful confirmation.
      */
     public void askConfirmation(User user, String message, Runnable confirmed) {
+        // Prefer a modal dialog when the server supports it and it is enabled.
+        // Falls through to the type-again prompt if the dialog cannot be shown.
+        if (useDialog(user) && showConfirmationDialog(user, message, confirmed)) {
+            return;
+        }
         // Check for pending confirmations
         if (toBeConfirmed.containsKey(user)) {
             if (toBeConfirmed.get(user).topLabel().equals(getTopLabel()) && toBeConfirmed.get(user).label().equalsIgnoreCase(getLabel())) {
@@ -133,6 +143,49 @@ public abstract class ConfirmableCommand extends CompositeCommand {
      */
     public void askConfirmation(User user, Runnable confirmed) {
         askConfirmation(user, "", confirmed);
+    }
+
+    /**
+     * Whether this confirmation should be presented as a modal dialog rather than
+     * the type-the-command-again prompt. True only for online players, when the
+     * server supports dialogs and the {@code island.confirmation.use-dialog}
+     * setting is enabled.
+     *
+     * @param user the user being asked
+     * @return true if a dialog should be shown
+     */
+    private boolean useDialog(User user) {
+        return user.isPlayer() && Dialogs.isSupported() && getPlugin().getSettings().isUseDialogConfirmation();
+    }
+
+    /**
+     * Shows a two-button [Confirm]/[Cancel] dialog. Confirming runs the action;
+     * cancelling (or dismissing with Escape) aborts it.
+     *
+     * @param user      the user to ask
+     * @param message   a pre-translated context message, or empty
+     * @param confirmed the action to run on confirmation
+     * @return true if the dialog was shown; false if it could not be built/shown,
+     *         in which case the caller should fall back to the type-again prompt
+     */
+    private boolean showConfirmationDialog(User user, String message, Runnable confirmed) {
+        try {
+            DialogBuilder builder = new DialogBuilder().title(user, "commands.confirmation.title");
+            if (message != null && !message.trim().isEmpty()) {
+                builder.body(Util.parseMiniMessageOrLegacy(message));
+            }
+            builder.body(user, "commands.confirmation.dialog-body")
+                    .confirmation(
+                            DialogButton.of(user, "commands.confirmation.buttons.confirm", u -> confirmed.run()),
+                            DialogButton.of(user, "commands.confirmation.buttons.cancel",
+                                    u -> u.sendMessage("commands.confirmation.request-cancelled")));
+            builder.build().show(user);
+            return true;
+        } catch (Exception e) {
+            getPlugin().logError("Could not show confirmation dialog, falling back to command prompt: "
+                    + e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/ConfirmableCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/ConfirmableCommand.java
@@ -148,14 +148,14 @@ public abstract class ConfirmableCommand extends CompositeCommand {
     /**
      * Whether this confirmation should be presented as a modal dialog rather than
      * the type-the-command-again prompt. True only for online players, when the
-     * server supports dialogs and the {@code island.confirmation.use-dialog}
+     * server supports dialogs and the {@code island.dialogs.confirmations}
      * setting is enabled.
      *
      * @param user the user being asked
      * @return true if a dialog should be shown
      */
     private boolean useDialog(User user) {
-        return user.isPlayer() && Dialogs.isSupported() && getPlugin().getSettings().isUseDialogConfirmation();
+        return user.isPlayer() && Dialogs.isSupported() && getPlugin().getSettings().isDialogConfirmations();
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
@@ -11,9 +11,13 @@ import java.util.Set;
 
 import org.bukkit.World;
 
+import net.kyori.adventure.text.Component;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.DelayedTeleportCommand;
+import world.bentobox.bentobox.api.dialogs.DialogBuilder;
+import world.bentobox.bentobox.api.dialogs.DialogButton;
+import world.bentobox.bentobox.api.dialogs.Dialogs;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
@@ -122,31 +126,76 @@ public class IslandGoCommand extends DelayedTeleportCommand {
                                 + "[hover: " + user.getTranslation("commands.island.sethome.click-to-teleport") + "]"));
                 return false;
             } else {
-                // We know where this location is. Now work out if it's an island name or a home name
-                IslandInfo info = names.get(name);
-                getIslands().setPrimaryIsland(user.getUniqueId(), info.island);
-                if (!info.islandName) {
-                    // This is a home name, not an island name
-                    this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer(), name) // Teleport to the named home for this player
-                            .thenAccept(r -> {
-                                if (Boolean.TRUE.equals(r)) {
-                                    // Success
-                                    getIslands().setPrimaryIsland(user.getUniqueId(), info.island);
-                                } else {
-                                    user.sendMessage("commands.island.go.failure");
-                                    getPlugin().logError(user.getName() + " could not teleport to their island - async teleport issue");
-                                }
-                            }));
-                    return true;
-                }
-               // Not a home name, an island name, so teleport to the island
-                this.delayCommand(user, () -> getIslands().homeTeleportAsync(info.island(), user));
+                // We know where this location is. Teleport there.
+                teleportToNamed(user, name, names.get(name));
                 return true;
             }
         }
-        
+
+        // No name given. If the player has several destinations, offer a picker dialog
+        if (showGoPicker(user, names)) {
+            return true;
+        }
+
         this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer()));
         return true;
+    }
+
+    /**
+     * Teleports the user to a resolved destination, whether it is a named home or an
+     * island name.
+     *
+     * @param user the user to teleport
+     * @param name the resolved (canonical) destination name
+     * @param info the island/home the name refers to
+     */
+    private void teleportToNamed(User user, String name, IslandInfo info) {
+        getIslands().setPrimaryIsland(user.getUniqueId(), info.island());
+        if (!info.islandName()) {
+            // This is a home name, not an island name
+            this.delayCommand(user, () -> getIslands().homeTeleportAsync(getWorld(), user.getPlayer(), name)
+                    .thenAccept(r -> {
+                        if (Boolean.TRUE.equals(r)) {
+                            getIslands().setPrimaryIsland(user.getUniqueId(), info.island());
+                        } else {
+                            user.sendMessage("commands.island.go.failure");
+                            getPlugin().logError(
+                                    user.getName() + " could not teleport to their island - async teleport issue");
+                        }
+                    }));
+        } else {
+            // An island name, so teleport to the island
+            this.delayCommand(user, () -> getIslands().homeTeleportAsync(info.island(), user));
+        }
+    }
+
+    /**
+     * Shows a button-per-destination picker dialog when the player has more than one
+     * island or home. Each button teleports to that destination.
+     *
+     * @param user  the user
+     * @param names the destination map
+     * @return true if the picker was shown; false to fall through to the default teleport
+     */
+    private boolean showGoPicker(User user, Map<String, IslandInfo> names) {
+        if (!user.isPlayer() || names.size() < 2 || !Dialogs.isSupported()
+                || !getPlugin().getSettings().isDialogGoPicker()) {
+            return false;
+        }
+        try {
+            DialogBuilder builder = new DialogBuilder().title(user, "commands.island.go.picker.title");
+            // Stable, alphabetical button order
+            names.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(en -> {
+                String name = en.getKey();
+                IslandInfo info = en.getValue();
+                builder.button(new DialogButton(Component.text(name), u -> teleportToNamed(u, name, info)));
+            });
+            builder.build().show(user);
+            return true;
+        } catch (Exception e) {
+            getPlugin().logError("Could not show go picker dialog, falling back to teleport: " + e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommand.java
@@ -10,6 +10,9 @@ import java.util.UUID;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.dialogs.DialogBuilder;
+import world.bentobox.bentobox.api.dialogs.DialogButton;
+import world.bentobox.bentobox.api.dialogs.Dialogs;
 import world.bentobox.bentobox.api.events.IslandBaseEvent;
 import world.bentobox.bentobox.api.events.team.TeamEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -230,12 +233,46 @@ public class IslandTeamInviteCommand extends CompositeCommand {
         // Send message to online player
         invitedPlayer.sendMessage("commands.island.team.invite.name-has-invited-you", TextVariables.NAME, user.getName(), TextVariables.DISPLAY_NAME, user.getDisplayName());
         invitedPlayer.sendMessage("commands.island.team.invite.to-accept-or-reject", TextVariables.LABEL, getTopLabel());
-        if (getIWM().getWorldSettings(getWorld()).isDisallowTeamMemberIslands()
-                && getIslands().hasIsland(getWorld(), invitedPlayer.getUniqueId())) {
+        boolean willLoseIsland = getIWM().getWorldSettings(getWorld()).isDisallowTeamMemberIslands()
+                && getIslands().hasIsland(getWorld(), invitedPlayer.getUniqueId());
+        if (willLoseIsland) {
             invitedPlayer.sendMessage("commands.island.team.invite.you-will-lose-your-island");
         }
+        // Auto-open an accept/decline dialog for the invited player if enabled
+        showInviteDialog(user, invitedPlayer, willLoseIsland);
         invitedPlayer = null;
         return true;
+    }
+
+    /**
+     * Opens an [Accept]/[Decline] dialog for the invited player, so they do not have
+     * to find and type the accept/reject command. Silently does nothing (leaving the
+     * chat messages as the fallback) if dialogs are disabled or unsupported.
+     *
+     * @param inviter       the player who sent the invite
+     * @param invited       the player who received it
+     * @param willLoseIsland whether accepting will cost the invited player their island
+     */
+    private void showInviteDialog(User inviter, User invited, boolean willLoseIsland) {
+        if (!invited.isPlayer() || !Dialogs.isSupported() || !getSettings().isDialogTeamInvites()) {
+            return;
+        }
+        try {
+            DialogBuilder builder = new DialogBuilder()
+                    .title(invited, "commands.island.team.invite.dialog.title", TextVariables.NAME, inviter.getName());
+            builder.body(invited, "commands.island.team.invite.dialog.body", TextVariables.NAME, inviter.getName());
+            if (willLoseIsland) {
+                builder.body(invited, "commands.island.team.invite.you-will-lose-your-island");
+            }
+            builder.confirmation(
+                    DialogButton.of(invited, "commands.island.team.invite.dialog.accept",
+                            u -> itc.getSubCommand("accept").ifPresent(c -> c.call(u, c.getLabel(), List.of()))),
+                    DialogButton.of(invited, "commands.island.team.invite.dialog.decline",
+                            u -> itc.getSubCommand("reject").ifPresent(c -> c.call(u, c.getLabel(), List.of()))));
+            builder.build().show(invited);
+        } catch (Exception e) {
+            getPlugin().logError("Could not show team invite dialog: " + e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/dialogs/BBDialog.java
+++ b/src/main/java/world/bentobox/bentobox/api/dialogs/BBDialog.java
@@ -1,0 +1,42 @@
+package world.bentobox.bentobox.api.dialogs;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import io.papermc.paper.dialog.Dialog;
+import world.bentobox.bentobox.api.user.User;
+
+/**
+ * A built dialog, ready to be shown to a player. Create one with a
+ * {@link DialogBuilder}.
+ *
+ * @author tastybento
+ * @since 3.21.0
+ */
+public class BBDialog {
+
+    private final Dialog dialog;
+
+    BBDialog(@NonNull Dialog dialog) {
+        this.dialog = dialog;
+    }
+
+    /**
+     * Shows this dialog to the given user. Has no effect if the user is not an
+     * online player.
+     *
+     * @param user the user to show the dialog to, not null
+     */
+    public void show(@NonNull User user) {
+        if (user.isPlayer() && user.getPlayer() != null) {
+            user.getPlayer().showDialog(dialog);
+        }
+    }
+
+    /**
+     * @return the underlying Paper dialog, for advanced use
+     */
+    @NonNull
+    public Dialog getDialog() {
+        return dialog;
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/dialogs/DialogBuilder.java
+++ b/src/main/java/world/bentobox/bentobox/api/dialogs/DialogBuilder.java
@@ -1,0 +1,209 @@
+package world.bentobox.bentobox.api.dialogs;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.eclipse.jdt.annotation.NonNull;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.body.PlainMessageDialogBody;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickCallback;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Fluent builder for modal {@link BBDialog dialogs}, in the spirit of
+ * {@code PanelBuilder}.
+ * <p>
+ * A dialog needs a {@link #title(Component) title} and either a
+ * {@link #confirmation(DialogButton, DialogButton) confirmation} (two buttons)
+ * or one or more {@link #button(DialogButton) buttons} (a multi-action menu).
+ * Titles and body lines are Adventure {@link Component Components}; the
+ * {@code title}/{@code body} overloads that take a {@link User} translate a
+ * locale key for that user and parse colors/formatting.
+ * <p>
+ * Example:
+ * <pre>{@code
+ * new DialogBuilder()
+ *     .title(user, "commands.island.reset.confirm-title")
+ *     .body(user, "commands.island.reset.confirm-body")
+ *     .confirmation(
+ *         DialogButton.of(user, "general.buttons.confirm", u -> doReset(u)),
+ *         DialogButton.of(user, "general.buttons.cancel", null))
+ *     .build()
+ *     .show(user);
+ * }</pre>
+ *
+ * @author tastybento
+ * @since 3.21.0
+ */
+public class DialogBuilder {
+
+    /** How long a button's server-side click callback stays valid after the dialog is shown. */
+    private static final Duration CALLBACK_LIFETIME = Duration.ofMinutes(10);
+
+    private Component title = Component.empty();
+    private final List<Component> body = new ArrayList<>();
+    private boolean escapable = true;
+    private boolean pause = false;
+
+    private DialogButton yesButton;
+    private DialogButton noButton;
+    private final List<DialogButton> buttons = new ArrayList<>();
+
+    /**
+     * Sets the dialog title from a component.
+     *
+     * @param title the title, not null
+     * @return this builder
+     */
+    public DialogBuilder title(@NonNull Component title) {
+        this.title = title;
+        return this;
+    }
+
+    /**
+     * Sets the dialog title from a localized translation for the given user.
+     *
+     * @param user      the user whose locale is used, not null
+     * @param reference the locale key, not null
+     * @param variables optional translation variables
+     * @return this builder
+     */
+    public DialogBuilder title(@NonNull User user, @NonNull String reference, String... variables) {
+        return title(Util.parseMiniMessageOrLegacy(user.getTranslation(reference, variables)));
+    }
+
+    /**
+     * Adds a line of body text from a component.
+     *
+     * @param line the body line, not null
+     * @return this builder
+     */
+    public DialogBuilder body(@NonNull Component line) {
+        this.body.add(line);
+        return this;
+    }
+
+    /**
+     * Adds a line of body text from a localized translation for the given user.
+     *
+     * @param user      the user whose locale is used, not null
+     * @param reference the locale key, not null
+     * @param variables optional translation variables
+     * @return this builder
+     */
+    public DialogBuilder body(@NonNull User user, @NonNull String reference, String... variables) {
+        return body(Util.parseMiniMessageOrLegacy(user.getTranslation(reference, variables)));
+    }
+
+    /**
+     * Sets whether the player can dismiss the dialog by pressing Escape. Defaults
+     * to {@code true}. Set to {@code false} for onboarding flows the player must
+     * answer, but note this is hostile for routine confirmations.
+     *
+     * @param escapable true if Escape dismisses the dialog
+     * @return this builder
+     */
+    public DialogBuilder escapable(boolean escapable) {
+        this.escapable = escapable;
+        return this;
+    }
+
+    /**
+     * Sets whether the dialog pauses the game. This only has an effect in
+     * single-player; on a server it is ignored. Defaults to {@code false}.
+     *
+     * @param pause true to pause the game while the dialog is open
+     * @return this builder
+     */
+    public DialogBuilder pause(boolean pause) {
+        this.pause = pause;
+        return this;
+    }
+
+    /**
+     * Makes this a two-button confirmation dialog. Mutually exclusive with
+     * {@link #button(DialogButton)}.
+     *
+     * @param yes the affirmative button, not null
+     * @param no  the negative button, not null
+     * @return this builder
+     */
+    public DialogBuilder confirmation(@NonNull DialogButton yes, @NonNull DialogButton no) {
+        this.yesButton = yes;
+        this.noButton = no;
+        return this;
+    }
+
+    /**
+     * Adds a button to a multi-action menu dialog. Mutually exclusive with
+     * {@link #confirmation(DialogButton, DialogButton)}.
+     *
+     * @param button the button, not null
+     * @return this builder
+     */
+    public DialogBuilder button(@NonNull DialogButton button) {
+        this.buttons.add(button);
+        return this;
+    }
+
+    /**
+     * Builds the dialog.
+     *
+     * @return the built dialog, ready to {@link BBDialog#show(User) show}
+     * @throws IllegalStateException if neither a confirmation nor any button was set
+     */
+    @NonNull
+    public BBDialog build() {
+        boolean confirmation = yesButton != null && noButton != null;
+        if (!confirmation && buttons.isEmpty()) {
+            throw new IllegalStateException("A dialog needs either a confirmation() or at least one button()");
+        }
+
+        List<PlainMessageDialogBody> bodyLines = body.stream().map(DialogBody::plainMessage).toList();
+        DialogBase base = DialogBase.builder(title).canCloseWithEscape(escapable).pause(pause)
+                .afterAction(DialogBase.DialogAfterAction.CLOSE).body(bodyLines).build();
+
+        DialogType type = confirmation ? DialogType.confirmation(toActionButton(yesButton), toActionButton(noButton))
+                : DialogType.multiAction(buttons.stream().map(this::toActionButton).toList()).build();
+
+        Dialog dialog = Dialog.create(factory -> factory.empty().base(base).type(type));
+        return new BBDialog(dialog);
+    }
+
+    private ActionButton toActionButton(DialogButton button) {
+        ActionButton.Builder b = ActionButton.builder(button.label())
+                .action(DialogAction.customClick((view, audience) -> runOnMainThread(button.onClick(), audience),
+                        ClickCallback.Options.builder().uses(1).lifetime(CALLBACK_LIFETIME).build()));
+        if (button.tooltip() != null) {
+            b.tooltip(button.tooltip());
+        }
+        return b.build();
+    }
+
+    /**
+     * Runs a button callback on the server's main thread with the clicking user.
+     * Server-side dialog callbacks may be delivered off the main thread, so BentoBox
+     * / addon code (which is not thread-safe) is dispatched back to it.
+     */
+    private static void runOnMainThread(Consumer<User> onClick, Audience audience) {
+        if (onClick == null || !(audience instanceof Player player)) {
+            return;
+        }
+        User user = User.getInstance(player);
+        Bukkit.getScheduler().runTask(BentoBox.getInstance(), () -> onClick.accept(user));
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/dialogs/DialogButton.java
+++ b/src/main/java/world/bentobox/bentobox/api/dialogs/DialogButton.java
@@ -1,0 +1,89 @@
+package world.bentobox.bentobox.api.dialogs;
+
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import net.kyori.adventure.text.Component;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * A single clickable button in a {@link DialogBuilder dialog}.
+ * <p>
+ * A button has a label, an optional tooltip shown on hover and an optional
+ * {@link #onClick()} callback. The callback is run on the server's main thread,
+ * with the {@link User} who clicked, when the button is pressed.
+ *
+ * @author tastybento
+ * @since 3.21.0
+ */
+public class DialogButton {
+
+    private final Component label;
+    private final @Nullable Component tooltip;
+    private final @Nullable Consumer<User> onClick;
+
+    /**
+     * Creates a button from Adventure components.
+     *
+     * @param label   the button label, not null
+     * @param tooltip the hover tooltip, or null for none
+     * @param onClick the action to run when clicked, or null for a button that just closes the dialog
+     */
+    public DialogButton(@NonNull Component label, @Nullable Component tooltip, @Nullable Consumer<User> onClick) {
+        this.label = label;
+        this.tooltip = tooltip;
+        this.onClick = onClick;
+    }
+
+    /**
+     * Creates a button from a component label with no tooltip.
+     *
+     * @param label   the button label, not null
+     * @param onClick the action to run when clicked, or null
+     */
+    public DialogButton(@NonNull Component label, @Nullable Consumer<User> onClick) {
+        this(label, null, onClick);
+    }
+
+    /**
+     * Creates a button whose label is a localized translation for the given user.
+     * The reference is translated and parsed to a component so that colors and
+     * formatting in the locale entry are honored.
+     *
+     * @param user      the user whose locale is used, not null
+     * @param reference the locale key of the label, not null
+     * @param onClick   the action to run when clicked, or null
+     * @return a new button
+     */
+    @NonNull
+    public static DialogButton of(@NonNull User user, @NonNull String reference, @Nullable Consumer<User> onClick) {
+        return new DialogButton(Util.parseMiniMessageOrLegacy(user.getTranslation(reference)), onClick);
+    }
+
+    /**
+     * @return the button label
+     */
+    @NonNull
+    public Component label() {
+        return label;
+    }
+
+    /**
+     * @return the hover tooltip, or null if there is none
+     */
+    @Nullable
+    public Component tooltip() {
+        return tooltip;
+    }
+
+    /**
+     * @return the action to run when the button is clicked, or null if none
+     */
+    @Nullable
+    public Consumer<User> onClick() {
+        return onClick;
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/dialogs/Dialogs.java
+++ b/src/main/java/world/bentobox/bentobox/api/dialogs/Dialogs.java
@@ -1,0 +1,36 @@
+package world.bentobox.bentobox.api.dialogs;
+
+/**
+ * Utility helpers for the Dialogs API.
+ *
+ * @author tastybento
+ * @since 3.21.0
+ */
+public final class Dialogs {
+
+    private static final boolean SUPPORTED = classPresent("io.papermc.paper.dialog.Dialog");
+
+    private Dialogs() {
+        // Utility class
+    }
+
+    /**
+     * Whether the running server supports Paper's dialog system. Dialogs were
+     * added in Minecraft 26; on older servers this returns {@code false} and
+     * callers should fall back to chat or panel presentation.
+     *
+     * @return true if dialogs can be shown
+     */
+    public static boolean isSupported() {
+        return SUPPORTED;
+    }
+
+    private static boolean classPresent(String name) {
+        try {
+            Class.forName(name, false, Dialogs.class.getClassLoader());
+            return true;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/api/dialogs/package-info.java
+++ b/src/main/java/world/bentobox/bentobox/api/dialogs/package-info.java
@@ -1,0 +1,31 @@
+/**
+ * API for server-driven modal dialog creation and usage.
+ *
+ * <p>
+ * Alongside the {@link world.bentobox.bentobox.api.panels Panels API}, BentoBox
+ * provides a Dialogs API that wraps Paper's dialog system
+ * ({@code io.papermc.paper.dialog.Dialog}) so core and addons can present real
+ * modal choices to players without them having to type commands. Unlike
+ * inventory-GUI panels, dialogs are true modal UI: buttons, optional body text,
+ * and they can be configured so that pressing <kbd>Esc</kbd> does not dismiss
+ * them.
+ * </p>
+ * <p>
+ * Dialogs are built with a fluent {@link world.bentobox.bentobox.api.dialogs.DialogBuilder}
+ * in the spirit of {@code PanelBuilder}. Titles and body text are localized
+ * through the existing {@link world.bentobox.bentobox.api.user.User} translation
+ * system and are carried end-to-end as Adventure
+ * {@link net.kyori.adventure.text.Component Components}, so click/interaction
+ * data survives (the legacy {@code §}-string chat path cannot carry it).
+ * </p>
+ * <p>
+ * Buttons carry a {@link world.bentobox.bentobox.api.dialogs.DialogButton#onClick()}
+ * callback that runs on the server's main thread when the player clicks. Because
+ * the dialog classes only exist on Minecraft 26+, callers that need to degrade
+ * gracefully should guard with {@link world.bentobox.bentobox.api.dialogs.Dialogs#isSupported()}.
+ * </p>
+ *
+ * @author tastybento
+ * @since 3.21.0
+ */
+package world.bentobox.bentobox.api.dialogs;

--- a/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/JoinLeaveListener.java
@@ -1,6 +1,7 @@
 package world.bentobox.bentobox.listeners;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -16,8 +17,13 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
+import net.kyori.adventure.text.Component;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.dialogs.BBDialog;
+import world.bentobox.bentobox.api.dialogs.DialogBuilder;
+import world.bentobox.bentobox.api.dialogs.DialogButton;
+import world.bentobox.bentobox.api.dialogs.Dialogs;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -141,6 +147,12 @@ public class JoinLeaveListener implements Listener {
         // don't exist
         players.getPlayer(user.getUniqueId());
 
+        // If enabled and several game modes are installed, let the player pick one via a
+        // dialog instead of silently auto-creating islands per world.
+        if (showGameModeDialog(user)) {
+            return;
+        }
+
         plugin.getIWM().getOverWorlds().stream().filter(w -> plugin.getIWM().isCreateIslandOnFirstLoginEnabled(w))
                 .forEach(w -> {
                     // Even if that'd be extremely unlikely, it's better to check if the player
@@ -171,6 +183,40 @@ public class JoinLeaveListener implements Listener {
                         }
                     }
                 });
+    }
+
+    /**
+     * Shows a non-dismissable "choose your game" dialog to a brand new player when
+     * more than one game mode is installed and the option is enabled. Each button runs
+     * that game mode's player command. Shown a short moment after join so the client is
+     * ready.
+     *
+     * @param user the joining player
+     * @return true if the dialog was built and scheduled; false to fall through to the
+     *         default per-world first-login behaviour
+     */
+    private boolean showGameModeDialog(User user) {
+        if (!user.isPlayer() || !Dialogs.isSupported() || !plugin.getSettings().isDialogGameModeSelection()) {
+            return false;
+        }
+        List<GameModeAddon> modes = plugin.getAddonsManager().getGameModeAddons().stream()
+                .filter(gm -> gm.getPlayerCommand().isPresent()).toList();
+        if (modes.size() < 2) {
+            return false;
+        }
+        try {
+            DialogBuilder builder = new DialogBuilder().title(user, "general.dialogs.game-mode-selection.title")
+                    .escapable(false);
+            modes.forEach(gm -> builder.button(new DialogButton(Component.text(gm.getDescription().getName()),
+                    u -> gm.getPlayerCommand().ifPresent(c -> c.call(u, c.getLabel(), Collections.emptyList())))));
+            // Build now so a build failure falls back; show a little after join so the client is ready
+            BBDialog dialog = builder.build();
+            Bukkit.getScheduler().runTaskLater(plugin, () -> dialog.show(user), 20L);
+            return true;
+        } catch (Exception e) {
+            plugin.logError("Could not show game mode selection dialog: " + e.getMessage());
+            return false;
+        }
 
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -221,6 +221,12 @@ island:
     # Team invites will always require confirmation, for safety concerns.
     # Added since 1.8.0.
     invites: false
+    # Show sensitive-command confirmations as a modal [Confirm]/[Cancel] dialog
+    # instead of asking the player to type the command again. Requires a server
+    # that supports dialogs (Minecraft 26+); older servers always use the type-again
+    # prompt regardless of this setting.
+    # Added since 3.21.0.
+    use-dialog: true
   delay:
     # Time in seconds that players have to stand still before teleport commands activate, e.g. island go.
     time: 0

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -221,12 +221,25 @@ island:
     # Team invites will always require confirmation, for safety concerns.
     # Added since 1.8.0.
     invites: false
+  # Modal dialog options. Dialogs are the 'menu they can't click away' shown to
+  # players for high-friction flows. They require a server that supports dialogs
+  # (Minecraft 26+); on older servers every option below falls back automatically
+  # to the classic chat/command behaviour regardless of the setting.
+  # Added since 3.21.0.
+  dialogs:
     # Show sensitive-command confirmations as a modal [Confirm]/[Cancel] dialog
-    # instead of asking the player to type the command again. Requires a server
-    # that supports dialogs (Minecraft 26+); older servers always use the type-again
-    # prompt regardless of this setting.
-    # Added since 3.21.0.
-    use-dialog: true
+    # instead of asking the player to type the command again.
+    confirmations: true
+    # Auto-open an [Accept]/[Decline] dialog when a player receives a team invite,
+    # instead of relying on them to type the accept/reject command.
+    team-invites: true
+    # Show a button-per-destination picker when a player runs the island go/home
+    # command with no name and has more than one island or home to choose from.
+    go-picker: true
+    # Show a non-dismissable 'choose your game' dialog to brand new players when
+    # more than one game mode is installed. Off by default: it is intrusive and
+    # clicking a game runs that game mode's command for the player.
+    game-mode-selection: false
   delay:
     # Time in seconds that players have to stand still before teleport commands activate, e.g. island go.
     time: 0

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -674,6 +674,11 @@ commands:
     confirm: '<red>Napiš příkaz znovu během </red><aqua>[seconds]s</aqua><red> k potvrzení.</red>'
     previous-request-cancelled: '<gold>Předchozí žádost o potvrzení zamítnuta.</gold>'
     request-cancelled: '<red>Časový limit vypršel - </red><aqua>žádost zamítnuta.</aqua>'
+    title: '<red>Jsi si jistý?</red>'
+    dialog-body: '<gray>Potvrď pro pokračování, nebo zruš.</gray>'
+    buttons:
+      confirm: '<green>Potvrdit</green>'
+      cancel: '<red>Zrušit</red>'
   delay:
     previous-command-cancelled: '<red>Předchozí příkaz zrušen</red>'
     stand-still: '<gold>Nehýbej se! Teleportuji za [seconds] sekund</gold>'

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: ostrov
   islands: ostrovy
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Vyber si svou hru</green>'
   did-you-mean:
     suggestion: '<gray>Měli jste na mysli </gray><yellow>[command]</yellow><gray>? Klikněte sem nebo napište </gray><green>yes</green><gray> pro spuštění.</gray>[run_command: [command]][hover: Kliknutím spustíte [command]]'
     header: '<gray>Měli jste na mysli něco z tohoto? Klikněte pro spuštění:</gray>'
@@ -696,6 +699,8 @@ commands:
         <red>Teleportování z nějakého důvodu selhalo. Zkuste to prosím znovu</red>
         později.
       unknown-home: '<red>Neznámé domácí jméno!</red>'
+      picker:
+        title: '<green>Kam chceš jít?</green>'
     help:
       description: Hlavní příkaz ostrova
     spawn:
@@ -893,6 +898,11 @@ commands:
       invite:
         description: pozvi hráče jako člena tvého ostrova
         invitation-sent: '<green>Pozvánka poslána hráči [name]</green>'
+        dialog:
+          title: '<green>Pozvánka do týmu od [name]</green>'
+          body: '<gray>[name] tě pozval, aby ses připojil k jeho ostrovu. Přijmout?</gray>'
+          accept: '<green>Přijmout</green>'
+          decline: '<red>Odmítnout</red>'
         removing-invite: '<red>Odstraňuji pozvánku</red>'
         name-has-invited-you: '<green>[name] tě pozval jako člena jeho ostrova.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -714,6 +714,11 @@ commands:
     confirm: '<red>Befehl innerhalb von</red><aqua>[seconds]s</aqua><red>zur Bestätigung erneut eingeben.</red>'
     previous-request-cancelled: '<gold>Vorherige Bestätigungsanforderung abgebrochen.</gold>'
     request-cancelled: '<red>Bestätigungs-Timeout - </red><aqua>-Anforderung abgebrochen.</aqua>'
+    title: '<red>Bist du sicher?</red>'
+    dialog-body: '<gray>Bestätige, um fortzufahren, oder brich ab.</gray>'
+    buttons:
+      confirm: '<green>Bestätigen</green>'
+      cancel: '<red>Abbrechen</red>'
   delay:
     previous-command-cancelled: '<red>Vorheriger Befehl abgebrochen</red>'
     stand-still: '<gold>Nicht bewegen! Teleportiert in [seconds] Sekunden</gold>'

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -12,6 +12,9 @@ prefixes:
   an-island: eine Insel
   islands: Inseln
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Wähle dein Spiel</green>'
   did-you-mean:
     suggestion: '<gray>Meintest du </gray><yellow>[command]</yellow><gray>? Klicke hier oder tippe </gray><green>yes</green><gray>, um ihn auszuführen.</gray>[run_command: [command]][hover: Klicken, um [command] auszuführen]'
     header: '<gray>Meintest du einen dieser Befehle? Klicke zum Ausführen:</gray>'
@@ -736,6 +739,8 @@ commands:
         <red>Das Teleportieren ist aus irgendeinem Grund gescheitert. Bitte</red>
         versuchen Sie es später erneut.
       unknown-home: '<red>Unbekannter Home-Name!</red>'
+      picker:
+        title: '<green>Wohin möchtest du?</green>'
     help:
       description: Der wichtigste Inselbefehl
     spawn:
@@ -950,6 +955,11 @@ commands:
       invite:
         description: Einen Spieler auf deine Insel einladen
         invitation-sent: '<green>Einladung gesendet an [name]</green>'
+        dialog:
+          title: '<green>Team-Einladung von [name]</green>'
+          body: '<gray>[name] hat dich eingeladen, seiner Insel beizutreten. Annehmen?</gray>'
+          accept: '<green>Annehmen</green>'
+          decline: '<red>Ablehnen</red>'
         removing-invite: '<red>Einladung entfernen</red>'
         name-has-invited-you: |
           <green>[name] hat Sie eingeladen,</green>

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -22,6 +22,9 @@ general:
   success: '<green>Success!</green>'
   invalid: Invalid
   beta: '<light_purple><bold>This command is in beta. Make sure you have backups!</bold></light_purple>'
+  dialogs:
+    game-mode-selection:
+      title: '<green>Choose your game</green>'
   errors:
     command-cancelled: '<red>Command cancelled.</red>'
     no-permission: '<red>You don''t have the permission to execute this command (</red><gray>
@@ -666,6 +669,8 @@ commands:
       teleported: '<green>Teleported you to home </green><yellow>[number].</yellow>'
       failure: '<red>Teleporting failed for some reason. Please try again later.</red>'
       unknown-home: '<red>Unknown home name!</red>'
+      picker:
+        title: '<green>Where would you like to go?</green>'
     help:
       description: the main [prefix_island] command
     spawn:
@@ -877,6 +882,11 @@ commands:
         you-will-lose-your-island: |
           <red>WARNING! You will lose all</red>
           <red>your [prefix_islands] if you accept!</red>
+        dialog:
+          title: '<green>Team invite from [name]</green>'
+          body: '<gray>[name] has invited you to join their island. Accept?</gray>'
+          accept: '<green>Accept</green>'
+          decline: '<red>Decline</red>'
         gui:
           titles:
             team-invite-panel: Invite Players

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -646,6 +646,11 @@ commands:
     confirm: '<red>Type command again within </red><aqua>[seconds]s</aqua><red> to confirm.</red>'
     previous-request-cancelled: '<gold>Previous confirmation request cancelled.</gold>'
     request-cancelled: '<red>Confirmation timeout - </red><aqua>request cancelled.</aqua>'
+    title: '<red>Are you sure?</red>'
+    dialog-body: '<gray>Confirm to proceed, or cancel to abort.</gray>'
+    buttons:
+      confirm: '<green>Confirm</green>'
+      cancel: '<red>Cancel</red>'
   delay:
     previous-command-cancelled: '<red>Previous command cancelled</red>'
     stand-still: '<gold>Do not move! Teleporting in [seconds] seconds</gold>'

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -12,6 +12,9 @@ prefixes:
   an-island: una isla
   islands: islas
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Elige tu juego</green>'
   did-you-mean:
     suggestion: '<gray>¿Quisiste decir </gray><yellow>[command]</yellow><gray>? Haz clic aquí o escribe </gray><green>yes</green><gray> para ejecutarlo.</gray>[run_command: [command]][hover: Haz clic para ejecutar [command]]'
     header: '<gray>¿Quisiste decir uno de estos? Haz clic en uno para ejecutarlo:</gray>'
@@ -725,6 +728,8 @@ commands:
         <red>La teletransportación falló por alguna razón. Por favor, intenta de</red>
         nuevo más tarde.
       unknown-home: '<red>¡Nombre de hogar desconocido!</red>'
+      picker:
+        title: '<green>¿A dónde quieres ir?</green>'
     help:
       description: El comando principal de la isla.
     spawn:
@@ -929,6 +934,11 @@ commands:
       invite:
         description: invita a un jugador a unirse a tu isla
         invitation-sent: '<green>Invitación enviada a [name]</green>'
+        dialog:
+          title: '<green>Invitación de equipo de [name]</green>'
+          body: '<gray>[name] te ha invitado a unirte a su isla. ¿Aceptar?</gray>'
+          accept: '<green>Aceptar</green>'
+          decline: '<red>Rechazar</red>'
         removing-invite: '<red>Eliminando invitación</red>'
         name-has-invited-you: '<green>[name] Te ha invitado a unirte a su isla.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -703,6 +703,11 @@ commands:
     confirm: '<red>Vuelva a escribir el comando antes de </red><aqua>[seconds]s </aqua><red>para confirmar.</red>'
     previous-request-cancelled: '<gold>Previa solicitud de confirmación cancelada.</gold>'
     request-cancelled: '<red>Tiempo de espera de confirmación - </red><aqua>solicitud cancelada.</aqua>'
+    title: '<red>¿Estás seguro?</red>'
+    dialog-body: '<gray>Confirma para continuar, o cancela para abortar.</gray>'
+    buttons:
+      confirm: '<green>Confirmar</green>'
+      cancel: '<red>Cancelar</red>'
   delay:
     previous-command-cancelled: '<red>Anterior comando cancelado</red>'
     stand-still: '<gold>¡No te muevas! Teletransportación en [seconds] segundos</gold>'

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -726,6 +726,11 @@ commands:
       confirmer.
     previous-request-cancelled: '<gold>La demande de confirmation est annulée.</gold>'
     request-cancelled: '<red>Délai de confirmation dépassé - </red><aqua>demande annulée.</aqua>'
+    title: '<red>Es-tu sûr ?</red>'
+    dialog-body: '<gray>Confirme pour continuer, ou annule pour abandonner.</gray>'
+    buttons:
+      confirm: '<green>Confirmer</green>'
+      cancel: '<red>Annuler</red>'
   delay:
     previous-command-cancelled: '<red>Commande annulée</red>'
     stand-still: '<gold>Ne bougez pas ! Téléportation dans [seconds] secondes.</gold>'

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: une île
   islands: îles
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Choisis ton jeu</green>'
   did-you-mean:
     suggestion: '<gray>Vouliez-vous dire </gray><yellow>[command]</yellow><gray> ? Cliquez ici ou tapez </gray><green>yes</green><gray> pour l’exécuter.</gray>[run_command: [command]][hover: Cliquez pour exécuter [command]]'
     header: '<gray>Vouliez-vous dire l’un de ceux-ci ? Cliquez pour exécuter :</gray>'
@@ -748,6 +751,8 @@ commands:
         <red>La téléportation a échoué pour une raison quelconque. Veuillez</red>
         réessayer plus tard.
       unknown-home: '<red>Nom de maison inconnu!</red>'
+      picker:
+        title: '<green>Où veux-tu aller ?</green>'
     help:
       description: commande principale pour l'île
     spawn:
@@ -950,6 +955,11 @@ commands:
       invite:
         description: inviter un joueur à rejoindre votre île
         invitation-sent: '<green>Invitation envoyée à </green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>Invitation d''équipe de [name]</green>'
+          body: '<gray>[name] t''a invité à rejoindre son île. Accepter ?</gray>'
+          accept: '<green>Accepter</green>'
+          decline: '<red>Refuser</red>'
         removing-invite: '<red>Suppression de l''invitation.</red>'
         name-has-invited-you: '<aqua>[name] </aqua><green>vous a invité à rejoindre son île.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -685,6 +685,11 @@ commands:
     confirm: '<red>Ponovno upišite naredbu unutar </red><aqua>[seconds]s</aqua><red>za potvrdu.</red>'
     previous-request-cancelled: '<gold>Prethodni zahtjev za potvrdu otkazan.</gold>'
     request-cancelled: '<red>Istek potvrde - </red><aqua>zahtjev otkazan.</aqua>'
+    title: '<red>Jesi li siguran?</red>'
+    dialog-body: '<gray>Potvrdi za nastavak ili odustani.</gray>'
+    buttons:
+      confirm: '<green>Potvrdi</green>'
+      cancel: '<red>Odustani</red>'
   delay:
     previous-command-cancelled: '<red>Prethodna naredba poništena</red>'
     stand-still: '<gold>Ne miči se! Teleportiranje za [seconds] sekundi</gold>'

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: otok
   islands: ostrva
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Odaberi svoju igru</green>'
   did-you-mean:
     suggestion: '<gray>Jeste li mislili </gray><yellow>[command]</yellow><gray>? Kliknite ovdje ili upišite </gray><green>yes</green><gray> za pokretanje.</gray>[run_command: [command]][hover: Kliknite za pokretanje [command]]'
     header: '<gray>Jeste li mislili nešto od ovoga? Kliknite za pokretanje:</gray>'
@@ -707,6 +710,8 @@ commands:
         <red>Teleportacija je neuspjela iz nekog razloga. Molimo pokušajte ponovno</red>
         kasnije.
       unknown-home: '<red>Nepoznato kućno ime!</red>'
+      picker:
+        title: '<green>Kamo želiš ići?</green>'
     help:
       description: glavna otočka komanda
     spawn:
@@ -907,6 +912,11 @@ commands:
       invite:
         description: pozovite igrača da se pridruži vašem otoku
         invitation-sent: '<green>Pozivnica poslana na </green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>Pozivnica tima od [name]</green>'
+          body: '<gray>[name] te pozvao da se pridružiš njegovom otoku. Prihvatiti?</gray>'
+          accept: '<green>Prihvati</green>'
+          decline: '<red>Odbij</red>'
         removing-invite: '<red>Uklanjanje pozivnice.</red>'
         name-has-invited-you: '<green>[name] vas je pozvao da se pridružite njihovom otoku.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: egy sziget
   islands: szigetek
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Válaszd ki a játékod</green>'
   did-you-mean:
     suggestion: '<gray>Erre gondoltál: </gray><yellow>[command]</yellow><gray>? Kattints ide, vagy írd be: </gray><green>yes</green><gray> a futtatáshoz.</gray>[run_command: [command]][hover: Kattints a futtatáshoz: [command]]'
     header: '<gray>Ezek egyikére gondoltál? Kattints egyre a futtatáshoz:</gray>'
@@ -742,6 +745,8 @@ commands:
       teleported: '<green>hazateleportált </green><yellow>[number].</yellow>'
       failure: '<red>A teleportálás valamiért sikertelen. Kérlek, próbáld újra később.</red>'
       unknown-home: '<red>Ismeretlen otthonnév!</red>'
+      picker:
+        title: '<green>Hová szeretnél menni?</green>'
     help:
       description: a főszigeti parancsnokság
     spawn:
@@ -951,6 +956,11 @@ commands:
       invite:
         description: hívj meg egy játékost a szigetedre
         invitation-sent: '<green>Meghívó elküldve a </green><aqua>[name]</aqua><green>címre.</green>'
+        dialog:
+          title: '<green>Csapatmeghívó [name] játékostól</green>'
+          body: '<gray>[name] meghívott, hogy csatlakozz a szigetéhez. Elfogadod?</gray>'
+          accept: '<green>Elfogadás</green>'
+          decline: '<red>Elutasítás</red>'
         removing-invite: '<red>Meghívó eltávolítása.</red>'
         name-has-invited-you: '<green>[name] meghívott téged, hogy csatlakozz a szigetéhez.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -722,6 +722,11 @@ commands:
     confirm: '<red>A megerősítéshez írja be újra a parancsot </red><aqua>[seconds]s</aqua><red>időn belül.</red>'
     previous-request-cancelled: '<gold>Az előző megerősítési kérés törölve.</gold>'
     request-cancelled: '<red>Megerősítés időtúllépése – </red><aqua>kérés törölve.</aqua>'
+    title: '<red>Biztos vagy benne?</red>'
+    dialog-body: '<gray>Erősítsd meg a folytatáshoz, vagy mégse a megszakításhoz.</gray>'
+    buttons:
+      confirm: '<green>Megerősítés</green>'
+      cancel: '<red>Mégse</red>'
   delay:
     previous-command-cancelled: '<red>Az előző parancs megszakítva</red>'
     stand-still: '<gold>Ne mozdulj! Teleportálás [seconds] másodpercen belül</gold>'

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -696,6 +696,11 @@ commands:
     confirm: '<red>Ketik perintah lagi dalam </red><aqua>[seconds]s</aqua><red>untuk mengonfirmasi.</red>'
     previous-request-cancelled: '<gold>Permintaan konfirmasi sebelumnya dibatalkan.</gold>'
     request-cancelled: '<red>Batas waktu konfirmasi - </red><aqua>permintaan dibatalkan.</aqua>'
+    title: '<red>Apakah kamu yakin?</red>'
+    dialog-body: '<gray>Konfirmasi untuk melanjutkan, atau batalkan.</gray>'
+    buttons:
+      confirm: '<green>Konfirmasi</green>'
+      cancel: '<red>Batal</red>'
   delay:
     previous-command-cancelled: '<red>Perintah sebelumnya dibatalkan</red>'
     stand-still: '<gold>Jangan bergerak! Teleportasi dalam [seconds] detik</gold>'

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: sebuah pulau
   islands: pulau-pulau
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Pilih permainanmu</green>'
   did-you-mean:
     suggestion: '<gray>Apakah maksud Anda </gray><yellow>[command]</yellow><gray>? Klik di sini atau ketik </gray><green>yes</green><gray> untuk menjalankannya.</gray>[run_command: [command]][hover: Klik untuk menjalankan [command]]'
     header: '<gray>Apakah maksud Anda salah satu dari ini? Klik salah satu untuk menjalankan:</gray>'
@@ -716,6 +719,8 @@ commands:
       teleported: '<green>Teleportasi Anda ke rumah </green><yellow>[number].</yellow>'
       failure: '<red>Teleportasi gagal karena suatu alasan. Silakan coba lagi nanti.</red>'
       unknown-home: '<red>Nama rumah tidak diketahui!</red>'
+      picker:
+        title: '<green>Mau pergi ke mana?</green>'
     help:
       description: komando pulau utama
     spawn:
@@ -920,6 +925,11 @@ commands:
       invite:
         description: undang pemain untuk bergabung dengan pulau Anda
         invitation-sent: '<green>Undangan dikirim ke </green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>Undangan tim dari [name]</green>'
+          body: '<gray>[name] mengundangmu untuk bergabung ke pulaunya. Terima?</gray>'
+          accept: '<green>Terima</green>'
+          decline: '<red>Tolak</red>'
         removing-invite: '<red>Menghapus undangan.</red>'
         name-has-invited-you: '<green>[name] telah mengundang Anda untuk bergabung dengan pulau mereka.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -711,6 +711,11 @@ commands:
     confirm: '<red>Riscrivi il comando entro </red><aqua>[seconds]s</aqua><red>per confermare.</red>'
     previous-request-cancelled: '<gold>Richiesta di conferma precedente cancellata.</gold>'
     request-cancelled: '<red>Timeout di conferma - </red><aqua>richiesta cancellata.</aqua>'
+    title: '<red>Sei sicuro?</red>'
+    dialog-body: '<gray>Conferma per procedere, o annulla.</gray>'
+    buttons:
+      confirm: '<green>Conferma</green>'
+      cancel: '<red>Annulla</red>'
   delay:
     previous-command-cancelled: '<red>Comando precedente annullato</red>'
     stand-still: '<gold>Non muoverti! Teletrasporto tra [seconds] secondi</gold>'

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: un'isola
   islands: isole
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Scegli il tuo gioco</green>'
   did-you-mean:
     suggestion: '<gray>Intendevi </gray><yellow>[command]</yellow><gray>? Clicca qui o scrivi </gray><green>yes</green><gray> per eseguirlo.</gray>[run_command: [command]][hover: Clicca per eseguire [command]]'
     header: '<gray>Intendevi uno di questi? Cliccane uno per eseguirlo:</gray>'
@@ -733,6 +736,8 @@ commands:
         <red>Teletrasporto non riuscito per qualche motivo. Per favore riprova più</red>
         tardi.
       unknown-home: '<red>Nome di casa sconosciuto!</red>'
+      picker:
+        title: '<green>Dove vuoi andare?</green>'
     help:
       description: Comando principale dell'isola
     spawn:
@@ -941,6 +946,11 @@ commands:
       invite:
         description: invita un giocatore ad essere membro della tua isola
         invitation-sent: '<green>Invito inviato a [name]</green>'
+        dialog:
+          title: '<green>Invito al team da [name]</green>'
+          body: '<gray>[name] ti ha invitato a unirti alla sua isola. Accettare?</gray>'
+          accept: '<green>Accetta</green>'
+          decline: '<red>Rifiuta</red>'
         removing-invite: '<red>Rimuovendo l''invito</red>'
         name-has-invited-you: '<green>[name] ti ha invitato ad essere membro della sua isola.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: 島
   islands: 島
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>ゲームを選んでください</green>'
   did-you-mean:
     suggestion: '<gray>もしかして </gray><yellow>[command]</yellow><gray>？ここをクリックするか、</gray><green>yes</green><gray> と入力すると実行されます。</gray>[run_command: [command]][hover: クリックで [command] を実行]'
     header: '<gray>もしかして次のいずれかですか？クリックすると実行されます:</gray>'
@@ -639,6 +642,8 @@ commands:
       teleported: '<green>テレポート #[number]をホームにします。</green>'
       failure: '<red>何らかの理由でテレポートが失敗しました。後でもう一度やり直してください。</red>'
       unknown-home: '<red>不明な家の名前！</red>'
+      picker:
+        title: '<green>どこへ行きますか？</green>'
     help:
       description: 本島のコマンド
     spawn:
@@ -829,6 +834,11 @@ commands:
       invite:
         description: 島に参加するプレーヤーを招待
         invitation-sent: 招待状を [name] に送信
+        dialog:
+          title: '<green>[name] からのチーム招待</green>'
+          body: '<gray>[name] があなたを島に招待しました。承認しますか？</gray>'
+          accept: '<green>承認</green>'
+          decline: '<red>拒否</red>'
         removing-invite: 招待の削除
         name-has-invited-you: '[name]は、彼らの島に参加することを招待しました。'
         to-accept-or-reject: /[label] team accept を受け入れるか、/[label] team reject を拒否すると言う

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -619,6 +619,11 @@ commands:
     confirm: '<red>[seconds]秒でコマンドをもう一度入力して確認します。</red>'
     previous-request-cancelled: '<red>前の確認要求が取り消されました</red>'
     request-cancelled: '<red>確認のタイムアウト-要求が取り消されました</red>'
+    title: '<red>本当によろしいですか？</red>'
+    dialog-body: '<gray>続行するには確認を、中止するにはキャンセルを選んでください。</gray>'
+    buttons:
+      confirm: '<green>確認</green>'
+      cancel: '<red>キャンセル</red>'
   delay:
     previous-command-cancelled: '<red>前のコマンドがキャンセルされました</red>'
     stand-still: '<gold>移動しないでください！ [seconds]秒でのテレポート</gold>'

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -639,6 +639,11 @@ commands:
     confirm: '<red>계속하려면 </red><aqua>[seconds]초안에</aqua><red> 명령어를 다시 사용하세요.</red>'
     previous-request-cancelled: '<gold>이전 확인 요청이 취소되었습니다.</gold>'
     request-cancelled: '<red>확인 시간 종료 - </red><aqua>요청이 취소되었습니다.</aqua>'
+    title: '<red>정말 실행하시겠습니까?</red>'
+    dialog-body: '<gray>계속하려면 확인을, 취소하려면 취소를 누르세요.</gray>'
+    buttons:
+      confirm: '<green>확인</green>'
+      cancel: '<red>취소</red>'
   delay:
     previous-command-cancelled: '<red>전에 사용한 커맨드가 취소되어습니다</red>'
     stand-still: '<gold>움직이지마세요! [seconds] 초후 이동됩니다!</gold>'

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -12,6 +12,9 @@ prefixes:
   an-island: 섬
   islands: 섬들
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>게임을 선택하세요</green>'
   did-you-mean:
     suggestion: '<gray>혹시 </gray><yellow>[command]</yellow><gray> 명령어를 입력하려고 하셨나요? 여기를 클릭하거나 </gray><green>yes</green><gray>를 입력하면 실행됩니다.</gray>[run_command: [command]][hover: 클릭하여 [command] 실행]'
     header: '<gray>다음 중 하나를 입력하려고 하셨나요? 클릭하면 실행됩니다:</gray>'
@@ -659,6 +662,8 @@ commands:
       teleported: '<green>집 </green><yellow># [번호] (으)로 이동했습니다.</yellow>'
       failure: '<red>전송이 어떤 이유로 실패했습니다. 나중에 다시 시도해 주세요.</red>'
       unknown-home: '<red>알 수 없는 홈 이름입니다!</red>'
+      picker:
+        title: '<green>어디로 갈까요?</green>'
     help:
       description: 섬의 명령어보기
     spawn:
@@ -845,6 +850,11 @@ commands:
       invite:
         description: 플레이어를 섬원으로 초대합니다
         invitation-sent: '<aqua>[name]</aqua><green>에게 초대를 보냈습니다.</green>'
+        dialog:
+          title: '<green>[name] 님의 팀 초대</green>'
+          body: '<gray>[name] 님이 섬에 초대했습니다. 수락하시겠습니까?</gray>'
+          accept: '<green>수락</green>'
+          decline: '<red>거절</red>'
         removing-invite: '<red>보낸 초대를 취소했습니다.</red>'
         name-has-invited-you: '<green>[name] 이(가) 당신을 섬원으로 초대하고 있습니다</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: salā
   islands: saliņas
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Izvēlies savu spēli</green>'
   did-you-mean:
     suggestion: '<gray>Vai jūs domājāt </gray><yellow>[command]</yellow><gray>? Noklikšķiniet šeit vai ierakstiet </gray><green>yes</green><gray>, lai to palaistu.</gray>[run_command: [command]][hover: Noklikšķiniet, lai palaistu [command]]'
     header: '<gray>Vai jūs domājāt kādu no šiem? Noklikšķiniet, lai palaistu:</gray>'
@@ -711,6 +714,8 @@ commands:
         <red>Teleportācija neizdevās kāda iemesla dēļ. Lūdzu, mēģiniet vēlreiz</red>
         vēlāk.
       unknown-home: '<red>Nezināms mājas nosaukums!</red>'
+      picker:
+        title: '<green>Kurp vēlies doties?</green>'
     help:
       description: Galvenā salas komanda
     spawn:
@@ -908,6 +913,11 @@ commands:
       invite:
         description: uzaicini spēlētāju pievienoties tavai salai
         invitation-sent: '<green>Ielūgums nosūtīts [name]</green>'
+        dialog:
+          title: '<green>Komandas ielūgums no [name]</green>'
+          body: '<gray>[name] uzaicināja tevi pievienoties savai salai. Pieņemt?</gray>'
+          accept: '<green>Pieņemt</green>'
+          decline: '<red>Noraidīt</red>'
         removing-invite: '<red>Ielūgumu atsauc</red>'
         name-has-invited-you: '<green>[name] ielūdza tevi pievienoties viņa komandai.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -689,6 +689,11 @@ commands:
     confirm: '<red>Ievadi komandu atkārtoti </red><aqua>[seconds]s</aqua><red>laikā, lai apstiprinātu.</red>'
     previous-request-cancelled: '<gold>Iepriekšējais apstiprinājumu pieprasījums ir apturēts.</gold>'
     request-cancelled: '<red>Apstiprinājuma noilgums - </red><aqua>pieprasījums apturēts.</aqua>'
+    title: '<red>Vai tu esi pārliecināts?</red>'
+    dialog-body: '<gray>Apstiprini, lai turpinātu, vai atcel.</gray>'
+    buttons:
+      confirm: '<green>Apstiprināt</green>'
+      cancel: '<red>Atcelt</red>'
   delay:
     previous-command-cancelled: '<red>Iepriekšēja komanda tika atcelta!</red>'
     stand-still: '<gold>Apstājies! Teleportēšana notiks pēc [seconds] sekundēm</gold>'

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -721,6 +721,11 @@ commands:
     confirm: '<red>Typ het commando opnieuw binnen </red><aqua>[seconds]s </aqua><red>om te bevestigen.</red>'
     previous-request-cancelled: '<gold>Eerder bevestigingsverzoek geannuleerd.</gold>'
     request-cancelled: '<red>Time-out voor bevestiging - </red><aqua>-verzoek geannuleerd.</aqua>'
+    title: '<red>Weet je het zeker?</red>'
+    dialog-body: '<gray>Bevestig om door te gaan, of annuleer.</gray>'
+    buttons:
+      confirm: '<green>Bevestigen</green>'
+      cancel: '<red>Annuleren</red>'
   delay:
     previous-command-cancelled: '<red>Vorige opdracht geannuleerd</red>'
     stand-still: '<gold>Beweeg niet! Teleporteren in [seconds]seconden</gold>'

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: een eiland
   islands: eilanden
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Kies je spel</green>'
   did-you-mean:
     suggestion: '<gray>Bedoelde je </gray><yellow>[command]</yellow><gray>? Klik hier of typ </gray><green>yes</green><gray> om het uit te voeren.</gray>[run_command: [command]][hover: Klik om [command] uit te voeren]'
     header: '<gray>Bedoelde je een van deze? Klik op één om uit te voeren:</gray>'
@@ -743,6 +746,8 @@ commands:
         <red>Teleporteren is om een of andere reden mislukt. Probeer het later</red>
         opnieuw.
       unknown-home: '<red>Onbekende thuisnaam!</red>'
+      picker:
+        title: '<green>Waar wil je heen?</green>'
     help:
       description: het commando van het hoofdeiland
     spawn:
@@ -951,6 +956,11 @@ commands:
       invite:
         description: nodig een speler uit om zich bij je eiland aan te sluiten
         invitation-sent: '<green>uitnodiging verzonden naar </green><aqua>[name] </aqua><green>.</green>'
+        dialog:
+          title: '<green>Teamuitnodiging van [name]</green>'
+          body: '<gray>[name] heeft je uitgenodigd om zich bij hun eiland aan te sluiten. Accepteren?</gray>'
+          accept: '<green>Accepteren</green>'
+          decline: '<red>Weigeren</red>'
         removing-invite: '<red>Uitnodiging verwijderen.</red>'
         name-has-invited-you: '<green>[name] heeft je uitgenodigd om lid te worden van hun eiland.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -693,6 +693,11 @@ commands:
     confirm: '<red>Wprowadź komendę w ciągu </red><aqua>[seconds]s</aqua><red>, by potwierdzić.</red>'
     previous-request-cancelled: '<gold>Poprzednie żądanie potwierdzenia zostało anulowane.</gold>'
     request-cancelled: '<red>Limit czasu potwierdzenia - </red><aqua>żądanie anulowane.</aqua>'
+    title: '<red>Jesteś pewien?</red>'
+    dialog-body: '<gray>Potwierdź, aby kontynuować, lub anuluj.</gray>'
+    buttons:
+      confirm: '<green>Potwierdź</green>'
+      cancel: '<red>Anuluj</red>'
   delay:
     previous-command-cancelled: '<red>Anulowano poprzednią komendę.</red>'
     stand-still: '<gold>Nie ruszaj się! Teleportowanie za [seconds] sekund...</gold>'

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: wyspa
   islands: wyspy
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Wybierz swoją grę</green>'
   did-you-mean:
     suggestion: '<gray>Czy chodziło ci o </gray><yellow>[command]</yellow><gray>? Kliknij tutaj lub wpisz </gray><green>yes</green><gray>, aby uruchomić.</gray>[run_command: [command]][hover: Kliknij, aby uruchomić [command]]'
     header: '<gray>Czy chodziło ci o któreś z tych? Kliknij, aby uruchomić:</gray>'
@@ -715,6 +718,8 @@ commands:
         <red>Teleportacja nie powiodła się z jakiegoś powodu. Proszę spróbować</red>
         ponownie później.
       unknown-home: '<red>Nieznana nazwa domu!</red>'
+      picker:
+        title: '<green>Dokąd chcesz iść?</green>'
     help:
       description: Główne komendy wyspy
     spawn:
@@ -917,6 +922,11 @@ commands:
       invite:
         description: zaproś gracza, by dołączył do Twojej wyspy
         invitation-sent: Zaproszenie wysłane do [name]
+        dialog:
+          title: '<green>Zaproszenie do drużyny od [name]</green>'
+          body: '<gray>[name] zaprosił cię do swojej wyspy. Zaakceptować?</gray>'
+          accept: '<green>Zaakceptuj</green>'
+          decline: '<red>Odrzuć</red>'
         removing-invite: Usuwanie zaproszenia
         name-has-invited-you: '[name] zaprosił cię do przyłączenia się do jego wyspy.'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -10,6 +10,9 @@ prefixes:
   an-island: uma ilha
   islands: ilhas
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Escolha seu jogo</green>'
   did-you-mean:
     suggestion: '<gray>Você quis dizer </gray><yellow>[command]</yellow><gray>? Clique aqui ou digite </gray><green>yes</green><gray> para executá-lo.</gray>[run_command: [command]][hover: Clique para executar [command]]'
     header: '<gray>Você quis dizer um destes? Clique em um para executar:</gray>'
@@ -711,6 +714,8 @@ commands:
         <red>A teletransporte falhou por algum motivo. Por favor, tente novamente</red>
         mais tarde.
       unknown-home: '<red>Nome de lar desconhecido!</red>'
+      picker:
+        title: '<green>Para onde você quer ir?</green>'
     help:
       description: o comando principal de ilhas
     spawn:
@@ -913,6 +918,11 @@ commands:
       invite:
         description: convidar um jogador a equipe de sua ilha
         invitation-sent: '<green>Convite enviado pra </green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>Convite de equipe de [name]</green>'
+          body: '<gray>[name] convidou você para entrar na ilha dele. Aceitar?</gray>'
+          accept: '<green>Aceitar</green>'
+          decline: '<red>Recusar</red>'
         removing-invite: '<red>Removendo convite.</red>'
         name-has-invited-you: '<green>[name] te convidou a se juntar a ilha.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -689,6 +689,11 @@ commands:
     confirm: '<red>Digite o comando novamente dentro de </red><aqua>[seconds]s</aqua><red> para confirmar.</red>'
     previous-request-cancelled: '<gold>Pedido anterior de confirmação cancelado.</gold>'
     request-cancelled: '<red>Limite de confirmação ultrapassado - </red><aqua>pedido cancelado.</aqua>'
+    title: '<red>Você tem certeza?</red>'
+    dialog-body: '<gray>Confirme para continuar, ou cancele para abortar.</gray>'
+    buttons:
+      confirm: '<green>Confirmar</green>'
+      cancel: '<red>Cancelar</red>'
   delay:
     previous-command-cancelled: '<red>Comando anterior cancelado</red>'
     stand-still: '<gold>Não se mova! Teleportando em [seconds] segundos</gold>'

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: uma ilha
   islands: ilhas
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Escolhe o teu jogo</green>'
   did-you-mean:
     suggestion: '<gray>Queria dizer </gray><yellow>[command]</yellow><gray>? Clique aqui ou escreva </gray><green>yes</green><gray> para o executar.</gray>[run_command: [command]][hover: Clique para executar [command]]'
     header: '<gray>Queria dizer um destes? Clique num para executar:</gray>'
@@ -720,6 +723,8 @@ commands:
         <red>A teletransporte falhou por algum motivo. Por favor, tente novamente</red>
         mais tarde.
       unknown-home: '<red>Nome residencial desconhecido!</red>'
+      picker:
+        title: '<green>Para onde queres ir?</green>'
     help:
       description: o comando da ilha principal
     spawn:
@@ -922,6 +927,11 @@ commands:
       invite:
         description: convide um jogador para se juntar à sua ilha
         invitation-sent: '<green>Convite enviado para </green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>Convite de equipa de [name]</green>'
+          body: '<gray>[name] convidou-te para te juntares à ilha dele. Aceitar?</gray>'
+          accept: '<green>Aceitar</green>'
+          decline: '<red>Recusar</red>'
         removing-invite: '<red>Removendo convite.</red>'
         name-has-invited-you: '<green>[name] convidou você para se juntar à ilha deles.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -698,6 +698,11 @@ commands:
     confirm: '<red>Digite o comando novamente dentro de </red><aqua>[segundos]s</aqua><red>para confirmar.</red>'
     previous-request-cancelled: '<gold>Solicitação de confirmação anterior cancelada.</gold>'
     request-cancelled: '<red>Tempo limite de confirmação - solicitação </red><aqua>cancelada.</aqua>'
+    title: '<red>Tens a certeza?</red>'
+    dialog-body: '<gray>Confirma para continuar, ou cancela para abortar.</gray>'
+    buttons:
+      confirm: '<green>Confirmar</green>'
+      cancel: '<red>Cancelar</red>'
   delay:
     previous-command-cancelled: '<red>Comando anterior cancelado</red>'
     stand-still: '<gold>Não se mova! Teletransportando em [segundos] segundos</gold>'

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: o insulă
   islands: insule
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Alege-ți jocul</green>'
   did-you-mean:
     suggestion: '<gray>Ai vrut să spui </gray><yellow>[command]</yellow><gray>? Dă clic aici sau tastează </gray><green>yes</green><gray> pentru a-l rula.</gray>[run_command: [command]][hover: Dă clic pentru a rula [command]]'
     header: '<gray>Ai vrut să spui una dintre acestea? Dă clic pe una pentru a o rula:</gray>'
@@ -728,6 +731,8 @@ commands:
         <red>Teleportarea a eșuat din anumite motive. Vă rugăm să încercați din</red>
         nou mai târziu.
       unknown-home: '<red>Nume de casă necunoscut!</red>'
+      picker:
+        title: '<green>Unde vrei să mergi?</green>'
     help:
       description: comandamentul insulei principale
     spawn:
@@ -934,6 +939,11 @@ commands:
       invite:
         description: invită un jucător să se alăture insulei tale
         invitation-sent: '<green>Invitație trimisă la </green><aqua>[name] </aqua><green>.</green>'
+        dialog:
+          title: '<green>Invitație de echipă de la [name]</green>'
+          body: '<gray>[name] te-a invitat să te alături insulei sale. Accepți?</gray>'
+          accept: '<green>Acceptă</green>'
+          decline: '<red>Refuză</red>'
         removing-invite: '<red>Eliminarea invitației.</red>'
         name-has-invited-you: |
           <green>[name] v-a invitat</green>

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -706,6 +706,11 @@ commands:
     confirm: '<red>Tastați din nou comanda în </red><aqua>[seconds] s </aqua><red>pentru a confirma.</red>'
     previous-request-cancelled: '<gold>Cererea de confirmare anterioară a fost anulată.</gold>'
     request-cancelled: '<red>Timpul limită de confirmare - cererea </red><aqua>a fost anulată.</aqua>'
+    title: '<red>Ești sigur?</red>'
+    dialog-body: '<gray>Confirmă pentru a continua, sau anulează.</gray>'
+    buttons:
+      confirm: '<green>Confirmă</green>'
+      cancel: '<red>Anulează</red>'
   delay:
     previous-command-cancelled: '<red>Comanda anterioară a fost anulată</red>'
     stand-still: '<gold>Nu vă mișcați! Se teleportează în [seconds] secunde</gold>'

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -17,6 +17,9 @@ prefixes:
   an-island: остров
   islands: острова
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Выберите свою игру</green>'
   did-you-mean:
     suggestion: '<gray>Возможно, вы имели в виду </gray><yellow>[command]</yellow><gray>? Нажмите здесь или введите </gray><green>yes</green><gray>, чтобы выполнить.</gray>[run_command: [command]][hover: Нажмите, чтобы выполнить [command]]'
     header: '<gray>Возможно, вы имели в виду одну из этих команд? Нажмите, чтобы выполнить:</gray>'
@@ -705,6 +708,8 @@ commands:
       failure: <red>Телепортация не удалась по какой-то причине. Пожалуйста, попробуйте
         снова позже.</red>
       unknown-home: <red>Неизвестное название точки дома!</red>
+      picker:
+        title: '<green>Куда вы хотите отправиться?</green>'
     help:
       description: основная команда режима
     spawn:
@@ -903,6 +908,11 @@ commands:
       invite:
         description: приглашает игрока посетить ваш остров
         invitation-sent: <green>Приглашение отправлено игроку <aqua>[name]</aqua>.</green>
+        dialog:
+          title: '<green>Приглашение в команду от [name]</green>'
+          body: '<gray>[name] пригласил вас присоединиться к своему острову. Принять?</gray>'
+          accept: '<green>Принять</green>'
+          decline: '<red>Отклонить</red>'
         removing-invite: <red>Удаление приглашения.</red>
         name-has-invited-you: <green>[name] пригласил вас посетить его остров.</green>
         to-accept-or-reject: <green>Введите /[label] team accept чтобы принять либо

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -684,6 +684,11 @@ commands:
     confirm: <red>Подтвердите, повторив команду в течение <aqua>[seconds] секунд</aqua>.</red>
     previous-request-cancelled: <gold>Предыдущий запрос на подтверждение был отменён.</gold>
     request-cancelled: <red>Время подтверждения истекло - <aqua>запрос отменён</aqua>.</red>
+    title: '<red>Вы уверены?</red>'
+    dialog-body: '<gray>Подтвердите, чтобы продолжить, или отмените.</gray>'
+    buttons:
+      confirm: '<green>Подтвердить</green>'
+      cancel: '<red>Отмена</red>'
   delay:
     previous-command-cancelled: <red>Предыдущая команда была отменена</red>
     stand-still: <gold>Не двигайтесь! Телепортация через [seconds] секунды</gold>

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -679,6 +679,11 @@ commands:
     confirm: '<dark_red>Onaylamak icin </dark_red><yellow>[seconds] </yellow><dark_red>saniye icinde tekrar yaz!</dark_red>'
     previous-request-cancelled: '<dark_red>Istek iptal edildi!</dark_red>'
     request-cancelled: '<dark_red>Istek zaman aşımına ugradı ve iptal edildi!</dark_red>'
+    title: '<red>Emin misin?</red>'
+    dialog-body: '<gray>Devam etmek için onayla, iptal etmek için vazgeç.</gray>'
+    buttons:
+      confirm: '<green>Onayla</green>'
+      cancel: '<red>İptal</red>'
   delay:
     previous-command-cancelled: '<red>Önceki komut iptal edildi.</red>'
     stand-still: '<gold>Sakın hareket etme. </gold><yellow>[seconds] </yellow><gold>saniye içerisinde ışınlanacaksın.</gold>'

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -12,6 +12,9 @@ prefixes:
   an-island: bir ada
   islands: adalar
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Oyununu seç</green>'
   did-you-mean:
     suggestion: '<gray>Şunu mu demek istediniz: </gray><yellow>[command]</yellow><gray>? Çalıştırmak için buraya tıklayın veya </gray><green>yes</green><gray> yazın.</gray>[run_command: [command]][hover: [command] çalıştırmak için tıklayın]'
     header: '<gray>Şunlardan birini mi demek istediniz? Çalıştırmak için birine tıklayın:</gray>'
@@ -701,6 +704,8 @@ commands:
         <red>Bir nedenden dolayı ışınlanma başarısız oldu. Lütfen daha sonra</red>
         tekrar deneyin.
       unknown-home: '<red>Bilinmeyen ev adı!</red>'
+      picker:
+        title: '<green>Nereye gitmek istersin?</green>'
     help:
       description: Ana ada komudu
     spawn:
@@ -894,6 +899,11 @@ commands:
       invite:
         description: Adana oyuncu davet et.
         invitation-sent: '<light_purple>[name] </light_purple><aqua>oyuncusuna davet gonderildi!</aqua>'
+        dialog:
+          title: '<green>[name] adlı oyuncudan takım daveti</green>'
+          body: '<gray>[name] seni adasına katılmaya davet etti. Kabul edilsin mi?</gray>'
+          accept: '<green>Kabul et</green>'
+          decline: '<red>Reddet</red>'
         removing-invite: '<dark_red>Davet iptal edildi.</dark_red>'
         name-has-invited-you: '<light_purple>[name] </light_purple><aqua>seni adasına katılman icin davet etti!</aqua>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -625,6 +625,11 @@ commands:
     confirm: '<red>Повторіть команду протягом </red><aqua>[seconds]с</aqua><red>для підтвердження.</red>'
     previous-request-cancelled: '<gold>Попередній запит підтвердження скасовано.</gold>'
     request-cancelled: '<red>Час підтвердження вийшов — </red><aqua>запит скасовано.</aqua>'
+    title: '<red>Ви впевнені?</red>'
+    dialog-body: '<gray>Підтвердьте, щоб продовжити, або скасуйте.</gray>'
+    buttons:
+      confirm: '<green>Підтвердити</green>'
+      cancel: '<red>Скасувати</red>'
   delay:
     previous-command-cancelled: '<red>Попередню команду скасовано</red>'
     stand-still: '<gold>Не рухайтеся! Телепорт через [seconds] секунд</gold>'

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -18,6 +18,9 @@ prefixes:
   an-island: острів
   islands: острови
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Виберіть свою гру</green>'
   did-you-mean:
     suggestion: '<gray>Можливо, ви мали на увазі </gray><yellow>[command]</yellow><gray>? Натисніть тут або введіть </gray><green>yes</green><gray>, щоб виконати.</gray>[run_command: [command]][hover: Натисніть, щоб виконати [command]]'
     header: '<gray>Можливо, ви мали на увазі одну з цих команд? Натисніть, щоб виконати:</gray>'
@@ -645,6 +648,8 @@ commands:
       teleported: '<green>Телепортовано до дому </green><yellow>[number].</yellow>'
       failure: '<red>Не вдалося телепортуватися. Спробуйте пізніше.</red>'
       unknown-home: '<red>Невідома назва дому!</red>'
+      picker:
+        title: '<green>Куди ви хочете піти?</green>'
     help:
       description: головна команда [prefix_island]
     spawn:
@@ -837,6 +842,11 @@ commands:
       invite:
         description: запросити гравця приєднатися до вашого [prefix_island]
         invitation-sent: '<green>Запрошення надіслано для </green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>Запрошення в команду від [name]</green>'
+          body: '<gray>[name] запросив вас приєднатися до свого острова. Прийняти?</gray>'
+          accept: '<green>Прийняти</green>'
+          decline: '<red>Відхилити</red>'
         removing-invite: '<red>Видаляю запрошення.</red>'
         name-has-invited-you: |
           <green>[name] запросив(ла) вас</green>

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -685,6 +685,11 @@ commands:
     confirm: '<red>Nhập lệnh đó lại trong </red><aqua>[seconds] giây</aqua><red> để xác nhận.</red>'
     previous-request-cancelled: '<gold>Lần xác nhận trước đã bị hủy.</gold>'
     request-cancelled: '<red>Hết thời gian xác nhận - </red><aqua>yêu cầu đã bị hủy.</aqua>'
+    title: '<red>Bạn có chắc không?</red>'
+    dialog-body: '<gray>Xác nhận để tiếp tục, hoặc hủy để dừng lại.</gray>'
+    buttons:
+      confirm: '<green>Xác nhận</green>'
+      cancel: '<red>Hủy</red>'
   delay:
     previous-command-cancelled: '<red>Lệnh trước đã bị hủy</red>'
     stand-still: '<gold>Đừng di chuyển! Dịch chuyển trong [seconds] giây</gold>'

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -11,6 +11,9 @@ prefixes:
   an-island: một hòn đảo
   islands: đảo
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>Chọn trò chơi của bạn</green>'
   did-you-mean:
     suggestion: '<gray>Có phải bạn muốn nhập </gray><yellow>[command]</yellow><gray>? Nhấp vào đây hoặc gõ </gray><green>yes</green><gray> để chạy lệnh.</gray>[run_command: [command]][hover: Nhấp để chạy [command]]'
     header: '<gray>Có phải bạn muốn nhập một trong các lệnh sau? Nhấp vào một lệnh để chạy:</gray>'
@@ -705,6 +708,8 @@ commands:
       teleported: '<green>Đang dịch chuyển về nhà </green><yellow>#[number].</yellow>'
       failure: '<red>Di chuyển không thành công vì một số lý do. Vui lòng thử lại sau.</red>'
       unknown-home: '<red>Tên nhà không tồn tại!</red>'
+      picker:
+        title: '<green>Bạn muốn đi đâu?</green>'
     help:
       description: lệnh chính cho đảo
     spawn:
@@ -898,6 +903,11 @@ commands:
       invite:
         description: mời người chơi vào đảo của bạn
         invitation-sent: '<green>Lời mời đã gửi tới </green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>Lời mời nhóm từ [name]</green>'
+          body: '<gray>[name] đã mời bạn tham gia đảo của họ. Chấp nhận?</gray>'
+          accept: '<green>Chấp nhận</green>'
+          decline: '<red>Từ chối</red>'
         removing-invite: '<red>Đang xóa lời mời.</red>'
         name-has-invited-you: '<green>[name] đã mời bạn vào đảo họ.</green>'
         to-accept-or-reject: >-

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -637,6 +637,11 @@ commands:
     confirm: '<red>请在</red><aqua>[seconds]</aqua><red>秒内再次输入命令以确认.</red>'
     previous-request-cancelled: '<gold>先前的确认请求已取消.</gold>'
     request-cancelled: '<red>确认超时 </red><gray>- </gray><aqua>请求已取消.</aqua>'
+    title: '<red>确定吗？</red>'
+    dialog-body: '<gray>确认以继续，或取消以中止。</gray>'
+    buttons:
+      confirm: '<green>确认</green>'
+      cancel: '<red>取消</red>'
   delay:
     previous-command-cancelled: '<red>上一个命令已取消.</red>'
     stand-still: '<gold>请勿移动! 传送将在</gold><aqua>[seconds]</aqua><gold>秒后开始.</gold>'

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -15,6 +15,9 @@ prefixes:
   an-island: 岛屿
   islands: 岛屿
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>选择你的游戏</green>'
   did-you-mean:
     suggestion: '<gray>你是想输入 </gray><yellow>[command]</yellow><gray> 吗？点击此处或输入 </gray><green>yes</green><gray> 来执行。</gray>[run_command: [command]][hover: 点击执行 [command]]'
     header: '<gray>你是想输入以下命令之一吗？点击即可执行:</gray>'
@@ -657,6 +660,8 @@ commands:
       teleported: '<green>正在将你传送到你的岛屿传送点: </green><yellow>[number]</yellow><green>.</green>'
       failure: '<red>传送失败，出于某种原因。请稍后再试。</red>'
       unknown-home: '<red>未知岛屿传送点名称!</red>'
+      picker:
+        title: '<green>想去哪里？</green>'
     help:
       description: 岛屿主要命令
     spawn:
@@ -842,6 +847,11 @@ commands:
       invite:
         description: 邀请一位玩家以成员身份加入团队(对方会失去自己领取的岛屿)
         invitation-sent: '<green>邀请已发送给</green><aqua>[name]</aqua><green>.</green>'
+        dialog:
+          title: '<green>来自 [name] 的队伍邀请</green>'
+          body: '<gray>[name] 邀请你加入他们的岛屿。接受吗？</gray>'
+          accept: '<green>接受</green>'
+          decline: '<red>拒绝</red>'
         removing-invite: '<red>邀请已取消.</red>'
         name-has-invited-you: '<aqua>[name]</aqua><green>邀请你以成员身份加入TA的岛屿.</green>'
         to-accept-or-reject: |-

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -635,6 +635,11 @@ commands:
     confirm: '<red>於 </red><aqua>[seconds] </aqua><red>秒內再次輸入命令來確認</red>'
     previous-request-cancelled: '<gold>上一個確認請求已取消</gold>'
     request-cancelled: '<red>確認超時 - </red><aqua>請求已取消</aqua>'
+    title: '<red>確定嗎？</red>'
+    dialog-body: '<gray>確認以繼續，或取消以中止。</gray>'
+    buttons:
+      confirm: '<green>確認</green>'
+      cancel: '<red>取消</red>'
   delay:
     previous-command-cancelled: '<red>上一個命令已取消。</red>'
     stand-still: '<gold>請不要移動！ 將在 </gold><aqua>[seconds] </aqua><gold>秒後傳送。</gold>'

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -14,6 +14,9 @@ prefixes:
   an-island: 一個島
   islands: 島嶼
 general:
+  dialogs:
+    game-mode-selection:
+      title: '<green>選擇你的遊戲</green>'
   did-you-mean:
     suggestion: '<gray>你是想輸入 </gray><yellow>[command]</yellow><gray> 嗎？點擊此處或輸入 </gray><green>yes</green><gray> 來執行。</gray>[run_command: [command]][hover: 點擊執行 [command]]'
     header: '<gray>你是想輸入以下指令之一嗎？點擊即可執行:</gray>'
@@ -655,6 +658,8 @@ commands:
       teleported: '<green>傳送到您的第 </green><yellow>#[number] 號家。</yellow>'
       failure: '<red>傳送由於某種原因失敗。請稍後再試。</red>'
       unknown-home: '<red>未知島嶼傳送點。</red>'
+      picker:
+        title: '<green>想去哪裡？</green>'
     help:
       description: 主要島嶼命令
     spawn:
@@ -841,6 +846,11 @@ commands:
       invite:
         description: 邀請玩家來您的島嶼
         invitation-sent: '<green>邀請已經發送給 [name]</green>'
+        dialog:
+          title: '<green>來自 [name] 的隊伍邀請</green>'
+          body: '<gray>[name] 邀請你加入他們的島嶼。接受嗎？</gray>'
+          accept: '<green>接受</green>'
+          decline: '<red>拒絕</red>'
         removing-invite: '<red>移除邀請</red>'
         name-has-invited-you: '<green>[name] 邀請您去他們的島嶼。</green>'
         to-accept-or-reject: |-

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandGoCommandTest.java
@@ -251,6 +251,36 @@ class IslandGoCommandTest extends CommonTestSetup {
     }
 
     /**
+     * With the go picker enabled and several destinations, a bare /go tries to show the
+     * dialog; when it cannot be built (as under test) it falls back to the default teleport.
+     * Test method for {@link IslandGoCommand#execute(User, String, List)}
+     */
+    @Test
+    void testExecuteNoArgsGoPickerFallsBack() {
+        when(island.getName()).thenReturn("MyIsland");
+        when(island.getHomes()).thenReturn(Map.of("Home", mock(Location.class)));
+        when(s.isDialogGoPicker()).thenReturn(true);
+        assertTrue(igc.execute(user, igc.getLabel(), Collections.emptyList()));
+        verify(plugin).logError(Mockito.contains("go picker"));
+        // Fell back to the default home teleport
+        verify(im).homeTeleportAsync(world, mockPlayer);
+    }
+
+    /**
+     * With the go picker disabled, a bare /go teleports directly without touching dialogs.
+     * Test method for {@link IslandGoCommand#execute(User, String, List)}
+     */
+    @Test
+    void testExecuteNoArgsGoPickerDisabled() {
+        when(island.getName()).thenReturn("MyIsland");
+        when(island.getHomes()).thenReturn(Map.of("Home", mock(Location.class)));
+        when(s.isDialogGoPicker()).thenReturn(false);
+        assertTrue(igc.execute(user, igc.getLabel(), Collections.emptyList()));
+        verify(plugin, Mockito.never()).logError(Mockito.contains("go picker"));
+        verify(im).homeTeleportAsync(world, mockPlayer);
+    }
+
+    /**
      * Test method for {@link IslandGoCommand#execute(User, String, List)}
      */
     @Test

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
@@ -365,7 +365,7 @@ class IslandResetCommandTest extends CommonTestSetup {
         // Require confirmation, and prefer a dialog for an online player
         when(s.isResetConfirmation()).thenReturn(true);
         when(s.getConfirmationTime()).thenReturn(20);
-        when(s.isUseDialogConfirmation()).thenReturn(true);
+        when(s.isDialogConfirmations()).thenReturn(true);
         when(user.isPlayer()).thenReturn(true);
 
         assertTrue(irc.execute(user, irc.getLabel(), Collections.emptyList()));

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandResetCommandTest.java
@@ -350,6 +350,32 @@ class IslandResetCommandTest extends CommonTestSetup {
     }
 
     /**
+     * When dialog confirmations are enabled but the dialog cannot be shown (no live
+     * dialog registry, as under test), the command must fall back to the classic
+     * type-again prompt rather than silently losing the confirmation.
+     * Test method for {@link IslandResetCommand#execute(User, String, java.util.List)}
+     */
+    @Test
+    void testConfirmationDialogFallsBackWhenUnavailable() throws Exception {
+        when(im.hasIsland(any(), eq(uuid))).thenReturn(true);
+        when(im.inTeam(any(), eq(uuid))).thenReturn(false);
+        when(pm.getResetsLeft(world, uuid)).thenReturn(1);
+        when(im.getIsland(any(), eq(uuid))).thenReturn(mock(Island.class));
+
+        // Require confirmation, and prefer a dialog for an online player
+        when(s.isResetConfirmation()).thenReturn(true);
+        when(s.getConfirmationTime()).thenReturn(20);
+        when(s.isUseDialogConfirmation()).thenReturn(true);
+        when(user.isPlayer()).thenReturn(true);
+
+        assertTrue(irc.execute(user, irc.getLabel(), Collections.emptyList()));
+        // The dialog could not be built under test, so we fell back to the prompt
+        verify(user).sendMessage("commands.confirmation.confirm", "[seconds]", String.valueOf(s.getConfirmationTime()));
+        // and the failure was logged
+        verify(plugin).logError(Mockito.contains("confirmation dialog"));
+    }
+
+    /**
      * Test method for {@link IslandResetCommand#execute(User, String, java.util.List)}
      */
     @Test

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamInviteCommandTest.java
@@ -307,6 +307,27 @@ class IslandTeamInviteCommandTest extends RanksManagerTestSetup {
     }
 
     /**
+     * With team-invite dialogs enabled and an online target, execute attempts to show the
+     * accept/decline dialog; when it cannot be built (as under test) the chat invite still
+     * goes out and the failure is logged.
+     * Test method for
+     * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#execute(User, String, java.util.List)}.
+     */
+    @Test
+    void testExecuteInviteDialogFallsBack() {
+        when(im.getIsland(world, uuid)).thenReturn(island);
+        testCanExecuteSuccess();
+        when(target.isPlayer()).thenReturn(true);
+        when(s.isDialogTeamInvites()).thenReturn(true);
+        assertTrue(itl.execute(user, itl.getLabel(), List.of("target")));
+        // Chat invite still sent as the fallback
+        verify(user).sendMessage("commands.island.team.invite.invitation-sent", TextVariables.NAME, "target",
+                TextVariables.DISPLAY_NAME, "&Ctarget");
+        // Dialog build failed under test and was logged
+        verify(plugin).logError(Mockito.contains("team invite dialog"));
+    }
+
+    /**
      * Test method for
      * {@link world.bentobox.bentobox.api.commands.island.team.IslandTeamInviteCommand#execute(User, String, java.util.List)}.
      */

--- a/src/test/java/world/bentobox/bentobox/api/dialogs/DialogBuilderTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/dialogs/DialogBuilderTest.java
@@ -1,0 +1,91 @@
+package world.bentobox.bentobox.api.dialogs;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import net.kyori.adventure.text.Component;
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.user.User;
+
+/**
+ * Tests the Dialogs API builder (#3021).
+ * <p>
+ * Note: {@link DialogBuilder#build()} of a complete dialog needs the server's
+ * dialog registry provider (Paper {@code DialogInstancesProvider}), which
+ * MockBukkit does not supply - much like NMS paste handling. Those paths are
+ * therefore exercised on a live server, not here. This test covers the pure
+ * logic: support detection, button holders and pre-factory validation.
+ *
+ * @author tastybento
+ */
+class DialogBuilderTest extends CommonTestSetup {
+
+    private User user;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        user = User.getInstance(mockPlayer);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * Test method for {@link Dialogs#isSupported()}. The Paper dialog classes are on
+     * the compile/test classpath, so support must be reported.
+     */
+    @Test
+    void testDialogsSupported() {
+        assertTrue(Dialogs.isSupported());
+    }
+
+    /**
+     * Test method for {@link DialogButton}.
+     */
+    @Test
+    void testDialogButtonHoldsFields() {
+        AtomicReference<User> clicked = new AtomicReference<>();
+        DialogButton b = new DialogButton(Component.text("Go"), Component.text("tip"), clicked::set);
+        assertNotNull(b.label());
+        assertNotNull(b.tooltip());
+        assertNotNull(b.onClick());
+        b.onClick().accept(user);
+        // The callback ran with our user
+        assertSame(user, clicked.get());
+    }
+
+    /**
+     * Test method for {@link DialogButton} with no tooltip.
+     */
+    @Test
+    void testDialogButtonNoTooltip() {
+        DialogButton b = new DialogButton(Component.text("Go"), null);
+        assertNotNull(b.label());
+        assertTrue(b.tooltip() == null);
+        assertTrue(b.onClick() == null);
+    }
+
+    /**
+     * Test method for {@link DialogBuilder#build()} - a dialog with neither a
+     * confirmation nor any button is invalid, and this is rejected before any
+     * server-side factory is touched.
+     */
+    @Test
+    void testBuildNoButtonsThrows() {
+        DialogBuilder builder = new DialogBuilder().title(Component.text("Empty"));
+        assertThrows(IllegalStateException.class, builder::build);
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -16,6 +17,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -44,6 +46,7 @@ import world.bentobox.bentobox.RanksManagerTestSetup;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.AddonDescription;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.database.objects.Players;
@@ -288,6 +291,31 @@ class JoinLeaveListenerTest extends RanksManagerTestSetup {
         // Verify
         verify(pm, times(3)).getPlayer(any());
         checkSpigotMessage("commands.island.create.on-first-login");
+    }
+
+    /**
+     * With the game-mode selection dialog enabled and several game modes installed, a first
+     * join tries to show the dialog; when it cannot be built (as under test) it logs and
+     * falls through to the normal first-login handling.
+     * Test method for {@link world.bentobox.bentobox.listeners.JoinLeaveListener#onPlayerJoin(PlayerJoinEvent)}.
+     */
+    @Test
+    void testOnPlayerJoinGameModeDialogFallsBack() {
+        when(settings.isDialogGameModeSelection()).thenReturn(true);
+        AddonDescription desc = mock(AddonDescription.class);
+        when(desc.getName()).thenReturn("BSkyBlock");
+        CompositeCommand cmd = mock(CompositeCommand.class);
+        GameModeAddon gm1 = mock(GameModeAddon.class);
+        GameModeAddon gm2 = mock(GameModeAddon.class);
+        when(gm1.getPlayerCommand()).thenReturn(Optional.of(cmd));
+        when(gm2.getPlayerCommand()).thenReturn(Optional.of(cmd));
+        when(gm1.getDescription()).thenReturn(desc);
+        when(gm2.getDescription()).thenReturn(desc);
+        when(am.getGameModeAddons()).thenReturn(List.of(gm1, gm2));
+
+        jll.onPlayerJoin(new PlayerJoinEvent(mockPlayer, component));
+
+        verify(plugin).logError(contains("game mode selection dialog"));
     }
 
     /**


### PR DESCRIPTION
Closes #3021.

## What

Introduces a public **`api/dialogs/`** package wrapping Paper's modal dialog system (`io.papermc.paper.dialog.Dialog`, Minecraft 26+) alongside the Panels API, and wires it into **all four** high-friction flows from the issue. Dialogs are real modal UI — the "menu players can't click away".

## API surface (`world.bentobox.bentobox.api.dialogs`)

| Type | Purpose |
|------|---------|
| `DialogButton` | Label + optional tooltip + an `onClick` `Consumer<User>`, run on the **main thread** when clicked. |
| `DialogBuilder` | Fluent: `title`/`body` (localized via `User`), `escapable`, `pause`, plus `confirmation(yes, no)` and multi-action `button(...)`. `build()` → `BBDialog`. |
| `BBDialog` | Built dialog; `show(User)`. |
| `Dialogs` | `isSupported()` guard for graceful degradation. |

Everything is Adventure `Component`-based end-to-end so click data survives (the legacy `§`-string path cannot carry it).

## Consumers

All are gated by a new consolidated **`island.dialogs.*`** config section, and every one **falls back** to the prior behaviour if the dialog can't be built/shown (older server, error):

1. **Confirmations** (`island.dialogs.confirmations`, default **true**) — `ConfirmableCommand.askConfirmation` shows `[Confirm]`/`[Cancel]` instead of asking the player to re-type the command.
2. **Go picker** (`island.dialogs.go-picker`, default **true**) — a bare `/island go` with more than one island/home opens a button-per-destination picker; each button teleports there.
3. **Team invites** (`island.dialogs.team-invites`, default **true**) — receiving an invite auto-opens an `[Accept]`/`[Decline]` dialog that runs the accept/reject command.
4. **First-join game-mode selection** (`island.dialogs.game-mode-selection`, default **false**) — a non-dismissable "choose your game" dialog for brand new players when several game modes are installed; each button runs that mode's command. Off by default because it is intrusive/non-dismissable.

## Locales

All new `en-US` keys translated into every other locale (22 files) preserving each file's MiniMessage style.

## Tests

`DialogBuilderTest` (support detection, button holders, validation) plus fallback/gating tests in `IslandResetCommandTest`, `IslandGoCommandTest`, `IslandTeamInviteCommandTest` and `JoinLeaveListenerTest`. Full `./gradlew build` green.

> **MockBukkit limitation:** building a *complete* dialog needs the server's dialog registry provider (`DialogInstancesProvider`), which MockBukkit does not supply — like NMS. So actual dialog display is verified on a live server; unit tests cover support detection, validation and the graceful fallbacks.

## Open questions for reviewers

- **Public API stability** — binary-compat-committed surface; worth a look at the builder/type shape before release.
- **Bedrock/Geyser** — do dialogs render as Bedrock forms, or is a Panels fallback needed? Needs live testing.
- **Defaults** — confirmations/go-picker/team-invites default on; game-mode-selection deliberately off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)