### PR TITLE
Resolve player names without depending on stored capitalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - `plugin.yml` and `config.yml` are filtered for the `${version}` placeholder at build time; locale files are copied without filtering.
 - Locale translations are produced with Claude, not GitLocalize. When a key is added to `en-US.yml`, translate it into every other `src/main/resources/locales/*.yml` file in the same PR, preserving each file's existing style (e.g. the MiniMessage-tagged names in `zh-CN.yml` / `zh-HK.yml`).
 - Java preview features are enabled for both compilation and test execution.
-- Local builds produce version `{buildVersion}-LOCAL-SNAPSHOT` (current: `3.22.0-LOCAL-SNAPSHOT`); CI builds append `-b{BUILD_NUMBER}-SNAPSHOT`; `origin/master` builds produce the bare version. The authoritative version is `buildVersion` in `build.gradle.kts`.
+- Local builds produce version `{buildVersion}-LOCAL-SNAPSHOT` (current: `3.22.1-LOCAL-SNAPSHOT`); CI builds append `-b{BUILD_NUMBER}-SNAPSHOT`; `origin/master` builds produce the bare version. The authoritative version is `buildVersion` in `build.gradle.kts`.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 group = "world.bentobox" // From <groupId>
 
 // Base properties from <properties>
-val buildVersion = "3.22.0"
+val buildVersion = "3.22.1"
 val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 

--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -3,13 +3,19 @@ package world.bentobox.bentobox.managers;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
@@ -32,7 +38,16 @@ public class PlayersManager {
     private Database<Players> handler;
     private final Database<Names> names;
     private final ExpiringMap<UUID, Players> playerCache = new ExpiringMap<>(2, TimeUnit.HOURS);
-    private final @NonNull List<Names> nameCache;
+    /**
+     * Name to UUID lookup, keyed on the lower cased name so that lookups never depend
+     * on how the name happened to be capitalized when it was stored. Minecraft names are
+     * unique ignoring case, so the key is unambiguous.
+     * <p>
+     * This table is the whole reason {@link #getUUID(String)} can be called from a command:
+     * it is loaded once at startup and kept current as players join, so a lookup never has
+     * to hit the database. Keep {@code getUUID} free of blocking calls.
+     */
+    private final @NonNull Map<String, Names> nameCache = new ConcurrentHashMap<>();
     private final Set<UUID> inTeleport; // this needs databasing
 
     /**
@@ -48,8 +63,25 @@ public class PlayersManager {
         handler = new Database<>(plugin, Players.class);
         // Set up the names database
         names = new Database<>(plugin, Names.class);
-        nameCache = names.loadObjects();
+        names.loadObjects().forEach(this::cacheName);
         inTeleport = new HashSet<>();
+    }
+
+    /**
+     * Key used for name lookups. Names are matched ignoring case throughout.
+     */
+    private static String nameKey(@NonNull String name) {
+        return name.toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Puts a name record into the lookup cache, ignoring records that cannot be used.
+     */
+    private void cacheName(@Nullable Names name) {
+        if (name != null && name.getUuid() != null && name.getUniqueId() != null
+                && !name.getUniqueId().isEmpty()) {
+            nameCache.put(nameKey(name.getUniqueId()), name);
+        }
     }
 
     /**
@@ -133,6 +165,10 @@ public class PlayersManager {
 
     /**
      * Attempts to return a UUID for a given player's name.
+     * <p>
+     * Names are matched ignoring case: Minecraft names are unique ignoring case, so
+     * {@code Oli713664} and {@code oli713664} are the same player and both must resolve.
+     *
      * @param name - name of player
      * @return UUID of player or null if unknown
      */
@@ -147,8 +183,29 @@ public class PlayersManager {
                 // Not used
             }
         }
-        return nameCache.stream().filter(n -> n.getUniqueId().equalsIgnoreCase(name)).findFirst()
-                .map(Names::getUuid).orElse(null);
+        if (name.isBlank()) {
+            return null;
+        }
+        // Every step below is an in-memory lookup. The Names table exists precisely so that
+        // resolving a name never blocks the calling thread, so nothing here may touch the
+        // database or the network - see the class comment on nameCache.
+
+        // An online player is authoritative. Bukkit matches the name ignoring case, and this
+        // beats anything stored, which may be a leftover record from a previous holder of the
+        // name or predate a rename.
+        Player online = Bukkit.getPlayerExact(name);
+        if (online != null) {
+            return online.getUniqueId();
+        }
+        Names cached = nameCache.get(nameKey(name));
+        if (cached != null) {
+            return cached.getUuid();
+        }
+        // Last resort: the server's own user cache, which knows players BentoBox has never
+        // seen. Unlike the deprecated getOfflinePlayer(String), this never makes a web
+        // request - it returns null on a miss rather than going looking.
+        OfflinePlayer offline = Bukkit.getOfflinePlayerIfCached(name);
+        return offline == null ? null : offline.getUniqueId();
     }
 
     /**
@@ -166,9 +223,19 @@ public class PlayersManager {
         handler.saveObjectAsync(player);
         // Update names
         Names newName = new Names(user.getName(), user.getUniqueId());
+        // Drop any record that still points at this player under some other spelling - an old
+        // name, or this name stored with different capitalization. Left in place it keeps
+        // resolving to a UUID that is no longer correct for that name, and on a case sensitive
+        // file system it shadows the record written below.
+        for (Iterator<Names> it = nameCache.values().iterator(); it.hasNext();) {
+            Names old = it.next();
+            if (user.getUniqueId().equals(old.getUuid()) && !user.getName().equals(old.getUniqueId())) {
+                names.deleteID(old.getUniqueId());
+                it.remove();
+            }
+        }
         // Add to cache
-        nameCache.removeIf(name -> user.getUniqueId().equals(name.getUuid()));
-        nameCache.add(newName);
+        cacheName(newName);
         // Add to names database
         return names.saveObjectAsync(newName);
     }
@@ -342,6 +409,15 @@ public class PlayersManager {
      */
     public void removePlayer(Player player) {
         handler.deleteID(player.getUniqueId().toString());
+        // Drop the name lookup too, otherwise the name keeps resolving to a player that
+        // no longer has any data.
+        for (Iterator<Names> it = nameCache.values().iterator(); it.hasNext();) {
+            Names name = it.next();
+            if (player.getUniqueId().equals(name.getUuid())) {
+                names.deleteID(name.getUniqueId());
+                it.remove();
+            }
+        }
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/CommonTestSetup.java
+++ b/src/test/java/world/bentobox/bentobox/CommonTestSetup.java
@@ -141,6 +141,10 @@ public abstract class CommonTestSetup {
         mockedBukkit.when(Bukkit::getPluginManager).thenReturn(pim);
         mockedBukkit.when(Bukkit::getItemFactory).thenReturn(itemFactory);
         mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+        // Nobody is online and nothing is in the user cache unless a test says so. Without
+        // this RETURNS_DEEP_STUBS hands back a mock player for every name ever looked up.
+        mockedBukkit.when(() -> Bukkit.getPlayerExact(anyString())).thenReturn(null);
+        mockedBukkit.when(() -> Bukkit.getOfflinePlayerIfCached(anyString())).thenReturn(null);
         // Location
         when(location.getWorld()).thenReturn(world);
         when(location.getBlockX()).thenReturn(0);

--- a/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
@@ -508,6 +508,75 @@ class PlayersManagerTest extends CommonTestSetup {
     }
 
     /**
+     * Names are unique ignoring case in Minecraft, so any capitalization of a known name
+     * must resolve to the same player. See BentoBox issue #3052.
+     */
+    @Test
+    void testGetUUIDIgnoresCase() {
+        assertEquals(uuid, pm.getUUID("tastybento"));
+        assertEquals(uuid, pm.getUUID("TastyBento"));
+        assertEquals(uuid, pm.getUUID("TASTYBENTO"));
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
+     */
+    @Test
+    void testGetUUIDOnlinePlayerBeatsStaleRecord() {
+        // The stored record points at someone else, e.g. a previous holder of the name
+        Player online = mock(Player.class);
+        when(online.getUniqueId()).thenReturn(notUUID);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("tastybento")).thenReturn(online);
+        assertEquals(notUUID, pm.getUUID("tastybento"));
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
+     */
+    @Test
+    void testGetUUIDFallsBackToCachedOfflinePlayer() {
+        OfflinePlayer cached = mock(OfflinePlayer.class);
+        when(cached.getUniqueId()).thenReturn(notUUID);
+        mockedBukkit.when(() -> Bukkit.getOfflinePlayerIfCached("someoneelse")).thenReturn(cached);
+        assertEquals(notUUID, pm.getUUID("someoneelse"));
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
+     */
+    @Test
+    void testGetUUIDBlankName() {
+        assertNull(pm.getUUID(""));
+        assertNull(pm.getUUID("   "));
+    }
+
+    /**
+     * A record stored under a different spelling of the same name must be deleted, otherwise
+     * it shadows the current one on a case sensitive file system.
+     */
+    @Test
+    void testSetPlayerNameRemovesDifferentlyCasedRecord() throws Exception {
+        when(user.getName()).thenReturn("TastyBento");
+        pm.setPlayerName(user);
+        verify(namesHandler).deleteID("tastybento");
+        assertEquals(uuid, pm.getUUID("tastybento"));
+        assertEquals(uuid, pm.getUUID("TastyBento"));
+    }
+
+    /**
+     * Re-saving the same name must not delete the record that was just written.
+     */
+    @Test
+    void testSetPlayerNameKeepsUnchangedRecord() throws Exception {
+        pm.setPlayerName(user);
+        verify(namesHandler, never()).deleteID("tastybento");
+        assertEquals(uuid, pm.getUUID("tastybento"));
+    }
+
+    /**
      * Test method for
      * {@link world.bentobox.bentobox.managers.PlayersManager#isInTeleport(java.util.UUID)}.
      */


### PR DESCRIPTION
Fixes #3052

## The report

`/ob team trust Oli713664` failed to find the player, and `/ob info Oli713664` answered "that player does not have an island" for a player who has one.

## What was actually wrong

Nothing in the command path lower cases a typed argument — not `CompositeCommand.execute`, not `getCommandFromArgs`, not the Brigadier registrar (which rebuilds args verbatim from `ctx.getInput()`), not the did-you-mean matcher, and not `Util.tabLimit` (it lower cases only for prefix matching and returns the original spelling). `PlayersManager.getUUID` already compared with `equalsIgnoreCase`. So the capitalization was not itself the fault — but the record it compared against could be the wrong one.

`setPlayerName` removed the previous `Names` record from the in-memory cache and **never deleted it from the database**. After a restart every leftover was loaded back, and `getUUID` took `findFirst()` over an unordered list, so a name could resolve to a UUID that had not held it for months. On a case sensitive file system a leftover `oli713664.json` and the current `Oli713664.json` both matched `equalsIgnoreCase`, and whichever the directory listing yielded first won.

That accounts for both symptoms: "no such player" on trust, and `general.errors.player-has-no-island` on info — which is exactly what you get when the lookup returns a *stale* UUID rather than `null`.

## The fix

- **`nameCache` is keyed on the lower cased name.** Minecraft names are unique ignoring case, so there is exactly one entry per name and the match no longer depends on how it was spelled when stored. It also moves from a plain `ArrayList` — mutated from the join listener while commands read it — to a `ConcurrentHashMap`, and the lookup drops from a linear scan of every name ever seen to a single hash lookup.
- **Stale records are deleted.** `setPlayerName` removes any record still pointing at this player under another spelling, and `removePlayer` drops the name lookup too. Existing databases heal as players log in.
- **`getUUID` consults the online player first.** A player standing on the server is authoritative and beats anything stored. It then falls back to the server's own user cache for players BentoBox has never recorded.

### On blocking

The `Names` table exists so that resolving a name never blocks the caller, so every step in `getUUID` is in-memory: `Bukkit.getPlayerExact`, the cache, then `Bukkit.getOfflinePlayerIfCached` — the variant that returns `null` on a miss rather than asking Mojang, unlike the deprecated `getOfflinePlayer(String)`. An earlier draft had a `names.objectExists`/`loadObject` fallback for the shared-database case; it was dropped because on SQL that is two synchronous JDBC round trips on the command thread for every cache miss, including every typo. There is a comment on `nameCache` recording the invariant.

One caveat worth knowing: the stale-record purge calls `names.deleteID(...)`, which JSON and SQL queue asynchronously but `MongoDBDatabaseHandler` runs inline. It only fires when a player's stored name actually differs from their current one — once per rename, not once per join — and `JoinLeaveListener` already does synchronous DB work on that path. Happy to defer it to a startup sweep instead if preferred.

## Tests

Six new cases in `PlayersManagerTest`: mixed-case resolution, online-beats-stale-record, the user-cache fallback, blank input, and both branches of the stale-record deletion.

`CommonTestSetup` mocks `Bukkit` with `RETURNS_DEEP_STUBS`, which handed back a mock player for **every** name ever looked up. It now reports nobody online and nothing cached, which is what MockBukkit's empty server should say; tests that want an online player stub it themselves.

Full suite: 3436 tests, 0 failures.

Also bumps `buildVersion` to 3.22.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvPaJ5jKchGph4FvaJjRu8