### PR TITLE
Clean up flags of addons dropped for missing dependencies

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -595,6 +595,11 @@ public class AddonsManager {
                 if (!names.contains(dependency)) {
                     plugin.logError(a.getDescription().getName() + " has dependency on " + dependency
                             + " that does not exist. Addon will not load!");
+                    // The addon's onLoad has already run and may have registered flags whose
+                    // listeners would otherwise stay active for an addon that never enables,
+                    // firing with no worlds behind them
+                    a.setState(State.MISSING_DEPENDENCY);
+                    plugin.getFlagsManager().unregister(a);
                     addonsIterator.remove();
                     break;
                 }

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -331,6 +331,11 @@ public class Util {
      * @return true if the same
      */
     public static boolean sameWorld(World world, World world2) {
+        if (world == null || world2 == null) {
+            // A null world, e.g. from a game mode addon that never made its worlds,
+            // matches nothing
+            return false;
+        }
         return stripName(world).equals(stripName(world2));
     }
 

--- a/src/test/java/world/bentobox/bentobox/util/UtilTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/UtilTest.java
@@ -49,6 +49,20 @@ class UtilTest extends CommonTestSetup {
     }
 
     /**
+     * A null world on either side must compare as not-the-same rather than throwing —
+     * a game mode addon that never enabled (e.g. missing dependency) leaves its island
+     * world null, and a listener that outlived it may still call inWorld() with that.
+     */
+    @Test
+    void testSameWorldNullSafe() {
+        when(world.getName()).thenReturn("world_name");
+        assertFalse(Util.sameWorld(null, world));
+        assertFalse(Util.sameWorld(world, null));
+        assertFalse(Util.sameWorld(null, null));
+        assertTrue(Util.sameWorld(world, world));
+    }
+
+    /**
      * Sulfur Cube (Minecraft 26.2) is slime-like but passive. When the SULFUR_CUBE entity type is
      * present, {@link Util#isPassiveEntity(org.bukkit.entity.Entity)} must classify it as passive
      * and {@link Util#isHostileEntity(org.bukkit.entity.Entity)} must not treat it as hostile,


### PR DESCRIPTION
## What

When an addon is dropped in `sortAddons()` because a hard dependency is missing, its `onLoad()` has already run — `loadAddon()` calls it before the dependency check. Any flags it registered are live at that point, and `FlagsManager` registers flag listeners immediately under the BentoBox plugin. Those listeners survived the drop as zombies: registered, firing on global events, backed by an addon that never enabled and never created its worlds.

Two changes:

- `sortAddons()` now marks the dropped addon `MISSING_DEPENDENCY` and calls `FlagsManager#unregister(addon)`, removing its flags and unregistering their listeners.
- `Util.sameWorld()` returns `false` when either world is null instead of NPEing, so anything else that reaches a world-less addon degrades to "not in this world".

## How this surfaced

Removing the Level addon from a server running ChunkBlock (which hard-depends on Level) produced:

```
[BentoBox] ChunkBlock has dependency on Level that does not exist. Addon will not load!
...
Could not pass event PlayerJoinEvent to BentoBox
java.lang.NullPointerException: Cannot invoke "org.bukkit.World.getName()" because "world" is null
    at world.bentobox.bentobox.util.Util.stripName(Util.java:338)
    at world.bentobox.bentobox.util.Util.sameWorld(Util.java:334)
    at world.bentobox.bentobox.api.addons.GameModeAddon.inWorld(GameModeAddon.java:82)
    at world.bentobox.chunkblock.listeners.BossBarListener.onJoin(...)
```

plus the same NPE from a flag-registered move listener on **every PlayerMoveEvent** (1000+ in one short session's log).

## Remaining gap (follow-up)

Commands registered by the dropped addon's `onLoad` also stay registered — there is no per-addon command unregistration. They fail benignly rather than spamming, so this PR leaves them for a follow-up.

## Testing

New `UtilTest#testSameWorldNullSafe`; full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7xSdVPS5vRu6wqf6XshRq