### PR TITLE
Compile against Paper 26.2 now that MockBukkit supports it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,19 +89,18 @@ val javaVersion = "25"
 val junitVersion = "5.10.2"
 val mockitoVersion = "5.11.0"
 // MockBukkit's modern, per-Minecraft-version artifacts are published to Paper's Maven repo
-// under org.mockbukkit.mockbukkit (see the testImplementation coordinate below). The closest
-// available to Paper 26.2 is the 26.1.2 line (no 26.2 build exists yet); 4.113.2 is the latest.
-val mockBukkitVersion = "4.113.2"
+// under org.mockbukkit.mockbukkit (see the testImplementation coordinate below). 4.116.1 is the
+// first release with a 26.2 artifact, built against 26.2.build.111-stable.
+val mockBukkitVersion = "4.116.1"
 val mongodbVersion = "3.12.12"
 val mariadbVersion = "3.0.5"
 val mysqlVersion = "8.0.27"
 val postgresqlVersion = "42.2.18"
 val hikaricpVersion = "5.0.1"
-// Compile against the latest stable 26.1.2 dev bundle. This is the newest Paper API that has a
-// matching MockBukkit release (mockbukkit-v26.1.2); MockBukkit does not yet support 26.2's new
-// registries. Minecraft 26.2 is still fully supported at runtime (see ServerCompatibility and
-// the Modrinth game-versions list); 26.2-only blocks/entities are accessed via Enums.getIfPresent.
-val paperVersion = "26.1.2.build.72-stable"
+// Compile against the 26.2 dev bundle MockBukkit 4.116.1 was built against, so the API under
+// test and the API compiled against are the same. Note 26.2 brings Adventure 5, which makes
+// ClickEvent generic (payload() rather than value()) and seals Component so it cannot be mocked.
+val paperVersion = "26.2.build.111-stable"
 val bstatsVersion = "3.0.0"
 val vaultVersion = "1.7.1"
 val levelVersion = "2.21.3"
@@ -257,7 +256,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitVersion")
     testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
-    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v26.1.2:$mockBukkitVersion")
+    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v26.2:$mockBukkitVersion")
     testImplementation("org.awaitility:awaitility:$awaitilityVersion")
     testImplementation("io.papermc.paper:paper-api:$paperVersion")
     testImplementation("com.github.MilkBowl:VaultAPI:$vaultVersion")

--- a/src/test/java/world/bentobox/bentobox/listeners/BlockEndDragonTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/BlockEndDragonTest.java
@@ -131,7 +131,8 @@ class BlockEndDragonTest extends CommonTestSetup {
      */
     @Test
     void testOnPlayerJoinWorld() {
-        Component component = mock(Component.class);
+        // Adventure 5 seals Component, so it cannot be mocked
+        Component component = Component.empty();
         PlayerJoinEvent event = new PlayerJoinEvent(mockPlayer, component);
         bed.onPlayerJoinWorld(event);
         verify(block).setType(Material.END_PORTAL, false);

--- a/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/JoinLeaveListenerTest.java
@@ -87,8 +87,8 @@ class JoinLeaveListenerTest extends RanksManagerTestSetup {
 
     private AddonDescription desc;
     
-    @Mock
-    private Component component;
+    // Adventure 5 seals Component, so join/quit messages are real components now
+    private final Component component = Component.empty();
 
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/bentobox/suggestions/DidYouMeanScenarioTest.java
+++ b/src/test/java/world/bentobox/bentobox/suggestions/DidYouMeanScenarioTest.java
@@ -314,8 +314,11 @@ class DidYouMeanScenarioTest extends CommonTestSetup {
     }
 
     private boolean hasClickRunning(Component component, String command) {
-        ClickEvent click = component.clickEvent();
-        if (click != null && click.action() == ClickEvent.Action.RUN_COMMAND && command.equals(click.value())) {
+        // Adventure 5 made the click event generic: what used to be a bare string value is
+        // now a typed payload
+        ClickEvent<?> click = component.clickEvent();
+        if (click != null && click.action() == ClickEvent.Action.RUN_COMMAND
+                && click.payload() instanceof ClickEvent.Payload.Text text && command.equals(text.value())) {
             return true;
         }
         return component.children().stream().anyMatch(child -> hasClickRunning(child, command));


### PR DESCRIPTION
The Paper pin sat at the 26.1.2 dev bundle for one reason, recorded in `build.gradle.kts`: MockBukkit had no 26.2 artifact, so the API under test could not match the API compiled against. [MockBukkit 4.116.1](https://github.com/MockBukkit/MockBukkit/releases/tag/v4.116.1) ships `mockbukkit-v26.2`, built against `26.2.build.111-stable`. That reason is gone.

- `paperVersion` → `26.2.build.111-stable` (the exact bundle MockBukkit was built against)
- `mockBukkitVersion` → `4.116.1`, artifact → `mockbukkit-v26.2`
- the two now-stale comments explaining the pin are rewritten

**Main code compiled unchanged. Full suite green: 3462 tests.**

## Adventure 5

26.2 brings Adventure 5, which needed three test fixes — and these are the interesting part of this PR, because they are what addon authors will hit:

**`ClickEvent` is now generic with a typed payload.** `click.value()` → `click.payload() instanceof ClickEvent.Payload.Text`. `ClickEvent.Action` is also no longer an enum, so `values()` / `valueOf()` are gone (`==` comparison still works).

**`Component` is sealed, so Mockito cannot mock it.** Two tests passed `mock(Component.class)` as a join/quit message; they now use a real `Component.empty()`. Note this fails at *runtime*, not compile time — a build won't catch it, only running the tests will. 77 Adventure types are sealed in 5, including `TextComponent`, `Style`, `BossBar`, `Title`, `Book`, `Sound` and the builders.

## Blast radius for addons

I diffed `adventure-api` 4.26.1 against 5.2.0 to get the real removal list rather than working from what this PR happened to hit. The removals an addon could plausibly call:

| Removed | Replacement |
|---|---|
| `ClickEvent.value()` | `payload()` |
| `ClickEvent.Action.values()` / `valueOf()` | no longer an enum |
| `BossBar.percent()`, `MIN/MAX_PERCENT` | `progress()` |
| `TranslatableComponent.args()` | `arguments()` |
| `Component.replaceFirstText()`, `TextComponent.ofChildren()` | removed |
| `TranslationRegistry`, `MessageType`, `Audience.sendMessage(Identity, …)` | removed |
| `Title.Times.of()`, `HoverEvent.ShowItem/ShowEntity.of()`, `NamedTextColor.ofExact()`, `TextDecoration.as()` | removed |

Surveyed 59 local addon repos against that list: **41 never touch Adventure, and of the 18 that do, none use anything that was removed.** (The detector was validated by pointing it at this repo pre-fix, where it found exactly the three real breakages and nothing else.) TradeWinds is the only addon using Adventure's own `BossBar`, and it already calls `progress()`.

Caveats worth keeping in mind: that survey covers local checkouts only, not third-party addons. And it covers *recompiles* — an addon jar built against Adventure 4 that calls a removed method already breaks at runtime on a 26.2 server today, since Adventure 5 arrives with the server rather than with BentoBox. This PR does not change that.

**Suggested release note:** call out the two concrete edits above (`ClickEvent.value()` → `payload()`, and mocked `Component` in tests), since those are what a third-party author will actually run into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEwab2kL4i1FNnBYvSmp