### PR TITLE
Send players returning from a standard nether to their own island

### DIFF
--- a/src/main/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListener.java
@@ -453,9 +453,13 @@ public non-sealed class PlayerTeleportListener extends AbstractTeleportListener 
         else
         {
             // Cannot be portal. Should recalculate position.
-            // TODO: Currently, it is always spawn location. However, default home must be assigned.
+            // Prefer the island's spawn point, but most islands never get one because it is only
+            // set by a {spawn here} sign in the blueprint. Fall back to the island's home so that
+            // players returning from a standard nether always land on their own island instead of
+            // the world spawn, which is usually somebody else's island near 0,0.
             Location toLocation = this.getIsland(overWorld, event.getPlayer()).
-                    map(island -> island.getSpawnPoint(World.Environment.NORMAL)).
+                    map(island -> Objects.requireNonNullElseGet(island.getSpawnPoint(World.Environment.NORMAL),
+                            () -> this.plugin.getIslands().getHomeLocation(island))).
                     orElseGet(() -> {
                         // If player do not have island, try spawn.
                         Location spawnLocation = this.getSpawnLocation(overWorld);

--- a/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableSet;
 
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -309,6 +310,84 @@ class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.createEndPlatform(dest);
 
         verify(normalWorld, times(0)).getBlockAt(anyInt(), anyInt(), anyInt());
+    }
+
+    /**
+     * Sets up a return trip from a standard (non-island) nether: the player portals from the
+     * nether world back to the overworld, with nether islands and portal linking both off.
+     *
+     * @return the portal event, ready to be passed to
+     *         {@link PlayerTeleportListener#onPlayerPortalEvent(PlayerPortalEvent)}
+     */
+    private PlayerPortalEvent standardNetherReturnEvent() {
+        World netherWorld = mock(World.class);
+        when(netherWorld.getEnvironment()).thenReturn(Environment.NETHER);
+        mockedUtil.when(() -> Util.getWorld(netherWorld)).thenReturn(world);
+        // Standard nether: no island nethers. Portal linking is off by default in TestWorldSettings.
+        when(iwm.isNetherIslands(world)).thenReturn(false);
+
+        Location from = mock(Location.class);
+        when(from.getWorld()).thenReturn(netherWorld);
+        when(from.toVector()).thenReturn(new Vector(0, 0, 0));
+        return new PlayerPortalEvent(mockPlayer, from, location, TeleportCause.NETHER_PORTAL, 0, false, 0);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
+     * Islands only have a spawn point if their blueprint contains a {spawn here} sign, which
+     * most do not. Without one, a player returning from a standard nether must still be sent
+     * to their own island's home and not to the world spawn.
+     * Regression test for AOneBlock issue #549.
+     */
+    @Test
+    void testPortalProcessFromStandardNetherNoSpawnPointUsesHome() {
+        PlayerPortalEvent e = standardNetherReturnEvent();
+        when(im.getIsland(world, uuid)).thenReturn(island);
+        // No {spawn here} sign was pasted, so the island has no spawn point
+        when(island.getSpawnPoint(Environment.NORMAL)).thenReturn(null);
+        Location home = mock(Location.class);
+        when(home.getWorld()).thenReturn(world);
+        when(home.clone()).thenReturn(home);
+        when(im.getHomeLocation(island)).thenReturn(home);
+
+        ptl.onPlayerPortalEvent(e);
+
+        assertSame(home, e.getTo());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
+     * If the island does have a spawn point, it still wins over the home location.
+     */
+    @Test
+    void testPortalProcessFromStandardNetherSpawnPointWins() {
+        PlayerPortalEvent e = standardNetherReturnEvent();
+        when(im.getIsland(world, uuid)).thenReturn(island);
+        Location spawnPoint = mock(Location.class);
+        when(spawnPoint.getWorld()).thenReturn(world);
+        when(spawnPoint.clone()).thenReturn(spawnPoint);
+        when(island.getSpawnPoint(Environment.NORMAL)).thenReturn(spawnPoint);
+
+        ptl.onPlayerPortalEvent(e);
+
+        assertSame(spawnPoint, e.getTo());
+        verify(im, never()).getHomeLocation(any(Island.class));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
+     * A player without an island still falls back to the world spawn.
+     */
+    @Test
+    void testPortalProcessFromStandardNetherNoIslandUsesSpawn() {
+        PlayerPortalEvent e = standardNetherReturnEvent();
+        when(im.getIsland(world, uuid)).thenReturn(null);
+        // No spawn island, but the world spawn is safe
+        when(im.isSafeLocation(location)).thenReturn(true);
+
+        ptl.onPlayerPortalEvent(e);
+
+        assertSame(location, e.getTo());
     }
 
     /**


### PR DESCRIPTION
## Problem

Reported as [AOneBlock#549](https://github.com/BentoBoxWorld/AOneBlock/issues/549): with AOneBlock's default config (shared nether, `create-and-link-portals: false`), a player who goes through a nether portal and comes back is always dumped on the island near 0,0 — usually somebody else's island, where they have no build rights. `/ob home` works fine, so the island and home data are correct.

## Cause

`PlayerTeleportListener.handleFromStandardNetherOrEnd` resolved the return destination from the island's spawn point only:

```java
Location toLocation = this.getIsland(overWorld, event.getPlayer()).
        map(island -> island.getSpawnPoint(World.Environment.NORMAL)).
        orElseGet(() -> { /* world spawn / from-location fallback */ });
```

`Optional.map` collapses to empty when the mapper returns `null`, so **an island with no spawn point is indistinguishable from having no island at all** and execution falls through to the world-spawn fallback.

An island only gets a spawn point when its blueprint contains a sign whose first line is `{spawn here}` (`DefaultPasteUtil.handleSpawnSign`). AOneBlock's default blueprint is a single bedrock block, so its islands never have one — the fallback fires every single time. BSkyBlock is unaffected because it defaults to island nethers and never reaches this branch.

The code carried a standing `// TODO: Currently, it is always spawn location. However, default home must be assigned.` at that exact spot.

## Fix

Fall back to the island's home location, which is `@NonNull` and defaults to the protection centre, so the player always lands on their own island. The end-exit-portal path already does the equivalent via `getSafeRespawnLocation`.

## Tests

Three new tests in `PlayerTeleportListenerTest` covering the return trip from a standard nether:

- island with no spawn point → routed to the island home (fails without this change)
- island with a spawn point → spawn point still wins, home never consulted
- no island → world-spawn fallback unchanged

Full suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ijeqd5GdQNHbJQh6MwQyP