### PR TITLE
Add general.metrics config toggle to opt out of bStats

### DIFF
--- a/src/main/java/world/bentobox/bentobox/BentoBox.java
+++ b/src/main/java/world/bentobox/bentobox/BentoBox.java
@@ -258,8 +258,10 @@ public class BentoBox extends JavaPlugin implements Listener {
         flagsManager.registerListeners();
 
         // Load metrics
-        metrics = new BStats(this);
-        metrics.registerMetrics();
+        if (settings.isMetrics()) {
+            metrics = new BStats(this);
+            metrics.registerMetrics();
+        }
 
         // Register Multiverse hook - MV loads AFTER BentoBox
         // Make sure all worlds are already registered to Multiverse.

--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -44,6 +44,14 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "general.charge-for-blueprint-on-reset")
     private boolean chargeForBlueprintOnReset = false;
 
+    @ConfigComment("Submit anonymous, aggregate usage statistics to bStats (https://bstats.org/plugin/bukkit/BentoBox/3555).")
+    @ConfigComment("No personal data is ever sent - see https://github.com/BentoBoxWorld/.github/blob/master/PRIVACY.md")
+    @ConfigComment("Setting this to false disables metrics for BentoBox only; the global switch in")
+    @ConfigComment("plugins/bStats/config.yml disables bStats for every plugin on the server.")
+    @ConfigComment("Changing this setting requires a server restart.")
+    @ConfigEntry(path = "general.metrics", since = "3.22.3")
+    private boolean metrics = true;
+
     /* COMMANDS */
     @ConfigComment("Console commands to run when BentoBox has loaded all worlds and addons.")
     @ConfigComment("Commands are run as the console.")
@@ -607,6 +615,22 @@ public class Settings implements ConfigObject {
 
     public void setChargeForBlueprintOnReset(boolean chargeForBlueprintOnReset) {
         this.chargeForBlueprintOnReset = chargeForBlueprintOnReset;
+    }
+
+    /**
+     * @return whether anonymous usage statistics are submitted to bStats
+     * @since 3.22.3
+     */
+    public boolean isMetrics() {
+        return metrics;
+    }
+
+    /**
+     * @param metrics whether anonymous usage statistics are submitted to bStats
+     * @since 3.22.3
+     */
+    public void setMetrics(boolean metrics) {
+        this.metrics = metrics;
     }
 
     public DatabaseType getDatabaseType() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,13 @@ general:
   # Whether to charge the blueprint bundle cost when a player resets their island.
   # If false, only island creation will charge the cost.
   charge-for-blueprint-on-reset: false
+  # Submit anonymous, aggregate usage statistics to bStats (https://bstats.org/plugin/bukkit/BentoBox/3555).
+  # No personal data is ever sent - see https://github.com/BentoBoxWorld/.github/blob/master/PRIVACY.md
+  # Setting this to false disables metrics for BentoBox only; the global switch in
+  # plugins/bStats/config.yml disables bStats for every plugin on the server.
+  # Changing this setting requires a server restart.
+  # Added since 3.22.3.
+  metrics: true
   # Console commands to run when BentoBox has loaded all worlds and addons.
   # Commands are run as the console.
   # e.g. set aliases for worlds in Multiverse here, or anything you need to

--- a/src/test/java/world/bentobox/bentobox/SettingsTest.java
+++ b/src/test/java/world/bentobox/bentobox/SettingsTest.java
@@ -68,6 +68,23 @@ class SettingsTest {
     }
 
     /**
+     * Test method for {@link world.bentobox.bentobox.Settings#isMetrics()}.
+     */
+    @Test
+    void testIsMetrics() {
+        assertTrue(s.isMetrics());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bentobox.Settings#setMetrics(boolean)}.
+     */
+    @Test
+    void testSetMetrics() {
+        s.setMetrics(false);
+        assertFalse(s.isMetrics());
+    }
+
+    /**
      * Test method for {@link world.bentobox.bentobox.Settings#getDatabaseType()}.
      */
     @Test


### PR DESCRIPTION
Adds a BentoBox-specific metrics opt-out, complementing the global bStats switch.

- New `general.metrics` setting (default `true`, `since 3.22.3`) in `Settings.java` and the bundled `config.yml`, with comments linking the privacy policy (BentoBoxWorld/.github#14).
- `BentoBox.onEnable` only constructs/registers `BStats` when the setting is on. `getMetrics()` then returns an empty `Optional`, and all recording call sites (`NewIsland`, `JoinLeaveListener`, `CompositeCommand`) already go through `ifPresent`, so nothing is collected or submitted.
- Config comment notes a restart is required — `/bentobox reload` cannot unregister bStats.
- `SettingsTest` covers the new getter/setter; `SettingsTest`, `BStatsTest`, and `CommandFailureStatsTest` pass.

The privacy policy and docs PRs will be updated to mention this toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkVFZoe4hB2Req885z5ea7