### PR TITLE
Stop the panel click cooldown eating Bedrock players' clicks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,9 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - `plugin.yml` and `config.yml` are filtered for the `${version}` placeholder at build time; locale files are copied without filtering.
 - Locale translations are produced with Claude, not GitLocalize. When a key is added to `en-US.yml`, translate it into every other `src/main/resources/locales/*.yml` file in the same PR, preserving each file's existing style (e.g. the MiniMessage-tagged names in `zh-CN.yml` / `zh-HK.yml`).
 - Java preview features are enabled for both compilation and test execution.
-- Local builds produce version `{buildVersion}-LOCAL-SNAPSHOT` (current: `3.22.1-LOCAL-SNAPSHOT`); CI builds append `-b{BUILD_NUMBER}-SNAPSHOT`; `origin/master` builds produce the bare version. The authoritative version is `buildVersion` in `build.gradle.kts`.
+- The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.1`). Two related but different strings come out of it:
+  - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`.
+  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally this doubles the marker (`3.22.1-SNAPSHOT-LOCAL-LOCAL`) because `project.version` already ends in `-LOCAL`; cosmetic, but expected, so don't "fix" it by guessing.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,9 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - Java preview features are enabled for both compilation and test execution.
 - The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.1`). Two related but different strings come out of it:
   - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`.
