### PR TITLE
Run our own commands that Brigadier will not parse

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
@@ -142,6 +142,32 @@ public class CommandsManager {
     }
 
     /**
+     * Resolves a top level command from the first token of something that was
+     * typed: its label, one of its aliases, or either of those in the
+     * {@code addon:label} form, in any case.
+     *
+     * @param label first token of a command line, without the leading slash
+     * @return the command, or {@code null} if BentoBox does not own that label
+     * @since 3.22.0
+     */
+    @Nullable
+    public CompositeCommand resolveCommand(@NonNull String label) {
+        int colon = label.indexOf(':');
+        String name = colon >= 0 ? label.substring(colon + 1) : label;
+        CompositeCommand command = commands.get(name);
+        if (command != null) {
+            return command;
+        }
+        for (CompositeCommand c : commands.values()) {
+            if (c.getLabel().equalsIgnoreCase(name)
+                    || c.getAliases().stream().anyMatch(a -> a.equalsIgnoreCase(name))) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Get a map of every command registered in BentoBox
      * @return the commands
      */

--- a/src/main/java/world/bentobox/bentobox/suggestions/DidYouMeanListener.java
+++ b/src/main/java/world/bentobox/bentobox/suggestions/DidYouMeanListener.java
@@ -1,8 +1,10 @@
 package world.bentobox.bentobox.suggestions;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -10,10 +12,12 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.command.UnknownCommandEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.eclipse.jdt.annotation.Nullable;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
 
 /**
@@ -40,11 +44,20 @@ public class DidYouMeanListener implements Listener {
     }
 
     /**
-     * Fires only when no plugin owns the typed command, so BentoBox never
-     * shadows another plugin's command here.
+     * Fires when no plugin owns the typed command, and also when Brigadier
+     * refused to parse one, so BentoBox never shadows another plugin's command
+     * here.
      */
     @EventHandler(priority = EventPriority.NORMAL)
     public void onUnknownCommand(UnknownCommandEvent e) {
+        // A command line of our own that Brigadier would not parse must still reach
+        // the command tree, which reports for itself. This has to run whatever the
+        // did-you-mean settings say: it is dispatch, not a suggestion.
+        if (dispatchOwnCommand(e.getSender(), e.getCommandLine())) {
+            // The command has spoken for itself, so drop Brigadier's error
+            e.message(null);
+            return;
+        }
         if (!plugin.getSettings().isDidYouMeanUnknownCommands() || !(e.getSender() instanceof Player player)) {
             return;
         }
@@ -53,6 +66,41 @@ public class DidYouMeanListener implements Listener {
             // Our suggestion replaces the vanilla "Unknown command" message
             e.message(null);
         }
+    }
+
+    /**
+     * Runs a BentoBox command line that never made it to its command.
+     * <p>
+     * Brigadier hides nodes the sender may not use, and a hidden node is not just
+     * invisible: the parse walks into the matching sub-command literal, finds it
+     * unusable and dead-ends there, without ever falling back to the catch-all
+     * argument beside it. The sender then gets "Incorrect argument for command"
+     * from Brigadier rather than the command's own "you do not have permission"
+     * message, and nothing runs. Dispatching the line through the command tree
+     * restores what happens when the same command is registered the legacy way:
+     * the command checks its own permissions and says what is wrong.
+     * <p>
+     * Nothing has run at this point - Paper reports an unknown command from its
+     * parse step, before execution - so there is no risk of running it twice.
+     *
+     * @param sender      whoever typed it
+     * @param commandLine the command line, without the leading slash
+     * @return true if this was one of our commands and it was dispatched
+     */
+    private boolean dispatchOwnCommand(CommandSender sender, @Nullable String commandLine) {
+        if (commandLine == null || commandLine.isBlank()) {
+            return false;
+        }
+        String[] tokens = commandLine.trim().split("\\s+");
+        CompositeCommand command = plugin.getCommandsManager().resolveCommand(tokens[0]);
+        if (command == null) {
+            return false;
+        }
+        // Commands echo the label back in their help, so drop any addon: prefix
+        int colon = tokens[0].indexOf(':');
+        String label = colon >= 0 ? tokens[0].substring(colon + 1) : tokens[0];
+        command.execute(sender, label, Arrays.copyOfRange(tokens, 1, tokens.length));
+        return true;
     }
 
     /**
@@ -80,7 +128,15 @@ public class DidYouMeanListener implements Listener {
             Bukkit.getScheduler().runTask(plugin, () -> {
                 Player player = Bukkit.getPlayer(uuid);
                 if (player != null) {
-                    player.performCommand(command.substring(1));
+                    try {
+                        player.performCommand(command.substring(1));
+                    } catch (Exception ex) {
+                        // Bukkit wraps anything the dispatch throws, and letting that out
+                        // of a scheduled task only produces a stack trace nobody can act
+                        // on. The player has already seen whatever the command said.
+                        plugin.logError("Could not run the accepted suggestion '" + command + "' for "
+                                + player.getName() + ": " + ex.getMessage());
+                    }
                 }
             });
             return true;

--- a/src/main/java/world/bentobox/bentobox/suggestions/SuggestionsManager.java
+++ b/src/main/java/world/bentobox/bentobox/suggestions/SuggestionsManager.java
@@ -76,7 +76,7 @@ public class SuggestionsManager {
         World contextWorld = user.isPlayer() ? Util.getWorld(user.getWorld()) : null;
         List<Match> matches = CommandMatcher.matchCommandLine(tokens,
                 plugin.getCommandsManager().getCommands().values(), contextWorld, cmd -> isAccessible(user, cmd));
-        return sendSuggestions(user, matches);
+        return sendSuggestions(user, dropTyped(matches, "/" + String.join(" ", tokens)));
     }
 
     /**
@@ -95,7 +95,24 @@ public class SuggestionsManager {
             @NonNull String typedPrefix, @NonNull List<String> args) {
         List<Match> matches = CommandMatcher.matchSubtree(args, command, typedPrefix,
                 cmd -> isAccessible(user, cmd));
-        return sendSuggestions(user, matches);
+        return sendSuggestions(user, dropTyped(matches, typedPrefix + " " + String.join(" ", args)));
+    }
+
+    /**
+     * Drops any match that is exactly what was typed.
+     * <p>
+     * The matcher re-attaches tokens it could not match as arguments, so a
+     * command line that fails for a reason other than a mistyped label - no
+     * permission for the sub-command, say - can come back as a suggestion to run
+     * the very thing that just failed. That cannot help, and if the player
+     * accepts it the same failure happens again.
+     *
+     * @param matches   candidate matches
+     * @param typedLine what was typed, starting with '/'
+     * @return the matches that differ from what was typed
+     */
+    private static List<Match> dropTyped(@NonNull List<Match> matches, @NonNull String typedLine) {
+        return matches.stream().filter(m -> !m.commandString().equalsIgnoreCase(typedLine.trim())).toList();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/suggestions/UnparseableCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/suggestions/UnparseableCommandTest.java
@@ -1,0 +1,239 @@
+package world.bentobox.bentobox.suggestions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandException;
+import org.bukkit.event.command.UnknownCommandEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import net.kyori.adventure.text.Component;
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Regression tests for Border issue 179: {@code /oneblock border color green}
+ * threw an unhandled {@code CommandException} out of a BentoBox task.
+ * <p>
+ * Brigadier hides nodes the sender may not use, and hiding is not passive: the
+ * parse walks into the {@code color} literal, finds the sender cannot use it and
+ * dead-ends there rather than falling back to the catch-all argument beside it.
+ * Paper reports that as an unknown command, so before this fix:
+ * <ol>
+ * <li>the player saw Brigadier's "Incorrect argument for command" instead of the
+ * command's own "you do not have permission" message, and nothing ran;</li>
+ * <li>the did-you-mean matcher re-attached the tokens it could not match and
+ * suggested the very line that had just failed;</li>
+ * <li>accepting that suggestion re-dispatched it through
+ * {@code Player#performCommand}, where the same failure escaped the scheduled
+ * task as an unhandled exception.</li>
+ * </ol>
+ *
+ * @author tastybento
+ */
+class UnparseableCommandTest extends CommonTestSetup {
+
+    private static final String LINE = "oneblock border color green";
+
+    private SuggestionsManager suggestionsManager;
+    private DidYouMeanListener listener;
+    private GameModeCommand oneblock;
+    private Map<String, CompositeCommand> registeredCommands;
+    @Mock
+    private CommandSourceStack commandSourceStack;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+        registeredCommands = new HashMap<>();
+        when(cm.getCommands()).thenReturn(registeredCommands);
+        mockedUtil.when(() -> Util.getWorld(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        oneblock = new GameModeCommand("oneblock", "ob");
+        oneblock.setWorld(world);
+        registeredCommands.put("oneblock", oneblock);
+        when(cm.resolveCommand("oneblock")).thenReturn(oneblock);
+        suggestionsManager = new SuggestionsManager(plugin);
+        when(plugin.getSuggestionsManager()).thenReturn(suggestionsManager);
+        listener = new DidYouMeanListener(plugin);
+        when(commandSourceStack.getSender()).thenReturn(mockPlayer);
+        when(lm.get(any(), eq("general.did-you-mean.suggestion"))).thenReturn("Did you mean [command]?");
+        when(lm.get(any(), eq("general.did-you-mean.header"))).thenReturn("Did you mean one of these?");
+        when(lm.get(any(), eq("general.did-you-mean.option"))).thenReturn("  [command]");
+        // The player may toggle their border but has no colour permission
+        when(mockPlayer.hasPermission(anyString())).thenReturn(false);
+        when(mockPlayer.hasPermission("aoneblock.border.toggle")).thenReturn(true);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * The command line reaches its command, which reports the missing permission
+     * itself, and Brigadier's error is dropped.
+     */
+    @Test
+    void testCommandRunsAndReportsTheMissingPermission() {
+        UnknownCommandEvent e = unknownCommand(LINE);
+
+        listener.onUnknownCommand(e);
+
+        assertNull(e.message(), "Brigadier's parse error must not be shown as well");
+        checkSpigotMessage("general.errors.no-permission");
+    }
+
+    /**
+     * Nothing is suggested, because there is nothing better to suggest than what
+     * was typed - which is what used to be offered.
+     */
+    @Test
+    void testTheTypedLineIsNotSuggestedBack() {
+        listener.onUnknownCommand(unknownCommand(LINE));
+
+        checkSpigotMessage("Did you mean", 0);
+        assertFalse(listener.acceptPending(uuid), "Nothing may be left pending for 'yes' to run");
+    }
+
+    /**
+     * The matcher must never offer the line the player just typed, whatever the
+     * reason the parse failed.
+     */
+    @Test
+    void testMatcherDropsAMatchIdenticalToTheInput() {
+        User user = User.getInstance(mockPlayer);
+
+        assertFalse(suggestionsManager.suggestCommand(user, LINE));
+    }
+
+    /**
+     * A genuinely mistyped command still gets its suggestion - the fallback only
+     * takes lines that start with one of our own labels.
+     */
+    @Test
+    void testAnUnknownCommandStillGetsASuggestion() {
+        when(mockPlayer.hasPermission(anyString())).thenReturn(true);
+        UnknownCommandEvent e = unknownCommand("teams");
+
+        listener.onUnknownCommand(e);
+
+        assertNull(e.message());
+        checkSpigotMessage("Did you mean /oneblock team?");
+    }
+
+    /**
+     * Something else entirely is left to the server to report on.
+     */
+    @Test
+    void testAForeignCommandIsLeftAlone() {
+        UnknownCommandEvent e = unknownCommand("xyzzy");
+
+        listener.onUnknownCommand(e);
+
+        assertNotNull(e.message());
+    }
+
+    /**
+     * Whatever the dispatch of an accepted suggestion throws, it must not escape
+     * the scheduled task.
+     */
+    @Test
+    void testAcceptedSuggestionSwallowsDispatchFailures() {
+        when(mockPlayer.hasPermission(anyString())).thenReturn(true);
+        listener.onUnknownCommand(unknownCommand("teams"));
+        assertTrue(listener.acceptPending(uuid));
+        ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+        verify(sch).runTask(eq(plugin), task.capture());
+        mockedBukkit.when(() -> Bukkit.getPlayer(uuid)).thenReturn(mockPlayer);
+        doThrow(new CommandException("Unhandled exception executing 'oneblock team'"))
+                .when(mockPlayer).performCommand(anyString());
+
+        task.getValue().run();
+
+        verify(plugin).logError(anyString());
+    }
+
+    private UnknownCommandEvent unknownCommand(String commandLine) {
+        return new UnknownCommandEvent(commandSourceStack, commandLine, Component.text("Unknown command"));
+    }
+
+    /**
+     * A game mode player command with the Border addon's sub-commands hung off
+     * it, as Border registers them: {@code /oneblock border} with
+     * {@code type} and {@code color} below it.
+     */
+    private static class GameModeCommand extends CompositeCommand {
+
+        GameModeCommand(String label, String... aliases) {
+            super(label, aliases);
+        }
+
+        @Override
+        public void setup() {
+            new SubCommand(this, "go", "");
+            CompositeCommand team = new SubCommand(this, "team", "");
+            new SubCommand(team, "invite", "");
+            CompositeCommand border = new SubCommand(this, "border", "aoneblock.border.toggle");
+            new SubCommand(border, "type", "aoneblock.border.type");
+            new SubCommand(border, "color", "aoneblock.border.color");
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    private static class SubCommand extends CompositeCommand {
+
+        private final String perm;
+
+        SubCommand(CompositeCommand parent, String label, String perm) {
+            super(parent, label);
+            this.perm = perm;
+            // setup() has already run, so the permission is applied here
+            setPermission(perm);
+        }
+
+        @Override
+        public void setup() {
+            // Permissions are set by the constructor, which runs after this
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return getLabel() + "(" + perm + ")";
+        }
+    }
+}


### PR DESCRIPTION
Fixes BentoBoxWorld/Border#179 — `/oneblock border color green` produced an unhandled `CommandException` out of a BentoBox scheduled task, and never changed the border colour.

## Root cause

`BrigadierCommandRegistrar` puts a permission check in each sub-command literal's Brigadier `requires` predicate, so clients only see what they can use. Hiding a node that way is not passive:

* `CommandNode#getRelevantNodes` returns **only** the literal matching the typed token, so the greedy catch-all argument beside it is never considered;
* `CommandDispatcher#parseNodes` then **silently skips** that literal when `canUse(source)` is false.

So a player without `[gamemode].border.color` gets a parse that walks `oneblock` → `border` and dead-ends at `color`: Brigadier's `INCORRECT_ARGUMENT` at the cursor where `color` starts (exactly the `...ck border <--[HERE]` in the report). The command line never reaches `CompositeCommand`, so instead of "you do not have permission" the player gets a red Brigadier error, and nothing runs.

Paper reports **any** `CommandSyntaxException` from `Commands#finishParsing` as an `UnknownCommandEvent`, not just genuinely unknown commands. That produced the rest of the report:

1. `CommandMatcher` re-attaches the tokens it could not match verbatim, so it suggested *the very line that had just failed*;
2. accepting that suggestion re-dispatched it through `Player#performCommand` inside a scheduled task with nothing catching what Bukkit throws — the unhandled `CommandException` in the report.

## Changes

* `DidYouMeanListener` — a command line of ours that Brigadier refused to parse is dispatched through the command tree, which checks its own permissions and reports for itself; Brigadier's error is then dropped. Nothing has run at that point (Paper fails in its parse step, before execution), so there is no double execution.
* `CommandsManager#resolveCommand` — resolves a top level command from a typed first token: label, alias, or either in `addon:label` form.
* `SuggestionsManager` — never suggest a line identical to what was typed.
* `DidYouMeanListener#acceptPending` — log dispatch failures instead of letting them escape the scheduled task.

## Testing

New `UnparseableCommandTest` reproduces the report end to end (permission-hidden sub-command → command reports for itself, nothing suggested back, nothing left pending, dispatch failures swallowed). Verified each test fails without the corresponding fix. Full suite green: 3391 tests, 0 failures.

## Not addressed here

`BrigadierCommandRegistrar#refreshTrees` compares `childCount(label)` before and after the rebuild, but `dispatcher.getRoot().getChild(label)` returns Paper's *wrapped* (`ApiMirrorRootNode`) node while the merge lands on the NMS copy — so the count never changes and `refreshClients()` is never called. #3039's symptom is likely still present on a real server; the unit tests pass only because they use a plain `RootCommandNode`. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6rYr6Z66LQz9XTbnbUupy