### PR TITLE
Fix Island.setFlag silently ignoring flags not already in the map

### DIFF
--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -1050,7 +1050,12 @@ public class Island implements DataObject, MetaDataAble {
      * @param doSubflags - whether to set subflags
      */
     public void setFlag(Flag flag, int value, boolean doSubflags) {
-        if (flags.containsKey(flag.getID()) && flags.get(flag.getID()) != value) {
+        // Only mark the island changed when the value actually differs, but do
+        // set flags that are not in the map yet: islands can be created with an
+        // empty flag map, and skipping absent flags silently discarded the
+        // write and left the flag on its default rank.
+        Integer current = flags.get(flag.getID());
+        if (current == null || current != value) {
             flags.put(flag.getID(), value);
             setChanged();
         }

--- a/src/test/java/world/bentobox/bentobox/database/objects/IslandTest.java
+++ b/src/test/java/world/bentobox/bentobox/database/objects/IslandTest.java
@@ -458,10 +458,30 @@ class IslandTest extends CommonTestSetup {
     @Test
     void testSetFlag() {
         Flag flag = new Flag.Builder("TEST_FLAG", Material.STONE).build();
-        // Must first put the flag so setFlag sees it exists
         island.getFlags().put(flag.getID(), RanksManager.MEMBER_RANK);
         island.setFlag(flag, RanksManager.VISITOR_RANK);
         assertEquals(RanksManager.VISITOR_RANK, island.getFlag(flag));
+    }
+
+    @Test
+    void testSetFlagWhenNotAlreadyInTheMap() {
+        // Islands can be created with an empty flag map; setting a flag that is
+        // not in it must still take effect, not silently leave the default rank
+        Flag flag = new Flag.Builder("TEST_ABSENT_FLAG", Material.STONE)
+                .defaultRank(RanksManager.MEMBER_RANK).build();
+        assertFalse(island.getFlags().containsKey(flag.getID()));
+        island.setFlag(flag, RanksManager.VISITOR_RANK);
+        assertEquals(RanksManager.VISITOR_RANK, island.getFlag(flag));
+    }
+
+    @Test
+    void testSetFlagMarksChangedOnlyWhenValueDiffers() {
+        Flag flag = new Flag.Builder("TEST_CHANGED_FLAG", Material.STONE).build();
+        island.setFlag(flag, RanksManager.VISITOR_RANK);
+        assertTrue(island.isChanged(), "Setting a new flag value must mark the island changed");
+        island.clearChanged();
+        island.setFlag(flag, RanksManager.VISITOR_RANK);
+        assertFalse(island.isChanged(), "Re-setting the same value must not mark the island changed");
     }
 
     @Test


### PR DESCRIPTION
## Problem

`Island.setFlag(Flag, int, boolean)` does nothing when the flag is not already a key in the island's flag map:

```java
if (flags.containsKey(flag.getID()) && flags.get(flag.getID()) != value) {
    flags.put(flag.getID(), value);
    setChanged();
}
```

Islands created through `IslandsManager.createIsland` start with an **empty** flag map, so any addon calling `island.setFlag(...)` on a fresh island has the write discarded with no error, and the flag stays on its default rank.

It is easy to miss because `setSettingsFlag()` puts unconditionally — `SETTING`/`WORLD_SETTING` flags work fine while `PROTECTION` ranks silently do not.

Found in a game mode addon that sets `BOAT`, `CRAFTING`, `HURT_MONSTERS`, `ITEM_DROP` and `ITEM_PICKUP` to visitor rank on its unowned islands: none of them applied, and the island JSON showed `"flags": {}`.

## Cause

Introduced in b1fe76c4 (Multipaper, #2343), which replaced

```java
flags.put(flag.getID(), value);
...
setChanged();
```

with the guarded version above. The goal — not calling `setChanged()` (and the MultiLib sync it triggers) when a flag is set to the value it already has — is sound; the `containsKey` clause went further and also skipped flags that were not yet in the map.

## Fix

Write the value whenever it differs from the current one, treating "absent" as different, and keep skipping `setChanged()` for genuine no-op writes:

```java
Integer current = flags.get(flag.getID());
if (current == null || current != value) {
    flags.put(flag.getID(), value);
    setChanged();
}
```

## Tests

- `testSetFlag` no longer needs to pre-seed the map to pass (the workaround comment it carried was documenting the bug).
- `testSetFlagWhenNotAlreadyInTheMap` — setting a flag absent from the map takes effect.
- `testSetFlagMarksChangedOnlyWhenValueDiffers` — pins the MultiLib-friendly half: a new value marks the island changed, re-setting the same value does not.

Full suite green locally: 3417 tests, 0 failures.