### PR TITLE
Show the world's protection flags when the player is not on an island

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommand.java
@@ -8,6 +8,7 @@ import world.bentobox.bentobox.api.panels.builders.TabbedPanelBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.panels.settings.SettingsTab;
+import world.bentobox.bentobox.panels.settings.WorldProtectionInfoTab;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -56,9 +57,9 @@ public class IslandSettingsCommand extends CompositeCommand {
      * <ul>
      *   <li>If player is in the game world: Uses location to find island</li>
      *   <li>If player is in different world: Uses player's owned island</li>
-     *   <li>If no island is found, the panel still opens and shows the world's
-     *       settings and default flags - useful when standing in the
-     *       wilderness and wondering what rules apply</li>
+     *   <li>If no island is found, the panel still opens and shows the
+     *       protection flags that apply out in the world - useful when standing
+     *       in the wilderness and wondering what rules apply there</li>
      * </ul>
      */
     @Override
@@ -69,31 +70,52 @@ public class IslandSettingsCommand extends CompositeCommand {
         } else {
             island = getIslands().getIsland(getWorld(), user);
         }
-        // A null island is fine: the panel falls back to world settings and
-        // the world's default island flags
+        // A null island is fine: the panel falls back to the world's protection
+        // flags, which are what applies off-island
         return true;
     }
 
     /**
      * Opens the settings GUI panel.
      * <p>
-     * Creates a tabbed panel with:
+     * With an island, creates a tabbed panel with:
      * <ul>
      *   <li>Tab 1: Protection flags</li>
      *   <li>Tab 2: Settings flags</li>
      * </ul>
+     * Without an island there is nothing to configure, so a single read-only tab
+     * of the world's protection flags is shown instead. That answers the only
+     * question a player can ask out in the world: what am I allowed to do here?
      */
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        new TabbedPanelBuilder()
-        .user(user)
+        buildPanel(user).build().openPanel();
+        return true;
+    }
+
+    /**
+     * Builds the panel shown by this command.
+     * @param user user to show it to
+     * @return the panel builder for the island the player is on, or for the world
+     *         if they are not on one
+     * @since 3.22.0
+     */
+    protected TabbedPanelBuilder buildPanel(User user) {
+        if (island == null) {
+            return new TabbedPanelBuilder()
+                    .user(user)
+                    .world(getWorld())
+                    .tab(1, new WorldProtectionInfoTab(getWorld(), user))
+                    .startingSlot(1)
+                    .size(54);
+        }
+        return new TabbedPanelBuilder()
+                .user(user)
                 .island(island)
-        .world(island == null ? getWorld() : island.getWorld())
+                .world(island.getWorld())
                 .tab(1, new SettingsTab(getWorld(), user, Flag.Type.PROTECTION))
                 .tab(2, new SettingsTab(getWorld(), user, Flag.Type.SETTING))
-        .startingSlot(1)
-        .size(54)
-        .build().openPanel();
-        return true;
+                .startingSlot(1)
+                .size(54);
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/Flag.java
@@ -465,7 +465,7 @@ public class Flag implements Comparable<Flag> {
         }
 
         return switch (getType()) {
-        case PROTECTION -> createProtectionFlag(plugin, user, world, island, pib).build();
+        case PROTECTION -> createProtectionFlag(user, world, island, pib).build();
         case SETTING -> createSettingFlag(user, island, pib).build();
         case WORLD_SETTING -> createWorldSettingFlag(user, world, pib).build();
 
@@ -496,27 +496,20 @@ public class Flag implements Comparable<Flag> {
     }
 
     /**
-     * Renders a protection flag. With no island (the player is in the wilderness,
-     * or looking at a world they have no island in) the world's default island
-     * flag rank is shown instead, so the panel still answers "what applies
-     * here" rather than showing nothing.
+     * Renders a protection flag. With no island - the player is in the wilderness,
+     * or looking at a world they have no island in - there are no island ranks to
+     * show, so the world's own on/off state for this flag is shown instead. That
+     * matches how the flag is actually evaluated off-island: see
+     * {@link FlagListener#checkIsland(org.bukkit.event.Event, org.bukkit.entity.Player, org.bukkit.Location, Flag, boolean)},
+     * which falls back to {@link #isSetForWorld(World)} when there is no island
+     * at the location.
      */
-    private PanelItemBuilder createProtectionFlag(BentoBox plugin, User user, World world, Island island,
-            PanelItemBuilder pib) {
-        // Not a ternary: mixing int and Integer would unbox the map lookup and
-        // NPE when the world has no default for this flag
-        Integer rank;
-        if (island != null) {
-            rank = island.getFlag(this);
-        } else if (world != null) {
-            rank = plugin.getIWM().getDefaultIslandFlags(world).get(this);
-        } else {
-            rank = null;
+    private PanelItemBuilder createProtectionFlag(User user, World world, Island island, PanelItemBuilder pib) {
+        if (island == null) {
+            // Off-island the world setting decides, not any island's ranks
+            return createWorldSettingFlag(user, world, pib);
         }
-        if (rank == null) {
-            return pib;
-        }
-        int y = rank;
+        int y = island.getFlag(this);
         // Protection flag
 
         pib.description(user.getTranslation("protection.panel.flag-item.description-layout",

--- a/src/main/java/world/bentobox/bentobox/panels/settings/WorldProtectionInfoTab.java
+++ b/src/main/java/world/bentobox/bentobox/panels/settings/WorldProtectionInfoTab.java
@@ -1,0 +1,66 @@
+package world.bentobox.bentobox.panels.settings;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import world.bentobox.bentobox.api.flags.Flag.Type;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.Tab;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+
+/**
+ * Implements a read-only {@link Tab} that shows the protection flags that apply
+ * where the player is standing when they are not on an island, i.e. out in the
+ * world. Each flag shows whether it is active or disabled for the world, which
+ * is exactly how it is evaluated off-island - can I break blocks out here, can I
+ * place them, and so on.
+ * <p>
+ * This is the player-facing, non-clickable equivalent of
+ * {@link WorldDefaultSettingsTab}, which lets admins change the same values.
+ *
+ * @author tastybento
+ * @since 3.22.0
+ */
+public class WorldProtectionInfoTab extends SettingsTab implements Tab {
+
+    /**
+     * @param world - world
+     * @param user - user
+     */
+    public WorldProtectionInfoTab(World world, User user) {
+        super(world, user, Type.PROTECTION);
+    }
+
+    @Override
+    public PanelItem getIcon() {
+        return new PanelItemBuilder().icon(Material.STONE_BRICKS).name(getName())
+                .description(user.getTranslation(PROTECTION_PANEL + "WORLD_DEFAULTS.description")).build();
+    }
+
+    @Override
+    public String getName() {
+        return user.getTranslation(PROTECTION_PANEL + "WORLD_DEFAULTS.title", "[world_name]",
+                plugin.getIWM().getFriendlyName(world));
+    }
+
+    /**
+     * The flag items are rendered by {@link SettingsTab}, which shows the world's
+     * state for each flag because there is no island. They are stripped of their
+     * click handlers here: only an admin may change these values, and the flag's
+     * own {@link world.bentobox.bentobox.api.flags.clicklisteners.CycleClick}
+     * would just tell the player they are not on an island.
+     */
+    @Override
+    public @NonNull List<@Nullable PanelItem> getPanelItems() {
+        List<@Nullable PanelItem> items = super.getPanelItems();
+        items.stream().filter(Objects::nonNull).forEach(i -> i.setClickHandler(null));
+        return items;
+    }
+
+}

--- a/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/island/IslandSettingsCommandTest.java
@@ -1,0 +1,136 @@
+package world.bentobox.bentobox.api.commands.island;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.flags.Flag.Type;
+import world.bentobox.bentobox.api.panels.Tab;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+import world.bentobox.bentobox.managers.LocalesManager;
+import world.bentobox.bentobox.panels.settings.SettingsTab;
+import world.bentobox.bentobox.panels.settings.WorldProtectionInfoTab;
+import world.bentobox.bentobox.util.Util;
+
+/**
+ * Tests for {@link IslandSettingsCommand}, in particular what is shown to a
+ * player who is not on an island.
+ *
+ * @author tastybento
+ */
+class IslandSettingsCommandTest extends CommonTestSetup {
+
+    @Mock
+    private CompositeCommand ic;
+    @Mock
+    private User user;
+    @Mock
+    private LocalesManager testLm;
+
+    private IslandSettingsCommand isc;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        User.setPlugin(plugin);
+        mockedUtil.when(() -> Util.getWorld(any())).thenReturn(world);
+
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+
+        when(user.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(user.getWorld()).thenReturn(world);
+        when(user.getPlayer()).thenReturn(mockPlayer);
+        when(user.getLocation()).thenReturn(mock(Location.class));
+        when(user.getTranslation(anyString())).thenAnswer(i -> i.getArgument(0, String.class));
+
+        when(ic.getSubCommandAliases()).thenReturn(new HashMap<>());
+        when(ic.getPermissionPrefix()).thenReturn("bskyblock.");
+        when(ic.getWorld()).thenReturn(world);
+
+        when(plugin.getIslands()).thenReturn(im);
+        when(testLm.get(any(User.class), anyString())).thenAnswer(i -> i.getArgument(1, String.class));
+        when(plugin.getLocalesManager()).thenReturn(testLm);
+
+        isc = new IslandSettingsCommand(ic);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * A player standing on an island gets the island's protection and settings tabs.
+     */
+    @Test
+    void testBuildPanelWithIsland() {
+        when(im.getIslandAt(any(Location.class))).thenReturn(Optional.of(island));
+        when(island.getWorld()).thenReturn(world);
+
+        assertTrue(isc.canExecute(user, "settings", Collections.emptyList()));
+        Map<Integer, Tab> tabs = isc.buildPanel(user).getTabs();
+
+        assertEquals(2, tabs.size());
+        assertEquals(Type.PROTECTION, ((SettingsTab) tabs.get(1)).getType());
+        assertEquals(Type.SETTING, ((SettingsTab) tabs.get(2)).getType());
+        assertEquals(island, isc.buildPanel(user).getIsland());
+    }
+
+    /**
+     * With no island the command still runs - it is the moment a player most
+     * wants to know what the rules are where they are standing.
+     */
+    @Test
+    void testCanExecuteWithoutIsland() {
+        when(im.getIslandAt(any(Location.class))).thenReturn(Optional.empty());
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
+
+        assertTrue(isc.canExecute(user, "settings", Collections.emptyList()));
+        verify(user, never()).sendMessage("general.errors.no-island");
+    }
+
+    /**
+     * With no island only the world's protection flags are shown: settings flags
+     * are an island concept and there is no island to configure.
+     */
+    @Test
+    void testBuildPanelWithoutIslandShowsOnlyWorldProtection() {
+        when(im.getIslandAt(any(Location.class))).thenReturn(Optional.empty());
+        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
+        isc.canExecute(user, "settings", Collections.emptyList());
+
+        var tpb = isc.buildPanel(user);
+        Map<Integer, Tab> tabs = tpb.getTabs();
+
+        assertEquals(1, tabs.size());
+        assertInstanceOf(WorldProtectionInfoTab.class, tabs.get(1));
+        assertEquals(world, tpb.getWorld());
+        // No island is set on the panel
+        assertNull(tpb.getIsland());
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/FlagTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -363,12 +364,41 @@ class FlagTest extends RanksManagerTestSetup {
     }
     
     /**
-     * A protection flag with no island falls back to the world's default island
-     * flag rank, so the settings panel still shows what applies (e.g. when a
-     * player is in the wilderness).
+     * A protection flag with no island shows the world's on/off state for the
+     * flag - that is what applies off-island - and not any island ranks.
      */
     @Test
-    void testToPanelItemWithoutIslandUsesWorldDefaults() {
+    void testToPanelItemWithoutIslandShowsWorldSettingActive() {
+        User user = mockTranslatingUser();
+        // Flag is on for the world, so it is allowed outside islands
+        worldFlags.put("flagID", true);
+
+        PanelItem pi = f.toPanelItem(plugin, user, world, null, false);
+
+        assertEquals(Material.ACACIA_PLANKS, pi.getItem().getType());
+        verify(user).getTranslation("protection.panel.flag-item.setting-active");
+        verify(user, never()).getTranslation("protection.panel.flag-item.setting-disabled");
+        verify(user).getTranslation(eq("protection.panel.flag-item.setting-layout"), eq("[description]"), any(),
+                eq("[setting]"), any());
+        // No island means no ranks to show
+        verify(user, never()).getTranslation(eq("protection.panel.flag-item.description-layout"), any(), any());
+    }
+
+    /**
+     * As above, but the flag is off for the world.
+     */
+    @Test
+    void testToPanelItemWithoutIslandShowsWorldSettingDisabled() {
+        User user = mockTranslatingUser();
+        worldFlags.put("flagID", false);
+
+        f.toPanelItem(plugin, user, world, null, false);
+
+        verify(user).getTranslation("protection.panel.flag-item.setting-disabled");
+        verify(user, never()).getTranslation("protection.panel.flag-item.setting-active");
+    }
+
+    private User mockTranslatingUser() {
         User user = mock(User.class);
         when(user.getUniqueId()).thenReturn(UUID.randomUUID());
         Answer<String> answer = invocation -> {
@@ -379,15 +409,7 @@ class FlagTest extends RanksManagerTestSetup {
         };
         when(user.getTranslation(any(String.class), any(), any())).thenAnswer(answer);
         when(user.getTranslation(any(String.class))).thenAnswer(answer);
-        when(iwm.getDefaultIslandFlags(world)).thenReturn(Map.of(f, RanksManager.VISITOR_RANK));
-        mockedRanksManager.when(RanksManager::getInstance).thenReturn(rm);
-        when(rm.getRanks()).thenReturn(Map.of("ranks.visitor", RanksManager.VISITOR_RANK));
-
-        PanelItem pi = f.toPanelItem(plugin, user, world, null, false);
-
-        assertEquals(Material.ACACIA_PLANKS, pi.getItem().getType());
-        // The rank lines were rendered from the world defaults
-        verify(user).getTranslation(eq("protection.panel.flag-item.description-layout"), eq("[description]"), any());
+        return user;
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/panels/settings/WorldProtectionInfoTabTest.java
+++ b/src/test/java/world/bentobox/bentobox/panels/settings/WorldProtectionInfoTabTest.java
@@ -1,0 +1,84 @@
+package world.bentobox.bentobox.panels.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.flags.Flag;
+import world.bentobox.bentobox.api.flags.Flag.Mode;
+import world.bentobox.bentobox.api.flags.Flag.Type;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.user.User;
+
+class WorldProtectionInfoTabTest extends CommonTestSetup {
+
+    private WorldProtectionInfoTab tab;
+    private User user;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        when(plugin.getFlagsManager()).thenReturn(fm);
+
+        user = User.getInstance(mockPlayer);
+        tab = new WorldProtectionInfoTab(world, user);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testGetIcon() {
+        PanelItem icon = tab.getIcon();
+        assertNotNull(icon);
+        assertEquals(Material.STONE_BRICKS, icon.getItem().getType());
+    }
+
+    @Test
+    void testGetName() {
+        assertEquals("protection.panel.WORLD_DEFAULTS.title", tab.getName());
+    }
+
+    /**
+     * Any player may see this tab - it only tells them what they can do where
+     * they are standing.
+     */
+    @Test
+    void testGetPermission() {
+        assertEquals("", tab.getPermission());
+    }
+
+    @Test
+    void testGetPanelItemsNoFlags() {
+        assertTrue(tab.getPanelItems().isEmpty());
+    }
+
+    /**
+     * The items must not be clickable: a player cannot change the world's
+     * protection settings.
+     */
+    @Test
+    void testGetPanelItemsAreNotClickable() {
+        Flag testFlag = new Flag.Builder("TEST_FLAG", Material.STONE).type(Type.PROTECTION).mode(Mode.BASIC).build();
+        when(fm.getFlags()).thenReturn(List.of(testFlag));
+
+        List<PanelItem> items = tab.getPanelItems();
+
+        assertFalse(items.isEmpty());
+        items.forEach(i -> assertTrue(i.getClickHandler().isEmpty()));
+    }
+}


### PR DESCRIPTION
Follow-up to #3055, which opened `/island settings` when the player has no island. The panel opened, but what it showed was not what applies where the player is standing.

### What was wrong

- **The protection tab showed island defaults.** It fell back to `IWM.getDefaultIslandFlags()` — the rank map new islands are created with, which is the admin panel's *Island Defaults* tab. That is not the rule in force out in the world. Any flag not listed under `default-island-flags` in the game mode config produced `rank == null` and rendered with a name and no lore at all.
- **The settings tab was blank.** It was still built, but `createSettingFlag` early-returns on a null island, so every item was a bare name with no active/disabled state.

### What applies off-island

`FlagListener.checkIsland` falls through to `flag.isSetForWorld(loc.getWorld())` when there is no island at the location — the world-protections values an admin edits on the *World Protections* tab:

https://github.com/BentoBoxWorld/BentoBox/blob/develop/src/main/java/world/bentobox/bentobox/api/flags/FlagListener.java#L201-L208

So that is what the panel now shows: each protection flag as active or disabled. That answers the only question a player can ask out in the wilderness — can I break blocks here, can I place them?

### Changes

- `Flag.createProtectionFlag` delegates to `createWorldSettingFlag` when there is no island. This also removes the null-rank blank-item case, since `isSetForWorld` always resolves.
- New `WorldProtectionInfoTab`: the read-only, player-facing twin of `WorldDefaultSettingsTab`. It extends `SettingsTab`, so hidden flags, game-mode filtering, sub-flag hiding and the basic/advanced/expert toggle all still work, then strips the click handlers — only an admin may change these values, and the flag's own `CycleClick` would just reply "you are not on an island". `PanelListenerManager` cancels the click event up front, so a handler-less item is inert.
- `IslandSettingsCommand` shows that single tab when there is no island. The settings tab is dropped in that case: settings are island-level and there is nothing to configure.
- Panel construction moved into `IslandSettingsCommand#buildPanel` so the tab wiring is testable without opening an inventory.

No new locale keys — the tab reuses the existing `protection.panel.WORLD_DEFAULTS.{title,description}` entries ("Protection settings when player is outside their island"), which already read correctly for a player.

### Deliberately unchanged

A player who **owns** an island but is standing in the wilderness still gets their own island's settings, via the existing `canExecute` fallback. That is long-standing behaviour and lets players open their settings from anywhere. Say the word if you'd rather the panel always follow the location — it's one line.

### Testing

Rewrote `FlagTest`'s no-island cases to cover both world states and assert no rank lines are emitted; added `WorldProtectionInfoTabTest` (icon, title, empty permission, items not clickable) and `IslandSettingsCommandTest` (two tabs with an island; one `WorldProtectionInfoTab` and no island on the panel without). Full suite: 3427 tests, 0 failures. Also built and run on a local 26.2 server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvPaJ5jKchGph4FvaJjRu8
