### PR TITLE
Withdraw an addon's commands when the addon never enables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,11 +156,11 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - `plugin.yml` and `config.yml` are filtered for the `${version}` placeholder at build time; locale files are copied without filtering.
 - Locale translations are produced with Claude, not GitLocalize. When a key is added to `en-US.yml`, translate it into every other `src/main/resources/locales/*.yml` file in the same PR, preserving each file's existing style (e.g. the MiniMessage-tagged names in `zh-CN.yml` / `zh-HK.yml`).
 - Java preview features are enabled for both compilation and test execution.
-- The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.1`). Two related but different strings come out of it:
-  - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`.
-  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally it matches the artifact version, `3.22.1-SNAPSHOT-LOCAL`.
+- The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.2`). Two related but different strings come out of it:
+  - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.2-SNAPSHOT-LOCAL.jar`.
+  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.2-SNAPSHOT-b1234`. Locally it matches the artifact version, `3.22.2-SNAPSHOT-LOCAL`.
 
-  The invariant to preserve when editing this block: **exactly one** of `project.version` and `build.number` carries the build marker. Locally the marker is baked into the revision so the jar filename stays distinguishable from a CI snapshot, which is why `finalBuildNumber` is empty there; setting both is what once stamped `3.22.1-SNAPSHOT-LOCAL-LOCAL` into `plugin.yml`.
+  The invariant to preserve when editing this block: **exactly one** of `project.version` and `build.number` carries the build marker. Locally the marker is baked into the revision so the jar filename stays distinguishable from a CI snapshot, which is why `finalBuildNumber` is empty there; setting both is what once stamped `3.22.2-SNAPSHOT-LOCAL-LOCAL` into `plugin.yml`.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 group = "world.bentobox" // From <groupId>
 
 // Base properties from <properties>
-val buildVersion = "3.22.1"
+val buildVersion = "3.22.2"
 val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -26,6 +26,7 @@ import world.bentobox.bentobox.BStats.CommandFailure;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.command.CommandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -291,6 +292,16 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      * @since 1.5.3
      */
     public boolean call(User user, String cmdLabel, List<String> cmdArgs) {
+        // A game mode's commands are handed their world when the addon enables. If
+        // the addon never got that far its commands are still live but have nothing
+        // behind them, and the first island or world settings lookup throws (#3059).
+        if (addon instanceof GameModeAddon && getWorld() == null) {
+            user.sendMessage("general.errors.general");
+            plugin.logError(addon.getDescription().getName() + " is not enabled, so /" + cmdLabel
+                    + " has no world to act on. Check the startup log for why the addon did not load.");
+            recordFailure(CommandFailure.CANNOT_EXECUTE);
+            return false;
+        }
         // Check for console and permissions
         if (isOnlyPlayer() && !user.isPlayer()) {
             user.sendMessage("general.errors.use-in-game");

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -258,9 +258,11 @@ public class AddonsManager {
         } catch (NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
             // Looks like the addon is incompatible, because it tries to refer to missing classes...
             handleAddonIncompatibility(addon, e);
+            withdrawAddon(addon);
         } catch (Exception e) {
             // Unhandled exception. We'll give a bit of debug here.
             handleAddonError(addon, e);
+            withdrawAddon(addon);
         }
 
     }
@@ -360,10 +362,37 @@ public class AddonsManager {
         } catch (NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
             // Looks like the addon is incompatible, because it tries to refer to missing classes...
             handleAddonIncompatibility(addon, e);
+            withdrawAddon(addon);
         } catch (Exception e) {
             // Unhandled exception. We'll give a bit of debug here.
             handleAddonError(addon, e);
+            withdrawAddon(addon);
         }
+    }
+
+    /**
+     * Takes back everything an addon registered on its way up, for an addon that
+     * will never be enabled.
+     * <p>
+     * An addon's {@code onLoad()} runs before anything knows whether the addon can
+     * actually be enabled, and addons routinely register listeners, flags and
+     * commands there. If the addon then never enables - a missing dependency, an
+     * incompatibility, an exception - those registrations are left behind pointing
+     * at an addon that is not running. For a game mode that is not merely untidy:
+     * its commands are live but their world is only set once the addon enables, and
+     * a game mode command with a null world throws a {@code NullPointerException}
+     * as soon as a player runs it (#3059).
+     *
+     * @param addon addon that is being given up on
+     * @since 3.22.2
+     */
+    private void withdrawAddon(@NonNull Addon addon) {
+        if (listeners.containsKey(addon)) {
+            listeners.get(addon).forEach(HandlerList::unregisterAll);
+            listeners.remove(addon);
+        }
+        plugin.getFlagsManager().unregister(addon);
+        plugin.getCommandsManager().unregisterCommands(addon);
     }
 
     /**
@@ -595,11 +624,12 @@ public class AddonsManager {
                 if (!names.contains(dependency)) {
                     plugin.logError(a.getDescription().getName() + " has dependency on " + dependency
                             + " that does not exist. Addon will not load!");
-                    // The addon's onLoad has already run and may have registered flags whose
-                    // listeners would otherwise stay active for an addon that never enables,
-                    // firing with no worlds behind them
+                    // The addon's onLoad has already run and may have registered listeners,
+                    // flags and commands that would otherwise stay live for an addon that
+                    // never enables - and a game mode's commands only get their world when
+                    // it does enable, so they throw for every player who runs one (#3059).
                     a.setState(State.MISSING_DEPENDENCY);
-                    plugin.getFlagsManager().unregister(a);
+                    withdrawAddon(a);
                     addonsIterator.remove();
                     break;
                 }

--- a/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
@@ -15,6 +15,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.commands.BentoBoxCommand;
 import world.bentobox.bentobox.commands.brigadier.BrigadierCommandRegistrar;
@@ -119,6 +120,53 @@ public class CommandsManager {
     public void refreshCommandTrees() {
         if (brigadier != null) {
             brigadier.refreshTrees();
+        }
+    }
+
+    /**
+     * Unregisters the top level commands owned by an addon.
+     * <p>
+     * Addons commonly build their commands in {@code onLoad()}, and a
+     * {@link CompositeCommand} registers itself the moment it is constructed. An
+     * addon that never gets as far as being enabled - a missing dependency, an
+     * incompatibility, an exception on the way up - therefore leaves live commands
+     * behind whose world was never set, and a game mode command with a null world
+     * throws as soon as anyone runs it (#3059). This takes them back out again.
+     * <p>
+     * Brigadier keeps its nodes, because it has no API for removing one, but a
+     * node whose label no longer resolves to a command is refused by its
+     * {@code requires} predicate and does nothing if it is run anyway, so it is
+     * invisible to clients from here on.
+     *
+     * @param addon addon whose commands should be removed
+     * @since 3.22.2
+     */
+    public void unregisterCommands(@NonNull Addon addon) {
+        List<CompositeCommand> owned = commands.values().stream().filter(c -> addon.equals(c.getAddon())).toList();
+        if (owned.isEmpty()) {
+            return;
+        }
+        owned.forEach(c -> commands.remove(c.getLabel()));
+        if (commandMap != null) {
+            // Use reflection to obtain the knownCommands in the commandMap
+            try {
+                @SuppressWarnings("unchecked")
+                Map<String, Command> knownCommands = (Map<String, Command>) commandMap.getClass()
+                        .getMethod("getKnownCommands").invoke(commandMap);
+                // Remove by key rather than through the values() view - see
+                // unregisterCommands() for why.
+                List<String> labels = knownCommands.entrySet().stream().filter(e -> owned.contains(e.getValue()))
+                        .map(Entry::getKey).toList();
+                labels.forEach(knownCommands::remove);
+                owned.forEach(c -> c.unregister(commandMap));
+            } catch (Exception e) {
+                BentoBox.getInstance()
+                        .logError("Could not unregister commands for " + addon.getDescription().getName() + ": " + e);
+            }
+        }
+        if (brigadier != null) {
+            // Clients are still offering the commands that have just gone away
+            brigadier.refreshClients();
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -229,8 +229,11 @@ public class IslandWorldManager {
      */
     @NonNull
     public WorldSettings getWorldSettings(@NonNull World world) {
-        return Objects.requireNonNull(gameModes.get(world),
-                "Attempt to get WorldSettings for non-game world " + world.getName()).getWorldSettings();
+        // Lazy message: a null world used to throw here while building the very
+        // string meant to explain the problem, which said nothing about the world
+        // being null (#3059).
+        return Objects.requireNonNull(gameModes.get(world), () -> "Attempt to get WorldSettings for non-game world "
+                + (world == null ? "null" : world.getName())).getWorldSettings();
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/api/commands/GameModeCommandWithoutWorldTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/GameModeCommandWithoutWorldTest.java
@@ -1,0 +1,157 @@
+package world.bentobox.bentobox.api.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.addons.AddonDescription;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * A game mode addon's commands are created in its {@code onLoad()} but only
+ * given their world when the addon <i>enables</i>. An addon that never enables -
+ * ChunkBlock with the Level addon it depends on missing, in the report behind
+ * #3059 - therefore leaves live commands with no world behind them, and every
+ * player who ran one got an "unexpected error" and a
+ * {@code NullPointerException} in the console.
+ * <p>
+ * The commands are now taken back out when the addon is given up on, but a
+ * command that does slip through must fail politely rather than throw.
+ *
+ * @author tastybento
+ */
+class GameModeCommandWithoutWorldTest extends CommonTestSetup {
+
+    @Mock
+    private User user;
+    @Mock
+    private GameModeAddon gameMode;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+        AddonDescription description = mock(AddonDescription.class);
+        when(description.getName()).thenReturn("ChunkBlock");
+        when(gameMode.getDescription()).thenReturn(description);
+        when(user.getTranslation(anyString()))
+                .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+        when(user.isPlayer()).thenReturn(true);
+        when(user.isOp()).thenReturn(true);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testWorldlessGameModeCommandIsRefusedRatherThanThrowing() {
+        PlayerCommand command = new PlayerCommand(gameMode);
+        assertNull(command.getWorld(), "Precondition: the addon never enabled, so no world was set");
+
+        assertFalse(command.call(user, "ch", List.of()));
+        assertFalse(command.hasRun, "The command body must not run with no world behind it");
+    }
+
+    @Test
+    void testWorldlessGameModeCommandTellsThePlayer() {
+        PlayerCommand command = new PlayerCommand(gameMode);
+
+        command.call(user, "ch", List.of());
+
+        verify(user).sendMessage("general.errors.general");
+    }
+
+    /**
+     * A sub-command inherits its world from the top of the tree, so it is just as
+     * exposed as the top level command is.
+     */
+    @Test
+    void testWorldlessGameModeSubCommandIsRefused() {
+        PlayerCommand command = new PlayerCommand(gameMode);
+        CompositeCommand create = command.getSubCommand("create").orElseThrow();
+
+        assertFalse(create.call(user, "create", List.of()));
+    }
+
+    /**
+     * BentoBox's own commands legitimately have no world - {@code /bentobox} is not
+     * tied to one - and must not be caught by the guard.
+     */
+    @Test
+    void testWorldlessNonGameModeCommandStillRuns() {
+        PlainCommand command = new PlainCommand();
+
+        assertTrue(command.call(user, "bentobox", List.of()));
+    }
+
+    private static class PlayerCommand extends CompositeCommand {
+        boolean hasRun;
+
+        PlayerCommand(GameModeAddon addon) {
+            super(addon, "ch");
+        }
+
+        @Override
+        public void setup() {
+            new CreateCommand(this);
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            hasRun = true;
+            return true;
+        }
+    }
+
+    private static class CreateCommand extends CompositeCommand {
+        CreateCommand(CompositeCommand parent) {
+            super(parent, "create");
+        }
+
+        @Override
+        public void setup() {
+            // Nothing to set up
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    private static class PlainCommand extends CompositeCommand {
+        PlainCommand() {
+            super("bentobox");
+        }
+
+        @Override
+        public void setup() {
+            // Nothing to set up
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
@@ -875,6 +875,47 @@ class AddonsManagerTest extends CommonTestSetup {
         verify(cm).unregisterCommands();
     }
 
+    // ---- an addon that will never enable leaves nothing behind ----
+
+    /**
+     * A game mode builds its commands in {@code onLoad()}, which has already run by
+     * the time the missing dependency is spotted, but only gets its world when it
+     * enables - which it now never will. Leaving the commands registered means a
+     * {@code NullPointerException} for every player who runs one (#3059).
+     */
+    @Test
+    void testMissingDependencyUnregistersTheAddonsCommands() {
+        GameModeAddon gma = new MyGameMode();
+        gma.setDescription(new AddonDescription.Builder("main", "ChunkBlock", "1.0")
+                .dependencies(List.of("Level")).build());
+        gma.setState(State.LOADED);
+        am.getAddons().add(gma);
+
+        am.loadAddons();
+
+        verify(cm).unregisterCommands(gma);
+        assertEquals(State.MISSING_DEPENDENCY, gma.getState());
+        assertFalse(am.getAddons().contains(gma), "The addon is dropped entirely");
+    }
+
+    @Test
+    void testSatisfiedDependencyKeepsTheAddonsCommands() {
+        GameModeAddon gma = new MyGameMode();
+        gma.setDescription(new AddonDescription.Builder("main", "ChunkBlock", "1.0")
+                .dependencies(List.of("Level")).build());
+        gma.setState(State.LOADED);
+        Addon level = mock(Addon.class);
+        when(level.getDescription()).thenReturn(new AddonDescription.Builder("main", "Level", "1.0").build());
+        when(level.getState()).thenReturn(State.LOADED);
+        am.getAddons().add(gma);
+        am.getAddons().add(level);
+
+        am.loadAddons();
+
+        verify(cm, never()).unregisterCommands(gma);
+        assertEquals(State.LOADED, gma.getState());
+    }
+
     class MyGameMode extends GameModeAddon {
 
         @Override

--- a/src/test/java/world/bentobox/bentobox/managers/CommandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/CommandsManagerTest.java
@@ -18,6 +18,8 @@ import org.mockito.Mock;
 
 import io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager;
 import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.addons.AddonDescription;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 
 /**
@@ -36,6 +38,8 @@ class CommandsManagerTest extends CommonTestSetup {
 
     @Mock
     private LifecycleEventManager<Plugin> lifecycleManager;
+    @Mock
+    private Addon addon;
 
     private CommandsManager cm;
     private CompositeCommand command;
@@ -48,6 +52,10 @@ class CommandsManagerTest extends CommonTestSetup {
         // the legacy path, which would make these tests prove nothing
         when(plugin.getLifecycleManager()).thenReturn(lifecycleManager);
         assertTrue(plugin.getSettings().isUseBrigadierCommands(), "Brigadier registration is on by default");
+
+        AddonDescription description = mock(AddonDescription.class);
+        when(description.getName()).thenReturn("ChunkBlock");
+        when(addon.getDescription()).thenReturn(description);
 
         cm = new CommandsManager();
         command = mock(CompositeCommand.class);
@@ -110,5 +118,65 @@ class CommandsManagerTest extends CommonTestSetup {
         cm.unregisterCommands();
 
         assertTrue(cm.getCommands().isEmpty());
+    }
+
+    /**
+     * An addon that never enables must not leave its commands behind. A game mode's
+     * commands are only given their world when the addon enables, so a leftover
+     * command throws for every player who runs it - see #3059.
+     */
+    @Test
+    void testUnregisterByAddonTakesThatAddonsCommandsOutOfTheCommandMap() {
+        when(command.<Addon>getAddon()).thenReturn(addon);
+        cm.registerCommand(command);
+        assertSame(command, server.getCommandMap().getCommand("ai"), "Precondition: the command was registered");
+
+        cm.unregisterCommands(addon);
+
+        assertNull(server.getCommandMap().getCommand("ai"), "The command must not still be runnable");
+        assertNull(cm.getCommand("ai"), "A leftover entry would keep the Brigadier node alive");
+    }
+
+    @Test
+    void testUnregisterByAddonLeavesOtherAddonsAlone() {
+        when(command.<Addon>getAddon()).thenReturn(addon);
+        CompositeCommand other = mock(CompositeCommand.class);
+        when(other.getLabel()).thenReturn("bsb");
+        when(other.getName()).thenReturn("bsb");
+        when(other.getAliases()).thenReturn(new ArrayList<>());
+        when(other.getSubCommands()).thenReturn(new LinkedHashMap<>());
+        // Built outside the when() - stubbing a mock inside another stubbing call
+        // trips Mockito's unfinished stubbing check
+        Addon otherAddon = namedAddon("BSkyBlock");
+        when(other.<Addon>getAddon()).thenReturn(otherAddon);
+        cm.registerCommand(command);
+        cm.registerCommand(other);
+
+        cm.unregisterCommands(addon);
+
+        assertNull(server.getCommandMap().getCommand("ai"));
+        assertSame(other, server.getCommandMap().getCommand("bsb"), "Only the failed addon's commands go");
+    }
+
+    @Test
+    void testUnregisterByAddonWithNoCommandsIsSafe() {
+        when(command.<Addon>getAddon()).thenReturn(addon);
+        cm.registerCommand(command);
+
+        cm.unregisterCommands(namedAddon("Level"));
+
+        assertSame(command, server.getCommandMap().getCommand("ai"));
+    }
+
+    /**
+     * An addon mock complete enough to be registered with: the command map prefix
+     * comes from the addon's description.
+     */
+    private static Addon namedAddon(String name) {
+        Addon a = mock(Addon.class);
+        AddonDescription description = mock(AddonDescription.class);
+        when(description.getName()).thenReturn(name);
+        when(a.getDescription()).thenReturn(description);
+        return a;
     }
 }


### PR DESCRIPTION
Fixes #3059.

Reported on Discord: a player ran `/ch` on a server with ChunkBlock installed but not the Level addon it depends on, and every subcommand answered "An unexpected error occurred while running the command" with an NPE in the console.

## The bug

A game mode addon builds its commands in `onLoad()`, and `CompositeCommand`'s constructor registers them with the Bukkit command map the moment they are constructed. The world is only attached much later, in `AddonsManager#enableAddon`:

