### PR TITLE
Throttle notifications per distinct message, not just the last one

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/user/Notifier.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/Notifier.java
@@ -1,13 +1,9 @@
 package world.bentobox.bentobox.api.user;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jdt.annotation.NonNull;
-
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 
 /**
  * Utilities class that helps to avoid spamming the User with potential repeated messages
@@ -16,44 +12,37 @@ import com.google.common.cache.LoadingCache;
 public class Notifier {
 
     /**
-     * Time in seconds before {@link #notificationCache} removes the entry related to the player.
+     * Time in seconds before a sent message may be sent to the same user again.
      */
     private static final int NOTIFICATION_DELAY = 4;
 
-    private record Notification(String message, long time) {}
-
-    private final LoadingCache<User, Notification> notificationCache = CacheBuilder.newBuilder()
-            .expireAfterAccess(NOTIFICATION_DELAY, TimeUnit.SECONDS)
-            .maximumSize(500)
-            .build(
-                    new CacheLoader<>() {
-                        @Override
-                        public @NonNull Notification load(@NonNull User user) {
-                            return new Notification(null, 0);
-                        }
-                    }
-                    );
+    private record Notification(User user, String message) {}
 
     /**
-     * Sends message to a user only if the message hasn't been sent recently
+     * Recently sent notifications, keyed by user and message so that each distinct
+     * message is throttled independently. A user alternating between two different
+     * messages (e.g. hitting two different limits back-to-back) is throttled on both.
+     */
+    private final Cache<Notification, Boolean> notificationCache = CacheBuilder.newBuilder()
+            .expireAfterWrite(NOTIFICATION_DELAY, TimeUnit.SECONDS)
+            .maximumSize(2000)
+            .build();
+
+    /**
+     * Sends a message to a user unless the same message was sent to them within the last
+     * {@code NOTIFICATION_DELAY} seconds. Different messages are throttled independently.
      * @param user - user
      * @param message - message to send (already translated)
-     * @return true if message sent successfully, false it is being throttled
+     * @return true if message sent successfully, false if it is being throttled
      */
     public synchronized boolean notify(User user, String message) {
-        try {
-            Notification lastNotification = notificationCache.get(user);
-            long now = System.currentTimeMillis();
-
-            if (now >= lastNotification.time() + (NOTIFICATION_DELAY * 1000) || !message.equals(lastNotification.message())) {
-                notificationCache.put(user, new Notification(message, now));
-                user.sendRawMessage(message);
-                return true;
-            }
-            return false;
-        } catch (ExecutionException e) {
+        Notification notification = new Notification(user, message);
+        if (notificationCache.getIfPresent(notification) != null) {
             return false;
         }
+        notificationCache.put(notification, Boolean.TRUE);
+        user.sendRawMessage(message);
+        return true;
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/user/NotifierTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/user/NotifierTest.java
@@ -54,6 +54,53 @@ class NotifierTest {
     }
 
     /**
+     * Two different messages in quick succession should both be sent - only repeats are throttled.
+     */
+    @Test
+    void testNotifyDifferentMessagesBothSent() {
+        User user = mock(User.class);
+        assertTrue(n.notify(user, "message one"));
+        assertTrue(n.notify(user, "message two"));
+        Mockito.verify(user).sendRawMessage("message one");
+        Mockito.verify(user).sendRawMessage("message two");
+    }
+
+    /**
+     * Alternating between two messages must not defeat the throttle. Previously only the last
+     * message was remembered, so two different repeating messages (e.g. two different limits
+     * being hit back-to-back) would spam through unthrottled.
+     */
+    @Test
+    void testNotifyAlternatingMessagesThrottled() {
+        User user = mock(User.class);
+        assertTrue(n.notify(user, "message one"));
+        assertTrue(n.notify(user, "message two"));
+        // Spam
+        for (int i = 0; i < 10; i++) {
+            assertFalse(n.notify(user, "message one"));
+            assertFalse(n.notify(user, "message two"));
+        }
+        Mockito.verify(user).sendRawMessage("message one");
+        Mockito.verify(user).sendRawMessage("message two");
+    }
+
+    /**
+     * The same message to different users is throttled per user, not globally.
+     */
+    @Test
+    void testNotifyDifferentUsersIndependent() {
+        User user1 = mock(User.class);
+        User user2 = mock(User.class);
+        String message = "a message";
+        assertTrue(n.notify(user1, message));
+        assertTrue(n.notify(user2, message));
+        assertFalse(n.notify(user1, message));
+        assertFalse(n.notify(user2, message));
+        Mockito.verify(user1).sendRawMessage(message);
+        Mockito.verify(user2).sendRawMessage(message);
+    }
+
+    /**
      * Test method for {@link world.bentobox.bentobox.api.user.Notifier#notify(world.bentobox.bentobox.api.user.User, java.lang.String)}.
      */
     @Test


### PR DESCRIPTION
## Problem

`Notifier` caches only the **single last message** sent to a user and sends whenever the new message differs from it. A player alternating between two different messages — e.g. hitting two different entity limits back-to-back, as reported in BentoBoxWorld/Limits#293 (mixed animal/monster limit messages while mining OneBlock) — bypasses the 4-second throttle entirely: every message differs from the previous one, so all of them spam through.

## Fix

Key the cache by `(user, message)` instead of by user, so each distinct message is throttled independently within the delay window:

- Guava `Cache` with `expireAfterWrite(4s)` — a throttled attempt does not refresh the window, matching the previous fixed-window behaviour.
- Repeats of the same message are still suppressed exactly as before; the only behaviour change is that *different* messages no longer reset each other's throttle.
- `maximumSize` raised 500 → 2000 since entries are now per user+message rather than per user.
- Simplified: no `CacheLoader`/`ExecutionException` needed with `getIfPresent`.

## Tests

Existing `NotifierTest` cases pass unchanged. Added:
- `testNotifyDifferentMessagesBothSent` — distinct messages are not throttled against each other
- `testNotifyAlternatingMessagesThrottled` — the regression case from Limits#293
- `testNotifyDifferentUsersIndependent` — throttle is per user, not global

This supersedes the addon-side debounce proposed in BentoBoxWorld/Limits#293 — with this in core, every addon using `User.notify()` gets the fix for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRV9jT5Yjp42ZZBazTX6rq