### PR TITLE
Show the settings panel when the player has no island

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
@@ -56,7 +56,9 @@ public class IslandSettingsCommand extends CompositeCommand {
      * <ul>
      *   <li>If player is in the game world: Uses location to find island</li>
      *   <li>If player is in different world: Uses player's owned island</li>
-     *   <li>Fails if no island is found</li>
+     *   <li>If no island is found, the panel still opens and shows the world's
+     *       settings and default flags - useful when standing in the
+     *       wilderness and wondering what rules apply</li>
      * </ul>
      */
     @Override
@@ -67,10 +69,8 @@ public class IslandSettingsCommand extends CompositeCommand {
         } else {
             island = getIslands().getIsland(getWorld(), user);
         }
-        if (island == null) {
-            user.sendMessage("general.errors.no-island");
-            return false;
-        }
+        // A null island is fine: the panel falls back to world settings and
+        // the world's default island flags
         return true;
     }
 
@@ -88,7 +88,7 @@ public class IslandSettingsCommand extends CompositeCommand {
         new TabbedPanelBuilder()
         .user(user)
                 .island(island)
-        .world(island.getWorld())
+        .world(island == null ? getWorld() : island.getWorld())
                 .tab(1, new SettingsTab(getWorld(), user, Flag.Type.PROTECTION))
                 .tab(2, new SettingsTab(getWorld(), user, Flag.Type.SETTING))
         .startingSlot(1)

--- a/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
@@ -465,7 +465,7 @@ public class Flag implements Comparable<Flag> {
         }
 
         return switch (getType()) {
-        case PROTECTION -> createProtectionFlag(plugin, user, island, pib).build();
+        case PROTECTION -> createProtectionFlag(plugin, user, world, island, pib).build();
         case SETTING -> createSettingFlag(user, island, pib).build();
         case WORLD_SETTING -> createWorldSettingFlag(user, world, pib).build();
 
@@ -495,25 +495,43 @@ public class Flag implements Comparable<Flag> {
         return pib;
     }
 
-    private PanelItemBuilder createProtectionFlag(BentoBox plugin, User user, Island island, PanelItemBuilder pib) {
+    /**
+     * Renders a protection flag. With no island (the player is in the wilderness,
+     * or looking at a world they have no island in) the world's default island
+     * flag rank is shown instead, so the panel still answers "what applies
+     * here" rather than showing nothing.
+     */
+    private PanelItemBuilder createProtectionFlag(BentoBox plugin, User user, World world, Island island,
+            PanelItemBuilder pib) {
+        // Not a ternary: mixing int and Integer would unbox the map lookup and
+        // NPE when the world has no default for this flag
+        Integer rank;
         if (island != null) {
-            int y = island.getFlag(this);
-            // Protection flag
-
-            pib.description(user.getTranslation("protection.panel.flag-item.description-layout",
-                    TextVariables.DESCRIPTION, user.getTranslation(getDescriptionReference())));
-
-            RanksManager.getInstance().getRanks().forEach((reference, score) -> {
-                String rankName = user.getTranslation(reference);
-                if (score > RanksManager.BANNED_RANK && score < y) {
-                    pib.description(getRankTranslation(user, "protection.panel.flag-item.blocked-rank", rankName));
-                } else if (score <= RanksManager.OWNER_RANK && score > y) {
-                    pib.description(getRankTranslation(user, "protection.panel.flag-item.allowed-rank", rankName));
-                } else if (score == y) {
-                    pib.description(getRankTranslation(user, "protection.panel.flag-item.minimal-rank", rankName));
-                }
-            });
+            rank = island.getFlag(this);
+        } else if (world != null) {
+            rank = plugin.getIWM().getDefaultIslandFlags(world).get(this);
+        } else {
+            rank = null;
         }
+        if (rank == null) {
+            return pib;
+        }
+        int y = rank;
+        // Protection flag
+
+        pib.description(user.getTranslation("protection.panel.flag-item.description-layout",
+                TextVariables.DESCRIPTION, user.getTranslation(getDescriptionReference())));
+
+        RanksManager.getInstance().getRanks().forEach((reference, score) -> {
+            String rankName = user.getTranslation(reference);
+            if (score > RanksManager.BANNED_RANK && score < y) {
+                pib.description(getRankTranslation(user, "protection.panel.flag-item.blocked-rank", rankName));
+            } else if (score <= RanksManager.OWNER_RANK && score > y) {
+                pib.description(getRankTranslation(user, "protection.panel.flag-item.allowed-rank", rankName));
+            } else if (score == y) {
+                pib.description(getRankTranslation(user, "protection.panel.flag-item.minimal-rank", rankName));
+            }
+        });
 
         return pib;
     }

--- a/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
@@ -363,6 +363,34 @@ class FlagTest extends RanksManagerTestSetup {
     }
     
     /**
+     * A protection flag with no island falls back to the world's default island
+     * flag rank, so the settings panel still shows what applies (e.g. when a
+     * player is in the wilderness).
+     */
+    @Test
+    void testToPanelItemWithoutIslandUsesWorldDefaults() {
+        User user = mock(User.class);
+        when(user.getUniqueId()).thenReturn(UUID.randomUUID());
+        Answer<String> answer = invocation -> {
+            StringBuilder sb = new StringBuilder();
+            Arrays.stream(invocation.getArguments()).forEach(sb::append);
+            sb.append("mock");
+            return sb.toString();
+        };
+        when(user.getTranslation(any(String.class), any(), any())).thenAnswer(answer);
+        when(user.getTranslation(any(String.class))).thenAnswer(answer);
+        when(iwm.getDefaultIslandFlags(world)).thenReturn(Map.of(f, RanksManager.VISITOR_RANK));
+        mockedRanksManager.when(RanksManager::getInstance).thenReturn(rm);
+        when(rm.getRanks()).thenReturn(Map.of("ranks.visitor", RanksManager.VISITOR_RANK));
+
+        PanelItem pi = f.toPanelItem(plugin, user, world, null, false);
+
+        assertEquals(Material.ACACIA_PLANKS, pi.getItem().getType());
+        // The rank lines were rendered from the world defaults
+        verify(user).getTranslation(eq("protection.panel.flag-item.description-layout"), eq("[description]"), any());
+    }
+
+    /**
      * Test method for {@link world.bentobox.bentobox.api.flags.Flag#setTranslatedName(java.util.Locale, String)}.
      */
     @Test


### PR DESCRIPTION
## Problem

`/island settings` refuses to open whenever the player is not standing on an island and does not own one:

```
You do not have an island!
```

That is exactly the moment a player most wants to ask *"what rules apply where I am standing?"* — out in the wilderness, or in a game mode where players do not own islands at all (my sea-trading mode has unowned NPC islands and open ocean between them; players rowing between islands get only the error).

## Change

The panel now opens regardless of whether an island was found:

- `IslandSettingsCommand.canExecute` no longer fails on a null island; `execute` falls back to `getWorld()` for the panel world.
- `Flag.createProtectionFlag` takes the world and, when there is no island, renders the world's **default island flag ranks** (`IslandWorldManager#getDefaultIslandFlags`) instead of rendering no state at all. World settings already showed world state.

Clicking is already safe in this case: `CycleClick` null-checks the island and replies with `general.errors.not-on-island`, so with no island the panel is informational.

Also fixes an unboxing hazard noticed while editing `createProtectionFlag`: the rank lookup is deliberately an `if/else` rather than a ternary, because mixing `int` (`island.getFlag`) with `Integer` (map lookup) in a conditional expression unboxes the `Integer` and NPEs when the world has no default for that flag. (`IslandDefaultSettingsTab` hits exactly that path — caught by the existing test suite.)

## Tests

- New `FlagTest#testToPanelItemWithoutIslandUsesWorldDefaults`.
- Full suite green locally: 3416 tests, 0 failures.