### PR TITLE
Release 3.22.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - `plugin.yml` and `config.yml` are filtered for the `${version}` placeholder at build time; locale files are copied without filtering.
 - Locale translations are produced with Claude, not GitLocalize. When a key is added to `en-US.yml`, translate it into every other `src/main/resources/locales/*.yml` file in the same PR, preserving each file's existing style (e.g. the MiniMessage-tagged names in `zh-CN.yml` / `zh-HK.yml`).
 - Java preview features are enabled for both compilation and test execution.
-- Local builds produce version `{buildVersion}-LOCAL-SNAPSHOT` (current: `3.22.0-LOCAL-SNAPSHOT`); CI builds append `-b{BUILD_NUMBER}-SNAPSHOT`; `origin/master` builds produce the bare version. The authoritative version is `buildVersion` in `build.gradle.kts`.
+- Local builds produce version `{buildVersion}-LOCAL-SNAPSHOT` (current: `3.22.1-LOCAL-SNAPSHOT`); CI builds append `-b{BUILD_NUMBER}-SNAPSHOT`; `origin/master` builds produce the bare version. The authoritative version is `buildVersion` in `build.gradle.kts`.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,11 +156,11 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - `plugin.yml` and `config.yml` are filtered for the `${version}` placeholder at build time; locale files are copied without filtering.
 - Locale translations are produced with Claude, not GitLocalize. When a key is added to `en-US.yml`, translate it into every other `src/main/resources/locales/*.yml` file in the same PR, preserving each file's existing style (e.g. the MiniMessage-tagged names in `zh-CN.yml` / `zh-HK.yml`).
 - Java preview features are enabled for both compilation and test execution.
-- The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.1`). Two related but different strings come out of it:
-  - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`.
-  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally it matches the artifact version, `3.22.1-SNAPSHOT-LOCAL`.
+- The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.2`). Two related but different strings come out of it:
+  - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.2-SNAPSHOT-LOCAL.jar`.
+  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.2-SNAPSHOT-b1234`. Locally it matches the artifact version, `3.22.2-SNAPSHOT-LOCAL`.
 
-  The invariant to preserve when editing this block: **exactly one** of `project.version` and `build.number` carries the build marker. Locally the marker is baked into the revision so the jar filename stays distinguishable from a CI snapshot, which is why `finalBuildNumber` is empty there; setting both is what once stamped `3.22.1-SNAPSHOT-LOCAL-LOCAL` into `plugin.yml`.
+  The invariant to preserve when editing this block: **exactly one** of `project.version` and `build.number` carries the build marker. Locally the marker is baked into the revision so the jar filename stays distinguishable from a CI snapshot, which is why `finalBuildNumber` is empty there; setting both is what once stamped `3.22.2-SNAPSHOT-LOCAL-LOCAL` into `plugin.yml`.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,9 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - `plugin.yml` and `config.yml` are filtered for the `${version}` placeholder at build time; locale files are copied without filtering.
 - Locale translations are produced with Claude, not GitLocalize. When a key is added to `en-US.yml`, translate it into every other `src/main/resources/locales/*.yml` file in the same PR, preserving each file's existing style (e.g. the MiniMessage-tagged names in `zh-CN.yml` / `zh-HK.yml`).
 - Java preview features are enabled for both compilation and test execution.
-- Local builds produce version `{buildVersion}-LOCAL-SNAPSHOT` (current: `3.22.1-LOCAL-SNAPSHOT`); CI builds append `-b{BUILD_NUMBER}-SNAPSHOT`; `origin/master` builds produce the bare version. The authoritative version is `buildVersion` in `build.gradle.kts`.
+- The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.1`). Two related but different strings come out of it:
+  - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`.
+  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally this doubles the marker (`3.22.1-SNAPSHOT-LOCAL-LOCAL`) because `project.version` already ends in `-LOCAL`; cosmetic, but expected, so don't "fix" it by guessing.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,9 @@ A template like `<green>[description]</green>` looks harmless but is a trap. Tra
 - Java preview features are enabled for both compilation and test execution.
 - The authoritative version is `buildVersion` in `build.gradle.kts` (current: `3.22.1`). Two related but different strings come out of it:
   - **Gradle artifact version** (`project.version`, and so the jar name): `{buildVersion}-SNAPSHOT-LOCAL` locally, `{buildVersion}-SNAPSHOT` on CI (when `BUILD_NUMBER` is set), and the bare `{buildVersion}` when `GIT_BRANCH=origin/master`. So a local build yields `build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`.
-  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally this doubles the marker (`3.22.1-SNAPSHOT-LOCAL-LOCAL`) because `project.version` already ends in `-LOCAL`; cosmetic, but expected, so don't "fix" it by guessing.
+  - **`plugin.yml` version**, the one `/bentobox version` reports: the template is `${project.version}${build.number}`, so CI appends the build number — `3.22.1-SNAPSHOT-b1234`. Locally it matches the artifact version, `3.22.1-SNAPSHOT-LOCAL`.
+
+  The invariant to preserve when editing this block: **exactly one** of `project.version` and `build.number` carries the build marker. Locally the marker is baked into the revision so the jar filename stays distinguishable from a CI snapshot, which is why `finalBuildNumber` is empty there; setting both is what once stamped `3.22.1-SNAPSHOT-LOCAL-LOCAL` into `plugin.yml`.
 
 ### Minecraft 26.x / Java 25 toolchain
 

--- a/README.md
+++ b/README.md
@@ -132,3 +132,63 @@ dependencies {
 ```
 **Note:** Due to a Gradle issue with versions for Maven, you need to use -SNAPSHOT at the end.
 
+## Building from Source
+
+BentoBox builds with Gradle. You do **not** need to install Gradle — the repository ships
+the Gradle wrapper, which downloads the exact version the project is built with.
+
+### Requirements
+
+* **JDK 25** — BentoBox compiles to Java 25 bytecode, because the Paper API it builds against does.
+* **Git** and an internet connection for the first build.
+
+### Quick start
+
+```bash
+git clone https://github.com/BentoBoxWorld/BentoBox.git
+cd BentoBox
+./gradlew clean build          # use gradlew.bat on Windows
+```
+
+The shaded (fat) jar is written to `build/libs/`, named `BentoBox-<version>.jar` — for example
+`build/libs/BentoBox-3.22.1-SNAPSHOT-LOCAL.jar`. Drop that straight into your test server's
+`plugins` folder.
+
+`build` runs the tests and produces the shaded jar. If you only want the jar, run
+`./gradlew clean shadowJar` instead.
+
+> **The first build is slow.** The Paperweight plugin downloads and remaps a Paper development
+> bundle before anything compiles. This is a one-off cost — later builds reuse the cached bundle.
+
+### Other useful tasks
+
+| Command | What it does |
+| --- | --- |
+| `./gradlew test` | Run the JUnit 5 test suite |
+| `./gradlew test --tests "world.bentobox.bentobox.managers.IslandsManagerTest"` | Run a single test class |
+| `./gradlew test jacocoTestReport` | Test with a coverage report in `build/reports/jacoco/` |
+| `./gradlew javadocJar` | Build `BentoBox-<version>-javadoc.jar` |
+| `./gradlew sourcesJar` | Build `BentoBox-<version>-sources.jar` |
+| `./gradlew publishToMavenLocal` | Install to `~/.m2` so a local addon can build against it |
+
+Tasks can be combined on one command line, e.g. `./gradlew clean build javadocJar sourcesJar`.
+
+### If Gradle can't find a Java 25 toolchain
+
+Compilation always happens on Java 25 regardless of which JVM runs Gradle itself. If Gradle
+reports that no matching toolchain is available, point it at your JDK 25 installation:
+
+```bash
+./gradlew build -Porg.gradle.java.installations.paths=/path/to/jdk-25
+```
+
+This is what CI does — it runs the Gradle daemon on Java 21 and compiles on a separate
+Java 25 install discovered via `-Porg.gradle.java.installations.fromEnv=JAVA_HOME_25_X64`.
+
+### Version numbers
+
+The version is derived from `buildVersion` in `build.gradle.kts`:
+
+* local builds → `3.22.1-SNAPSHOT-LOCAL`
+* CI builds → `3.22.1-SNAPSHOT` (with the build number recorded separately)
+* release builds from `origin/master` → `3.22.1`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,13 @@ val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 
 // CI/CD Logic (Translates Maven <profiles>)
-// Default version format: 3.10.2-LOCAL-SNAPSHOT
-var finalBuildNumber = buildNumberDefault
-var finalRevision = "$buildVersion$snapshotSuffix$finalBuildNumber"
+// Invariant: plugin.yml renders ${project.version}${build.number}, so exactly one of the
+// two must carry the build marker. Locally the marker is baked into the revision (it keeps
+// the jar filename distinguishable from a CI snapshot), so the build number stays empty --
+// setting both is what produced the doubled '3.22.1-SNAPSHOT-LOCAL-LOCAL' in plugin.yml.
+// Default version format: 3.22.1-SNAPSHOT-LOCAL
+var finalBuildNumber = ""
+var finalRevision = "$buildVersion$snapshotSuffix$buildNumberDefault"
 
 // 'ci' profile logic: Activated by env.BUILD_NUMBER from CI/CD pipeline
 // Overrides build number with actual CI build number

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 group = "world.bentobox" // From <groupId>
 
 // Base properties from <properties>
-val buildVersion = "3.22.0"
+val buildVersion = "3.22.1"
 val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 group = "world.bentobox" // From <groupId>
 
 // Base properties from <properties>
-val buildVersion = "3.22.1"
+val buildVersion = "3.22.2"
 val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 

--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -88,10 +88,27 @@ public class BentoBox extends JavaPlugin implements Listener {
     // Notifier
     private Notifier notifier;
 
-    // Click limiter. The value tracks whether the "slow down" notice has already been sent for
-    // the current cooldown window, so a spam-clicked panel translates that message at most once
-    // per window instead of on every rejected click.
-    private ExpiringMap<Pair<UUID, String>, AtomicBoolean> lastClick ;
+    // Click limiter. See ClickWindow and onTimeout.
+    private ExpiringMap<Pair<UUID, String>, ClickWindow> lastClick ;
+
+    /**
+     * A panel click cooldown window.
+     * <p>
+     * Records the server tick the window opened on, whether a click that can actually do something
+     * has already been let through in that tick, and whether the "slow down" notice has been sent
+     * for the window - so a spam-clicked panel translates that message at most once per window
+     * instead of on every rejected click.
+     */
+    private static final class ClickWindow {
+        private final int tick;
+        private final AtomicBoolean actioned;
+        private final AtomicBoolean notified = new AtomicBoolean();
+
+        ClickWindow(int tick, boolean actioned) {
+            this.tick = tick;
+            this.actioned = new AtomicBoolean(actioned);
+        }
+    }
 
     private HeadGetter headGetter;
 
