### PR TITLE
fix: do not discard database writes queued during shutdown

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -23,6 +23,7 @@ import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.user.Notifier;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.AbstractDatabaseHandler;
 import world.bentobox.bentobox.database.DatabaseSetup;
 import world.bentobox.bentobox.hooks.BentoBoxHookRegistrar;
 import world.bentobox.bentobox.hooks.VaultHook;
@@ -324,6 +325,11 @@ public class BentoBox extends JavaPlugin implements Listener {
         if (addonsManager != null) {
             addonsManager.disableAddons();
         }
+        // Write out anything addons queued on their way out. The asynchronous save task has already
+        // stopped by this point, so without this those writes would be discarded. Pladdons are
+        // disabled by the server before BentoBox, so their onDisable() saves are always in this
+        // position. Must run before any database is closed below.
+        AbstractDatabaseHandler.flushAll();
         // Save data
         if (playersManager != null) {
             playersManager.shutdown();

--- a/src/main/java/world/bentobox/bentobox/database/AbstractDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/AbstractDatabaseHandler.java
@@ -2,8 +2,12 @@ package world.bentobox.bentobox.database;
 
 import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -33,12 +37,31 @@ public abstract class AbstractDatabaseHandler<T> {
     protected Queue<Runnable> processQueue;
 
     /**
+     * Every handler created in this JVM, so that queued writes can be flushed on shutdown.
+     * <p>
+     * A handler is created per {@link Database} instance, each with its own {@link #processQueue},
+     * and nothing else keeps a list of them. Weakly held so handlers belonging to a discarded
+     * {@code Database} can still be collected.
+     * @since 3.22.0
+     */
+    private static final Set<AbstractDatabaseHandler<?>> HANDLERS =
+            Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+
+    /**
      * Async save task that runs repeatedly
      */
     private BukkitTask asyncSaveTask;
     private boolean inSave;
 
     protected boolean shutdown;
+
+    /**
+     * True while {@link #flush()} is draining the queue on the calling thread. Queued writes
+     * normally refuse to run once BentoBox is disabled; during a flush they must be allowed to
+     * complete, because that is the whole point of the flush.
+     * @since 3.22.0
+     */
+    protected volatile boolean draining;
 
     /**
      * Name of the folder where databases using files will live
@@ -115,9 +138,53 @@ public abstract class AbstractDatabaseHandler<T> {
                 inSave = false;
             }
         }, 0L, 1L);
+        HANDLERS.add(this);
     }
 
     protected AbstractDatabaseHandler() {}
+
+    /**
+     * Runs every write still sitting in this handler's queue, on the calling thread.
+     * <p>
+     * Queued writes are normally drained by an asynchronous repeating task. That task stops once
+     * BentoBox is disabled, so anything queued during shutdown is never written. Pladdons are
+     * disabled by the server <i>before</i> BentoBox, which means everything they save from
+     * {@code onDisable()} lands in a queue that is about to be abandoned.
+     *
+     * @since 3.22.0
+     */
+    public void flush() {
+        if (processQueue == null || processQueue.isEmpty()) {
+            return;
+        }
+        draining = true;
+        try {
+            while (!processQueue.isEmpty()) {
+                try {
+                    processQueue.poll().run();
+                } catch (Exception e) {
+                    plugin.logError("Could not flush a queued database write: " + e.getMessage());
+                }
+            }
+        } finally {
+            draining = false;
+        }
+    }
+
+    /**
+     * Flushes every handler's outstanding writes on the calling thread. Called during BentoBox
+     * shutdown, once all addons have been disabled and before any database is closed, so that
+     * writes queued by addons on their way out are not discarded.
+     *
+     * @since 3.22.0
+     */
+    public static void flushAll() {
+        List<AbstractDatabaseHandler<?>> handlers;
+        synchronized (HANDLERS) {
+            handlers = new ArrayList<>(HANDLERS);
+        }
+        handlers.forEach(AbstractDatabaseHandler::flush);
+    }
 
     /**
      * Loads all the records in this table and returns a list of them
@@ -161,6 +228,31 @@ public abstract class AbstractDatabaseHandler<T> {
      * @return completable future that is true if saved
      */
     public abstract CompletableFuture<Boolean> saveObject(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException ;
+
+    /**
+     * Save T into the corresponding database on the calling thread, bypassing the asynchronous save
+     * queue. The returned future is already complete when this method returns.
+     * <p>
+     * Normal saves are queued and written by an asynchronous task. That task stops running once
+     * BentoBox is disabled, and any write still sitting in the queue at that point is discarded, so
+     * a save issued while the server is shutting down can be lost silently. This is not
+     * hypothetical: Pladdons are disabled by the server <i>before</i> BentoBox itself, so anything a
+     * Pladdon persists from {@code onDisable()} is queued and never drained.
+     * <p>
+     * Use this only where a write must not be lost and there is no later chance to retry - shutdown
+     * paths, essentially. Everywhere else prefer {@link #saveObject(Object)}, as this blocks the
+     * calling thread for the duration of the write.
+     * <p>
+     * The default implementation delegates to {@link #saveObject(Object)}, which is already correct
+     * for handlers that write synchronously. Handlers that queue writes must override it.
+     *
+     * @param instance that should be inserted into the database
+     * @return completable future, already complete, that is true if saved
+     * @since 3.22.0
+     */
+    public CompletableFuture<Boolean> saveObjectNow(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+        return saveObject(instance);
+    }
 
     /**
      * Deletes the object with the unique id from the database. If the object does not exist, it will fail silently.

--- a/src/main/java/world/bentobox/bentobox/database/Database.java
+++ b/src/main/java/world/bentobox/bentobox/database/Database.java
@@ -113,12 +113,47 @@ public class Database<T> {
      * @param instance to save
      * @return true - always.
      * @since 1.13.0
+     * @deprecated The name implies the write has happened by the time this returns, but it has not -
+     *             this is identical to {@link #saveObjectAsync(Object)} and always returns
+     *             {@code true} without waiting for, or checking, the result.
+     *             <p>
+     *             Use {@link #saveObjectAsync(Object)} for normal saves. Use
+     *             {@link #saveObjectNow(Object)} only where a lost write cannot be retried, such as
+     *             a shutdown path - it blocks the calling thread, so it is not a drop-in
+     *             replacement for this method.
      */
+    @Deprecated(since = "3.22.0")
     public boolean saveObject(T instance) {
         saveObjectAsync(instance).thenAccept(r -> {
             if (r != null && !r) logger.severe(() -> "Could not save object to database!");
         });
         return true;
+    }
+
+    /**
+     * Save object on the calling thread, bypassing the asynchronous save queue, and return once the
+     * write has been attempted.
+     * <p>
+     * Queued writes are discarded if BentoBox is disabled before the queue drains, so a save issued
+     * while the server is shutting down can be lost. Pladdons are disabled by the server before
+     * BentoBox itself, which means anything a Pladdon persists from {@code onDisable()} needs this
+     * method rather than {@link #saveObject(Object)} or {@link #saveObjectAsync(Object)}.
+     * <p>
+     * Use this only on shutdown paths where a lost write cannot be retried. It blocks the calling
+     * thread for the duration of the write.
+     *
+     * @param instance to save
+     * @return true if the object was saved
+     * @since 3.22.0
+     */
+    public boolean saveObjectNow(T instance) {
+        try {
+            return Boolean.TRUE.equals(handler.saveObjectNow(instance).getNow(false));
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | SecurityException
+                | IntrospectionException e) {
+            logger.severe(() -> "Could not save object to database! Error: " + e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/database/json/JSONDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/json/JSONDatabaseHandler.java
@@ -99,6 +99,20 @@ public class JSONDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T> {
 
     @Override
     public CompletableFuture<Boolean> saveObject(T instance) throws IntrospectionException, IllegalAccessException, InvocationTargetException {
+        return save(instance, false);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> saveObjectNow(T instance) throws IntrospectionException, IllegalAccessException, InvocationTargetException {
+        return save(instance, true);
+    }
+
+    /**
+     * @param instance the object to write
+     * @param forceSync true to write on the calling thread instead of queuing the write
+     * @return completable future that is true if saved
+     */
+    private CompletableFuture<Boolean> save(T instance, boolean forceSync) throws IntrospectionException, IllegalAccessException, InvocationTargetException {
         CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
         // Null check
         if (instance == null) {
@@ -131,7 +145,7 @@ public class JSONDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T> {
         }
 
         String toStore = getGson().toJson(instance);
-        if (plugin.isEnabled()) {
+        if (!forceSync && plugin.isEnabled()) {
             // Async
             processQueue.add(() -> store(completableFuture, toStore, file, tableFolder, backupTableFolder, fileName, true));
         } else {
@@ -142,8 +156,9 @@ public class JSONDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T> {
     }
 
     private void store(CompletableFuture<Boolean> completableFuture, String toStore, File file, File tableFolder, File backupTableFolder, String fileName, boolean async) {
-        // Do not save anything if plug is disabled and this was an async request
-        if (async && !plugin.isEnabled()) return;
+        // Do not save anything if plug is disabled and this was an async request, unless we are
+        // deliberately flushing the queue on shutdown (see AbstractDatabaseHandler#flush)
+        if (async && !plugin.isEnabled() && !draining) return;
         File tmpFile = new File(backupTableFolder, fileName);
         if (file.exists()) {
             // Make a backup of file

--- a/src/main/java/world/bentobox/bentobox/database/sql/SQLDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/SQLDatabaseHandler.java
@@ -37,6 +37,7 @@ public class SQLDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T>
 {
     protected static final String COULD_NOT_LOAD_OBJECTS = "Could not load objects ";
     protected static final String COULD_NOT_LOAD_OBJECT = "Could not load object ";
+    protected static final String NOT_A_DATA_OBJECT = "This class is not a DataObject: ";
 
     /**
      * DataSource of database
@@ -251,6 +252,113 @@ public class SQLDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T>
     @Override
     public CompletableFuture<Boolean> saveObject(T instance)
     {
+        return this.save(instance, false);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<Boolean> saveObjectNow(T instance)
+    {
+        return this.save(instance, true);
+    }
+
+
+    /**
+     * Binds a serialised instance to a save statement. The upsert syntax differs between databases,
+     * so the order the parameters are bound in is left to each handler.
+     * @since 3.22.0
+     */
+    @FunctionalInterface
+    protected interface SaveBinder
+    {
+        /**
+         * @param statement the statement to bind
+         * @param json the serialised instance
+         * @param uniqueId the instance's unique id
+         * @throws SQLException if a parameter cannot be bound
+         */
+        void bind(PreparedStatement statement, String json, String uniqueId) throws SQLException;
+    }
+
+
+    /**
+     * Shared save path for SQL handlers that build their own upsert statement. Validates and
+     * serialises the instance, then either writes on the calling thread or queues the write.
+     * <p>
+     * Exists so that handlers do not each repeat the validation, serialisation and dispatch around
+     * a statement whose only real difference is the order its parameters are bound in.
+     *
+     * @param instance the object to write
+     * @param forceSync true to write on the calling thread instead of queuing the write
+     * @param databaseName database name, used in error messages
+     * @param binder binds the serialised instance to the prepared statement
+     * @return completable future that is true if saved
+     * @since 3.22.0
+     */
+    protected CompletableFuture<Boolean> saveInstance(T instance, boolean forceSync, String databaseName,
+            SaveBinder binder)
+    {
+        CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+
+        // Null check
+        if (instance == null)
+        {
+            this.plugin.logError(databaseName + " database request to store a null. ");
+            completableFuture.complete(false);
+            return completableFuture;
+        }
+
+        if (!(instance instanceof DataObject dataObj))
+        {
+            this.plugin.logError(NOT_A_DATA_OBJECT + instance.getClass().getName());
+            completableFuture.complete(false);
+            return completableFuture;
+        }
+
+        String toStore = this.getGson().toJson(instance);
+        String uniqueId = dataObj.getUniqueId();
+
+        Runnable write = () ->
+        {
+            try (Connection connection = this.dataSource.getConnection();
+                    PreparedStatement preparedStatement =
+                            connection.prepareStatement(this.getSqlConfig().getSaveObjectSQL()))
+            {
+                binder.bind(preparedStatement, toStore, uniqueId);
+                preparedStatement.execute();
+                completableFuture.complete(true);
+            }
+            catch (SQLException e)
+            {
+                this.plugin.logError("Could not save object " + instance.getClass().getName() + " " + uniqueId + " " +
+                        e.getMessage());
+                completableFuture.complete(false);
+            }
+        };
+
+        if (forceSync)
+        {
+            write.run();
+        }
+        else
+        {
+            this.processQueue.add(write);
+        }
+
+        return completableFuture;
+    }
+
+
+    /**
+     * @param instance the object to write
+     * @param forceSync true to write on the calling thread instead of queuing the write
+     * @return completable future that is true if saved
+     */
+    private CompletableFuture<Boolean> save(T instance, boolean forceSync)
+    {
         CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
 
         // Null check
@@ -263,7 +371,7 @@ public class SQLDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T>
 
         if (!(instance instanceof DataObject))
         {
-            this.plugin.logError("This class is not a DataObject: " + instance.getClass().getName());
+            this.plugin.logError(NOT_A_DATA_OBJECT + instance.getClass().getName());
             completableFuture.complete(false);
             return completableFuture;
         }
@@ -271,7 +379,7 @@ public class SQLDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T>
         // This has to be on the main thread to avoid concurrent modification errors
         String toStore = this.getGson().toJson(instance);
 
-        if (this.plugin.isEnabled())
+        if (!forceSync && this.plugin.isEnabled())
         {
             // Async
             this.processQueue.add(() -> store(completableFuture,
@@ -300,8 +408,9 @@ public class SQLDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T>
      */
     private void store(CompletableFuture<Boolean> completableFuture, String name, String toStore, String storeSQL, boolean async)
     {
-        // Do not save anything if plug is disabled and this was an async request
-        if (async && !this.plugin.isEnabled())
+        // Do not save anything if plug is disabled and this was an async request, unless we are
+        // deliberately flushing the queue on shutdown (see AbstractDatabaseHandler#flush)
+        if (async && !this.plugin.isEnabled() && !this.draining)
         {
             return;
         }
@@ -368,7 +477,7 @@ public class SQLDatabaseHandler<T> extends AbstractJSONDatabaseHandler<T>
 
         if (!(instance instanceof DataObject))
         {
-            this.plugin.logError("This class is not a DataObject: " + instance.getClass().getName());
+            this.plugin.logError(NOT_A_DATA_OBJECT + instance.getClass().getName());
             return;
         }
 

--- a/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/postgresql/PostgreSQLDatabaseHandler.java
@@ -1,15 +1,11 @@
 package world.bentobox.bentobox.database.sql.postgresql;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
-
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.DatabaseConnector;
-import world.bentobox.bentobox.database.objects.DataObject;
 import world.bentobox.bentobox.database.sql.SQLConfiguration;
 import world.bentobox.bentobox.database.sql.SQLDatabaseHandler;
 
@@ -54,52 +50,32 @@ public class PostgreSQLDatabaseHandler<T> extends SQLDatabaseHandler<T>
                 );
     }
 
-
     /**
      * {@inheritDoc}
      */
     @Override
     public CompletableFuture<Boolean> saveObject(T instance)
     {
-        CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+        return this.saveInstance(instance, false, "PostgreSQL", PostgreSQLDatabaseHandler::bindSave);
+    }
 
-        // Null check
-        if (instance == null)
-        {
-            this.plugin.logError("PostgreSQL database request to store a null. ");
-            completableFuture.complete(false);
-            return completableFuture;
-        }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<Boolean> saveObjectNow(T instance)
+    {
+        return this.saveInstance(instance, true, "PostgreSQL", PostgreSQLDatabaseHandler::bindSave);
+    }
 
-        if (!(instance instanceof DataObject))
-        {
-            this.plugin.logError("This class is not a DataObject: " + instance.getClass().getName());
-            completableFuture.complete(false);
-            return completableFuture;
-        }
-
-        Gson gson = this.getGson();
-        String toStore = gson.toJson(instance);
-        String uniqueId = ((DataObject) instance).getUniqueId();
-
-        this.processQueue.add(() ->
-        {
-            try (Connection connection = this.dataSource.getConnection();
-                    PreparedStatement preparedStatement = connection.prepareStatement(this.getSqlConfig().getSaveObjectSQL()))
-            {
-                preparedStatement.setString(1, uniqueId); // INSERT
-                preparedStatement.setString(2, toStore); // INSERT
-                preparedStatement.setString(3, toStore); // ON CONFLICT
-                preparedStatement.execute();
-                completableFuture.complete(true);
-            }
-            catch (SQLException e)
-            {
-                this.plugin.logError("Could not save object " + instance.getClass().getName() + " " + e.getMessage());
-                completableFuture.complete(false);
-            }
-        });
-
-        return completableFuture;
+    /**
+     * PostgreSQL's upsert takes the id first for the INSERT, then the json, then the json again for
+     * the ON CONFLICT update.
+     */
+    private static void bindSave(PreparedStatement statement, String json, String uniqueId) throws SQLException
+    {
+        statement.setString(1, uniqueId);
+        statement.setString(2, json);
+        statement.setString(3, json);
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/sql/sqlite/SQLiteDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/sql/sqlite/SQLiteDatabaseHandler.java
@@ -6,11 +6,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
-import com.google.gson.Gson;
-
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.DatabaseConnector;
-import world.bentobox.bentobox.database.objects.DataObject;
 import world.bentobox.bentobox.database.sql.SQLConfiguration;
 import world.bentobox.bentobox.database.sql.SQLDatabaseHandler;
 
@@ -38,7 +35,6 @@ public class SQLiteDatabaseHandler<T> extends SQLDatabaseHandler<T>
                 setUseQuotes(false)
                 );
     }
-
 
     /**
      * Creates the table in the database if it doesn't exist already
@@ -76,7 +72,6 @@ public class SQLiteDatabaseHandler<T> extends SQLDatabaseHandler<T>
         }
     }
 
-
     private void rename(PreparedStatement pstmt)
     {
         try (ResultSet resultSet = pstmt.executeQuery())
@@ -97,7 +92,6 @@ public class SQLiteDatabaseHandler<T> extends SQLDatabaseHandler<T>
         }
     }
 
-
     private void executeStatement(String sql) {
         try (Connection connection = this.dataSource.getConnection();
                 PreparedStatement preparedStatement = connection.prepareStatement(sql))
@@ -111,48 +105,25 @@ public class SQLiteDatabaseHandler<T> extends SQLDatabaseHandler<T>
         }
     }
 
-
     @Override
     public CompletableFuture<Boolean> saveObject(T instance)
     {
-        CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+        return this.saveInstance(instance, false, "SQLite", SQLiteDatabaseHandler::bindSave);
+    }
 
-        // Null check
-        if (instance == null)
-        {
-            this.plugin.logError("SQLite database request to store a null. ");
-            completableFuture.complete(false);
-            return completableFuture;
-        }
+    @Override
+    public CompletableFuture<Boolean> saveObjectNow(T instance)
+    {
+        return this.saveInstance(instance, true, "SQLite", SQLiteDatabaseHandler::bindSave);
+    }
 
-        if (!(instance instanceof DataObject))
-        {
-            this.plugin.logError("This class is not a DataObject: " + instance.getClass().getName());
-            completableFuture.complete(false);
-            return completableFuture;
-        }
-
-        Gson gson = this.getGson();
-        String toStore = gson.toJson(instance);
-
-        this.processQueue.add(() ->
-        {
-            try (Connection connection = this.dataSource.getConnection();
-                    PreparedStatement preparedStatement = connection.prepareStatement(this.getSqlConfig().getSaveObjectSQL()))
-            {
-                preparedStatement.setString(1, toStore);
-                preparedStatement.setString(2, ((DataObject) instance).getUniqueId());
-                preparedStatement.setString(3, toStore);
-                preparedStatement.execute();
-                completableFuture.complete(true);
-            }
-            catch (SQLException e)
-            {
-                this.plugin.logError("Could not save object " + instance.getClass().getName() + " " + ((DataObject) instance).getUniqueId() + " " + e.getMessage());
-                completableFuture.complete(false);
-            }
-        });
-
-        return completableFuture;
+    /**
+     * SQLite's upsert takes the json first, then the id, then the json again for the update.
+     */
+    private static void bindSave(PreparedStatement statement, String json, String uniqueId) throws SQLException
+    {
+        statement.setString(1, json);
+        statement.setString(2, uniqueId);
+        statement.setString(3, json);
     }
 }

--- a/src/main/java/world/bentobox/bentobox/database/transition/TransitionDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/transition/TransitionDatabaseHandler.java
@@ -99,6 +99,15 @@ public class TransitionDatabaseHandler<T> extends AbstractDatabaseHandler<T> {
     }
 
     /* (non-Javadoc)
+     * @see world.bentobox.bentobox.database.AbstractDatabaseHandler#saveObjectNow(java.lang.Object)
+     */
+    @Override
+    public CompletableFuture<Boolean> saveObjectNow(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+        // Save only in the destination database
+        return toHandler.saveObjectNow(instance);
+    }
+
+    /* (non-Javadoc)
      * @see world.bentobox.bentobox.database.AbstractDatabaseHandler#deleteID(java.lang.String)
      */
     @Override

--- a/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandler.java
+++ b/src/main/java/world/bentobox/bentobox/database/yaml/YamlDatabaseHandler.java
@@ -349,6 +349,20 @@ public class YamlDatabaseHandler<T> extends AbstractDatabaseHandler<T> {
      */
     @Override
     public CompletableFuture<Boolean> saveObject(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+        return save(instance, false);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> saveObjectNow(T instance) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
+        return save(instance, true);
+    }
+
+    /**
+     * @param instance the object to write
+     * @param forceSync true to write on the calling thread instead of scheduling the write
+     * @return CompletableFuture that will be true if object is saved successfully
+     */
+    private CompletableFuture<Boolean> save(T instance, boolean forceSync) throws IllegalAccessException, InvocationTargetException, IntrospectionException {
         CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
         // Null check
         if (instance == null) {
@@ -359,7 +373,7 @@ public class YamlDatabaseHandler<T> extends AbstractDatabaseHandler<T> {
             plugin.logError("This class is not a DataObject: " + instance.getClass().getName());
             return CompletableFuture.completedFuture(false);
         }
-        if (plugin.isShutdown()) {
+        if (forceSync || plugin.isShutdown()) {
             try {
                 processFile(completableFuture, instance);
             } catch (IllegalAccessException | InvocationTargetException | IntrospectionException e) {

--- a/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandsManager.java
@@ -303,7 +303,7 @@ public class IslandsManager {
             // Mark island as deletable - physical cleanup is handled later by
             // the region-file purge (see PurgeRegionsService / HousekeepingManager).
             island.setDeletable(true);
-            handler.saveObject(island);
+            handler.saveObjectAsync(island);
             // Fire the deletion event immediately so listeners (hooks, maps, etc.)
             // can update now that the island is orphaned.
             IslandEvent.builder().deletedIslandInfo(new IslandDeletion(island)).reason(Reason.DELETED).build();

--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -62,7 +62,7 @@ public class PlayersManager {
 
     public void shutdown(){
         // Save all players in cache
-        playerCache.forEach((uuid, player) -> handler.saveObject(player));
+        playerCache.forEach((uuid, player) -> handler.saveObjectAsync(player));
         handler.close();
         playerCache.shutdown();
     }
@@ -163,7 +163,7 @@ public class PlayersManager {
         }
         Players player = getPlayer(user.getUniqueId());
         player.setPlayerName(user.getName());
-        handler.saveObject(player);
+        handler.saveObjectAsync(player);
         // Update names
         Names newName = new Names(user.getName(), user.getUniqueId());
         // Add to cache
@@ -226,7 +226,7 @@ public class PlayersManager {
     public void setResets(World world, UUID playerUUID, int resets) {
         Players p = getPlayer(playerUUID);
         p.setResets(world, resets);
-        handler.saveObject(p);
+        handler.saveObjectAsync(p);
     }
 
     /**
@@ -246,7 +246,7 @@ public class PlayersManager {
     public void setLocale(UUID playerUUID, String localeName) {
         Players p = getPlayer(playerUUID);
         p.setLocale(localeName);
-        handler.saveObject(p);
+        handler.saveObjectAsync(p);
     }
 
     /**
@@ -257,7 +257,7 @@ public class PlayersManager {
     public void addDeath(World world, UUID playerUUID) {
         Players p = getPlayer(playerUUID);
         p.addDeath(Util.getWorld(world));
-        handler.saveObject(p);
+        handler.saveObjectAsync(p);
     }
 
     /**
@@ -269,7 +269,7 @@ public class PlayersManager {
     public void setDeaths(World world, UUID playerUUID, int deaths) {
         Players p = getPlayer(playerUUID);
         p.setDeaths(Util.getWorld(world), deaths);
-        handler.saveObject(p);
+        handler.saveObjectAsync(p);
     }
 
     /**
@@ -333,7 +333,7 @@ public class PlayersManager {
     public void addReset(World world, UUID playerUUID) {
         Players p = getPlayer(playerUUID);
         p.addReset(world);
-        handler.saveObject(p);
+        handler.saveObjectAsync(p);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/RanksManager.java
@@ -80,7 +80,7 @@ public class RanksManager {
     }
 
     private void save() {
-        handler.saveObject(new Ranks(ranks));
+        handler.saveObjectAsync(new Ranks(ranks));
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/database/sql/SQLDatabaseHandlerTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/sql/SQLDatabaseHandlerTest.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.database.sql;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -13,6 +14,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +26,7 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
@@ -50,6 +53,7 @@ class SQLDatabaseHandlerTest extends CommonTestSetup {
         }
         Queue<Runnable> queue() { return processQueue; }
         boolean isShutdown()    { return shutdown; }
+        boolean isDraining()    { return draining; }
     }
 
     /** Handler whose type parameter is NOT a DataObject — used to exercise that branch. */
@@ -366,6 +370,152 @@ class SQLDatabaseHandlerTest extends CommonTestSetup {
 
         assertFalse(future.get());
         verify(plugin).logError(contains("Could not save object"));
+    }
+
+    // ── saveObjectNow ────────────────────────────────────────────────────────
+
+    /**
+     * A queued write is discarded if BentoBox is disabled before the queue drains, so anything
+     * saved while the server is shutting down can be lost. saveObjectNow must bypass the queue and
+     * write on the calling thread even while the plugin is still enabled.
+     */
+    @Test
+    void testSaveObjectNow_pluginEnabled_storesSynchronouslyAndSkipsQueue() throws Exception {
+        when(plugin.isEnabled()).thenReturn(true);
+        clearInvocations(ps);
+
+        CompletableFuture<Boolean> future = handler.saveObjectNow(new TestDataObject());
+
+        assertTrue(future.isDone());
+        assertTrue(future.get(5, TimeUnit.SECONDS));
+        assertTrue(handler.queue().isEmpty());
+        verify(ps).execute();
+    }
+
+    @Test
+    void testSaveObjectNow_pluginDisabled_storesSynchronously() throws Exception {
+        when(plugin.isEnabled()).thenReturn(false);
+        clearInvocations(ps);
+
+        CompletableFuture<Boolean> future = handler.saveObjectNow(new TestDataObject());
+
+        assertTrue(future.get(5, TimeUnit.SECONDS));
+        assertTrue(handler.queue().isEmpty());
+        verify(ps).execute();
+    }
+
+    @Test
+    void testSaveObjectNow_null_completesFalseAndLogsError() throws Exception {
+        CompletableFuture<Boolean> future = handler.saveObjectNow(null);
+
+        assertFalse(future.get(5, TimeUnit.SECONDS));
+        verify(plugin).logError(contains("null"));
+    }
+
+    @Test
+    void testSaveObjectNow_notDataObject_completesFalseAndLogsError() throws Exception {
+        StringHandler sh = new StringHandler(plugin, connector, sqlConfig);
+
+        CompletableFuture<Boolean> future = sh.saveObjectNow("not-a-data-object");
+
+        assertFalse(future.get(5, TimeUnit.SECONDS));
+        verify(plugin).logError(contains("This class is not a DataObject"));
+    }
+
+    @Test
+    void testSaveObjectNow_sqlException_completesFalse() throws Exception {
+        when(plugin.isEnabled()).thenReturn(true);
+        when(connection.prepareStatement(anyString())).thenThrow(new SQLException("write error"));
+
+        CompletableFuture<Boolean> future = handler.saveObjectNow(new TestDataObject());
+
+        assertFalse(future.get(5, TimeUnit.SECONDS));
+        verify(plugin).logError(contains("Could not save object"));
+    }
+
+    // ── flush ────────────────────────────────────────────────────────────────
+
+    /**
+     * The async task that drains the queue stops once BentoBox is disabled, and queued writes then
+     * refuse to run. Pladdons are disabled by the server before BentoBox, so everything they save
+     * from onDisable() sits in a queue that is about to be abandoned. flush() must run those writes
+     * even though the plugin is already disabled.
+     */
+    @Test
+    void testFlush_writesQueuedSavesAfterPluginDisabled() throws Exception {
+        // Addon queues a save while BentoBox is still enabled
+        when(plugin.isEnabled()).thenReturn(true);
+        clearInvocations(ps);
+        CompletableFuture<Boolean> future = handler.saveObject(new TestDataObject());
+        assertFalse(handler.queue().isEmpty());
+        verify(ps, never()).execute();
+
+        // BentoBox is now disabling. Without flush() this write would be discarded.
+        when(plugin.isEnabled()).thenReturn(false);
+        handler.flush();
+
+        assertTrue(handler.queue().isEmpty());
+        assertTrue(future.get(5, TimeUnit.SECONDS));
+        verify(ps).execute();
+    }
+
+    @Test
+    void testFlush_emptyQueue_doesNothing() {
+        assertTrue(handler.queue().isEmpty());
+
+        assertDoesNotThrow(() -> handler.flush());
+    }
+
+    /**
+     * A write that throws must not abandon the rest of the queue.
+     */
+    @Test
+    void testFlush_writeThrows_continuesAndLogs() throws Exception {
+        when(plugin.isEnabled()).thenReturn(true);
+        handler.saveObject(new TestDataObject());
+        handler.queue().add(() -> {
+            throw new IllegalStateException("boom");
+        });
+        CompletableFuture<Boolean> last = handler.saveObject(new TestDataObject());
+
+        when(plugin.isEnabled()).thenReturn(false);
+        handler.flush();
+
+        assertTrue(handler.queue().isEmpty());
+        assertTrue(last.get(5, TimeUnit.SECONDS));
+        verify(plugin).logError(contains("Could not flush a queued database write"));
+    }
+
+    /**
+     * draining must be cleared afterwards, so a handler that survives the flush does not keep
+     * bypassing the disabled-plugin guard.
+     */
+    @Test
+    void testFlush_clearsDrainingFlag() {
+        when(plugin.isEnabled()).thenReturn(true);
+        handler.saveObject(new TestDataObject());
+        assertFalse(handler.isDraining());
+
+        when(plugin.isEnabled()).thenReturn(false);
+        handler.flush();
+
+        assertFalse(handler.isDraining());
+    }
+
+    /**
+     * draining must be cleared even when a queued write throws.
+     */
+    @Test
+    void testFlush_clearsDrainingFlagAfterThrow() {
+        when(plugin.isEnabled()).thenReturn(true);
+        handler.queue().add(() -> {
+            throw new IllegalStateException("boom");
+        });
+
+        when(plugin.isEnabled()).thenReturn(false);
+        handler.flush();
+
+        assertFalse(handler.isDraining());
     }
 
     // ── deleteID ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The bug

Queued writes are drained by an asynchronous repeating task. That task stops once BentoBox is disabled, and `store(...)` then refuses to run a queued write:

```java
if (async && !plugin.isEnabled()) return;   // silently discarded
```

Pladdons are disabled by the server **before** BentoBox, so everything a Pladdon persists from `onDisable()` is queued into something about to be abandoned. From a real shutdown log:

```
08:03:10  Disabling BentoBox-InvSwitcher   <- saves here, write is queued
08:03:10  Disabling BentoBox
08:03:10  [BentoBox] Closing database.      <- queue never drained
08:03:10  tastybentotoo left the game       <- PlayerQuitEvent fires after the DB is closed
```

Whether the async task manages a tick in first is a race, which is why this presents as intermittent data loss with nothing in the log.

## Scope

Nine addons save state in `onDisable`, and all nine are Pladdons: **Boxed, AOneBlock, Raft, Challenges, Limits, DragonFights, CheckMeOut, ControlPanel, InvSwitcher**. Third-party Pladdons doing the same are affected identically and have no way to know.

Reproduced end to end on a live server with InvSwitcher: pick up items on an island, restart while still connected, and the items are gone — the shutdown save never lands, and `onPlayerJoin` then re-applies the stale stored inventory over the player's real one, so it is an active rollback rather than merely a missed write.

## Changes

**Drain on the way out** — fixes existing addons with no addon changes at all:

- `AbstractDatabaseHandler.flush()` runs this handler's outstanding writes on the calling thread; `flushAll()` does it for every handler. Per-write `try/catch` so one bad write cannot abandon the rest.
- Handlers are tracked in a **weak** static registry. `getHandler()` creates one per `Database` instance, each with its own queue, and nothing else kept a list of them — there was no way to reach them all. Weak so handlers from a discarded `Database` stay collectable.
- A `volatile boolean draining` exempts flushed writes from the disabled-plugin guard in the JSON and SQL handlers. Without it the flush would discard exactly what it exists to save.
- `BentoBox.onDisable()` calls `flushAll()` after `disableAddons()` and before anything closes. That covers Pladdons (already disabled by the server) and ordinary addons (disabled a line earlier), while `playersManager`/`islandsManager` shutdown saves that run afterwards already take the synchronous path.

**Explicit synchronous save** — for callers wanting a guarantee rather than a rescue:

- `AbstractDatabaseHandler.saveObjectNow(T)` and `Database.saveObjectNow(T)`, overridden in every queueing handler (JSON, SQL, SQLite, PostgreSQL, Yaml, Transition delegating onward). Each shares a private `save(instance, forceSync)` with `saveObject` so the paths cannot drift. MongoDB needed no override — already synchronous.
- Non-abstract on the base class, defaulting to `saveObject(T)`, so third-party `AbstractDatabaseHandler` subclasses still compile.

**Deprecates `Database.saveObject(T)`** — the reason this was hard to find. It reads as though the write has completed on return, but delegates to `saveObjectAsync` and always returns `true` without waiting for or checking the result. Now points at `saveObjectAsync(T)` for normal saves, and warns that `saveObjectNow(T)` is **not** a drop-in replacement because it blocks — a mechanical migration to it would turn island/player/economy writes into synchronous main-thread writes. The nine internal call sites move to `saveObjectAsync`, so the deprecation does not arrive pre-suppressed by warnings in our own code.

## Verification

Full suite: **3401 tests, 0 failures, 0 errors**.

10 new tests in `SQLDatabaseHandlerTest`. Verified they actually detect the regressions — with both fixes reverted:

```
RESULT tests=50 failures=4 errors=0
  FAILED: testFlush_writeThrows_continuesAndLogs()
  FAILED: testFlush_writesQueuedSavesAfterPluginDisabled()
  FAILED: testSaveObjectNow_pluginEnabled_storesSynchronouslyAndSkipsQueue()
  FAILED: testSaveObjectNow_sqlException_completesFalse()
```

Those 4 pin the behaviour; the other 6 pass either way by design (null / not-a-DataObject early returns, the empty-queue no-op, the draining-flag lifecycle, and the plugin-disabled `saveObjectNow` variant which takes the sync path regardless) and are coverage rather than regression detection.

All `CompletableFuture.get()` calls in the new tests are bounded with a timeout. An earlier draft used unbounded `get()`, which meant that under a regression the queued write never completed the future and the test **hung instead of failing** — it would have stalled CI rather than reporting.

## Notes for review

- Worth a look at whether `flushAll()` should bound how long it will spend draining. It is bounded by queue depth today, which in practice is small, but a pathological queue would extend shutdown.
- The `draining` exemption deliberately weakens a guard that exists to stop writes after teardown. It is only ever true inside `flush()`, which runs before any connector is closed, and is cleared in a `finally`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXnYDGiASdSUZFtNyS4jbc