### PR TITLE
Rebuild the Brigadier tree once addons have enabled

### DIFF
--- a/src/main/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrar.java
@@ -20,6 +20,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 
 import io.papermc.paper.command.brigadier.CommandSourceStack;
@@ -141,6 +142,67 @@ public class BrigadierCommandRegistrar {
             // /bentobox reload - need the new tree pushed to them.
             Bukkit.getOnlinePlayers().forEach(Player::updateCommands);
         }
+    }
+
+    /**
+     * Rebuilds the literal tree of every registered top level command, picking up
+     * sub-commands added since the node was first built.
+     * <p>
+     * This is needed because a top level command's children are baked in when its
+     * node is created, and addons add their sub-commands to game mode commands
+     * later - {@code enableAddons()} runs a tick after the lifecycle window has
+     * closed. Without this the late sub-commands still run, because the greedy
+     * argument catches them, but the client is never told they exist.
+     * <p>
+     * Brigadier merges same-named literals rather than replacing them
+     * ({@code CommandNode#addChild} copies the incoming command across and
+     * recursively merges its children), so re-registering a freshly built tree
+     * grafts the new children onto the live node and leaves the existing ones
+     * alone. Nodes are never removed, but a sub-command that has gone away
+     * resolves to null and its {@code requires} predicate stops matching, so it
+     * disappears from clients anyway.
+     */
+    public void refreshTrees() {
+        if (dispatcher == null) {
+            return;
+        }
+        boolean changed = false;
+        for (CompositeCommand command : new ArrayList<>(plugin.getCommandsManager().getCommands().values())) {
+            String label = command.getLabel().toLowerCase(Locale.ENGLISH);
+            if (!registeredLabels.contains(label)) {
+                // Never registered at all - the normal path builds it and pushes it.
+                registerCommand(command);
+                continue;
+            }
+            int before = childCount(label);
+            dispatcher.register(buildTopLevel(label));
+            // Merging is a no-op when nothing new turned up, and pushing the tree to
+            // every online player for no reason is not free.
+            changed |= childCount(label) != before;
+        }
+        if (changed) {
+            refreshClients();
+        }
+    }
+
+    /**
+     * Total number of nodes in a top level command's tree, used to tell whether a
+     * rebuild actually added anything.
+     *
+     * @param label top level label
+     * @return node count, 0 if the label has no node
+     */
+    private int childCount(@NonNull String label) {
+        CommandNode<CommandSourceStack> node = dispatcher == null ? null : dispatcher.getRoot().getChild(label);
+        return node == null ? 0 : countNodes(node);
+    }
+
+    private static int countNodes(@NonNull CommandNode<CommandSourceStack> node) {
+        int count = 1;
+        for (CommandNode<CommandSourceStack> child : node.getChildren()) {
+            count += countNodes(child);
+        }
+        return count;
     }
 
     /**
@@ -294,6 +356,13 @@ public class BrigadierCommandRegistrar {
     /**
      * The visible literal subcommands at the position the greedy argument starts,
      * i.e. the ones Brigadier itself will already be suggesting.
+     * <p>
+     * A sub-command only counts if it actually has a literal node in the
+     * dispatcher. The command tree and the live {@link CompositeCommand} tree can
+     * disagree - a sub-command registered after this node was built has no literal
+     * of its own - and dropping such a sub-command here would remove it from the
+     * greedy argument's suggestions as well, leaving no way for the client to
+     * learn about it at all.
      */
     private Set<String> literalSiblings(SuggestionsBuilder builder, CommandSender sender) {
         // Everything before the greedy argument was consumed by literal nodes.
@@ -305,13 +374,48 @@ public class BrigadierCommandRegistrar {
         if (current == null || consumed.length - 1 >= MAX_TREE_DEPTH) {
             return Set.of();
         }
+        Set<String> advertised = advertisedChildren(consumed);
         Set<String> labels = new HashSet<>();
         for (CompositeCommand sub : current.getSubCommands().values()) {
-            if (!sub.isHidden() && canUse(sub, sender)) {
+            if (!sub.isHidden() && canUse(sub, sender)
+                    && advertised.contains(sub.getLabel().toLowerCase(Locale.ENGLISH))) {
                 labels.add(sub.getLabel());
             }
         }
         return labels;
+    }
+
+    /**
+     * The names of the literal children Brigadier holds at the node the given
+     * tokens lead to, which are exactly the ones it will suggest by itself.
+     *
+     * @param consumed tokens consumed by literal nodes, label first
+     * @return literal child names, lower case, or an empty set if the path does
+     *         not exist in the dispatcher
+     */
+    private Set<String> advertisedChildren(String[] consumed) {
+        if (dispatcher == null || consumed.length == 0) {
+            return Set.of();
+        }
+        CommandNode<CommandSourceStack> node = dispatcher.getRoot()
+                .getChild(consumed[0].toLowerCase(Locale.ENGLISH));
+        if (node != null && node.getRedirect() != null) {
+            // An alias or the namespaced form - the children live on the main node.
+            node = node.getRedirect();
+        }
+        for (int i = 1; i < consumed.length && node != null; i++) {
+            node = node.getChild(consumed[i].toLowerCase(Locale.ENGLISH));
+        }
+        if (node == null) {
+            return Set.of();
+        }
+        Set<String> names = new HashSet<>();
+        for (CommandNode<CommandSourceStack> child : node.getChildren()) {
+            if (child instanceof LiteralCommandNode) {
+                names.add(child.getName().toLowerCase(Locale.ENGLISH));
+            }
+        }
+        return names;
     }
 
     /*

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -280,6 +280,9 @@ public class AddonsManager {
                 .filter(g -> !(g instanceof GameModeAddon)).forEach(this::enableAddon);
         // Set perms for enabled addons
         this.getEnabledAddons().forEach(this::setPerms);
+        // Addons add their sub-commands to game mode commands as they enable, which is
+        // after the command tree was handed to Paper, so rebuild it now it is complete.
+        plugin.getCommandsManager().refreshCommandTrees();
         plugin.log("Addons successfully enabled.");
     }
 
@@ -723,6 +726,9 @@ public class AddonsManager {
      */
     public void allLoaded() {
         this.getEnabledAddons().forEach(this::allLoaded);
+        // Anything an addon registered in allLoaded() is later still than enableAddons(),
+        // so the tree needs another pass. It is a no-op when nothing has changed.
+        plugin.getCommandsManager().refreshCommandTrees();
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
@@ -84,6 +84,26 @@ public class CommandsManager {
     }
 
     /**
+     * Rebuilds the Brigadier command tree so that sub-commands registered after a
+     * top level command was first advertised are included.
+     * <p>
+     * Addons add their sub-commands to game mode commands as they enable, which
+     * happens a tick after Paper's command lifecycle window has closed and the
+     * tree was built. Those sub-commands run either way, but without this the
+     * client is never told about them, so they are missing from tab completion.
+     * <p>
+     * Does nothing when Brigadier registration is off - the legacy command map
+     * resolves completions dynamically and has never had this problem.
+     *
+     * @since 3.22.0
+     */
+    public void refreshCommandTrees() {
+        if (brigadier != null) {
+            brigadier.refreshTrees();
+        }
+    }
+
+    /**
      * Unregisters all BentoBox registered commands with Bukkit
      */
     public void unregisterCommands() {

--- a/src/test/java/world/bentobox/bentobox/commands/brigadier/BrigadierTreeRefreshTest.java
+++ b/src/test/java/world/bentobox/bentobox/commands/brigadier/BrigadierTreeRefreshTest.java
@@ -1,0 +1,234 @@
+package world.bentobox.bentobox.commands.brigadier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.tree.CommandNode;
+
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * Regression tests for sub-commands registered after a top level command's node was built.
+ * <p>
+ * Addons add their sub-commands to a game mode command while they enable, which happens a tick
+ * after Paper's command lifecycle window closed and the tree was handed over. Those sub-commands
+ * always ran - the greedy argument catches them - but the client was never told they exist, so
+ * they were missing from tab completion. See issue #3039.
+ *
+ * @author tastybento
+ */
+class BrigadierTreeRefreshTest {
+
+    private static final String TOP_LABEL = "ai";
+
+    private BentoBox plugin;
+    private CommandsManager commandsManager;
+    private CompositeCommand topCommand;
+    private Map<String, CompositeCommand> subCommands;
+    private CommandDispatcher<CommandSourceStack> dispatcher;
+    private BrigadierCommandRegistrar registrar;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // The registrar pushes the tree to online players, which needs a server
+        MockBukkit.mock();
+
+        subCommands = new LinkedHashMap<>();
+        topCommand = mockCommand(TOP_LABEL, subCommands);
+        when(topCommand.getAliases()).thenReturn(List.of("island"));
+
+        commandsManager = mock(CommandsManager.class);
+        when(commandsManager.getCommand(TOP_LABEL)).thenReturn(topCommand);
+        when(commandsManager.getCommands()).thenReturn(Map.of(TOP_LABEL, topCommand));
+
+        plugin = mock(BentoBox.class);
+        when(plugin.getCommandsManager()).thenReturn(commandsManager);
+
+        registrar = new BrigadierCommandRegistrar(plugin);
+        dispatcher = new CommandDispatcher<>();
+        captureDispatcher(dispatcher);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * Stands in for the COMMANDS lifecycle window handing over the live dispatcher.
+     */
+    private void captureDispatcher(CommandDispatcher<CommandSourceStack> d) throws Exception {
+        Field field = BrigadierCommandRegistrar.class.getDeclaredField("dispatcher");
+        field.setAccessible(true);
+        field.set(registrar, d);
+    }
+
+    private CompositeCommand mockCommand(String label, Map<String, CompositeCommand> children) {
+        CompositeCommand command = mock(CompositeCommand.class);
+        when(command.getLabel()).thenReturn(label);
+        when(command.getSubCommands()).thenReturn(children);
+        when(command.getPermission()).thenReturn("");
+        when(command.isHidden()).thenReturn(false);
+        when(command.isOnlyConsole()).thenReturn(false);
+        return command;
+    }
+
+    private void addSubCommand(String label) {
+        subCommands.put(label, mockCommand(label, new LinkedHashMap<>()));
+    }
+
+    /**
+     * @return the literal child of the top level node, or null if it has none by that name
+     */
+    private CommandNode<CommandSourceStack> child(String label) {
+        CommandNode<CommandSourceStack> top = dispatcher.getRoot().getChild(TOP_LABEL);
+        return top == null ? null : top.getChild(label);
+    }
+
+    @Test
+    void testSubCommandsPresentAtRegistrationAreAdvertised() {
+        addSubCommand("go");
+        addSubCommand("team");
+
+        registrar.registerCommand(topCommand);
+
+        assertNotNull(child("go"));
+        assertNotNull(child("team"));
+    }
+
+    /**
+     * The state that produced the bug: the addon's sub-command exists on the CompositeCommand but
+     * the node was already built without it.
+     */
+    @Test
+    void testSubCommandAddedAfterRegistrationIsNotAdvertisedYet() {
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+
+        addSubCommand("deathchest");
+
+        assertNull(child("deathchest"));
+    }
+
+    @Test
+    void testRefreshTreesGraftsOnTheLateSubCommand() {
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+        addSubCommand("deathchest");
+
+        registrar.refreshTrees();
+
+        assertNotNull(child("deathchest"), "A sub-command added after registration must be advertised");
+        assertNotNull(child("go"), "Existing sub-commands must survive the merge");
+    }
+
+    /**
+     * Brigadier merges same-named literals rather than replacing them, so the greedy catch-all
+     * must not end up duplicated by repeated refreshes.
+     */
+    @Test
+    void testRepeatedRefreshesDoNotDuplicateNodes() {
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+        int childCount = dispatcher.getRoot().getChild(TOP_LABEL).getChildren().size();
+
+        registrar.refreshTrees();
+        registrar.refreshTrees();
+
+        assertEquals(childCount, dispatcher.getRoot().getChild(TOP_LABEL).getChildren().size());
+    }
+
+    @Test
+    void testRefreshKeepsTheGreedyCatchAll() {
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+
+        registrar.refreshTrees();
+
+        assertNotNull(child("args"), "The catch-all argument must still be there after a refresh");
+    }
+
+    @Test
+    void testRefreshRegistersACommandThatWasNeverRegistered() {
+        addSubCommand("go");
+        // Never call registerCommand - the command manager knows about it but the tree does not
+        registrar.refreshTrees();
+
+        assertNotNull(dispatcher.getRoot().getChild(TOP_LABEL));
+        assertNotNull(child("go"));
+    }
+
+    @Test
+    void testAliasesStillRedirectAfterARefresh() {
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+
+        registrar.refreshTrees();
+
+        CommandNode<CommandSourceStack> alias = dispatcher.getRoot().getChild("island");
+        assertNotNull(alias);
+        assertSame(dispatcher.getRoot().getChild(TOP_LABEL), alias.getRedirect(),
+                "The alias must still point at the live main node, not a discarded rebuild");
+        assertTrue(alias.getChildren().isEmpty());
+    }
+
+    @Test
+    void testHiddenSubCommandsAreStillNotAdvertised() {
+        CompositeCommand hidden = mockCommand("secret", new LinkedHashMap<>());
+        when(hidden.isHidden()).thenReturn(true);
+        subCommands.put("secret", hidden);
+
+        registrar.registerCommand(topCommand);
+        registrar.refreshTrees();
+
+        assertNull(child("secret"));
+    }
+
+    /**
+     * The merge is a no-op when nothing new turned up, so the tree must come out identical
+     * rather than gaining duplicate or replaced nodes.
+     */
+    @Test
+    void testRefreshWithNothingNewLeavesTheTreeAlone() {
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+        CommandNode<CommandSourceStack> before = dispatcher.getRoot().getChild(TOP_LABEL);
+
+        registrar.refreshTrees();
+
+        assertSame(before, dispatcher.getRoot().getChild(TOP_LABEL),
+                "The live node must be merged into, never swapped out");
+        assertEquals(before.getChildren().size(), dispatcher.getRoot().getChild(TOP_LABEL).getChildren().size());
+    }
+
+    @Test
+    void testRefreshBeforeTheLifecycleWindowIsANoOp() throws Exception {
+        captureDispatcher(null);
+        addSubCommand("go");
+
+        registrar.refreshTrees();
+
+        assertFalse(registrar.isAvailable());
+        assertTrue(dispatcher.getRoot().getChildren().isEmpty());
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
@@ -562,6 +562,24 @@ class AddonsManagerTest extends CommonTestSetup {
         verify(plugin).log("Enabling game mode addons...");
     }
 
+    /**
+     * Addons add their sub-commands while enabling, after the Brigadier tree was handed to
+     * Paper, so the tree has to be rebuilt once they are all up or the client never sees them.
+     * See issue #3039.
+     */
+    @Test
+    void testEnableAddonsRefreshesTheCommandTree() {
+        GameModeAddon gma = new MyGameMode();
+        AddonDescription desc = new AddonDescription.Builder("main", "TestGM", "1.0").apiVersion("1").build();
+        gma.setDescription(desc);
+        gma.setState(State.LOADED);
+        am.getAddons().add(gma);
+
+        am.enableAddons();
+
+        verify(cm).refreshCommandTrees();
+    }
+
     @Test
     void testEnableAddonsSkipsDisabledAddons() {
         Addon addon = mock(Addon.class);
@@ -669,6 +687,17 @@ class AddonsManagerTest extends CommonTestSetup {
 
         am.allLoaded();
         verify(addon).allLoaded();
+    }
+
+    /**
+     * allLoaded() runs later than enableAddons(), so anything an addon registered there needs
+     * another pass over the command tree.
+     */
+    @Test
+    void testAllLoadedRefreshesTheCommandTree() {
+        am.allLoaded();
+
+        verify(cm).refreshCommandTrees();
     }
 
     @Test


### PR DESCRIPTION
Fixes #3039

## The problem

A top level command's literal children are baked in when its Brigadier node is built, and that happens while Paper's `COMMANDS` lifecycle window is open — immediately after `onEnable` returns. Addons add their sub-commands to game mode commands from `enableAddons()`, which `BentoBox.java:193` defers to the first tick. Every addon sub-command therefore missed the tree.

They still ran — the greedy `args` argument catches anything the literals do not match, and `CompositeCommand.execute` walks the live sub-command map — and they still appeared in `/<gamemode> help`, which iterates that same live map. Only the client was never told they exist, so they were absent from tab completion and from the suggestions shown while typing.

## The fix

Brigadier merges same-named literals rather than replacing them: `CommandNode#addChild` copies the incoming node's command across and recursively merges its children into the existing node. So re-registering a freshly built tree grafts on whatever appeared since.

- `BrigadierCommandRegistrar#refreshTrees()` rebuilds every registered top level command. A label that was never registered falls through to the normal `registerCommand` path.
- Called at the end of `AddonsManager#enableAddons()`, and again after `allLoaded()` — that one runs later still, from the blueprint polling task, so anything an addon registers there is covered too.
- Aliases are deliberately **not** re-registered. `CommandDispatcher#register` returns the *new* node while the root keeps the original, so the alias redirects already point at the node that gets merged into. Re-registering them would leave redirects aimed at a discarded node.
- A rebuild that adds nothing does not push the tree to clients, so the second pass is normally free.

`literalSiblings()` needed changing as well, and this is the part worth reviewing. It removed every live sub-command from the greedy argument's suggestions on the grounds that Brigadier already suggests them — which is only true for sub-commands that actually have a literal node. A late sub-command was therefore dropped from the dynamic fallback *as well*, leaving it no route to the client at all. It now consults the dispatcher for what is really advertised at that point in the tree, so any future divergence between the tree and the live command map is covered by the fallback rather than silenced by it.

## Testing

`BrigadierTreeRefreshTest` runs against a real `CommandDispatcher` with a mocked plugin, and pins both halves: `testSubCommandAddedAfterRegistrationIsNotAdvertisedYet` captures the broken state, `testRefreshTreesGraftsOnTheLateSubCommand` the fix. Also covered: repeated refreshes do not duplicate nodes, the greedy catch-all survives, aliases still redirect to the live node, hidden sub-commands stay hidden, a no-change refresh leaves the node identical, and a refresh before the lifecycle window is a no-op.

Two `AddonsManagerTest` cases pin the wiring, so a future edit that drops the calls fails rather than silently regressing.

Full suite: 3367 tests, 0 failures.

The **bug** was reproduced in game on Paper 26.1.2 with AcidIsland plus an addon that adds a sub-command in `onEnable`, which is where the issue came from. The **fix** has not been run on that server yet — it is covered by the tests above but wants an in-game confirmation before merge. A shaded jar builds cleanly from this branch.

## Note for review

The behaviour depends on Brigadier's merge semantics in `CommandNode#addChild`. I checked that against the bytecode in `brigadier-1.3.10.jar` rather than assuming it, since replacing rather than merging would wipe the existing children.