@@ -682,21 +699,46 @@ public class BentoBox extends JavaPlugin implements Listener {
      * @return false if they can click and the timeout is started, otherwise true.
      */
     public boolean onTimeout(User user, Panel panel) {
+        return onTimeout(user, panel, true);
+    }
+
+    /**
+     * Checks if a user can click a GUI or needs to slow down.
+     * @param user user
+     * @param panel panel being clicked
+     * @param actionable whether this click lands on something that can actually do work, e.g. a
+     *        panel item with a click handler, as opposed to a filler icon or the player's own
+     *        inventory
+     * @return false if they can click and the timeout is started, otherwise true.
+     * @since 3.22.1
+     */
+    public boolean onTimeout(User user, Panel panel, boolean actionable) {
         Pair<UUID, String> key = new Pair<>(user.getUniqueId(), panel.getName());
-        AtomicBoolean notified = lastClick.get(key);
-        if (notified != null) {
-            // Still within the cooldown window: reject the click. Only translate and send the
-            // "slow down" notice once per window (on the first rejected click). Re-translating
-            // it on every spam click is what needlessly raised MSPT - the message itself is
-            // already throttled by the Notifier, so the player sees no difference.
-            if (notified.compareAndSet(false, true)) {
-                user.notify("general.errors.slow-down");
-            }
-            return true;
+        ClickWindow window = lastClick.get(key);
+        if (window == null) {
+            // First click of a new window - allow it. Do not re-put on later rejected clicks so
+            // the window still expires one cooldown period after this click, not after the last
+            // spam click.
+            lastClick.put(key, new ClickWindow(Bukkit.getCurrentTick(), actionable));
+            return false;
         }
-        // First click of a new window - allow it. Do not re-put on later rejected clicks so the
-        // window still expires one cooldown period after this click, not after the last spam click.
-        lastClick.put(key, new AtomicBoolean(false));
-        return false;
+        if (window.tick == Bukkit.getCurrentTick()) {
+            // Same tick, so this is all one physical gesture: a player cannot click twice inside
+            // a single tick. Clients that expand one click into several packets - notably Geyser,
+            // which turns a single Bedrock tap into a take and a place-back - deliver them all in
+            // the same tick, and the packet that lands on the button is not necessarily the first
+            // one. Let the first click of the gesture that can actually do something through, and
+            // drop the remainder silently instead of telling the player to slow down (#3049).
+            return !actionable || !window.actioned.compareAndSet(false, true);
+        }
+        // A later tick, but still inside the cooldown window: this is genuine spam, so reject the
+        // click. Only translate and send the "slow down" notice once per window (on the first
+        // rejected click). Re-translating it on every spam click is what needlessly raised MSPT -
+        // the message itself is already throttled by the Notifier, so the player sees no
+        // difference.
+        if (window.notified.compareAndSet(false, true)) {
+            user.notify("general.errors.slow-down");
+        }
+        return true;
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -26,6 +26,7 @@ import world.bentobox.bentobox.BStats.CommandFailure;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.Settings;
 import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.command.CommandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -291,6 +292,16 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
      * @since 1.5.3
      */
     public boolean call(User user, String cmdLabel, List<String> cmdArgs) {
+        // A game mode's commands are handed their world when the addon enables. If
+        // the addon never got that far its commands are still live but have nothing
+        // behind them, and the first island or world settings lookup throws (#3059).
+        if (addon instanceof GameModeAddon && getWorld() == null) {
+            user.sendMessage("general.errors.general");
+            plugin.logError(addon.getDescription().getName() + " is not enabled, so /" + cmdLabel
+                    + " has no world to act on. Check the startup log for why the addon did not load.");
+            recordFailure(CommandFailure.CANNOT_EXECUTE);
+            return false;
+        }
         // Check for console and permissions
         if (isOnlyPlayer() && !user.isPlayer()) {
             user.sendMessage("general.errors.use-in-game");

--- a/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
+++ b/src/main/java/world/bentobox/bentobox/api/panels/TabbedPanel.java
@@ -224,6 +224,26 @@ public class TabbedPanel extends Panel implements PanelListener {
     }
 
     /**
+     * Checks whether a click on a raw slot of this panel can actually do any work, i.e. whether it
+     * lands on a tab icon in the top row or on a panel item that has a click handler. Filler icons,
+     * the footer and clicks in the player's own inventory are no-ops.
+     * <p>
+     * This is used to decide which click of a burst gets priority when a client sends several
+     * click packets for one physical click - see {@link BentoBox#onTimeout(User, Panel, boolean)}.
+     * @param rawSlot raw slot that was clicked
+     * @return {@code true} if a click on this slot does work
+     * @since 3.22.1
+     */
+    public boolean isActionableSlot(int rawSlot) {
+        // Top row tab icons are trapped by onInventoryClick rather than by a click handler
+        if (tpb.getTabs().containsKey(rawSlot)) {
+            return true;
+        }
+        PanelItem item = getItems().get(rawSlot);
+        return item != null && item.getClickHandler().isPresent();
+    }
+
+    /**
      * @return the active tab being shown to the user
      */
     public Tab getActiveTab() {

--- a/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PanelListenerManager.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.listeners;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.bukkit.entity.HumanEntity;
@@ -47,8 +48,13 @@ public class PanelListenerManager implements Listener {
             // early return, every click - even the throttled ones - would still pay for a
             // view.getTitle() render and a MiniMessage title parse below, which is what keeps MSPT
             // high while a settings GUI is being spam-clicked.
-            if (panel.getListener().filter(TabbedPanel.class::isInstance).isPresent()
-                    && BentoBox.getInstance().onTimeout(user, panel)) {
+            // Whether the clicked slot can actually do anything is passed along so that when a
+            // client sends several click packets for one physical click, the cooldown keeps the
+            // one that lands on a button rather than whichever arrived first (#3049).
+            Optional<TabbedPanel> tabbedPanel = panel.getListener().filter(TabbedPanel.class::isInstance)
+                    .map(TabbedPanel.class::cast);
+            if (tabbedPanel.isPresent() && BentoBox.getInstance().onTimeout(user, panel,
+                    tabbedPanel.get().isActionableSlot(event.getRawSlot()))) {
                 return;
             }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListener.java
@@ -453,9 +453,13 @@ public non-sealed class PlayerTeleportListener extends AbstractTeleportListener 
         else
         {
             // Cannot be portal. Should recalculate position.
-            // TODO: Currently, it is always spawn location. However, default home must be assigned.
+            // Prefer the island's spawn point, but most islands never get one because it is only
+            // set by a {spawn here} sign in the blueprint. Fall back to the island's home so that
+            // players returning from a standard nether always land on their own island instead of
+            // the world spawn, which is usually somebody else's island near 0,0.
             Location toLocation = this.getIsland(overWorld, event.getPlayer()).
-                    map(island -> island.getSpawnPoint(World.Environment.NORMAL)).
+                    map(island -> Objects.requireNonNullElseGet(island.getSpawnPoint(World.Environment.NORMAL),
+                            () -> this.plugin.getIslands().getHomeLocation(island))).
                     orElseGet(() -> {
                         // If player do not have island, try spawn.
                         Location spawnLocation = this.getSpawnLocation(overWorld);

--- a/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/AddonsManager.java
@@ -258,9 +258,11 @@ public class AddonsManager {
         } catch (NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
             // Looks like the addon is incompatible, because it tries to refer to missing classes...
             handleAddonIncompatibility(addon, e);
+            withdrawAddon(addon);
         } catch (Exception e) {
             // Unhandled exception. We'll give a bit of debug here.
             handleAddonError(addon, e);
+            withdrawAddon(addon);
         }
 
     }
@@ -360,10 +362,37 @@ public class AddonsManager {
         } catch (NoClassDefFoundError | NoSuchMethodError | NoSuchFieldError e) {
             // Looks like the addon is incompatible, because it tries to refer to missing classes...
             handleAddonIncompatibility(addon, e);
+            withdrawAddon(addon);
         } catch (Exception e) {
             // Unhandled exception. We'll give a bit of debug here.
             handleAddonError(addon, e);
+            withdrawAddon(addon);
         }
+    }
+
+    /**
+     * Takes back everything an addon registered on its way up, for an addon that
+     * will never be enabled.
+     * <p>
+     * An addon's {@code onLoad()} runs before anything knows whether the addon can
+     * actually be enabled, and addons routinely register listeners, flags and
+     * commands there. If the addon then never enables - a missing dependency, an
+     * incompatibility, an exception - those registrations are left behind pointing
+     * at an addon that is not running. For a game mode that is not merely untidy:
+     * its commands are live but their world is only set once the addon enables, and
+     * a game mode command with a null world throws a {@code NullPointerException}
+     * as soon as a player runs it (#3059).
+     *
+     * @param addon addon that is being given up on
+     * @since 3.22.2
+     */
+    private void withdrawAddon(@NonNull Addon addon) {
+        if (listeners.containsKey(addon)) {
+            listeners.get(addon).forEach(HandlerList::unregisterAll);
+            listeners.remove(addon);
+        }
+        plugin.getFlagsManager().unregister(addon);
+        plugin.getCommandsManager().unregisterCommands(addon);
     }
 
     /**
@@ -595,11 +624,12 @@ public class AddonsManager {
                 if (!names.contains(dependency)) {
                     plugin.logError(a.getDescription().getName() + " has dependency on " + dependency
                             + " that does not exist. Addon will not load!");
-                    // The addon's onLoad has already run and may have registered flags whose
-                    // listeners would otherwise stay active for an addon that never enables,
-                    // firing with no worlds behind them
+                    // The addon's onLoad has already run and may have registered listeners,
+                    // flags and commands that would otherwise stay live for an addon that
+                    // never enables - and a game mode's commands only get their world when
+                    // it does enable, so they throw for every player who runs one (#3059).
                     a.setState(State.MISSING_DEPENDENCY);
-                    plugin.getFlagsManager().unregister(a);
+                    withdrawAddon(a);
                     addonsIterator.remove();
                     break;
                 }

--- a/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/CommandsManager.java
@@ -15,6 +15,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.commands.BentoBoxCommand;
 import world.bentobox.bentobox.commands.brigadier.BrigadierCommandRegistrar;
@@ -119,6 +120,53 @@ public class CommandsManager {
     public void refreshCommandTrees() {
         if (brigadier != null) {
             brigadier.refreshTrees();
+        }
+    }
+
+    /**
+     * Unregisters the top level commands owned by an addon.
+     * <p>
+     * Addons commonly build their commands in {@code onLoad()}, and a
+     * {@link CompositeCommand} registers itself the moment it is constructed. An
+     * addon that never gets as far as being enabled - a missing dependency, an
+     * incompatibility, an exception on the way up - therefore leaves live commands
+     * behind whose world was never set, and a game mode command with a null world
+     * throws as soon as anyone runs it (#3059). This takes them back out again.
+     * <p>
+     * Brigadier keeps its nodes, because it has no API for removing one, but a
+     * node whose label no longer resolves to a command is refused by its
+     * {@code requires} predicate and does nothing if it is run anyway, so it is
+     * invisible to clients from here on.
+     *
+     * @param addon addon whose commands should be removed
+     * @since 3.22.2
+     */
+    public void unregisterCommands(@NonNull Addon addon) {
+        List<CompositeCommand> owned = commands.values().stream().filter(c -> addon.equals(c.getAddon())).toList();
+        if (owned.isEmpty()) {
+            return;
+        }
+        owned.forEach(c -> commands.remove(c.getLabel()));
+        if (commandMap != null) {
+            // Use reflection to obtain the knownCommands in the commandMap
+            try {
+                @SuppressWarnings("unchecked")
+                Map<String, Command> knownCommands = (Map<String, Command>) commandMap.getClass()
+                        .getMethod("getKnownCommands").invoke(commandMap);
+                // Remove by key rather than through the values() view - see
+                // unregisterCommands() for why.
+                List<String> labels = knownCommands.entrySet().stream().filter(e -> owned.contains(e.getValue()))
+                        .map(Entry::getKey).toList();
+                labels.forEach(knownCommands::remove);
+                owned.forEach(c -> c.unregister(commandMap));
+            } catch (Exception e) {
+                BentoBox.getInstance()
+                        .logError("Could not unregister commands for " + addon.getDescription().getName() + ": " + e);
+            }
+        }
+        if (brigadier != null) {
+            // Clients are still offering the commands that have just gone away
+            brigadier.refreshClients();
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/IslandWorldManager.java
@@ -229,8 +229,11 @@ public class IslandWorldManager {
      */
     @NonNull
     public WorldSettings getWorldSettings(@NonNull World world) {
-        return Objects.requireNonNull(gameModes.get(world),
-                "Attempt to get WorldSettings for non-game world " + world.getName()).getWorldSettings();
+        // Lazy message: a null world used to throw here while building the very
+        // string meant to explain the problem, which said nothing about the world
+        // being null (#3059).
+        return Objects.requireNonNull(gameModes.get(world), () -> "Attempt to get WorldSettings for non-game world "
+                + (world == null ? "null" : world.getName())).getWorldSettings();
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PlayersManager.java
@@ -3,13 +3,19 @@ package world.bentobox.bentobox.managers;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
@@ -32,7 +38,16 @@ public class PlayersManager {
     private Database<Players> handler;
     private final Database<Names> names;
     private final ExpiringMap<UUID, Players> playerCache = new ExpiringMap<>(2, TimeUnit.HOURS);
-    private final @NonNull List<Names> nameCache;
+    /**
+     * Name to UUID lookup, keyed on the lower cased name so that lookups never depend
+     * on how the name happened to be capitalized when it was stored. Minecraft names are
+     * unique ignoring case, so the key is unambiguous.
+     * <p>
+     * This table is the whole reason {@link #getUUID(String)} can be called from a command:
+     * it is loaded once at startup and kept current as players join, so a lookup never has
+     * to hit the database. Keep {@code getUUID} free of blocking calls.
+     */
+    private final @NonNull Map<String, Names> nameCache = new ConcurrentHashMap<>();
     private final Set<UUID> inTeleport; // this needs databasing
 
     /**
@@ -48,8 +63,25 @@ public class PlayersManager {
         handler = new Database<>(plugin, Players.class);
         // Set up the names database
         names = new Database<>(plugin, Names.class);
-        nameCache = names.loadObjects();
+        names.loadObjects().forEach(this::cacheName);
         inTeleport = new HashSet<>();
+    }
+
+    /**
+     * Key used for name lookups. Names are matched ignoring case throughout.
+     */
+    private static String nameKey(@NonNull String name) {
+        return name.toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Puts a name record into the lookup cache, ignoring records that cannot be used.
+     */
+    private void cacheName(@Nullable Names name) {
+        if (name != null && name.getUuid() != null && name.getUniqueId() != null
+                && !name.getUniqueId().isEmpty()) {
+            nameCache.put(nameKey(name.getUniqueId()), name);
+        }
     }
 
     /**
@@ -133,6 +165,10 @@ public class PlayersManager {
 
     /**
      * Attempts to return a UUID for a given player's name.
+     * <p>
+     * Names are matched ignoring case: Minecraft names are unique ignoring case, so
+     * {@code Oli713664} and {@code oli713664} are the same player and both must resolve.
+     *
      * @param name - name of player
      * @return UUID of player or null if unknown
      */
@@ -147,8 +183,29 @@ public class PlayersManager {
                 // Not used
             }
         }
-        return nameCache.stream().filter(n -> n.getUniqueId().equalsIgnoreCase(name)).findFirst()
-                .map(Names::getUuid).orElse(null);
+        if (name.isBlank()) {
+            return null;
+        }
+        // Every step below is an in-memory lookup. The Names table exists precisely so that
+        // resolving a name never blocks the calling thread, so nothing here may touch the
+        // database or the network - see the class comment on nameCache.
+
+        // An online player is authoritative. Bukkit matches the name ignoring case, and this
+        // beats anything stored, which may be a leftover record from a previous holder of the
+        // name or predate a rename.
+        Player online = Bukkit.getPlayerExact(name);
+        if (online != null) {
+            return online.getUniqueId();
+        }
+        Names cached = nameCache.get(nameKey(name));
+        if (cached != null) {
+            return cached.getUuid();
+        }
+        // Last resort: the server's own user cache, which knows players BentoBox has never
+        // seen. Unlike the deprecated getOfflinePlayer(String), this never makes a web
+        // request - it returns null on a miss rather than going looking.
+        OfflinePlayer offline = Bukkit.getOfflinePlayerIfCached(name);
+        return offline == null ? null : offline.getUniqueId();
     }
 
     /**
@@ -166,9 +223,19 @@ public class PlayersManager {
         handler.saveObjectAsync(player);
         // Update names
         Names newName = new Names(user.getName(), user.getUniqueId());
+        // Drop any record that still points at this player under some other spelling - an old
+        // name, or this name stored with different capitalization. Left in place it keeps
+        // resolving to a UUID that is no longer correct for that name, and on a case sensitive
+        // file system it shadows the record written below.
+        for (Iterator<Names> it = nameCache.values().iterator(); it.hasNext();) {
+            Names old = it.next();
+            if (user.getUniqueId().equals(old.getUuid()) && !user.getName().equals(old.getUniqueId())) {
+                names.deleteID(old.getUniqueId());
+                it.remove();
+            }
+        }
         // Add to cache
-        nameCache.removeIf(name -> user.getUniqueId().equals(name.getUuid()));
-        nameCache.add(newName);
+        cacheName(newName);
         // Add to names database
         return names.saveObjectAsync(newName);
     }
@@ -342,6 +409,15 @@ public class PlayersManager {
      */
     public void removePlayer(Player player) {
         handler.deleteID(player.getUniqueId().toString());
+        // Drop the name lookup too, otherwise the name keeps resolving to a player that
+        // no longer has any data.
+        for (Iterator<Names> it = nameCache.values().iterator(); it.hasNext();) {
+            Names name = it.next();
+            if (player.getUniqueId().equals(name.getUuid())) {
+                names.deleteID(name.getUniqueId());
+                it.remove();
+            }
+        }
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/BentoBoxClickCooldownTest.java
+++ b/src/test/java/world/bentobox/bentobox/BentoBoxClickCooldownTest.java
@@ -1,0 +1,133 @@
+package world.bentobox.bentobox;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Bukkit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import world.bentobox.bentobox.api.panels.Panel;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.ExpiringMap;
+
+/**
+ * Tests the panel click cooldown, {@link BentoBox#onTimeout(User, Panel, boolean)}.
+ *
+ * @author tastybento
+ */
+class BentoBoxClickCooldownTest extends CommonTestSetup {
+
+    private User user;
+    private Panel panel;
+    private int tick;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        user = User.getInstance(mockPlayer);
+        panel = mock(Panel.class);
+        when(panel.getName()).thenReturn("settings");
+
+        // The cooldown map is normally created in onEnable, which never runs for a mocked plugin
+        Field field = BentoBox.class.getDeclaredField("lastClick");
+        field.setAccessible(true);
+        field.set(plugin, new ExpiringMap<>(1, TimeUnit.MINUTES));
+
+        doCallRealMethod().when(plugin).onTimeout(any(User.class), any(Panel.class), anyBoolean());
+        doCallRealMethod().when(plugin).onTimeout(any(User.class), any(Panel.class));
+
+        // Drive the server tick by hand
+        tick = 100;
+        mockedBukkit.when(Bukkit::getCurrentTick).thenAnswer(invocation -> tick);
+    }
+
+    /**
+     * The first click of a window is always allowed.
+     */
+    @Test
+    void testFirstClickAllowed() {
+        assertFalse(plugin.onTimeout(user, panel, true));
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * A second click in the same tick is a duplicate packet, not spam, so it is dropped without
+     * telling the player to slow down. See #3049.
+     */
+    @Test
+    void testSameTickDuplicateIsSilentlyDropped() {
+        assertFalse(plugin.onTimeout(user, panel, true));
+        assertTrue(plugin.onTimeout(user, panel, true));
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * Geyser expands one Bedrock tap into several Java click packets, and the packet that lands on
+     * the button is not necessarily the first one. The click that can do work must survive even if
+     * a no-op click opened the window in the same tick. See #3049.
+     */
+    @Test
+    void testActionableClickSurvivesEarlierSameTickNoOpClick() {
+        // A click that lands on a filler icon or the player's own inventory opens the window
+        assertFalse(plugin.onTimeout(user, panel, false));
+        // The click that actually presses the button, same tick, still gets through
+        assertFalse(plugin.onTimeout(user, panel, true));
+        // But only once - any further clicks in that tick are dropped, silently
+        assertTrue(plugin.onTimeout(user, panel, true));
+        verify(notifier, never()).notify(any(), anyString());
+    }
+
+    /**
+     * Clicks in a later tick but still inside the cooldown are genuine spam and are rejected with
+     * the "slow down" notice, which is only sent once per window.
+     */
+    @Test
+    void testLaterTickInsideCooldownIsRejectedAndNotifiedOnce() {
+        assertFalse(plugin.onTimeout(user, panel, true));
+        tick++;
+        assertTrue(plugin.onTimeout(user, panel, true));
+        tick++;
+        assertTrue(plugin.onTimeout(user, panel, true));
+        // The notice is translated and sent at most once per window
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(notifier, times(1)).notify(any(), captor.capture());
+        assertTrue(captor.getValue().contains("slow-down"), captor.getValue());
+    }
+
+    /**
+     * The cooldown is per panel, so a click on a different panel is not blocked.
+     */
+    @Test
+    void testCooldownIsPerPanel() {
+        Panel other = mock(Panel.class);
+        when(other.getName()).thenReturn("other");
+        assertFalse(plugin.onTimeout(user, panel, true));
+        tick++;
+        assertFalse(plugin.onTimeout(user, other, true));
+    }
+
+    /**
+     * The two argument version treats the click as one that can do work.
+     */
+    @Test
+    void testTwoArgOverloadIsActionable() {
+        assertFalse(plugin.onTimeout(user, panel, false));
+        // Would only be allowed if the click counts as actionable
+        assertFalse(plugin.onTimeout(user, panel));
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/CommonTestSetup.java
+++ b/src/test/java/world/bentobox/bentobox/CommonTestSetup.java
@@ -141,6 +141,10 @@ public abstract class CommonTestSetup {
         mockedBukkit.when(Bukkit::getPluginManager).thenReturn(pim);
         mockedBukkit.when(Bukkit::getItemFactory).thenReturn(itemFactory);
         mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+        // Nobody is online and nothing is in the user cache unless a test says so. Without
+        // this RETURNS_DEEP_STUBS hands back a mock player for every name ever looked up.
+        mockedBukkit.when(() -> Bukkit.getPlayerExact(anyString())).thenReturn(null);
+        mockedBukkit.when(() -> Bukkit.getOfflinePlayerIfCached(anyString())).thenReturn(null);
         // Location
         when(location.getWorld()).thenReturn(world);
         when(location.getBlockX()).thenReturn(0);

--- a/src/test/java/world/bentobox/bentobox/api/commands/GameModeCommandWithoutWorldTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/GameModeCommandWithoutWorldTest.java
@@ -1,0 +1,157 @@
+package world.bentobox.bentobox.api.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.addons.AddonDescription;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * A game mode addon's commands are created in its {@code onLoad()} but only
+ * given their world when the addon <i>enables</i>. An addon that never enables -
+ * ChunkBlock with the Level addon it depends on missing, in the report behind
+ * #3059 - therefore leaves live commands with no world behind them, and every
+ * player who ran one got an "unexpected error" and a
+ * {@code NullPointerException} in the console.
+ * <p>
+ * The commands are now taken back out when the addon is given up on, but a
+ * command that does slip through must fail politely rather than throw.
+ *
+ * @author tastybento
+ */
+class GameModeCommandWithoutWorldTest extends CommonTestSetup {
+
+    @Mock
+    private User user;
+    @Mock
+    private GameModeAddon gameMode;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        CommandsManager cm = mock(CommandsManager.class);
+        when(plugin.getCommandsManager()).thenReturn(cm);
+        AddonDescription description = mock(AddonDescription.class);
+        when(description.getName()).thenReturn("ChunkBlock");
+        when(gameMode.getDescription()).thenReturn(description);
+        when(user.getTranslation(anyString()))
+                .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
+        when(user.isPlayer()).thenReturn(true);
+        when(user.isOp()).thenReturn(true);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testWorldlessGameModeCommandIsRefusedRatherThanThrowing() {
+        PlayerCommand command = new PlayerCommand(gameMode);
+        assertNull(command.getWorld(), "Precondition: the addon never enabled, so no world was set");
+
+        assertFalse(command.call(user, "ch", List.of()));
+        assertFalse(command.hasRun, "The command body must not run with no world behind it");
+    }
+
+    @Test
+    void testWorldlessGameModeCommandTellsThePlayer() {
+        PlayerCommand command = new PlayerCommand(gameMode);
+
+        command.call(user, "ch", List.of());
+
+        verify(user).sendMessage("general.errors.general");
+    }
+
+    /**
+     * A sub-command inherits its world from the top of the tree, so it is just as
+     * exposed as the top level command is.
+     */
+    @Test
+    void testWorldlessGameModeSubCommandIsRefused() {
+        PlayerCommand command = new PlayerCommand(gameMode);
+        CompositeCommand create = command.getSubCommand("create").orElseThrow();
+
+        assertFalse(create.call(user, "create", List.of()));
+    }
+
+    /**
+     * BentoBox's own commands legitimately have no world - {@code /bentobox} is not
+     * tied to one - and must not be caught by the guard.
+     */
+    @Test
+    void testWorldlessNonGameModeCommandStillRuns() {
+        PlainCommand command = new PlainCommand();
+
+        assertTrue(command.call(user, "bentobox", List.of()));
+    }
+
+    private static class PlayerCommand extends CompositeCommand {
+        boolean hasRun;
+
+        PlayerCommand(GameModeAddon addon) {
+            super(addon, "ch");
+        }
+
+        @Override
+        public void setup() {
+            new CreateCommand(this);
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            hasRun = true;
+            return true;
+        }
+    }
+
+    private static class CreateCommand extends CompositeCommand {
+        CreateCommand(CompositeCommand parent) {
+            super(parent, "create");
+        }
+
+        @Override
+        public void setup() {
+            // Nothing to set up
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    private static class PlainCommand extends CompositeCommand {
+        PlainCommand() {
+            super("bentobox");
+        }
+
+        @Override
+        public void setup() {
+            // Nothing to set up
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/PanelListenerManagerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -405,10 +406,11 @@ class PanelListenerManagerTest extends CommonTestSetup {
         // Set up panel with a TabbedPanel listener
         TabbedPanel tabbedPanel = mock(TabbedPanel.class);
         when(panel.getListener()).thenReturn(Optional.of(tabbedPanel));
+        when(tabbedPanel.isActionableSlot(0)).thenReturn(true);
         PanelListenerManager.getOpenPanels().put(uuid, panel);
 
         // Mock BentoBox.onTimeout to return true (on timeout)
-        when(plugin.onTimeout(any(User.class), eq(panel))).thenReturn(true);
+        when(plugin.onTimeout(any(User.class), eq(panel), anyBoolean())).thenReturn(true);
 
         InventoryClickEvent e = new InventoryClickEvent(view, type, 0, click, inv);
         plm.onInventoryClick(e);
@@ -426,10 +428,11 @@ class PanelListenerManagerTest extends CommonTestSetup {
         // Set up panel with a TabbedPanel listener
         TabbedPanel tabbedPanel = mock(TabbedPanel.class);
         when(panel.getListener()).thenReturn(Optional.of(tabbedPanel));
+        when(tabbedPanel.isActionableSlot(0)).thenReturn(true);
         PanelListenerManager.getOpenPanels().put(uuid, panel);
 
         // Mock BentoBox.onTimeout to return false (no timeout)
-        when(plugin.onTimeout(any(User.class), eq(panel))).thenReturn(false);
+        when(plugin.onTimeout(any(User.class), eq(panel), anyBoolean())).thenReturn(false);
 
         InventoryClickEvent e = new InventoryClickEvent(view, type, 0, click, inv);
         plm.onInventoryClick(e);
@@ -437,6 +440,28 @@ class PanelListenerManagerTest extends CommonTestSetup {
         // Click handler and panel listener should be called
         verify(ch).onClick(eq(panel), any(User.class), eq(click), eq(0));
         verify(tabbedPanel).onInventoryClick(any(), any());
+    }
+
+    /**
+     * Test that whether the clicked slot can do anything is passed to the cooldown check, so that a
+     * client that sends several click packets for one physical click does not have the click that
+     * matters thrown away. See #3049.
+     */
+    @Test
+    void testOnInventoryClickTabbedPanelPassesSlotActionability() {
+        TabbedPanel tabbedPanel = mock(TabbedPanel.class);
+        when(panel.getListener()).thenReturn(Optional.of(tabbedPanel));
+        PanelListenerManager.getOpenPanels().put(uuid, panel);
+
+        // Slot 0 holds an item with a click handler, slot 1 does not
+        when(tabbedPanel.isActionableSlot(0)).thenReturn(true);
+        when(tabbedPanel.isActionableSlot(1)).thenReturn(false);
+
+        plm.onInventoryClick(new InventoryClickEvent(view, type, 0, click, inv));
+        verify(plugin).onTimeout(any(User.class), eq(panel), eq(true));
+
+        plm.onInventoryClick(new InventoryClickEvent(view, type, 1, click, inv));
+        verify(plugin).onTimeout(any(User.class), eq(panel), eq(false));
     }
 
     /**
@@ -454,7 +479,7 @@ class PanelListenerManagerTest extends CommonTestSetup {
         verify(ch).onClick(eq(panel), any(User.class), eq(click), eq(0));
         verify(pl).onInventoryClick(any(), any());
         // onTimeout should NOT be called for non-TabbedPanel
-        verify(plugin, never()).onTimeout(any(User.class), any(Panel.class));
+        verify(plugin, never()).onTimeout(any(User.class), any(Panel.class), anyBoolean());
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/teleports/PlayerTeleportListenerTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableSet;
 
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 
 /**
@@ -309,6 +310,84 @@ class PlayerTeleportListenerTest extends CommonTestSetup {
         ptl.createEndPlatform(dest);
 
         verify(normalWorld, times(0)).getBlockAt(anyInt(), anyInt(), anyInt());
+    }
+
+    /**
+     * Sets up a return trip from a standard (non-island) nether: the player portals from the
+     * nether world back to the overworld, with nether islands and portal linking both off.
+     *
+     * @return the portal event, ready to be passed to
+     *         {@link PlayerTeleportListener#onPlayerPortalEvent(PlayerPortalEvent)}
+     */
+    private PlayerPortalEvent standardNetherReturnEvent() {
+        World netherWorld = mock(World.class);
+        when(netherWorld.getEnvironment()).thenReturn(Environment.NETHER);
+        mockedUtil.when(() -> Util.getWorld(netherWorld)).thenReturn(world);
+        // Standard nether: no island nethers. Portal linking is off by default in TestWorldSettings.
+        when(iwm.isNetherIslands(world)).thenReturn(false);
+
+        Location from = mock(Location.class);
+        when(from.getWorld()).thenReturn(netherWorld);
+        when(from.toVector()).thenReturn(new Vector(0, 0, 0));
+        return new PlayerPortalEvent(mockPlayer, from, location, TeleportCause.NETHER_PORTAL, 0, false, 0);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
+     * Islands only have a spawn point if their blueprint contains a {spawn here} sign, which
+     * most do not. Without one, a player returning from a standard nether must still be sent
+     * to their own island's home and not to the world spawn.
+     * Regression test for AOneBlock issue #549.
+     */
+    @Test
+    void testPortalProcessFromStandardNetherNoSpawnPointUsesHome() {
+        PlayerPortalEvent e = standardNetherReturnEvent();
+        when(im.getIsland(world, uuid)).thenReturn(island);
+        // No {spawn here} sign was pasted, so the island has no spawn point
+        when(island.getSpawnPoint(Environment.NORMAL)).thenReturn(null);
+        Location home = mock(Location.class);
+        when(home.getWorld()).thenReturn(world);
+        when(home.clone()).thenReturn(home);
+        when(im.getHomeLocation(island)).thenReturn(home);
+
+        ptl.onPlayerPortalEvent(e);
+
+        assertSame(home, e.getTo());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
+     * If the island does have a spawn point, it still wins over the home location.
+     */
+    @Test
+    void testPortalProcessFromStandardNetherSpawnPointWins() {
+        PlayerPortalEvent e = standardNetherReturnEvent();
+        when(im.getIsland(world, uuid)).thenReturn(island);
+        Location spawnPoint = mock(Location.class);
+        when(spawnPoint.getWorld()).thenReturn(world);
+        when(spawnPoint.clone()).thenReturn(spawnPoint);
+        when(island.getSpawnPoint(Environment.NORMAL)).thenReturn(spawnPoint);
+
+        ptl.onPlayerPortalEvent(e);
+
+        assertSame(spawnPoint, e.getTo());
+        verify(im, never()).getHomeLocation(any(Island.class));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.listeners.teleports.PlayerTeleportListener#onPlayerPortalEvent(org.bukkit.event.player.PlayerPortalEvent)}.
+     * A player without an island still falls back to the world spawn.
+     */
+    @Test
+    void testPortalProcessFromStandardNetherNoIslandUsesSpawn() {
+        PlayerPortalEvent e = standardNetherReturnEvent();
+        when(im.getIsland(world, uuid)).thenReturn(null);
+        // No spawn island, but the world spawn is safe
+        when(im.isSafeLocation(location)).thenReturn(true);
+
+        ptl.onPlayerPortalEvent(e);
+
+        assertSame(location, e.getTo());
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/AddonsManagerTest.java
@@ -875,6 +875,47 @@ class AddonsManagerTest extends CommonTestSetup {
         verify(cm).unregisterCommands();
     }
 
+    // ---- an addon that will never enable leaves nothing behind ----
+
+    /**
+     * A game mode builds its commands in {@code onLoad()}, which has already run by
+     * the time the missing dependency is spotted, but only gets its world when it
+     * enables - which it now never will. Leaving the commands registered means a
+     * {@code NullPointerException} for every player who runs one (#3059).
+     */
+    @Test
+    void testMissingDependencyUnregistersTheAddonsCommands() {
+        GameModeAddon gma = new MyGameMode();
+        gma.setDescription(new AddonDescription.Builder("main", "ChunkBlock", "1.0")
+                .dependencies(List.of("Level")).build());
+        gma.setState(State.LOADED);
+        am.getAddons().add(gma);
+
+        am.loadAddons();
+
+        verify(cm).unregisterCommands(gma);
+        assertEquals(State.MISSING_DEPENDENCY, gma.getState());
+        assertFalse(am.getAddons().contains(gma), "The addon is dropped entirely");
+    }
+
+    @Test
+    void testSatisfiedDependencyKeepsTheAddonsCommands() {
+        GameModeAddon gma = new MyGameMode();
+        gma.setDescription(new AddonDescription.Builder("main", "ChunkBlock", "1.0")
+                .dependencies(List.of("Level")).build());
+        gma.setState(State.LOADED);
+        Addon level = mock(Addon.class);
+        when(level.getDescription()).thenReturn(new AddonDescription.Builder("main", "Level", "1.0").build());
+        when(level.getState()).thenReturn(State.LOADED);
+        am.getAddons().add(gma);
+        am.getAddons().add(level);
+
+        am.loadAddons();
+
+        verify(cm, never()).unregisterCommands(gma);
+        assertEquals(State.LOADED, gma.getState());
+    }
+
     class MyGameMode extends GameModeAddon {
 
         @Override

--- a/src/test/java/world/bentobox/bentobox/managers/CommandsManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/CommandsManagerTest.java
@@ -18,6 +18,8 @@ import org.mockito.Mock;
 
 import io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager;
 import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.api.addons.AddonDescription;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 
 /**
@@ -36,6 +38,8 @@ class CommandsManagerTest extends CommonTestSetup {
 
     @Mock
     private LifecycleEventManager<Plugin> lifecycleManager;
+    @Mock
+    private Addon addon;
 
     private CommandsManager cm;
     private CompositeCommand command;
@@ -48,6 +52,10 @@ class CommandsManagerTest extends CommonTestSetup {
         // the legacy path, which would make these tests prove nothing
         when(plugin.getLifecycleManager()).thenReturn(lifecycleManager);
         assertTrue(plugin.getSettings().isUseBrigadierCommands(), "Brigadier registration is on by default");
+
+        AddonDescription description = mock(AddonDescription.class);
+        when(description.getName()).thenReturn("ChunkBlock");
+        when(addon.getDescription()).thenReturn(description);
 
         cm = new CommandsManager();
         command = mock(CompositeCommand.class);
@@ -110,5 +118,65 @@ class CommandsManagerTest extends CommonTestSetup {
         cm.unregisterCommands();
 
         assertTrue(cm.getCommands().isEmpty());
+    }
+
+    /**
+     * An addon that never enables must not leave its commands behind. A game mode's
+     * commands are only given their world when the addon enables, so a leftover
+     * command throws for every player who runs it - see #3059.
+     */
+    @Test
+    void testUnregisterByAddonTakesThatAddonsCommandsOutOfTheCommandMap() {
+        when(command.<Addon>getAddon()).thenReturn(addon);
+        cm.registerCommand(command);
+        assertSame(command, server.getCommandMap().getCommand("ai"), "Precondition: the command was registered");
+
+        cm.unregisterCommands(addon);
+
+        assertNull(server.getCommandMap().getCommand("ai"), "The command must not still be runnable");
+        assertNull(cm.getCommand("ai"), "A leftover entry would keep the Brigadier node alive");
+    }
+
+    @Test
+    void testUnregisterByAddonLeavesOtherAddonsAlone() {
+        when(command.<Addon>getAddon()).thenReturn(addon);
+        CompositeCommand other = mock(CompositeCommand.class);
+        when(other.getLabel()).thenReturn("bsb");
+        when(other.getName()).thenReturn("bsb");
+        when(other.getAliases()).thenReturn(new ArrayList<>());
+        when(other.getSubCommands()).thenReturn(new LinkedHashMap<>());
+        // Built outside the when() - stubbing a mock inside another stubbing call
+        // trips Mockito's unfinished stubbing check
+        Addon otherAddon = namedAddon("BSkyBlock");
+        when(other.<Addon>getAddon()).thenReturn(otherAddon);
+        cm.registerCommand(command);
+        cm.registerCommand(other);
+
+        cm.unregisterCommands(addon);
+
+        assertNull(server.getCommandMap().getCommand("ai"));
+        assertSame(other, server.getCommandMap().getCommand("bsb"), "Only the failed addon's commands go");
+    }
+
+    @Test
+    void testUnregisterByAddonWithNoCommandsIsSafe() {
+        when(command.<Addon>getAddon()).thenReturn(addon);
+        cm.registerCommand(command);
+
+        cm.unregisterCommands(namedAddon("Level"));
+
+        assertSame(command, server.getCommandMap().getCommand("ai"));
+    }
+
+    /**
+     * An addon mock complete enough to be registered with: the command map prefix
+     * comes from the addon's description.
+     */
+    private static Addon namedAddon(String name) {
+        Addon a = mock(Addon.class);
+        AddonDescription description = mock(AddonDescription.class);
+        when(description.getName()).thenReturn(name);
+        when(a.getDescription()).thenReturn(description);
+        return a;
     }
 }

--- a/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PlayersManagerTest.java
@@ -508,6 +508,75 @@ class PlayersManagerTest extends CommonTestSetup {
     }
 
     /**
+     * Names are unique ignoring case in Minecraft, so any capitalization of a known name
+     * must resolve to the same player. See BentoBox issue #3052.
+     */
+    @Test
+    void testGetUUIDIgnoresCase() {
+        assertEquals(uuid, pm.getUUID("tastybento"));
+        assertEquals(uuid, pm.getUUID("TastyBento"));
+        assertEquals(uuid, pm.getUUID("TASTYBENTO"));
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
+     */
+    @Test
+    void testGetUUIDOnlinePlayerBeatsStaleRecord() {
+        // The stored record points at someone else, e.g. a previous holder of the name
+        Player online = mock(Player.class);
+        when(online.getUniqueId()).thenReturn(notUUID);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("tastybento")).thenReturn(online);
+        assertEquals(notUUID, pm.getUUID("tastybento"));
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
+     */
+    @Test
+    void testGetUUIDFallsBackToCachedOfflinePlayer() {
+        OfflinePlayer cached = mock(OfflinePlayer.class);
+        when(cached.getUniqueId()).thenReturn(notUUID);
+        mockedBukkit.when(() -> Bukkit.getOfflinePlayerIfCached("someoneelse")).thenReturn(cached);
+        assertEquals(notUUID, pm.getUUID("someoneelse"));
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.bentobox.managers.PlayersManager#getUUID(java.lang.String)}.
+     */
+    @Test
+    void testGetUUIDBlankName() {
+        assertNull(pm.getUUID(""));
+        assertNull(pm.getUUID("   "));
+    }
+
+    /**
+     * A record stored under a different spelling of the same name must be deleted, otherwise
+     * it shadows the current one on a case sensitive file system.
+     */
+    @Test
+    void testSetPlayerNameRemovesDifferentlyCasedRecord() throws Exception {
+        when(user.getName()).thenReturn("TastyBento");
+        pm.setPlayerName(user);
+        verify(namesHandler).deleteID("tastybento");
+        assertEquals(uuid, pm.getUUID("tastybento"));
+        assertEquals(uuid, pm.getUUID("TastyBento"));
+    }
+
+    /**
+     * Re-saving the same name must not delete the record that was just written.
+     */
+    @Test
+    void testSetPlayerNameKeepsUnchangedRecord() throws Exception {
+        pm.setPlayerName(user);
+        verify(namesHandler, never()).deleteID("tastybento");
+        assertEquals(uuid, pm.getUUID("tastybento"));
+    }
+
+    /**
      * Test method for
      * {@link world.bentobox.bentobox.managers.PlayersManager#isInTeleport(java.util.UUID)}.
      */


### PR DESCRIPTION
Release PR for **BentoBox 3.22.1** — a bug-fix patch on top of 3.22.0.

Four fixes, no new features, no config keys and no locale changes.

* 🔺 Resolve player names without depending on stored capitalization — #3057, fixes #3052
* Stop the panel click cooldown eating Bedrock players' clicks — #3058, fixes #3049
* Withdraw an addon's commands when the addon never enables — #3060, fixes #3059
* Send players returning from a standard nether to their own island — #3061, fixes BentoBoxWorld/AOneBlock#549

Plus a local-build `plugin.yml` version fix and README/CLAUDE.md documentation updates.

Draft release notes accompany this PR. **Full Changelog**: https://github.com/BentoBoxWorld/BentoBox/compare/3.22.0...develop