-  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally this doubles the marker (`3.22.1-SNAPSHOT-LOCAL-LOCAL`) because `project.version` already ends in `-LOCAL`; cosmetic, but expected, so don't "fix" it by guessing.
+  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally it matches the artifact version, `3.22.1-SNAPSHOT-LOCAL`.
+
+  The invariant to preserve when editing this block: **exactly one** of `project.version` and `build.number` carries the build marker. Locally the marker is baked into the revision so the jar filename stays distinguishable from a CI snapshot, which is why `finalBuildNumber` is empty there; setting both is what once stamped `3.22.1-SNAPSHOT-LOCAL-LOCAL` into `plugin.yml`.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/README.md
+++ b/README.md
@@ -132,3 +132,63 @@ dependencies {
 ```
 **Note:** Due to a Gradle issue with versions for Maven, you need to use -SNAPSHOT at the end.
 
+## Building from Source
+
+BentoBox builds with Gradle. You do **not** need to install Gradle — the repository ships
+the Gradle wrapper, which downloads the exact version the project is built with.
+
+### Requirements
+
+* **JDK 25** — BentoBox compiles to Java 25 bytecode, because the Paper API it builds against does.
+* **Git** and an internet connection for the first build.
+
+### Quick start
+
+```bash
+git clone https://github.com/BentoBoxWorld/BentoBox.git
+cd BentoBox
+./gradlew clean build          # use gradlew.bat on Windows
+```
+
+The shaded (fat) jar is written to `build/libs/`, named `BentoBox-<version>.jar` — for example
+`build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`. Drop that straight into your test server's
+`plugins` folder.
+
+`build` runs the tests and produces the shaded jar. If you only want the jar, run
+`./gradlew clean shadowJar` instead.
+
+> **The first build is slow.** The Paperweight plugin downloads and remaps a Paper development
+> bundle before anything compiles. This is a one-off cost — later builds reuse the cached bundle.
+
+### Other useful tasks
+
+| Command | What it does |
+| --- | --- |
+| `./gradlew test` | Run the JUnit 5 test suite |
+| `./gradlew test --tests "world.bentobox.bentobox.managers.IslandsManagerTest"` | Run a single test class |
+| `./gradlew test jacocoTestReport` | Test with a coverage report in `build/reports/jacoco/` |
+| `./gradlew javadocJar` | Build `BentoBox-<version>-javadoc.jar` |
+| `./gradlew sourcesJar` | Build `BentoBox-<version>-sources.jar` |
+| `./gradlew publishToMavenLocal` | Install to `~/.m2` so a local addon can build against it |
+
+Tasks can be combined on one command line, e.g. `./gradlew clean build javadocJar sourcesJar`.
+
+### If Gradle can't find a Java 25 toolchain
+
+Compilation always happens on Java 25 regardless of which JVM runs Gradle itself. If Gradle
+reports that no matching toolchain is available, point it at your JDK 25 installation:
+
+```bash
+./gradlew build -Porg.gradle.java.installations.paths=/path/to/jdk-25
+```
+
+This is what CI does — it runs the Gradle daemon on Java 21 and compiles on a separate
+Java 25 install discovered via `-Porg.gradle.java.installations.fromEnv=JAVA_HOME_25_X64`.
+
+### Version numbers
+
+The version is derived from `buildVersion` in `build.gradle.kts`:
+
+* local builds → `3.22.1-SNAPSHOT-LOCAL`
+* CI builds → `3.22.1-SNAPSHOT` (with the build number recorded separately)
+* release builds from `origin/master` → `3.22.1`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,13 @@ val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 
 // CI/CD Logic (Translates Maven <profiles>)
-// Default version format: 3.10.2-LOCAL-SNAPSHOT
-var finalBuildNumber = buildNumberDefault
-var finalRevision = "$buildVersion$snapshotSuffix$finalBuildNumber"
+// Invariant: plugin.yml renders ${project.version}${build.number}, so exactly one of the
+// two must carry the build marker. Locally the marker is baked into the revision (it keeps
+// the jar filename distinguishable from a CI snapshot), so the build number stays empty --
+// setting both is what produced the doubled '3.22.1-SNAPSHOT-LOCAL-LOCAL' in plugin.yml.
+// Default version format: 3.22.1-SNAPSHOT-LOCAL
+var finalBuildNumber = ""
+var finalRevision = "$buildVersion$snapshotSuffix$buildNumberDefault"
 
 // 'ci' profile logic: Activated by env.BUILD_NUMBER from CI/CD pipeline
 // Overrides build number with actual CI build number

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -88,10 +88,27 @@ public class BentoBox extends JavaPlugin implements Listener {
     // Notifier
     private Notifier notifier;
 
-    // Click limiter. The value tracks whether the "slow down" notice has already been sent for
-    // the current cooldown window, so a spam-clicked panel translates that message at most once
-    // per window instead of on every rejected click.
-    private ExpiringMap<Pair<UUID, String>, AtomicBoolean> lastClick ;
+    // Click limiter. See ClickWindow and onTimeout.
+    private ExpiringMap<Pair<UUID, String>, ClickWindow> lastClick ;
+
+    /**
+     * A panel click cooldown window.
+     * <p>
+     * Records the server tick the window opened on, whether a click that can actually do something
+     * has already been let through in that tick, and whether the "slow down" notice has been sent
+     * for the window - so a spam-clicked panel translates that message at most once per window
+     * instead of on every rejected click.
+     */
+    private static final class ClickWindow {
+        private final int tick;
+        private final AtomicBoolean actioned;
+        private final AtomicBoolean notified = new AtomicBoolean();
+
+        ClickWindow(int tick, boolean actioned) {
+            this.tick = tick;
+            this.actioned = new AtomicBoolean(actioned);
+        }
+    }
 
     private HeadGetter headGetter;
 
@@ -682,21 +699,46 @@ public class BentoBox extends JavaPlugin implements Listener {
      * @return false if they can click and the timeout is started, otherwise true.
      */
     public boolean onTimeout(User user, Panel panel) {
+        return onTimeout(user, panel, true);
+    }
+
+    /**
+     * Checks if a user can click a GUI or needs to slow down.
+     * @param user user
+     * @param panel panel being clicked
+     * @param actionable whether this click lands on something that can actually do work, e.g. a
+     *        panel item with a click handler, as opposed to a filler icon or the player's own
+     *        inventory
+     * @return false if they can click and the timeout is started, otherwise true.
+     * @since 3.22.1
+     */
+    public boolean onTimeout(User user, Panel panel, boolean actionable) {
         Pair<UUID, String> key = new Pair<>(user.getUniqueId(), panel.getName());
-        AtomicBoolean notified = lastClick.get(key);
-        if (notified != null) {
-            // Still within the cooldown window: reject the click. Only translate and send the
-            // "slow down" notice once per window (on the first rejected click). Re-translating
-            // it on every spam click is what needlessly raised MSPT - the message itself is
-            // already throttled by the Notifier, so the player sees no difference.
-            if (notified.compareAndSet(false, true)) {
-                user.notify("general.errors.slow-down");
-            }
-            return true;
+        ClickWindow window = lastClick.get(key);
+        if (window == null) {
+            // First click of a new window - allow it. Do not re-put on later rejected clicks so
+            // the window still expires one cooldown period after this click, not after the last
+            // spam click.
+            lastClick.put(key, new ClickWindow(Bukkit.getCurrentTick(), actionable));
+            return false;
         }
-        // First click of a new window - allow it. Do not re-put on later rejected clicks so the
-        // window still expires one cooldown period after this click, not after the last spam click.
-        lastClick.put(key, new AtomicBoolean(false));
-        return false;
+        if (window.tick == Bukkit.getCurrentTick()) {
+            // Same tick, so this is all one physical gesture: a player cannot click twice inside
+            // a single tick. Clients that expand one click into several packets - notably Geyser,
+            // which turns a single Bedrock tap into a take and a place-back - deliver them all in
+            // the same tick, and the packet that lands on the button is not necessarily the first
+            // one. Let the first click of the gesture that can actually do something through, and
+            // drop the remainder silently instead of telling the player to slow down (#3049).
+            return !actionable || !window.actioned.compareAndSet(false, true);
+        }
+        // A later tick, but still inside the cooldown window: this is genuine spam, so reject the
+        // click. Only translate and send the "slow down" notice once per window (on the first
+        // rejected click). Re-translating it on every spam click is what needlessly raised MSPT -
+        // the message itself is already throttled by the Notifier, so the player sees no
+        // difference.
+        if (window.notified.compareAndSet(false, true)) {
+            user.notify("general.errors.slow-down");
+        }
+        return true;
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
@@ -224,6 +224,26 @@ public class TabbedPanel extends Panel implements PanelListener {
     }
 
     /**
+     * Checks whether a click on a raw slot of this panel can actually do any work, i.e. whether it
+     * lands on a tab icon in the top row or on a panel item that has a click handler. Filler icons,
+     * the footer and clicks in the player's own inventory are no-ops.
+     * <p>
+     * This is used to decide which click of a burst gets priority when a client sends several
+     * click packets for one physical click - see {@link BentoBox#onTimeout(User, Panel, boolean)}.
+     * @param rawSlot raw slot that was clicked
+     * @return {@code true} if a click on this slot does work
+     * @since 3.22.1
+     */
+    public boolean isActionableSlot(int rawSlot) {
+        // Top row tab icons are trapped by onInventoryClick rather than by a click handler
+        if (tpb.getTabs().containsKey(rawSlot)) {
+            return true;
+        }
+        PanelItem item = getItems().get(rawSlot);
+        return item != null && item.getClickHandler().isPresent();
+    }
+
+    /**
      * @return the active tab being shown to the user
      */
     public Tab getActiveTab() {

--- a/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.listeners;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.entity.HumanEntity;
@@ -47,8 +48,13 @@ public class PanelListenerManager implements Listener {
             // early return, every click - even the throttled ones - would still pay for a
             // view.getTitle() render and a MiniMessage title parse below, which is what keeps MSPT
             // high while a settings GUI is being spam-clicked.
-            if (panel.getListener().filter(TabbedPanel.class::isInstance).isPresent()
-                    && BentoBox.getInstance().onTimeout(user, panel)) {
+            // Whether the clicked slot can actually do anything is passed along so that when a
+            // client sends several click packets for one physical click, the cooldown keeps the
+            // one that lands on a button rather than whichever arrived first (#3049).
+            Optional<TabbedPanel> tabbedPanel = panel.getListener().filter(TabbedPanel.class::isInstance)
+                    .map(TabbedPanel.class::cast);
+            if (tabbedPanel.isPresent() && BentoBox.getInstance().onTimeout(user, panel,
+                    tabbedPanel.get().isActionableSlot(event.getRawSlot()))) {
                 return;
             }
 

--- a/src/test/java/world/bentobox/bentobox/BentoBoxClickCooldownTest.java
+++ b/src/test/java/world/bentobox/bentobox/BentoBoxClickCooldownTest.java
@@ -1,0 +1,133 @@
+package world.bentobox.bentobox;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Bukkit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import world.bentobox.bentobox.api.panels.Panel;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.ExpiringMap;
+
+/**
+ * Tests the panel click cooldown, {@link BentoBox#onTimeout(User, Panel, boolean)}.
+ *
+ * @author tastybento
+ */
+class BentoBoxClickCooldownTest extends CommonTestSetup {
+
+    private User user;
+    private Panel panel;
+    private int tick;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        user = User.getInstance(mockPlayer);
+        panel = mock(Panel.class);
+        when(panel.getName()).thenReturn("settings");
+
+        // The cooldown map is normally created in onEnable, which never runs for a mocked plugin
+        Field field = BentoBox.class.getDeclaredField("lastClick");
+        field.setAccessible(true);
+        field.set(plugin, new ExpiringMap<>(1, TimeUnit.MINUTES));
+
+        doCallRealMethod().when(plugin).onTimeout(any(User.class), any(Panel.class), anyBoolean());
+        doCallRealMethod().when(plugin).onTimeout(any(User.class), any(Panel.class));
+
+        // Drive the server tick by hand
+        tick = 100;
+        mockedBukkit.when(Bukkit::getCurrentTick).thenAnswer(invocation -> tick);
+    }
+
+    /**
+     * The first click of a window is always allowed.
+     */
+    @Test
+    void testFirstClickAllowed() {
+        assertFalse(plugin.onTimeout(user, panel, true));
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * A second click in the same tick is a duplicate packet, not spam, so it is dropped without
+     * telling the player to slow down. See #3049.
+     */
+    @Test
+    void testSameTickDuplicateIsSilentlyDropped() {
+        assertFalse(plugin.onTimeout(user, panel, true));
+        assertTrue(plugin.onTimeout(user, panel, true));
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * Geyser expands one Bedrock tap into several Java click packets, and the packet that lands on
+     * the button is not necessarily the first one. The click that can do work must survive even if
+     * a no-op click opened the window in the same tick. See #3049.
+     */
+    @Test
+    void testActionableClickSurvivesEarlierSameTickNoOpClick() {
+        // A click that lands on a filler icon or the player's own inventory opens the window
+        assertFalse(plugin.onTimeout(user, panel, false));
+        // The click that actually presses the button, same tick, still gets through
+        assertFalse(plugin.onTimeout(user, panel, true));
+        // But only once - any further clicks in that tick are dropped, silently
+        assertTrue(plugin.onTimeout(user, panel, true));
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * Clicks in a later tick but still inside the cooldown are genuine spam and are rejected with
+     * the "slow down" notice, which is only sent once per window.
+     */
+    @Test
+    void testLaterTickInsideCooldownIsRejectedAndNotifiedOnce() {
+        assertFalse(plugin.onTimeout(user, panel, true));
+        tick++;
+        assertTrue(plugin.onTimeout(user, panel, true));
+        tick++;
+        assertTrue(plugin.onTimeout(user, panel, true));
+        // The notice is translated and sent at most once per window
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(notifier, times(1)).notify(any(), captor.capture());
+        assertTrue(captor.getValue().contains("slow-down"), captor.getValue());
+    }
+
+    /**
+     * The cooldown is per panel, so a click on a different panel is not blocked.
+     */
+    @Test
+    void testCooldownIsPerPanel() {
+        Panel other = mock(Panel.class);
+        when(other.getName()).thenReturn("other");
+        assertFalse(plugin.onTimeout(user, panel, true));
+        tick++;
+        assertFalse(plugin.onTimeout(user, other, true));
+    }
+
+    /**
+     * The two argument version treats the click as one that can do work.
+     */
+    @Test
+    void testTwoArgOverloadIsActionable() {
+        assertFalse(plugin.onTimeout(user, panel, false));
+        // Would only be allowed if the click counts as actionable
+        assertFalse(plugin.onTimeout(user, panel));
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -405,10 +406,11 @@ class PanelListenerManagerTest extends CommonTestSetup {
         // Set up panel with a TabbedPanel listener
         TabbedPanel tabbedPanel = mock(TabbedPanel.class);
         when(panel.getListener()).thenReturn(Optional.of(tabbedPanel));
+        when(tabbedPanel.isActionableSlot(0)).thenReturn(true);
         PanelListenerManager.getOpenPanels().put(uuid, panel);
 
         // Mock BentoBox.onTimeout to return true (on timeout)
-        when(plugin.onTimeout(any(User.class), eq(panel))).thenReturn(true);
+        when(plugin.onTimeout(any(User.class), eq(panel), anyBoolean())).thenReturn(true);
 
         InventoryClickEvent e = new InventoryClickEvent(view, type, 0, click, inv);
         plm.onInventoryClick(e);
@@ -426,10 +428,11 @@ class PanelListenerManagerTest extends CommonTestSetup {
         // Set up panel with a TabbedPanel listener
         TabbedPanel tabbedPanel = mock(TabbedPanel.class);
         when(panel.getListener()).thenReturn(Optional.of(tabbedPanel));
+        when(tabbedPanel.isActionableSlot(0)).thenReturn(true);
         PanelListenerManager.getOpenPanels().put(uuid, panel);
 
         // Mock BentoBox.onTimeout to return false (no timeout)
-        when(plugin.onTimeout(any(User.class), eq(panel))).thenReturn(false);
+        when(plugin.onTimeout(any(User.class), eq(panel), anyBoolean())).thenReturn(false);
 
         InventoryClickEvent e = new InventoryClickEvent(view, type, 0, click, inv);
         plm.onInventoryClick(e);
@@ -437,6 +440,28 @@ class PanelListenerManagerTest extends CommonTestSetup {
         // Click handler and panel listener should be called
         verify(ch).onClick(eq(panel), any(User.class), eq(click), eq(0));
         verify(tabbedPanel).onInventoryClick(any(), any());
+    }
+
+    /**
+     * Test that whether the clicked slot can do anything is passed to the cooldown check, so that a
+     * client that sends several click packets for one physical click does not have the click that
+     * matters thrown away. See #3049.
+     */
+    @Test
+    void testOnInventoryClickTabbedPanelPassesSlotActionability() {
+        TabbedPanel tabbedPanel = mock(TabbedPanel.class);
+        when(panel.getListener()).thenReturn(Optional.of(tabbedPanel));
+        PanelListenerManager.getOpenPanels().put(uuid, panel);
+
+        // Slot 0 holds an item with a click handler, slot 1 does not
+        when(tabbedPanel.isActionableSlot(0)).thenReturn(true);
+        when(tabbedPanel.isActionableSlot(1)).thenReturn(false);
+
+        plm.onInventoryClick(new InventoryClickEvent(view, type, 0, click, inv));
+        verify(plugin).onTimeout(any(User.class), eq(panel), eq(true));
+
+        plm.onInventoryClick(new InventoryClickEvent(view, type, 1, click, inv));
+        verify(plugin).onTimeout(any(User.class), eq(panel), eq(false));
     }
 
     /**
@@ -454,7 +479,7 @@ class PanelListenerManagerTest extends CommonTestSetup {
         verify(ch).onClick(eq(panel), any(User.class), eq(click), eq(0));
         verify(pl).onInventoryClick(any(), any());
         // onTimeout should NOT be called for non-TabbedPanel
-        verify(plugin, never()).onTimeout(any(User.class), any(Panel.class));
+        verify(plugin, never()).onTimeout(any(User.class), any(Panel.class), anyBoolean());
     }
 
 }


### PR DESCRIPTION
Fixes #3049.

## The bug

A Bedrock player opens `/is settings` and taps any button. BentoBox answers with `general.errors.slow-down` and the click does nothing — on the *first* tap, even after waiting several seconds, with the default 250 ms `panel.click-cooldown-ms`.

## Cause

`lastClick` is an `ExpiringMap` with the cooldown as its TTL, so a genuine wait cannot leave an entry behind. The only way the first click is rejected is that one physical tap produces more than one `InventoryClickEvent` — which is exactly what Geyser does. Bedrock's inventory model sends a whole transaction per tap, and Geyser expands it into a sequence of Java `ServerboundContainerClick` packets (take, then place back) for a container the server keeps cancelling. They arrive in the same tick: packet 1 opens the cooldown window, packet 2 hits it.

This wasn't fatal until 43d32001b moved the check from `TabbedPanel.onInventoryClick` to `PanelListenerManager`. Before that it ran *after* the click handler, so it only blocked tab switching — the duplicate printed the message but the flag still toggled. Now it's an early `return` ahead of the handler, so whichever packet loses the race is discarded outright, and the packet that lands on the button is not necessarily the one that arrived first.

## Fix

Clicks in the same tick as the window opened are treated as one physical gesture — a player cannot click twice inside a single tick, so a same-tick repeat is packet-level duplication, not spam:

- the first click of the gesture that can actually do work (a panel item with a click handler, or a tab icon) is let through;
- the rest are dropped **silently**, with no "slow down" notice;
- a no-op click on a filler icon, the footer, or the player's own inventory no longer consumes the window that the real click needs.

Clicks in a *later* tick but still inside the cooldown are unchanged: rejected, with the notice sent at most once per window. Spam protection is intact — at most one action-bearing click per tick, which is the same rebuild ceiling as before.

## API

`onTimeout(User, Panel)` keeps its signature and behaviour (it now delegates with `actionable = true`); a three-argument overload carries the new flag. `TabbedPanel.isActionableSlot(int)` is new. Both additive, so no binary break for addons.

## Tests

New `BentoBoxClickCooldownTest` covers the same-tick duplicate, the Geyser ordering case (no-op click first, real click second), later-tick spam with a single notice, per-panel isolation, and the two-argument overload. `PanelListenerManagerTest` gains a case asserting the slot's actionability is passed through. Full suite passes.

## Note for review

This is diagnosed from the packet behaviour Geyser is known to produce, not from a Bedrock client here. @qwe664 offered to test dev builds — worth confirming with them before release. If the duplicates turn out to land in *adjacent* ticks rather than the same one, the gesture window needs widening from 1 tick to 2 or 3; everything else in the fix still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)