### PR TITLE
Do not put texture-less profiles on player heads

### DIFF
--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadCache.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadCache.java
@@ -83,6 +83,30 @@ public class HeadCache
 
 
     /**
+     * Checks if this cache holds a usable skin texture.
+     * <p>
+     * A profile that has a name and a UUID but no texture property is worse than no
+     * profile at all: the server resolves it against the Mojang session server every time
+     * the head is shown, which quickly earns an HTTP 429 and still renders a default skin.
+     *
+     * @return {@code true} if the cached profile has a skin texture.
+     * @since 3.23.0
+     */
+    public boolean hasTexture()
+    {
+        try
+        {
+            return this.playerProfile != null && this.playerProfile.getTextures().getSkin() != null;
+        }
+        catch (Exception e)
+        {
+            // Treat an unreadable profile as having no texture.
+            return false;
+        }
+    }
+
+
+    /**
      * Returns a new Player head with a cached texture. Be AWARE, usage does not use clone
      * method. If for some reason item stack is stored directly, then use clone in return
      * :)
@@ -94,8 +118,8 @@ public class HeadCache
         ItemStack item = new ItemStack(Material.PLAYER_HEAD);
         SkullMeta meta = (SkullMeta) item.getItemMeta();
 
-        // Set correct Skull texture
-        if (meta != null && this.playerProfile != null)
+        // Set correct Skull texture. Only if the texture is actually known - see hasTexture.
+        if (meta != null && this.hasTexture())
         {
             try {
                 meta.setOwnerProfile(this.playerProfile);

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadCache.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadCache.java
@@ -90,7 +90,7 @@ public class HeadCache
      * the head is shown, which quickly earns an HTTP 429 and still renders a default skin.
      *
      * @return {@code true} if the cached profile has a skin texture.
-     * @since 3.23.0
+     * @since 3.22.3
      */
     public boolean hasTexture()
     {

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -176,11 +176,21 @@ public class HeadGetter {
                                     HeadGetter.createProfile(userName, userId, HeadGetter.getTextureFromUUID(userId)));
                         }
 
-                        // Save in cache
-                        HeadGetter.cachedHeads.put(userName, cache);
+                        // Save in cache. A failed lookup must not evict a texture we already
+                        // have, otherwise one rate-limited call costs a working head for the
+                        // whole cache period.
+                        HeadCache previous = HeadGetter.cachedHeads.get(userName);
+
+                        if (cache.hasTexture() || previous == null || !previous.hasTexture()) {
+                            HeadGetter.cachedHeads.put(userName, cache);
+                        } else {
+                            cache = previous;
+                        }
 
                         // Tell requesters the head came in, but only if the texture is usable.
-                        if (cache.playerProfile != null && HeadGetter.headRequesters.containsKey(userName)) {
+                        // Handing out a profile with no texture makes the server look it up at
+                        // Mojang every time the head is shown, which ends in HTTP 429s.
+                        if (cache.hasTexture() && HeadGetter.headRequesters.containsKey(userName)) {
                             for (HeadRequester req : HeadGetter.headRequesters.get(userName)) {
                                 elementEntry.getValue().setHead(cache.getPlayerHead());
 


### PR DESCRIPTION
## Problem

Opening a panel full of player heads (a top ten, for example) can spam the console with:

```
[WARN]: Couldn't look up profile properties for c44d4387-e438-4880-bb8a-4e267340feda
MinecraftClientHttpException[type=HTTP_ERROR, status=429, response=null]
	at com.mojang.authlib.minecraft.client.MinecraftClient.buildHttpException(MinecraftClient.java:160)
	...
	at com.destroystokyo.paper.profile.PaperMinecraftSessionService.fetchProfile(PaperMinecraftSessionService.java:40)
	at org.bukkit.craftbukkit.profile.CraftPlayerProfile.getUpdatedProfile(CraftPlayerProfile.java:157)
```

Those lookups are made by the server, not by us. A `PlayerProfile` that carries a UUID **and** a name but no `textures` property is incomplete, so the server resolves it against the Mojang session server every time the head is shown — see PaperMC/Paper#13727 and the discussion on PaperMC/Paper#13692. Ten heads in a panel is ten lookups per open, which reaches HTTP 429 quickly and still renders a default skin at the end of it.

`HeadGetter` produces precisely that profile whenever its own texture fetch comes back empty: `createProfile()` always returns a profile, with or without a skin, and `getTextureFromUUID()` swallows every failure and returns `null`. It then hands the result to requesters regardless, because the check guarding delivery —

```java
// Tell requesters the head came in, but only if the texture is usable.
if (cache.playerProfile != null && HeadGetter.headRequesters.containsKey(userName)) {
```

— tests for a null profile, which `createProfile()` never returns. The comment describes an intent the code never implemented.

The failed lookup was also written straight over the cache, so one rate-limited call replaced a working head with a broken one for the whole cache period. Since the broken profile then triggers a fresh server-side lookup on every panel open, the failure sustains itself.

## Changes

- **`HeadCache`** gains `hasTexture()`, and `getPlayerHead()` only calls `setOwnerProfile()` when a skin is actually known. With no profile attached there is nothing for the server to resolve, so a failed lookup degrades to a plain head instead of one that keeps hitting Mojang.
- **`HeadGetter`** only notifies requesters when the texture is usable, making the existing comment true, and no longer lets a failed fetch evict a cached head that already has a texture.

No API is removed; `hasTexture()` is additive.

## Testing

`./gradlew compileJava` is clean and `PanelTest`, which exercises `HeadGetter`, passes. Other `*PanelTest` classes in the tree fail identically before and after this change (`UnfinishedStubbingException` during static init), unrelated to heads.

## Note for server owners

Setting `use-cache-server: true` is still worth doing independently. The defaults (`heads-per-call: 9`, `ticks-between-calls: 10`) allow roughly 18 direct requests per second to `sessionserver.mojang.com` from BentoBox's own fetcher, which is enough to trip the rate limit that starts this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HtnKzNE649pBrCdqMm7nw
