### PR TITLE
Add addon version, feature adoption and command failure metrics

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BStats.java
+++ b/src/main/java/world/bentobox/bentobox/BStats.java
@@ -1,17 +1,24 @@
 package world.bentobox.bentobox;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.DrilldownPie;
 import org.bstats.charts.SimpleBarChart;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
+import org.eclipse.jdt.annotation.NonNull;
 
+import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 
 /**
@@ -20,6 +27,21 @@ import world.bentobox.bentobox.api.addons.GameModeAddon;
 public class BStats {
 
     private static final int BSTATS_ID = 3555;
+
+    /**
+     * Maximum number of distinct command keys tracked between submissions. Once this
+     * is reached, counts of already-known commands keep rising but new ones are
+     * dropped. Guards against unbounded growth from addons with generated commands.
+     * @since 3.21.1
+     */
+    private static final int MAX_TRACKED_COMMANDS = 200;
+
+    /**
+     * Maximum number of failing commands reported per submission. Only the busiest
+     * are sent, to keep the chart readable and the payload small.
+     * @since 3.21.1
+     */
+    private static final int REPORTED_COMMANDS = 20;
 
     private final BentoBox plugin;
     private Metrics metrics;
@@ -37,6 +59,18 @@ public class BStats {
      */
     private final Set<UUID> connectedPlayerSet = new HashSet<>();
 
+    /**
+     * Counts of command failures by {@link CommandFailure} since the last data send.
+     * @since 3.21.1
+     */
+    private final Map<String, Integer> commandFailures = new HashMap<>();
+
+    /**
+     * Counts of command failures by command key since the last data send.
+     * @since 3.21.1
+     */
+    private final Map<String, Integer> commandFailurePaths = new HashMap<>();
+
 
     BStats(BentoBox plugin) {
         this.plugin = plugin;
@@ -53,10 +87,13 @@ public class BStats {
         // Pie Charts
         registerDefaultLanguageChart();
         registerDatabaseTypeChart();
-        registerAddonsChart();
-        registerGameModeAddonsChart();
-        registerHooksChart();
         registerPlayersPerServerChart();
+        registerAddonApiVersionsChart();
+        registerCommandFailuresChart();
+
+        // Drilldown Pie Charts
+        registerAddonVersionsChart();
+        registerGameModeVersionsChart();
 
         // Single Line charts
         registerIslandsCountChart();
@@ -66,6 +103,8 @@ public class BStats {
         registerAddonsBarChart();
         registerGameModeAddonsBarChart();
         registerHooksBarChart();
+        registerFeaturesChart();
+        registerCommandFailurePathsChart();
     }
 
     private void registerDefaultLanguageChart() {
@@ -106,46 +145,6 @@ public class BStats {
      */
     public void addPlayer(UUID uuid) {
         this.connectedPlayerSet.add(uuid);
-    }
-
-    /**
-     * Sends the enabled addons (except GameModeAddons) of this server.
-     * @since 1.1
-     */
-    private void registerAddonsChart() {
-        metrics.addCustomChart(new AdvancedPie("addons", () -> {
-            Map<String, Integer> values = new HashMap<>();
-            plugin.getAddonsManager().getEnabledAddons().stream()
-                    .filter(addon -> !(addon instanceof GameModeAddon) && addon.getDescription().isMetrics())
-                    .forEach(addon -> values.put(addon.getDescription().getName(), 1));
-            return values;
-        }));
-    }
-
-    /**
-     * Sends the enabled GameModeAddons of this server.
-     * @since 1.4.0
-     */
-    private void registerGameModeAddonsChart() {
-        metrics.addCustomChart(new AdvancedPie("gameModeAddons", () -> {
-            Map<String, Integer> values = new HashMap<>();
-            plugin.getAddonsManager().getGameModeAddons().stream()
-                    .filter(gameModeAddon -> gameModeAddon.getDescription().isMetrics())
-                    .forEach(gameModeAddon -> values.put(gameModeAddon.getDescription().getName(), 1));
-            return values;
-        }));
-    }
-
-    /**
-     * Sends the enabled Hooks of this server.
-     * @since 1.6.0
-     */
-    private void registerHooksChart() {
-        metrics.addCustomChart(new AdvancedPie("hooks", () -> {
-            Map<String, Integer> values = new HashMap<>();
-            plugin.getHooks().getHooks().forEach(hook -> values.put(hook.getPluginName(), 1));
-            return values;
-        }));
     }
 
     /**
@@ -206,5 +205,198 @@ public class BStats {
             plugin.getHooks().getHooks().forEach(hook -> values.put(hook.getPluginName(), 1));
             return values;
         }));
+    }
+
+    /**
+     * Sends the version of each enabled addon (except GameModeAddons), grouped by
+     * addon name. This is what tells us how long the tail is after a release and
+     * whether it is safe to make a breaking API change.
+     * @since 3.21.1
+     */
+    private void registerAddonVersionsChart() {
+        metrics.addCustomChart(new DrilldownPie("addonVersions",
+                () -> versionsOf(plugin.getAddonsManager().getEnabledAddons().stream()
+                        .filter(addon -> !(addon instanceof GameModeAddon)))));
+    }
+
+    /**
+     * Sends the version of each enabled GameModeAddon, grouped by game mode name.
+     * @since 3.21.1
+     */
+    private void registerGameModeVersionsChart() {
+        metrics.addCustomChart(new DrilldownPie("gameModeVersions",
+                () -> versionsOf(plugin.getAddonsManager().getGameModeAddons().stream())));
+    }
+
+    /**
+     * Builds a name to version to count map for the given addons, honouring their
+     * metrics opt-out.
+     * @param addons stream of addons
+     * @return map of addon name to a map of version to count
+     * @since 3.21.1
+     */
+    private Map<String, Map<String, Integer>> versionsOf(Stream<? extends Addon> addons) {
+        Map<String, Map<String, Integer>> values = new HashMap<>();
+        addons.filter(addon -> addon.getDescription().isMetrics())
+                .forEach(addon -> values.computeIfAbsent(addon.getDescription().getName(), k -> new HashMap<>())
+                        .merge(addon.getDescription().getVersion(), 1, Integer::sum));
+        return values;
+    }
+
+    /**
+     * Sends the BentoBox API version each enabled addon is built against. Tells us
+     * which API levels are still in use in the wild.
+     * @since 3.21.1
+     */
+    private void registerAddonApiVersionsChart() {
+        metrics.addCustomChart(new AdvancedPie("addonApiVersions", () -> {
+            Map<String, Integer> values = new HashMap<>();
+            plugin.getAddonsManager().getEnabledAddons().stream()
+                    .filter(addon -> addon.getDescription().isMetrics())
+                    .map(addon -> addon.getDescription().getApiVersion())
+                    .filter(version -> version != null && !version.isEmpty())
+                    .forEach(version -> values.merge(version, 1, Integer::sum));
+            return values;
+        }));
+    }
+
+    /**
+     * Sends the settings this server has changed away from their default value.
+     * <p>
+     * Only deviations are reported, so every bar is a signal: a feature that
+     * defaults to off appears under its own name when a server enables it, and a
+     * feature that defaults to on appears as {@code no-<name>} when a server turns
+     * it off. Comparing a bar against the total server count gives the adoption (or
+     * rejection) rate of that feature.
+     * @since 3.21.1
+     */
+    private void registerFeaturesChart() {
+        metrics.addCustomChart(new SimpleBarChart("features", () -> {
+            Map<String, Integer> values = new HashMap<>();
+            Settings s = plugin.getSettings();
+            // Features that default to off - reported when switched on
+            optedIn(values, "economy-charges-for-blueprints", s.isChargeForBlueprintOnReset());
+            optedIn(values, "name-uniqueness", s.isNameUniqueness());
+            optedIn(values, "dialogs-gamemode-selection", s.isDialogGameModeSelection());
+            optedIn(values, "head-cache-server", s.isUseCacheServer());
+            optedIn(values, "slow-deletion", s.isSlowDeletion());
+            optedIn(values, "keep-previous-island", s.isKeepPreviousIslandOnReset());
+            optedIn(values, "housekeeping-age", s.isHousekeepingAgeEnabled());
+            optedIn(values, "chunk-pregen", s.isPregenEnabled());
+            optedIn(values, "teleport-remove-mobs", s.isTeleportRemoveMobs());
+            optedIn(values, "hide-used-blueprints", s.isHideUsedBlueprints());
+            optedIn(values, "override-safety-check", s.isOverrideSafetyCheck());
+            // Features that default to on - reported when switched off
+            optedOut(values, "economy", s.isUseEconomy());
+            optedOut(values, "brigadier-commands", s.isUseBrigadierCommands());
+            optedOut(values, "did-you-mean-unknown-commands", s.isDidYouMeanUnknownCommands());
+            optedOut(values, "did-you-mean-subcommands", s.isDidYouMeanSubcommands());
+            optedOut(values, "dialogs-confirmations", s.isDialogConfirmations());
+            optedOut(values, "dialogs-team-invites", s.isDialogTeamInvites());
+            optedOut(values, "dialogs-go-picker", s.isDialogGoPicker());
+            optedOut(values, "close-panel-on-click-outside", s.isClosePanelOnClickOutside());
+            optedOut(values, "dynmap-island-markers", s.isDynmapIslandMarkers());
+            optedOut(values, "bluemap-island-markers", s.isBluemapIslandMarkers());
+            optedOut(values, "housekeeping-deleted", s.isHousekeepingDeletedEnabled());
+            optedOut(values, "update-check-bentobox", s.isCheckBentoBoxUpdates());
+            optedOut(values, "update-check-addons", s.isCheckAddonsUpdates());
+            return values;
+        }));
+    }
+
+    /**
+     * Records a feature that defaults to off and has been switched on.
+     * @since 3.21.1
+     */
+    private void optedIn(Map<String, Integer> values, String name, boolean enabled) {
+        if (enabled) {
+            values.put(name, 1);
+        }
+    }
+
+    /**
+     * Records a feature that defaults to on and has been switched off.
+     * @since 3.21.1
+     */
+    private void optedOut(Map<String, Integer> values, String name, boolean enabled) {
+        if (!enabled) {
+            values.put("no-" + name, 1);
+        }
+    }
+
+    /**
+     * Sends the number of command failures of each kind since the last data send.
+     * @since 3.21.1
+     */
+    private void registerCommandFailuresChart() {
+        metrics.addCustomChart(new AdvancedPie("commandFailures", () -> {
+            Map<String, Integer> values = new HashMap<>(commandFailures);
+            commandFailures.clear();
+            return values;
+        }));
+    }
+
+    /**
+     * Sends the commands that failed most often since the last data send. Only the
+     * busiest {@value #REPORTED_COMMANDS} are sent.
+     * @since 3.21.1
+     */
+    private void registerCommandFailurePathsChart() {
+        metrics.addCustomChart(new SimpleBarChart("commandFailurePaths", () -> {
+            Map<String, Integer> values = commandFailurePaths.entrySet().stream()
+                    .sorted(Map.Entry.<String, Integer>comparingByValue(Comparator.reverseOrder()))
+                    .limit(REPORTED_COMMANDS)
+                    .collect(LinkedHashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), Map::putAll);
+            commandFailurePaths.clear();
+            return values;
+        }));
+    }
+
+    /**
+     * Records that a command could not be run to completion.
+     * <p>
+     * Only the failure kind and the command's stable key are recorded - never what
+     * the player typed - because bStats data is public.
+     * @param failure kind of failure
+     * @param commandKey stable identifier of the command, see
+     *        {@link world.bentobox.bentobox.api.commands.CompositeCommand#getStatsKey()}
+     * @since 3.21.1
+     */
+    public void recordCommandFailure(@NonNull CommandFailure failure, @NonNull String commandKey) {
+        commandFailures.merge(failure.name().toLowerCase(Locale.ENGLISH), 1, Integer::sum);
+        // Only track a new command if there is room, otherwise a badly behaved addon
+        // could grow this map without limit between submissions.
+        if (commandFailurePaths.containsKey(commandKey) || commandFailurePaths.size() < MAX_TRACKED_COMMANDS) {
+            commandFailurePaths.merge(commandKey, 1, Integer::sum);
+        }
+    }
+
+    /**
+     * The ways in which running a command can fail.
+     * @since 3.21.1
+     */
+    public enum CommandFailure {
+        /**
+         * The player typed something that matched none of the available subcommands
+         * and a "did you mean" suggestion was offered instead.
+         */
+        UNKNOWN_SUBCOMMAND,
+        /**
+         * A player ran a console-only command, or the console ran a player-only one.
+         */
+        WRONG_CONTEXT,
+        /**
+         * The user lacked the permission for the command or one of its parents.
+         */
+        NO_PERMISSION,
+        /**
+         * The command refused to run in the current state: wrong world, no island,
+         * insufficient rank, cooldown still running, and so on.
+         */
+        CANNOT_EXECUTE,
+        /**
+         * The command ran but rejected its arguments, so the help was shown.
+         */
+        BAD_ARGS
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -20,6 +21,8 @@ import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
+import world.bentobox.bentobox.BStats;
+import world.bentobox.bentobox.BStats.CommandFailure;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.Addon;
@@ -211,13 +214,13 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
         this.parent = parent;
         subCommandLevel = parent.getLevel() + 1;
         // Add this sub-command to the parent
-        parent.getSubCommands().put(label.toLowerCase(java.util.Locale.ENGLISH), this);
+        parent.getSubCommands().put(label.toLowerCase(Locale.ENGLISH), this);
         setAliases(new ArrayList<>(Arrays.asList(aliases)));
         subCommands = new LinkedHashMap<>();
         subCommandAliases = new LinkedHashMap<>();
         // Add aliases to the parent for this command
         for (String alias : aliases) {
-            parent.getSubCommandAliases().put(alias.toLowerCase(java.util.Locale.ENGLISH), this);
+            parent.getSubCommandAliases().put(alias.toLowerCase(Locale.ENGLISH), this);
         }
         setUsage("");
         // Inherit permission prefix
@@ -270,6 +273,7 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
                     ? " " + String.join(" ", Arrays.asList(args).subList(0, cmd.subCommandLevel))
                     : "");
             if (plugin.getSuggestionsManager().suggestSubcommand(user, cmd, typedPrefix, cmdArgs)) {
+                cmd.recordFailure(CommandFailure.UNKNOWN_SUBCOMMAND);
                 return true;
             }
         }
@@ -290,22 +294,70 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
         // Check for console and permissions
         if (isOnlyPlayer() && !user.isPlayer()) {
             user.sendMessage("general.errors.use-in-game");
+            recordFailure(CommandFailure.WRONG_CONTEXT);
             return false;
         }
 
         if (isOnlyConsole() && user.isPlayer()) {
             user.sendMessage("general.errors.use-in-console");
+            recordFailure(CommandFailure.WRONG_CONTEXT);
             return false;
         }
 
         if (!this.runPermissionCheck(user)) {
             // Error message is displayed by permission check.
+            recordFailure(CommandFailure.NO_PERMISSION);
             return false;
         }
         // Set the user's addon context
         user.setAddon(addon);
         // Execute and trim args
-        return canExecute(user, cmdLabel, cmdArgs) && execute(user, cmdLabel, cmdArgs);
+        if (!canExecute(user, cmdLabel, cmdArgs)) {
+            recordFailure(CommandFailure.CANNOT_EXECUTE);
+            return false;
+        }
+        if (!execute(user, cmdLabel, cmdArgs)) {
+            recordFailure(CommandFailure.BAD_ARGS);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Records that this command could not be run to completion, so that the
+     * aggregate failure counts can be reported to bStats. Nothing the user typed is
+     * recorded - see {@link BStats#recordCommandFailure(CommandFailure, String)}.
+     *
+     * @param failure kind of failure
+     * @since 3.21.1
+     */
+    private void recordFailure(@NonNull CommandFailure failure) {
+        plugin.getMetrics().ifPresent(bStats -> bStats.recordCommandFailure(failure, getStatsKey()));
+    }
+
+    /**
+     * Returns a stable identifier for this command, suitable for aggregating
+     * statistics across servers.
+     * <p>
+     * Labels cannot be used for this: the top level label is set in the game mode's
+     * config, and {@link #getLabel()} is overwritten with whatever alias the player
+     * typed. The permission, however, is hard coded in {@link #setup()} and carries
+     * the addon's prefix, so {@code bskyblock.island.team.invite} means the same
+     * thing on every server. Commands without a permission fall back to their class
+     * name, which is equally stable.
+     *
+     * @return stable identifier of this command
+     * @since 3.21.1
+     */
+    public @NonNull String getStatsKey() {
+        String perm = getPermission();
+        if (perm != null && !perm.isEmpty()) {
+            // Addon permissions already carry the addon's prefix. BentoBox's own
+            // commands have no prefix, so give them one to keep the keys distinct.
+            return (permissionPrefix == null || permissionPrefix.isEmpty()) ? "bentobox." + perm : perm;
+        }
+        String addonName = addon == null ? "bentobox" : addon.getDescription().getName();
+        return addonName.toLowerCase(Locale.ENGLISH) + "." + getClass().getSimpleName();
     }
 
     /**
@@ -459,7 +511,7 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      * @return CompositeCommand or null if none found
      */
     public Optional<CompositeCommand> getSubCommand(String label) {
-        label = label.toLowerCase(java.util.Locale.ENGLISH);
+        label = label.toLowerCase(Locale.ENGLISH);
         if (subCommands.containsKey(label)) {
             return Optional.ofNullable(subCommands.get(label));
         }

--- a/src/test/java/world/bentobox/bentobox/BStatsTest.java
+++ b/src/test/java/world/bentobox/bentobox/BStatsTest.java
@@ -1,0 +1,88 @@
+package world.bentobox.bentobox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.bentobox.BStats.CommandFailure;
+
+/**
+ * Tests the accumulation of command failure statistics.
+ *
+ * @author tastybento
+ */
+class BStatsTest {
+
+    private BStats bStats;
+
+    @BeforeEach
+    public void setUp() {
+        bStats = new BStats(mock(BentoBox.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> field(String name) throws ReflectiveOperationException {
+        Field f = BStats.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return (Map<String, Integer>) f.get(bStats);
+    }
+
+    @Test
+    void testRecordCommandFailureCountsByType() throws ReflectiveOperationException {
+        bStats.recordCommandFailure(CommandFailure.NO_PERMISSION, "bskyblock.island.team.invite");
+        bStats.recordCommandFailure(CommandFailure.NO_PERMISSION, "bskyblock.island.team.kick");
+        bStats.recordCommandFailure(CommandFailure.BAD_ARGS, "bskyblock.island.team.invite");
+
+        Map<String, Integer> failures = field("commandFailures");
+        assertEquals(2, failures.size());
+        assertEquals(2, failures.get("no_permission"));
+        assertEquals(1, failures.get("bad_args"));
+    }
+
+    @Test
+    void testRecordCommandFailureCountsByCommand() throws ReflectiveOperationException {
+        bStats.recordCommandFailure(CommandFailure.NO_PERMISSION, "bskyblock.island.team.invite");
+        bStats.recordCommandFailure(CommandFailure.BAD_ARGS, "bskyblock.island.team.invite");
+        bStats.recordCommandFailure(CommandFailure.BAD_ARGS, "bskyblock.island.go");
+
+        Map<String, Integer> paths = field("commandFailurePaths");
+        assertEquals(2, paths.size());
+        assertEquals(2, paths.get("bskyblock.island.team.invite"));
+        assertEquals(1, paths.get("bskyblock.island.go"));
+    }
+
+    /**
+     * A badly behaved addon with generated command names must not be able to grow
+     * the map without limit between submissions.
+     */
+    @Test
+    void testRecordCommandFailureCapsDistinctCommands() throws ReflectiveOperationException {
+        for (int i = 0; i < 500; i++) {
+            bStats.recordCommandFailure(CommandFailure.BAD_ARGS, "addon.command" + i);
+        }
+        Map<String, Integer> paths = field("commandFailurePaths");
+        assertEquals(200, paths.size());
+        assertNull(paths.get("addon.command200"));
+
+        // Commands already being tracked keep counting once the cap is reached
+        bStats.recordCommandFailure(CommandFailure.BAD_ARGS, "addon.command0");
+        assertEquals(2, paths.get("addon.command0"));
+        assertEquals(200, paths.size());
+
+        // Every failure is still counted by type, capped or not
+        assertEquals(501, field("commandFailures").get("bad_args"));
+    }
+
+    @Test
+    void testRecordCommandFailureNoFailures() throws ReflectiveOperationException {
+        assertTrue(field("commandFailures").isEmpty());
+        assertTrue(field("commandFailurePaths").isEmpty());
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/api/commands/CommandFailureStatsTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/CommandFailureStatsTest.java
@@ -1,0 +1,232 @@
+package world.bentobox.bentobox.api.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+
+import world.bentobox.bentobox.BStats;
+import world.bentobox.bentobox.BStats.CommandFailure;
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * Tests that command failures are reported to bStats, and that they are keyed by
+ * something that means the same thing on every server.
+ *
+ * @author tastybento
+ */
+class CommandFailureStatsTest extends CommonTestSetup {
+
+    @Mock
+    private User user;
+    @Mock
+    private BStats bStats;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+        when(plugin.getMetrics()).thenReturn(Optional.of(bStats));
+        when(user.getTranslation(anyString()))
+                .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+        when(user.isPlayer()).thenReturn(true);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testNoPermissionIsRecorded() {
+        TopLevelCommand tlc = new TopLevelCommand();
+        CompositeCommand sub = tlc.getSubCommand("restricted").orElseThrow();
+        when(user.hasPermission(anyString())).thenReturn(false);
+
+        assertFalse(sub.call(user, "restricted", List.of()));
+        verify(bStats).recordCommandFailure(eq(CommandFailure.NO_PERMISSION), eq("bentobox.restricted"));
+    }
+
+    @Test
+    void testWrongContextIsRecorded() {
+        TopLevelCommand tlc = new TopLevelCommand();
+        CompositeCommand sub = tlc.getSubCommand("playeronly").orElseThrow();
+        when(user.isPlayer()).thenReturn(false);
+
+        assertFalse(sub.call(user, "playeronly", List.of()));
+        verify(bStats).recordCommandFailure(eq(CommandFailure.WRONG_CONTEXT), anyString());
+    }
+
+    @Test
+    void testCannotExecuteIsRecorded() {
+        TopLevelCommand tlc = new TopLevelCommand();
+        CompositeCommand sub = tlc.getSubCommand("blocked").orElseThrow();
+        when(user.isOp()).thenReturn(true);
+
+        assertFalse(sub.call(user, "blocked", List.of()));
+        verify(bStats).recordCommandFailure(eq(CommandFailure.CANNOT_EXECUTE), eq("bentobox.blocked"));
+    }
+
+    @Test
+    void testBadArgsIsRecorded() {
+        TopLevelCommand tlc = new TopLevelCommand();
+        CompositeCommand sub = tlc.getSubCommand("failing").orElseThrow();
+        when(user.isOp()).thenReturn(true);
+
+        assertFalse(sub.call(user, "failing", List.of()));
+        verify(bStats).recordCommandFailure(eq(CommandFailure.BAD_ARGS), eq("bentobox.failing"));
+    }
+
+    @Test
+    void testSuccessIsNotRecorded() {
+        TopLevelCommand tlc = new TopLevelCommand();
+        CompositeCommand sub = tlc.getSubCommand("working").orElseThrow();
+        when(user.isOp()).thenReturn(true);
+
+        assertTrue(sub.call(user, "working", List.of()));
+        verify(bStats, never()).recordCommandFailure(org.mockito.ArgumentMatchers.any(), anyString());
+    }
+
+    /**
+     * The permission is hard coded in setup(), so it is the same on every server
+     * even when the top level command has been renamed in the config.
+     */
+    @Test
+    void testGetStatsKeyUsesPermission() {
+        TopLevelCommand tlc = new TopLevelCommand();
+        assertEquals("bentobox.restricted", tlc.getSubCommand("restricted").orElseThrow().getStatsKey());
+    }
+
+    /**
+     * Commands without a permission fall back to their class name.
+     */
+    @Test
+    void testGetStatsKeyFallsBackToClassName() {
+        TopLevelCommand tlc = new TopLevelCommand();
+        assertEquals("bentobox.WorkingCommand", tlc.getSubCommand("working").orElseThrow().getStatsKey());
+    }
+
+    private static class TopLevelCommand extends CompositeCommand {
+        TopLevelCommand() {
+            super("top");
+        }
+
+        @Override
+        public void setup() {
+            new RestrictedCommand(this);
+            new PlayerOnlyCommand(this);
+            new BlockedCommand(this);
+            new FailingCommand(this);
+            new WorkingCommand(this);
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    private static class RestrictedCommand extends CompositeCommand {
+        RestrictedCommand(CompositeCommand parent) {
+            super(parent, "restricted");
+        }
+
+        @Override
+        public void setup() {
+            setPermission("restricted");
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    private static class PlayerOnlyCommand extends CompositeCommand {
+        PlayerOnlyCommand(CompositeCommand parent) {
+            super(parent, "playeronly");
+        }
+
+        @Override
+        public void setup() {
+            setOnlyPlayer(true);
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    private static class BlockedCommand extends CompositeCommand {
+        BlockedCommand(CompositeCommand parent) {
+            super(parent, "blocked");
+        }
+
+        @Override
+        public void setup() {
+            setPermission("blocked");
+        }
+
+        @Override
+        public boolean canExecute(User user, String label, List<String> args) {
+            return false;
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    private static class FailingCommand extends CompositeCommand {
+        FailingCommand(CompositeCommand parent) {
+            super(parent, "failing");
+        }
+
+        @Override
+        public void setup() {
+            setPermission("failing");
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return false;
+        }
+    }
+
+    private static class WorkingCommand extends CompositeCommand {
+        WorkingCommand(CompositeCommand parent) {
+            super(parent, "working");
+        }
+
+        @Override
+        public void setup() {
+            // No permission set on purpose
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Adds six bStats charts and removes three that were sending data nowhere. All six chart IDs already exist on [bstats.org/plugin/bukkit/BentoBox/3555](https://bstats.org/plugin/bukkit/BentoBox/3555), so data starts landing ~30 minutes after servers update.

Closes #3022.

## New charts

| Chart ID | Type | What it answers |
|---|---|---|
| `addonVersions` | Drilldown Pie | Which version of each addon is actually deployed |
| `gameModeVersions` | Drilldown Pie | Same, for game modes |
| `addonApiVersions` | Advanced Pie | Which BentoBox API levels addons in the wild are built against |
| `features` | Simple Bar | Which settings servers change away from default |
| `commandFailures` | Advanced Pie | How commands fail, by kind |
| `commandFailurePaths` | Simple Bar | Which commands fail most |

**Addon versions.** We knew *that* a server ran Level, not *which* Level. That was the biggest blind spot: no way to see how long the tail is after a release, or to judge when a breaking API change is safe.

**Non-default settings.** Reports only deviations from default, so every bar is a signal rather than a restatement of the defaults. A default-off setting appears under its own name when a server enables it (`chunk-pregen`); a default-on setting appears as `no-<name>` when disabled (`no-brigadier-commands`). Comparing a bar to the total server count gives that feature's adoption or rejection rate. 24 settings covered, including all four dialog toggles, both did-you-mean toggles and Brigadier — so we can finally see whether servers are *switching off* recently shipped work.

**Command friction (#3022).** `CompositeCommand.call()` is the single funnel where every failure mode is already distinguishable, so it now records which kind occurred and on which command. `UNKNOWN_SUBCOMMAND` is recorded only when did-you-mean actually produced a suggestion — the bare "leftover args and the command has subcommands" condition is too loose to be trusted, since plenty of commands legitimately have both. Everything else falls through and is classified as `CANNOT_EXECUTE` or `BAD_ARGS` naturally. That slice is therefore a lower bound, and it is gated on `did-you-mean-subcommands` being enabled.

## The command key

Labels cannot be used to key this data. The top-level label comes from the game mode config, and `getLabel()` is overwritten by `getCommandFromArgs()` with whatever alias the player typed — so the same command would key differently across servers, and differently on the same server depending on typing.

The permission is hard-coded in `setup()` and carries the addon's prefix, so `bskyblock.island.team.invite` means the same thing everywhere. `getStatsKey()` uses it, prepending `bentobox.` for core commands (which have an empty prefix) and falling back to `<addon>.<ClassName>` for commands with no permission.

## Privacy

Only the failure kind and that stable key are submitted — never arguments, player names or anything typed. bStats data is public, so this is the line to hold. Distinct keys are capped at 200 between submissions and only the busiest 20 are sent, so an addon with generated command names cannot grow the map without bound; failure counts *by kind* are never dropped.

## Removals

The `addons`, `gameModeAddons` and `hooks` advanced pies are gone. Those chart IDs do not exist on bstats.org — verified against `/api/v1/plugins/3555/charts` — so every submission was discarded on arrival. `addonsBar`, `gameModeAddonsBar` and `hooksBar` carry identical data and do have charts. This is why the Hooks pie never showed anything.

## Testing

`./gradlew build` green: **3366 tests, 0 failures** (+11 new).

- `BStatsTest` — accumulation by kind and by command, the 200-key cap, and that capped commands keep counting while new ones are dropped.
- `CommandFailureStatsTest` — each failure path records the right kind and key, successful commands record nothing, and `getStatsKey()` for both the permission and class-name cases.

Also diffed every registration in `BStats.java` against the live chart config: 26 IDs, each either type-matched or a bStats built-in, zero mismatches in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATRqygFLZ5CA3zrWmutx7H