### PR TITLE
Register commands with Paper's Brigadier API (#3023 phases 1 and 2)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -164,6 +164,13 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "general.did-you-mean.subcommands", since = "3.20.0")
     private boolean didYouMeanSubcommands = true;
 
+    @ConfigComment("Register commands with Paper's Brigadier command system instead of the legacy command map.")
+    @ConfigComment("Brigadier lets the client show subcommands and completions as the player types, rather than")
+    @ConfigComment("only after they press enter or TAB. Turn this off to go back to the legacy registration if")
+    @ConfigComment("another plugin conflicts with it.")
+    @ConfigEntry(path = "general.brigadier-commands", since = "3.22.0")
+    private boolean useBrigadierCommands = true;
+
     /* PANELS */
     @ConfigComment("Panel click cooldown. Value is in milliseconds. Prevents players spamming button presses in GUIs.")
     @ConfigEntry(path = "panel.click-cooldown-ms")
@@ -1926,6 +1933,22 @@ public class Settings implements ConfigObject {
      */
     public void setDidYouMeanSubcommands(boolean didYouMeanSubcommands) {
         this.didYouMeanSubcommands = didYouMeanSubcommands;
+    }
+
+    /**
+     * @return whether commands are registered with Paper's Brigadier system
+     * @since 3.22.0
+     */
+    public boolean isUseBrigadierCommands() {
+        return useBrigadierCommands;
+    }
+
+    /**
+     * @param useBrigadierCommands the useBrigadierCommands to set
+     * @since 3.22.0
+     */
+    public void setUseBrigadierCommands(boolean useBrigadierCommands) {
+        this.useBrigadierCommands = useBrigadierCommands;
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrar.java
@@ -1,0 +1,417 @@
+package world.bentobox.bentobox.commands.brigadier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+
+/**
+ * Registers BentoBox {@link CompositeCommand}s with Paper's Brigadier command
+ * system, so clients get native subcommand completion and highlighting
+ * <i>while</i> the player types rather than only after they press enter.
+ * <p>
+ * <b>Why this class captures the dispatcher.</b> Paper only permits Brigadier
+ * registration inside the {@code LifecycleEvents.COMMANDS} callback, and that
+ * event fires after {@code onEnable} returns but <i>before</i> the first server
+ * tick. BentoBox enables its addons on that first tick (see
+ * {@code BentoBox#completeSetup}), so game mode commands such as
+ * {@code /island} do not exist yet while the lifecycle window is open. Using the
+ * {@code Commands} registrar after the window closes throws
+ * {@code "No lifecycle owner context is set"}, and calling {@code getDispatcher()}
+ * on it then throws {@code "cannot access the dispatcher in this context"}.
+ * <p>
+ * The dispatcher instance itself is the live one the server dispatches against,
+ * so this class grabs it <i>while</i> the window is open and registers nodes into
+ * it afterwards as addons come up. Nodes added that way survive
+ * {@code syncCommands()} and are dispatchable by players and console alike.
+ * <p>
+ * Nodes never capture a {@link CompositeCommand} reference; every lookup goes
+ * through the label. That matters because Brigadier has no API for removing a
+ * node once added: a {@code /bentobox reload} that swaps the command objects
+ * therefore leaves no stale references behind, and a label that disappears
+ * entirely is hidden from clients because its {@code requires} predicate stops
+ * matching.
+ *
+ * @author tastybento
+ * @since 3.22.0
+ */
+public class BrigadierCommandRegistrar {
+
+    /**
+     * Maximum depth of the literal subcommand tree handed to clients. Deeper
+     * subcommands still work - they fall through to the greedy argument - they
+     * are simply not pre-advertised in the command tree packet.
+     */
+    private static final int MAX_TREE_DEPTH = 4;
+
+    private static final String ARGS = "args";
+
+    private final BentoBox plugin;
+
+    /**
+     * The live dispatcher, captured inside the COMMANDS lifecycle window. Null
+     * until that window has opened at least once.
+     */
+    @Nullable
+    private CommandDispatcher<CommandSourceStack> dispatcher;
+
+    /** Top level labels and aliases already given a node in the dispatcher. */
+    private final Set<String> registeredLabels = new HashSet<>();
+
+    public BrigadierCommandRegistrar(@NonNull BentoBox plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Hooks the Paper COMMANDS lifecycle event. Must be called during
+     * {@code onEnable}, before the lifecycle window opens.
+     */
+    public void hookLifecycle() {
+        plugin.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
+            dispatcher = event.registrar().getDispatcher();
+            // A reload rebuilds the tree, so anything registered before has gone.
+            registeredLabels.clear();
+            // Register everything already known. Commands created later come
+            // through registerCommand() directly.
+            new ArrayList<>(plugin.getCommandsManager().getCommands().values()).forEach(this::registerCommand);
+        });
+    }
+
+    /**
+     * @return {@code true} once the COMMANDS lifecycle window has opened and the
+     *         dispatcher has been captured.
+     */
+    public boolean isAvailable() {
+        return dispatcher != null;
+    }
+
+    /**
+     * Registers a top level command and all of its aliases with Brigadier. If the
+     * lifecycle window has not opened yet the command is a no-op here - it will
+     * be swept up by {@link #hookLifecycle()} when the window opens.
+     *
+     * @param command top level composite command
+     */
+    public void registerCommand(@NonNull CompositeCommand command) {
+        if (dispatcher == null) {
+            return;
+        }
+        String label = command.getLabel().toLowerCase(Locale.ENGLISH);
+        boolean added = false;
+        LiteralCommandNode<CommandSourceStack> main = null;
+        if (registeredLabels.add(label)) {
+            main = dispatcher.register(buildTopLevel(label));
+            added = true;
+        }
+        if (main != null) {
+            // Aliases and the namespaced form redirect rather than duplicating the
+            // tree - a game mode admin tree runs to dozens of nodes and every one
+            // of them is sent to every client.
+            for (String alias : command.getAliases()) {
+                added |= registerRedirect(alias, main, label);
+            }
+            added |= registerRedirect(namespace(command) + ":" + label, main, label);
+        }
+        if (added) {
+            // Players already online - an addon enabled at runtime, or a
+            // /bentobox reload - need the new tree pushed to them.
+            Bukkit.getOnlinePlayers().forEach(Player::updateCommands);
+        }
+    }
+
+    /**
+     * Pushes the tree for online players. Used after commands are unregistered,
+     * so clients stop offering commands that have gone away.
+     */
+    public void refreshClients() {
+        if (dispatcher != null) {
+            Bukkit.getOnlinePlayers().forEach(Player::updateCommands);
+        }
+    }
+
+    /**
+     * Registers {@code alias} as a Brigadier redirect onto the command's main
+     * node.
+     *
+     * @param alias    alias or namespaced label
+     * @param main     node to redirect to
+     * @param topLabel main label, used to resolve the command at runtime
+     * @return {@code true} if a node was added
+     */
+    private boolean registerRedirect(@NonNull String alias, @NonNull LiteralCommandNode<CommandSourceStack> main,
+            @NonNull String topLabel) {
+        String key = alias.toLowerCase(Locale.ENGLISH);
+        if (!registeredLabels.add(key)) {
+            return false;
+        }
+        dispatcher.register(Commands.literal(key).requires(source -> canUse(resolve(topLabel), source))
+                .executes(ctx -> run(topLabel, ctx)).redirect(main));
+        return true;
+    }
+
+    /**
+     * The command map prefix BentoBox has always used for the {@code plugin:label}
+     * form of a command.
+     */
+    private static String namespace(@NonNull CompositeCommand command) {
+        return command.getAddon() == null ? "bentobox"
+                : ((Addon) command.getAddon()).getDescription().getName().toLowerCase(Locale.ENGLISH);
+    }
+
+    /*
+     * ------------------------------------------------------------------
+     * Node building
+     * ------------------------------------------------------------------
+     */
+
+    /**
+     * Builds the literal node for a top level label. The node resolves its
+     * command by label at execution time rather than capturing it, so it stays
+     * correct across reloads.
+     */
+    private LiteralArgumentBuilder<CommandSourceStack> buildTopLevel(@NonNull String label) {
+        LiteralArgumentBuilder<CommandSourceStack> root = Commands.literal(label)
+                .requires(source -> canUse(resolve(label), source)).executes(ctx -> run(label, ctx));
+        addChildren(root, label, () -> resolve(label), 0);
+        return root;
+    }
+
+    /**
+     * Adds the literal subcommand children plus the catch-all greedy argument to
+     * {@code parent}.
+     *
+     * @param parent   builder being populated
+     * @param topLabel top level label, used to re-resolve the tree at runtime
+     * @param supplier resolves the command this node represents
+     * @param depth    current depth, guards against absurdly deep trees
+     */
+    private void addChildren(LiteralArgumentBuilder<CommandSourceStack> parent, @NonNull String topLabel,
+            @NonNull CommandSupplier supplier, int depth) {
+        CompositeCommand command = supplier.get();
+        if (command != null && depth < MAX_TREE_DEPTH) {
+            for (CompositeCommand sub : command.getSubCommands().values()) {
+                if (sub.isHidden()) {
+                    // Hidden commands still run, they are just not advertised.
+                    continue;
+                }
+                String subLabel = sub.getLabel().toLowerCase(Locale.ENGLISH);
+                CommandSupplier subSupplier = () -> {
+                    CompositeCommand p = supplier.get();
+                    return p == null ? null : p.getSubCommands().get(subLabel);
+                };
+                LiteralArgumentBuilder<CommandSourceStack> child = Commands.literal(subLabel)
+                        .requires(source -> canUse(subSupplier.get(), source)).executes(ctx -> run(topLabel, ctx));
+                addChildren(child, topLabel, subSupplier, depth + 1);
+                parent.then(child);
+            }
+        }
+        // Catch-all: anything the literals do not match is handed to the existing
+        // dispatch, preserving today's behaviour exactly.
+        parent.then(Commands.argument(ARGS, StringArgumentType.greedyString())
+                .suggests((ctx, builder) -> suggest(topLabel, ctx.getSource().getSender(), builder))
+                .executes(ctx -> run(topLabel, ctx)));
+    }
+
+    /*
+     * ------------------------------------------------------------------
+     * Execution and suggestions
+     * ------------------------------------------------------------------
+     */
+
+    /**
+     * Runs the command. Arguments are taken from the raw input rather than from
+     * Brigadier's parsed nodes, so dispatch is identical to the legacy command
+     * map path however the parse happened to split.
+     */
+    private int run(@NonNull String topLabel, CommandContext<CommandSourceStack> ctx) {
+        CompositeCommand command = resolve(topLabel);
+        if (command == null) {
+            return 0;
+        }
+        String[] tokens = tokenize(ctx.getInput());
+        String label = tokens.length > 0 ? tokens[0] : topLabel;
+        command.execute(ctx.getSource().getSender(), label, argsOf(tokens, false));
+        // Always report success. BentoBox commands report their own failures to
+        // the user; a Brigadier failure result would print a second, generic
+        // error on top of that.
+        return com.mojang.brigadier.Command.SINGLE_SUCCESS;
+    }
+
+    /**
+     * Maps {@link CompositeCommand#tabComplete} onto Brigadier's suggestion
+     * mechanism, which the client queries on every keystroke rather than only on
+     * TAB.
+     */
+    private CompletableFuture<Suggestions> suggest(@NonNull String topLabel, CommandSender sender,
+            SuggestionsBuilder builder) {
+        CompositeCommand command = resolve(topLabel);
+        if (command == null) {
+            return builder.buildFuture();
+        }
+        String[] tokens = tokenize(builder.getInput());
+        String label = tokens.length > 0 ? tokens[0] : topLabel;
+        String[] args = argsOf(tokens, builder.getInput().endsWith(" "));
+        List<String> options;
+        try {
+            options = new ArrayList<>(command.tabComplete(sender, label, args));
+        } catch (Exception e) {
+            plugin.logError("Brigadier suggestions failed for /" + topLabel + ": " + e.getMessage());
+            return builder.buildFuture();
+        }
+        // Literal sibling nodes already suggest these client-side, and Brigadier
+        // does not deduplicate across nodes, so drop them to avoid doubles.
+        options.removeAll(literalSiblings(builder, sender));
+
+        SuggestionsBuilder offset = atCurrentToken(builder);
+        options.forEach(offset::suggest);
+        return offset.buildFuture();
+    }
+
+    /**
+     * The visible literal subcommands at the position the greedy argument starts,
+     * i.e. the ones Brigadier itself will already be suggesting.
+     */
+    private Set<String> literalSiblings(SuggestionsBuilder builder, CommandSender sender) {
+        // Everything before the greedy argument was consumed by literal nodes.
+        String[] consumed = tokenize(builder.getInput().substring(0, builder.getStart()));
+        CompositeCommand current = consumed.length > 0 ? resolve(consumed[0]) : null;
+        for (int i = 1; i < consumed.length && current != null; i++) {
+            current = current.getSubCommands().get(consumed[i].toLowerCase(Locale.ENGLISH));
+        }
+        if (current == null || consumed.length - 1 >= MAX_TREE_DEPTH) {
+            return Set.of();
+        }
+        Set<String> labels = new HashSet<>();
+        for (CompositeCommand sub : current.getSubCommands().values()) {
+            if (!sub.isHidden() && canUse(sub, sender)) {
+                labels.add(sub.getLabel());
+            }
+        }
+        return labels;
+    }
+
+    /*
+     * ------------------------------------------------------------------
+     * Helpers
+     * ------------------------------------------------------------------
+     */
+
+    /**
+     * Splits a raw command line into label and arguments, dropping any leading
+     * slash and Paper's {@code plugin:} namespace prefix.
+     */
+    static String[] tokenize(@NonNull String input) {
+        String line = input.startsWith("/") ? input.substring(1) : input;
+        String[] tokens = line.split(" ");
+        if (tokens.length > 0) {
+            int colon = tokens[0].indexOf(':');
+            if (colon >= 0) {
+                tokens[0] = tokens[0].substring(colon + 1);
+            }
+        }
+        return tokens;
+    }
+
+    /**
+     * The argument array to hand to {@link CompositeCommand}, i.e. everything
+     * after the label.
+     *
+     * @param tokens        output of {@link #tokenize(String)}
+     * @param trailingSpace whether the raw input ended in a space, in which case
+     *                      CompositeCommand expects an extra empty element so that
+     *                      it completes the next argument rather than the last one
+     * @return arguments, never null
+     */
+    static String[] argsOf(String @NonNull [] tokens, boolean trailingSpace) {
+        String[] args = tokens.length > 1 ? Arrays.copyOfRange(tokens, 1, tokens.length) : new String[0];
+        if (trailingSpace) {
+            args = Arrays.copyOf(args, args.length + 1);
+            args[args.length - 1] = "";
+        }
+        return args;
+    }
+
+    /**
+     * Start index for suggestions inside the greedy argument. The argument covers
+     * everything from {@code builder.getStart()} to the cursor, but a suggestion
+     * must replace only the token currently being typed.
+     *
+     * @param builder Brigadier's builder for the greedy argument
+     * @return builder positioned at the start of the token being typed
+     */
+    static SuggestionsBuilder atCurrentToken(@NonNull SuggestionsBuilder builder) {
+        int lastSpace = builder.getRemaining().lastIndexOf(' ');
+        return lastSpace < 0 ? builder : builder.createOffset(builder.getStart() + lastSpace + 1);
+    }
+
+    /**
+     * Resolves a top level command by its label or by one of its aliases.
+     */
+    @Nullable
+    private CompositeCommand resolve(@NonNull String label) {
+        CompositeCommand command = plugin.getCommandsManager().getCommand(label);
+        if (command != null) {
+            return command;
+        }
+        for (CompositeCommand c : plugin.getCommandsManager().getCommands().values()) {
+            if (c.getAliases().stream().anyMatch(a -> a.equalsIgnoreCase(label))) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Mirrors the visibility rules {@link CompositeCommand} applies at execution
+     * time, so the client is only shown what it could actually run.
+     */
+    private static boolean canUse(@Nullable CompositeCommand command, CommandSourceStack source) {
+        return command != null && canUse(command, source.getSender());
+    }
+
+    private static boolean canUse(@NonNull CompositeCommand command, CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            // Hiding a node from the console would turn "that command is only
+            // available in game" into Brigadier's generic "unknown command", so
+            // the console keeps seeing everything and the command reports for
+            // itself, exactly as it did under the command map.
+            return true;
+        }
+        if (command.isOnlyConsole()) {
+            return false;
+        }
+        String permission = command.getPermission();
+        return permission == null || permission.isEmpty() || sender.isOp() || sender.hasPermission(permission);
+    }
+
+    /** Resolves a command lazily by label, so nodes never hold stale references. */
+    @FunctionalInterface
+    private interface CommandSupplier {
+        @Nullable
+        CompositeCommand get();
+    }
+}

--- a/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
@@ -15,6 +15,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.commands.BentoBoxCommand;
+import world.bentobox.bentobox.commands.brigadier.BrigadierCommandRegistrar;
 
 public class CommandsManager {
 
@@ -22,10 +23,47 @@ public class CommandsManager {
     private final Map<@NonNull String, @NonNull CompositeCommand> commands = new HashMap<>();
     private SimpleCommandMap commandMap;
 
-    // Reflection is required to access Bukkit's internal command map for dynamic command registration
-    @SuppressWarnings("java:S3011")
+    /**
+     * Brigadier registrar, or {@code null} when Brigadier registration is turned
+     * off in the config or is unavailable on this server, in which case the
+     * legacy command map path is used instead.
+     */
+    @Nullable
+    private final BrigadierCommandRegistrar brigadier;
+
+    public CommandsManager() {
+        BentoBox plugin = BentoBox.getInstance();
+        BrigadierCommandRegistrar registrar = null;
+        if (plugin.getSettings().isUseBrigadierCommands()) {
+            try {
+                registrar = new BrigadierCommandRegistrar(plugin);
+                // Must be hooked before Paper opens the COMMANDS lifecycle window,
+                // which happens as soon as onEnable returns.
+                registrar.hookLifecycle();
+            } catch (Exception | LinkageError e) {
+                plugin.logWarning(
+                        "Brigadier command registration is unavailable, falling back to the legacy command map: "
+                                + e.getMessage());
+                registrar = null;
+            }
+        }
+        this.brigadier = registrar;
+    }
+
     public void registerCommand(@NonNull CompositeCommand command) {
         commands.put(command.getLabel(), command);
+        if (brigadier != null) {
+            // Commands created before the lifecycle window opens are picked up by
+            // the registrar when it opens, so nothing more is needed here.
+            brigadier.registerCommand(command);
+            return;
+        }
+        registerWithCommandMap(command);
+    }
+
+    // Reflection is required to access Bukkit's internal command map for dynamic command registration
+    @SuppressWarnings("java:S3011")
+    private void registerWithCommandMap(@NonNull CompositeCommand command) {
         // Use reflection to obtain the commandMap method in Bukkit's server.
         try{
             Field commandMapField = Bukkit.getServer().getClass().getDeclaredField("commandMap");
@@ -49,6 +87,15 @@ public class CommandsManager {
      * Unregisters all BentoBox registered commands with Bukkit
      */
     public void unregisterCommands() {
+        if (brigadier != null) {
+            // Brigadier has no API for removing a node, so the nodes stay put and
+            // instead resolve to nothing: their requires predicate hides them from
+            // clients and their executor becomes a no-op. Any command re-registered
+            // after this reuses the node it already has.
+            commands.clear();
+            brigadier.refreshClients();
+            return;
+        }
         // Use reflection to obtain the knownCommands in the commandMap
         try {
             @SuppressWarnings("unchecked")

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -101,6 +101,12 @@ general:
     # BentoBox suggests the closest matching subcommand instead of showing an error.
     # Added since 3.20.0.
     subcommands: true
+  # Register commands with Paper's Brigadier command system instead of the legacy command map.
+  # Brigadier lets the client show subcommands and completions as the player types, rather than
+  # only after they press enter or TAB. Turn this off to go back to the legacy registration if
+  # another plugin conflicts with it.
+  # Added since 3.22.0.
+  brigadier-commands: true
 panel:
   # Panel click cooldown. Value is in milliseconds. Prevents players spamming button presses in GUIs.
   click-cooldown-ms: 250

--- a/src/test/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrarTest.java
+++ b/src/test/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrarTest.java
@@ -1,0 +1,85 @@
+package world.bentobox.bentobox.commands.brigadier;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+
+/**
+ * Tests the raw command line handling of {@link BrigadierCommandRegistrar}.
+ * <p>
+ * These are the parts that have to agree exactly with what
+ * {@code CompositeCommand} expects: Brigadier hands over one greedy string, and
+ * everything downstream depends on it being split the same way the legacy
+ * command map split it. They need no server, so they run as plain unit tests.
+ *
+ * @author tastybento
+ */
+class BrigadierCommandRegistrarTest {
+
+    @Test
+    void tokenizeSplitsLabelAndArguments() {
+        assertArrayEquals(new String[] { "island", "team", "invite" },
+                BrigadierCommandRegistrar.tokenize("island team invite"));
+    }
+
+    @Test
+    void tokenizeDropsLeadingSlash() {
+        assertArrayEquals(new String[] { "island", "go" }, BrigadierCommandRegistrar.tokenize("/island go"));
+    }
+
+    @Test
+    void tokenizeStripsThePluginNamespace() {
+        // Paper offers every command as plugin:label as well as label
+        assertArrayEquals(new String[] { "island", "go" },
+                BrigadierCommandRegistrar.tokenize("/bskyblock:island go"));
+        assertArrayEquals(new String[] { "acid" }, BrigadierCommandRegistrar.tokenize("acidisland:acid"));
+    }
+
+    @Test
+    void tokenizeLeavesColonsInArgumentsAlone() {
+        assertArrayEquals(new String[] { "island", "a:b" }, BrigadierCommandRegistrar.tokenize("island a:b"));
+    }
+
+    @Test
+    void argsOfDropsTheLabel() {
+        assertArrayEquals(new String[] { "team", "invite" },
+                BrigadierCommandRegistrar.argsOf(new String[] { "island", "team", "invite" }, false));
+    }
+
+    @Test
+    void argsOfIsEmptyForABareCommand() {
+        assertArrayEquals(new String[0], BrigadierCommandRegistrar.argsOf(new String[] { "island" }, false));
+    }
+
+    @Test
+    void argsOfAddsAnEmptyElementAfterATrailingSpace() {
+        // "/island team " must complete the argument after team, not team itself
+        assertArrayEquals(new String[] { "team", "" },
+                BrigadierCommandRegistrar.argsOf(new String[] { "island", "team" }, true));
+        assertArrayEquals(new String[] { "" }, BrigadierCommandRegistrar.argsOf(new String[] { "island" }, true));
+    }
+
+    @Test
+    void suggestionsReplaceOnlyTheTokenBeingTyped() {
+        // Greedy argument starts at index 7 of "island team inv"
+        SuggestionsBuilder builder = new SuggestionsBuilder("island team inv", 7);
+        assertEquals("team inv", builder.getRemaining());
+        // Only "inv" should be replaced, i.e. the offset starts at 12
+        assertEquals(12, BrigadierCommandRegistrar.atCurrentToken(builder).getStart());
+    }
+
+    @Test
+    void suggestionsAfterATrailingSpaceInsertAtTheCursor() {
+        SuggestionsBuilder builder = new SuggestionsBuilder("island team ", 7);
+        assertEquals(12, BrigadierCommandRegistrar.atCurrentToken(builder).getStart());
+    }
+
+    @Test
+    void suggestionsOnTheFirstArgumentKeepTheOriginalBuilder() {
+        SuggestionsBuilder builder = new SuggestionsBuilder("island tea", 7);
+        assertEquals(7, BrigadierCommandRegistrar.atCurrentToken(builder).getStart());
+    }
+}


### PR DESCRIPTION
Closes #3023 (phases 1 and 2).

Replaces the `SimpleCommandMap` reflection in `CommandsManager` with Brigadier registration, and exposes the `CompositeCommand` subcommand tree to clients so completions appear **while** the player types rather than only after enter or TAB.

Phases 1 and 2 are done together deliberately: the registration shim alone carries the entire risk of the change with none of the player-facing benefit.

## The timing problem, and why the dispatcher is captured

Paper only permits Brigadier registration inside the `LifecycleEvents.COMMANDS` callback. Probing the real ordering on a 26.2 server gives:

```
onEnable returns  ->  COMMANDS fires (cause=INITIAL)  ->  first server tick: completeSetup()
```

`completeSetup()` is where `enableAddons()` runs, so game mode commands such as `/island` and `/acid` **do not exist yet** while the lifecycle window is open. Using the registrar after the window closes throws `No lifecycle owner context is set`, and calling `getDispatcher()` on it then throws `cannot access the dispatcher in this context`.

Three escape routes were tested and rejected:

- **Re-fire the event** — `CraftServer#syncCommands()` does *not* re-run the COMMANDS lifecycle. Verified directly.
- **Move the addon enable earlier** — that was tried and reverted in #2214, so the deferred tick has to stay.
- **Use the registrar late** — throws, as above.

What does work: the `CommandDispatcher` instance is the live one the server dispatches against. `BrigadierCommandRegistrar` captures it *inside* the window and registers nodes into it afterwards as addons come up. Those nodes survive `syncCommands()` and dispatch correctly for players and console.

## Design consequences

- **No stale references.** Brigadier has no API for removing a node, so nodes never capture a `CompositeCommand` — they resolve it by label on every use. A reload that swaps the command objects leaves nothing stale behind, and a label that goes away is hidden because its `requires` predicate stops matching.
- **Aliases and `plugin:label` are redirects**, not duplicated trees. A game mode admin tree runs to dozens of nodes and every one of them is sent to every client.
- **Console keeps seeing player-only commands**, so `/ai` from console still reports "This command is only available in-game" rather than Brigadier's generic "unknown command".
- **Literal tree is depth-capped** at 4. Deeper subcommands still work — they fall through to the greedy argument — they are just not pre-advertised.

## Config

Guarded by `general.brigadier-commands` (default `true`). Turning it off restores the legacy command map path, which is kept intact as the fallback and is also used automatically if the registrar cannot hook.

## Testing

Verified on a Paper 26.2 test server with AcidIsland, AOneBlock, CaveBlock, Biomes, Challenges and Level:

- top-level commands and aliases (`/bbox version`)
- deep subcommands (`/acid range set`)
- namespaced form (`/acidisland:acid version`)
- unknown subcommand falling through to BentoBox's own error rather than Brigadier's
- player-only commands from console giving the correct message
- everything still working after `/bentobox reload`
- in-game client behaviour confirmed by @tastybento

Full test suite passes. New unit tests cover the raw command line tokenizing and the suggestion offset arithmetic — the parts that have to agree exactly with what `CompositeCommand` expects.

## Left for phase 3

Deliberately not half-done here:

- **No tooltips on subcommand names.** A literal node's suggestion cannot carry one, and emitting a parallel tooltipped suggestion would show every subcommand twice, since Brigadier does not deduplicate across nodes.
- **No typed arguments**, so no red-underline validation or quoting-free multi-word island names yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATRqygFLZ5CA3zrWmutx7H
