### PR TITLE
Keep BentoBox commands in the Bukkit command map

### DIFF
--- a/src/main/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrar.java
+++ b/src/main/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandRegistrar.java
@@ -2,9 +2,11 @@ package world.bentobox.bentobox.commands.brigadier;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -56,6 +58,16 @@ import world.bentobox.bentobox.api.commands.CompositeCommand;
  * therefore leaves no stale references behind, and a label that disappears
  * entirely is hidden from clients because its {@code requires} predicate stops
  * matching.
+ * <p>
+ * <b>Why this class merges rather than owning its labels.</b> Every command is
+ * registered with the Bukkit command map first, and on Paper that means Paper
+ * has already put a node of its own under the label - the command map is a view
+ * over this very dispatcher. That node has to stay: it is the one that carries
+ * the {@link CompositeCommand} back to anything dispatching through the command
+ * map, and replacing it with a plain literal turns the command into a
+ * {@code VanillaCommandWrapper} that demands {@code minecraft.command.<label>}
+ * (#3050). Brigadier merges same-named literals, so registering the tree grafts
+ * the sub-commands onto Paper's node and leaves the node itself alone.
  *
  * @author tastybento
  * @since 3.22.0
@@ -83,6 +95,16 @@ public class BrigadierCommandRegistrar {
     /** Top level labels and aliases already given a node in the dispatcher. */
     private final Set<String> registeredLabels = new HashSet<>();
 
+    /**
+     * The last tree built for each top level label, keyed by label.
+     * <p>
+     * These are the nodes handed to {@link CommandDispatcher#register}, i.e. a
+     * detached copy of exactly what was grafted into the dispatcher. They are kept
+     * because the live nodes cannot be walked back: Paper hands out its own nodes
+     * wrapped in a shadow that refuses {@code getChildren()}.
+     */
+    private final Map<String, LiteralCommandNode<CommandSourceStack>> trees = new HashMap<>();
+
     public BrigadierCommandRegistrar(@NonNull BentoBox plugin) {
         this.plugin = plugin;
     }
@@ -95,7 +117,7 @@ public class BrigadierCommandRegistrar {
         plugin.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
             dispatcher = event.registrar().getDispatcher();
             // A reload rebuilds the tree, so anything registered before has gone.
-            registeredLabels.clear();
+            reset();
             // Register everything already known. Commands created later come
             // through registerCommand() directly.
             new ArrayList<>(plugin.getCommandsManager().getCommands().values()).forEach(this::registerCommand);
@@ -123,11 +145,14 @@ public class BrigadierCommandRegistrar {
         }
         String label = command.getLabel().toLowerCase(Locale.ENGLISH);
         boolean added = false;
-        LiteralCommandNode<CommandSourceStack> main = null;
         if (registeredLabels.add(label)) {
-            main = dispatcher.register(buildTopLevel(label));
+            trees.put(label, dispatcher.register(buildTopLevel(label)));
             added = true;
         }
+        // The live node, which is not necessarily the one just built: Brigadier
+        // merges a same-named literal onto whatever is already there, so a redirect
+        // has to point at the node in the tree rather than at the discarded copy.
+        CommandNode<CommandSourceStack> main = dispatcher.getRoot().getChild(label);
         if (main != null) {
             // Aliases and the namespaced form redirect rather than duplicating the
             // tree - a game mode admin tree runs to dozens of nodes and every one
@@ -142,6 +167,21 @@ public class BrigadierCommandRegistrar {
             // /bentobox reload - need the new tree pushed to them.
             Bukkit.getOnlinePlayers().forEach(Player::updateCommands);
         }
+    }
+
+    /**
+     * Forgets everything registered so far, so that commands coming back after a
+     * reload have their tree grafted on again.
+     * <p>
+     * The nodes themselves are not removed - Brigadier has no API for that - but
+     * the command map removal that goes with this does take the top level ones out
+     * on Paper, and anything left over resolves to nothing.
+     *
+     * @since 3.22.0
+     */
+    public void reset() {
+        registeredLabels.clear();
+        trees.clear();
     }
 
     /**
@@ -174,27 +214,15 @@ public class BrigadierCommandRegistrar {
                 registerCommand(command);
                 continue;
             }
-            int before = childCount(label);
-            dispatcher.register(buildTopLevel(label));
+            LiteralCommandNode<CommandSourceStack> rebuilt = dispatcher.register(buildTopLevel(label));
+            LiteralCommandNode<CommandSourceStack> previous = trees.put(label, rebuilt);
             // Merging is a no-op when nothing new turned up, and pushing the tree to
             // every online player for no reason is not free.
-            changed |= childCount(label) != before;
+            changed |= previous == null || countNodes(previous) != countNodes(rebuilt);
         }
         if (changed) {
             refreshClients();
         }
-    }
-
-    /**
-     * Total number of nodes in a top level command's tree, used to tell whether a
-     * rebuild actually added anything.
-     *
-     * @param label top level label
-     * @return node count, 0 if the label has no node
-     */
-    private int childCount(@NonNull String label) {
-        CommandNode<CommandSourceStack> node = dispatcher == null ? null : dispatcher.getRoot().getChild(label);
-        return node == null ? 0 : countNodes(node);
     }
 
     private static int countNodes(@NonNull CommandNode<CommandSourceStack> node) {
@@ -224,10 +252,17 @@ public class BrigadierCommandRegistrar {
      * @param topLabel main label, used to resolve the command at runtime
      * @return {@code true} if a node was added
      */
-    private boolean registerRedirect(@NonNull String alias, @NonNull LiteralCommandNode<CommandSourceStack> main,
+    private boolean registerRedirect(@NonNull String alias, @NonNull CommandNode<CommandSourceStack> main,
             @NonNull String topLabel) {
         String key = alias.toLowerCase(Locale.ENGLISH);
         if (!registeredLabels.add(key)) {
+            return false;
+        }
+        if (dispatcher.getRoot().getChild(key) != null) {
+            // Something already holds this label. On Paper that is the command map
+            // entry for this very command, which dispatches it perfectly well by
+            // itself - and if it belongs to another plugin, merging a redirect onto
+            // it would take its executor over. Either way, leave it alone.
             return false;
         }
         dispatcher.register(Commands.literal(key).requires(source -> canUse(resolve(topLabel), source))
@@ -388,21 +423,24 @@ public class BrigadierCommandRegistrar {
     /**
      * The names of the literal children Brigadier holds at the node the given
      * tokens lead to, which are exactly the ones it will suggest by itself.
+     * <p>
+     * This walks the tree as it was built rather than the live one. The live top
+     * level node may be Paper's, and Paper hands those out wrapped in a shadow node
+     * that throws rather than let the API see its children. What was built is what
+     * was grafted on, so the two agree on the literals.
      *
      * @param consumed tokens consumed by literal nodes, label first
      * @return literal child names, lower case, or an empty set if the path does
-     *         not exist in the dispatcher
+     *         not exist in the tree
      */
     private Set<String> advertisedChildren(String[] consumed) {
         if (dispatcher == null || consumed.length == 0) {
             return Set.of();
         }
-        CommandNode<CommandSourceStack> node = dispatcher.getRoot()
-                .getChild(consumed[0].toLowerCase(Locale.ENGLISH));
-        if (node != null && node.getRedirect() != null) {
-            // An alias or the namespaced form - the children live on the main node.
-            node = node.getRedirect();
-        }
+        // An alias or the namespaced form leads to the same tree as the main label
+        CompositeCommand top = resolve(consumed[0]);
+        CommandNode<CommandSourceStack> node = top == null ? null
+                : trees.get(top.getLabel().toLowerCase(Locale.ENGLISH));
         for (int i = 1; i < consumed.length && node != null; i++) {
             node = node.getChild(consumed[i].toLowerCase(Locale.ENGLISH));
         }

--- a/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
@@ -2,8 +2,10 @@ package world.bentobox.bentobox.managers;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.bukkit.Bukkit;
@@ -50,15 +52,32 @@ public class CommandsManager {
         this.brigadier = registrar;
     }
 
+    /**
+     * Registers a top level command with the server.
+     * <p>
+     * The command goes into the Bukkit command map whatever Brigadier does with it
+     * afterwards. The command map is what every other plugin dispatches BentoBox
+     * commands through - NPC plugins, command signs, GUI plugins - and Paper builds
+     * its command map entries from whatever it finds in the Brigadier dispatcher. A
+     * node put there outside Paper's own command API carries no {@code
+     * APICommandMeta}, so Paper wraps it as a {@code VanillaCommandWrapper}, which
+     * demands {@code minecraft.command.<label>} and answers with the server's
+     * no-permission message before the command ever runs (#3050).
+     * <p>
+     * Order matters: Paper's command map removes whatever node already holds a
+     * label before installing its own, so the command map has to go first and
+     * Brigadier merges the sub-command tree onto Paper's node afterwards.
+     *
+     * @param command top level command
+     */
     public void registerCommand(@NonNull CompositeCommand command) {
         commands.put(command.getLabel(), command);
+        registerWithCommandMap(command);
         if (brigadier != null) {
             // Commands created before the lifecycle window opens are picked up by
             // the registrar when it opens, so nothing more is needed here.
             brigadier.registerCommand(command);
-            return;
         }
-        registerWithCommandMap(command);
     }
 
     // Reflection is required to access Bukkit's internal command map for dynamic command registration
@@ -108,26 +127,38 @@ public class CommandsManager {
      */
     public void unregisterCommands() {
         if (brigadier != null) {
-            // Brigadier has no API for removing a node, so the nodes stay put and
-            // instead resolve to nothing: their requires predicate hides them from
-            // clients and their executor becomes a no-op. Any command re-registered
-            // after this reuses the node it already has.
+            // The nodes go with the command map entries below - on Paper the two are
+            // the same thing. Forget what was registered so that a command coming
+            // back gets its sub-command tree grafted on again rather than being
+            // skipped as already known.
+            brigadier.reset();
+        }
+        if (commandMap == null) {
+            // Nothing was ever registered, so there is nothing to take out
             commands.clear();
-            brigadier.refreshClients();
             return;
         }
         // Use reflection to obtain the knownCommands in the commandMap
         try {
             @SuppressWarnings("unchecked")
             Map<String, Command> knownCommands = (Map<String, Command>) commandMap.getClass().getMethod("getKnownCommands").invoke(commandMap);
-            //noinspection SuspiciousMethodCalls
-            knownCommands.values().removeIf(commands.values()::contains);
+            // Remove by key rather than through the values() view. On Paper the known
+            // commands are a facade over the Brigadier dispatcher rather than a real
+            // map, and removing a key is the only operation that reliably takes the
+            // node out with it.
+            List<String> labels = knownCommands.entrySet().stream().filter(e -> commands.containsValue(e.getValue()))
+                    .map(Entry::getKey).toList();
+            labels.forEach(knownCommands::remove);
             // Not sure if this is needed, but it clears out all references
             commands.values().forEach(c -> c.unregister(commandMap));
             // Zap everything
             commands.clear();
         } catch(Exception e){
             BentoBox.getInstance().logError("Known commands reflection was not possible, BentoBox is now unstable, so restart server!");
+        }
+        if (brigadier != null) {
+            // Clients are still offering the commands that have just gone away
+            brigadier.refreshClients();
         }
     }
 

--- a/src/test/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandMapMergeTest.java
+++ b/src/test/java/world/bentobox/bentobox/commands/brigadier/BrigadierCommandMapMergeTest.java
@@ -1,0 +1,215 @@
+package world.bentobox.bentobox.commands.brigadier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.tree.CommandNode;
+
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * Regression tests for BentoBox commands vanishing from the Bukkit command map.
+ * <p>
+ * Every command is registered with the command map first, and on Paper that is a
+ * view over this dispatcher, so by the time the tree is built Paper already holds
+ * a node under the label. That node has to survive: it is what carries the
+ * {@link CompositeCommand} back to anything dispatching through the command map -
+ * NPC plugins, command signs, GUI plugins - and a plain literal in its place
+ * makes Paper synthesise a {@code VanillaCommandWrapper} that demands
+ * {@code minecraft.command.<label>} and refuses the command with the server's own
+ * no-permission message. See issue #3050.
+ *
+ * @author tastybento
+ */
+class BrigadierCommandMapMergeTest {
+
+    private static final String TOP_LABEL = "ai";
+    private static final String ALIAS = "island";
+
+    private CompositeCommand topCommand;
+    private Map<String, CompositeCommand> subCommands;
+    private CommandDispatcher<CommandSourceStack> dispatcher;
+    private BrigadierCommandRegistrar registrar;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // The registrar pushes the tree to online players, which needs a server
+        MockBukkit.mock();
+
+        subCommands = new LinkedHashMap<>();
+        topCommand = mockCommand(TOP_LABEL, subCommands);
+        when(topCommand.getAliases()).thenReturn(List.of(ALIAS));
+
+        CommandsManager commandsManager = mock(CommandsManager.class);
+        when(commandsManager.getCommand(TOP_LABEL)).thenReturn(topCommand);
+        when(commandsManager.getCommands()).thenReturn(Map.of(TOP_LABEL, topCommand));
+
+        BentoBox plugin = mock(BentoBox.class);
+        when(plugin.getCommandsManager()).thenReturn(commandsManager);
+
+        registrar = new BrigadierCommandRegistrar(plugin);
+        injectDispatcher(new CommandDispatcher<>());
+    }
+
+    /**
+     * Stands in for the COMMANDS lifecycle window handing over the live dispatcher.
+     */
+    private void injectDispatcher(CommandDispatcher<CommandSourceStack> live) throws Exception {
+        Field field = BrigadierCommandRegistrar.class.getDeclaredField("dispatcher");
+        field.setAccessible(true);
+        field.set(registrar, live);
+        this.dispatcher = live;
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    private CompositeCommand mockCommand(String label, Map<String, CompositeCommand> children) {
+        CompositeCommand command = mock(CompositeCommand.class);
+        when(command.getLabel()).thenReturn(label);
+        when(command.getSubCommands()).thenReturn(children);
+        when(command.getPermission()).thenReturn("");
+        when(command.isHidden()).thenReturn(false);
+        when(command.isOnlyConsole()).thenReturn(false);
+        return command;
+    }
+
+    private void addSubCommand(String label) {
+        subCommands.put(label, mockCommand(label, new LinkedHashMap<>()));
+    }
+
+    /**
+     * Stands in for the node Paper puts in the dispatcher when the command is
+     * registered with the command map.
+     */
+    private CommandNode<CommandSourceStack> givenCommandMapNode(String label) {
+        return dispatcher.register(Commands.literal(label).executes(ctx -> 1));
+    }
+
+    @Test
+    void testTheCommandMapNodeIsMergedIntoNotReplaced() {
+        CommandNode<CommandSourceStack> existing = givenCommandMapNode(TOP_LABEL);
+        addSubCommand("go");
+
+        registrar.registerCommand(topCommand);
+
+        assertSame(existing, dispatcher.getRoot().getChild(TOP_LABEL),
+                "Paper's node carries the command back to the command map and must not be swapped out");
+    }
+
+    @Test
+    void testSubCommandsAreGraftedOntoTheCommandMapNode() {
+        givenCommandMapNode(TOP_LABEL);
+        addSubCommand("go");
+        addSubCommand("team");
+
+        registrar.registerCommand(topCommand);
+
+        CommandNode<CommandSourceStack> top = dispatcher.getRoot().getChild(TOP_LABEL);
+        assertNotNull(top.getChild("go"));
+        assertNotNull(top.getChild("team"));
+        assertNotNull(top.getChild("args"), "The catch-all must be grafted on too");
+    }
+
+    @Test
+    void testLateSubCommandsAreGraftedOntoTheCommandMapNode() {
+        givenCommandMapNode(TOP_LABEL);
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+
+        addSubCommand("deathchest");
+        registrar.refreshTrees();
+
+        assertNotNull(dispatcher.getRoot().getChild(TOP_LABEL).getChild("deathchest"));
+    }
+
+    /**
+     * Brigadier merges by name and drops the redirect while doing it, so a redirect
+     * registered over an existing node would replace that node's executor with ours
+     * and give nothing back. The command map's own node dispatches the alias
+     * perfectly well, so it is left alone.
+     */
+    @Test
+    void testAnAliasHeldByTheCommandMapIsLeftAlone() {
+        givenCommandMapNode(TOP_LABEL);
+        CommandNode<CommandSourceStack> alias = givenCommandMapNode(ALIAS);
+        addSubCommand("go");
+
+        registrar.registerCommand(topCommand);
+
+        assertSame(alias, dispatcher.getRoot().getChild(ALIAS));
+        assertNull(dispatcher.getRoot().getChild(ALIAS).getRedirect(),
+                "An alias that already has a node must not be taken over");
+    }
+
+    /**
+     * Without a command map - the legacy path, and every other server - the alias
+     * still gets a redirect onto the main node, which must be the node that is
+     * actually in the tree.
+     */
+    @Test
+    void testAnUnclaimedAliasStillRedirectsToTheLiveNode() {
+        addSubCommand("go");
+
+        registrar.registerCommand(topCommand);
+
+        CommandNode<CommandSourceStack> alias = dispatcher.getRoot().getChild(ALIAS);
+        assertNotNull(alias);
+        assertSame(dispatcher.getRoot().getChild(TOP_LABEL), alias.getRedirect());
+    }
+
+    /**
+     * A reload takes the commands out of the command map, which on Paper takes the
+     * nodes with them. Registration has to start from scratch afterwards or the
+     * command comes back with no sub-command tree at all.
+     */
+    @Test
+    void testResetLetsACommandBeRegisteredAgain() throws Exception {
+        givenCommandMapNode(TOP_LABEL);
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+
+        // The command map removal that goes with a reload takes the node with it
+        injectDispatcher(new CommandDispatcher<>());
+        registrar.reset();
+        givenCommandMapNode(TOP_LABEL);
+        registrar.registerCommand(topCommand);
+
+        assertNotNull(dispatcher.getRoot().getChild(TOP_LABEL).getChild("go"),
+                "A command registered again after a reload must get its tree back");
+    }
+
+    @Test
+    void testRepeatedRefreshesDoNotDuplicateNodes() {
+        givenCommandMapNode(TOP_LABEL);
+        addSubCommand("go");
+        registrar.registerCommand(topCommand);
+        int children = dispatcher.getRoot().getChild(TOP_LABEL).getChildren().size();
+
+        registrar.refreshTrees();
+        registrar.refreshTrees();
+
+        assertEquals(children, dispatcher.getRoot().getChild(TOP_LABEL).getChildren().size());
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/managers/CommandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/CommandsManagerTest.java
@@ -1,0 +1,114 @@
+package world.bentobox.bentobox.managers;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager;
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+
+/**
+ * Tests that BentoBox commands reach the Bukkit command map.
+ * <p>
+ * Brigadier registration replaced the command map registration outright, and that
+ * took BentoBox commands out of the map every other plugin dispatches through:
+ * NPC plugins, command signs and GUI plugins were answered with the server's
+ * no-permission message instead of running the command, because Paper wraps a
+ * command it cannot find there as a {@code VanillaCommandWrapper} demanding
+ * {@code minecraft.command.<label>}. See issue #3050.
+ *
+ * @author tastybento
+ */
+class CommandsManagerTest extends CommonTestSetup {
+
+    @Mock
+    private LifecycleEventManager<Plugin> lifecycleManager;
+
+    private CommandsManager cm;
+    private CompositeCommand command;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        // Without this the registrar cannot hook Paper and quietly falls back to
+        // the legacy path, which would make these tests prove nothing
+        when(plugin.getLifecycleManager()).thenReturn(lifecycleManager);
+        assertTrue(plugin.getSettings().isUseBrigadierCommands(), "Brigadier registration is on by default");
+
+        cm = new CommandsManager();
+        command = mock(CompositeCommand.class);
+        when(command.getLabel()).thenReturn("ai");
+        when(command.getName()).thenReturn("ai");
+        when(command.getAliases()).thenReturn(new ArrayList<>(List.of("island")));
+        when(command.getSubCommands()).thenReturn(new LinkedHashMap<>());
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testRegisteredCommandIsInTheCommandMap() {
+        cm.registerCommand(command);
+
+        assertSame(command, server.getCommandMap().getCommand("ai"),
+                "Anything dispatching through the command map has to find the command itself");
+    }
+
+    @Test
+    void testAliasesAreInTheCommandMap() {
+        cm.registerCommand(command);
+
+        assertSame(command, server.getCommandMap().getCommand("island"));
+    }
+
+    @Test
+    void testTheNamespacedFormIsInTheCommandMap() {
+        cm.registerCommand(command);
+
+        assertSame(command, server.getCommandMap().getCommand("bentobox:ai"));
+    }
+
+    @Test
+    void testUnregisterTakesCommandsOutOfTheCommandMap() {
+        cm.registerCommand(command);
+
+        cm.unregisterCommands();
+
+        assertNull(server.getCommandMap().getCommand("ai"));
+        assertTrue(cm.getCommands().isEmpty());
+    }
+
+    @Test
+    void testCommandsComeBackAfterAReload() {
+        cm.registerCommand(command);
+        cm.unregisterCommands();
+
+        cm.registerCommand(command);
+
+        assertSame(command, server.getCommandMap().getCommand("ai"));
+    }
+
+    @Test
+    void testUnregisterWithoutRegisteringIsSafe() {
+        cm.unregisterCommands();
+
+        assertTrue(cm.getCommands().isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes #3050.

## The bug

After updating to a 3.22.0 dev build, an NPC that runs `/oneblock go` for a player answers with Paper's `messages.no-permission` text and runs nothing. Typing the same command by hand works, operators are unaffected, granting every BentoBox permission changes nothing, and only BentoBox commands are affected.

## Cause

`CommandsManager#registerCommand` stopped registering with the Bukkit command map when Brigadier registration landed (7b54347c9) - it returned as soon as the registrar had the command.

On Paper the command map is a facade over the Brigadier dispatcher (`CraftCommandMap` is backed by `BukkitBrigForwardingMap`) and it builds a Bukkit `Command` from whatever node is there:

```java
// BukkitBrigForwardingMap#get
if (node instanceof BukkitCommandNode b) return b.getBukkitCommand();
return PaperBrigadier.wrapNode(node);

// PaperBrigadier#wrapNode
if ((meta = node.apiCommandMeta) == null) return new VanillaCommandWrapper(node);
```

Our nodes go straight into the dispatcher, so they carry no `APICommandMeta` - only `PaperCommands#register` sets that, and it cannot be called once the `COMMANDS` lifecycle window has closed. Every BentoBox command therefore resolved through the command map as a `VanillaCommandWrapper`, whose constructor sets the permission to `minecraft.command.<label>` and whose `execute` calls `testPermission` before doing anything.

That accounts for every symptom: op passes any permission check, typed commands are parsed by Brigadier and never touch the command map, and every other plugin is registered in the map normally. Anything dispatching through the command map is affected, not only NPC plugins.

## Fix

Register with the command map **as well**, and first. Paper's map removes whatever node holds a label before installing its own, and Brigadier merges same-named literals rather than replacing them, so the sub-command tree grafts onto Paper's node:

- clients still get the literal tree for live completion
- the command map still hands back the real `CompositeCommand`, so it checks its own permissions and reports for itself

Knock-on changes the merge forces:

- an alias that already has a node is left alone. The merge drops the redirect, so registering one over Paper's node would replace its executor and give nothing back - and if the label belongs to another plugin, that is a hijack. Aliases keep Paper's node, i.e. exactly the completion behaviour of 3.21.0 and earlier.
- redirects (used when there is no command map entry) point at the node in the dispatcher rather than at the copy `register()` hands back, which the merge discards.
- the refresh change-check and the suggestion de-duplication walk the tree as it was built rather than the live one, because Paper wraps its own nodes in a shadow node that throws from `getChildren()`.
- unregistration removes by key. The known commands are not a real map on Paper, and removing a key is the operation that takes the node with it.

## Testing

`./gradlew test` passes. New:

- `CommandsManagerTest` - a registered command, its aliases and its namespaced form are all in the command map with Brigadier on; unregistration takes them out; commands come back after a reload.
- `BrigadierCommandMapMergeTest` - Paper's node is merged into rather than swapped out, sub-commands (including late ones) are grafted onto it, an alias already held is left alone, an unclaimed alias still redirects to the live node, and repeated refreshes do not duplicate nodes.

Existing `BrigadierTreeRefreshTest` and `UnparseableCommandTest` still pass unchanged.

Workaround for anyone hitting this before the next build: `general.brigadier-commands: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kee1qur11mLWdE4ygvh4pu