```java
gameMode.getPlayerCommand().ifPresent(c -> c.setWorld(gameMode.getOverWorld()));
```

`sortAddons()` spots the missing dependency *after* `onLoad()` has run. It set the state to `MISSING_DEPENDENCY`, unregistered the addon's flags and dropped it from the addon list — so `enableAddon` never ran — but it left the commands registered. `/ch` stayed live with `getWorld() == null`, and `IslandWorldManager.getWorldSettings(null)` threw on the first lookup.

The same hole existed for an addon abandoned because it is incompatible, or because it threw during `onLoad`/`onEnable`: whatever it registered on the way up stayed behind.

## The fix

**`AddonsManager#withdrawAddon`** takes back everything an addon registered on its way up — listeners, flags and commands — and is now called from all three abandonment paths (missing dependency, incompatibility, unhandled exception during load or enable). Previously only flags were unregistered, and only on the missing-dependency path.

**`CommandsManager#unregisterCommands(Addon)`** is the new method backing that: it pulls the addon's top level commands out of the internal map and the Bukkit command map. Brigadier keeps its nodes, since it has no removal API, but a node whose label no longer resolves to a command is refused by its `requires` predicate and does nothing if run anyway, so it disappears from clients too.

**`CompositeCommand#call`** refuses outright when a command belongs to a `GameModeAddon` and has no world, sending `general.errors.general` and logging which addon is not enabled. Defence in depth for any path the above misses. BentoBox's own world-less commands such as `/bentobox` are not affected.

**`IslandWorldManager#getWorldSettings`** now builds its "non-game world" message lazily. It used to evaluate `world.getName()` eagerly, so a null world threw inside the very string meant to explain the problem — which is why the report showed a bare NPE with no useful message.

## API

`CommandsManager#unregisterCommands(Addon)` is new and additive, so binary compatibility with existing addons is unaffected.

## Tests

- `GameModeCommandWithoutWorldTest` — new: a world-less game mode command is refused rather than throwing, tells the player, applies to sub-commands, and does not catch non-game-mode commands.
- `AddonsManagerTest` — a missing dependency unregisters the addon's commands; a satisfied one does not.
- `CommandsManagerTest` — per-addon unregister removes that addon's commands from the command map, leaves other addons alone, and is safe for an addon with no commands.

Full suite passes.

## Version

Bumped `buildVersion` to 3.22.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJPRnxgoMiVypeN21uRFW4
