### PR TITLE
Use server-provided player profiles for heads

### DIFF
--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.profile.PlayerProfile;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -100,10 +101,50 @@ public class HeadGetter {
                 || System.currentTimeMillis() - cache.getTimestamp() <= cacheTimeout)) {
             panelItem.setHead(cachedHeads.get(panelItem.getPlayerHeadName()).getPlayerHead());
             requester.setHead(panelItem);
-        } else {
-            // Get the name
-            headRequesters.computeIfAbsent(panelItem.getPlayerHeadName(), k -> new HashSet<>()).add(requester);
-            names.add(new Pair<>(panelItem.getPlayerHeadName(), panelItem));
+            return;
+        }
+
+        // If the player is online, the server already holds their completed profile,
+        // textures included, so the head can be delivered synchronously with no web
+        // lookup. This also avoids the async callback racing a GUI that has since been
+        // redrawn. The player list may only be read from the primary thread.
+        if (Bukkit.isPrimaryThread()) {
+            HeadCache live = getFromOnlinePlayer(panelItem.getPlayerHeadName());
+
+            if (live != null) {
+                cachedHeads.put(live.getUserName(), live);
+                panelItem.setHead(live.getPlayerHead());
+                requester.setHead(panelItem);
+                return;
+            }
+        }
+
+        // Queue for the async resolver
+        headRequesters.computeIfAbsent(panelItem.getPlayerHeadName(), k -> new HashSet<>()).add(requester);
+        names.add(new Pair<>(panelItem.getPlayerHeadName(), panelItem));
+    }
+
+    /**
+     * Builds a head cache entry from an online player's live profile, if the player is
+     * online and their profile carries a skin texture.
+     *
+     * @param userName exact name of the player.
+     * @return a cache entry with a usable texture, or null if unavailable.
+     * @since 3.22.3
+     */
+    private static @Nullable HeadCache getFromOnlinePlayer(String userName) {
+        Player player = Bukkit.getPlayerExact(userName);
+
+        if (player == null) {
+            return null;
+        }
+
+        try {
+            HeadCache cache = new HeadCache(userName, player.getUniqueId(), player.getPlayerProfile());
+            return cache.hasTexture() ? cache : null;
+        } catch (Exception e) {
+            // An unreadable profile just means we fall back to the async resolver.
+            return null;
         }
     }
 
@@ -156,24 +197,30 @@ public class HeadGetter {
                             userId = null;
                         }
 
-                        HeadCache cache;
+                        // Ask the server first: Paper completes profiles through its own
+                        // session-service cache, so this is free for anyone who has
+                        // logged in recently and avoids hand-rolled HTTP entirely.
+                        HeadCache cache = HeadGetter.getFromServer(userName, userId);
 
-                        if (plugin.getSettings().isUseCacheServer()) {
-                            // Cache server has an implementation to get a skin just from player name.
-                            Pair<UUID, String> playerSkin = HeadGetter.getTextureFromName(userName, userId);
+                        if (cache == null) {
+                            if (plugin.getSettings().isUseCacheServer()) {
+                                // Cache server has an implementation to get a skin just from player name.
+                                Pair<UUID, String> playerSkin = HeadGetter.getTextureFromName(userName, userId);
 
-                            // Create new cache object.
-                            cache = new HeadCache(userName, playerSkin.getKey(),
-                                    HeadGetter.createProfile(userName, playerSkin.getKey(), playerSkin.getValue()));
-                        } else {
-                            if (userId == null) {
-                                // Use MojangAPI to get userId from userName.
-                                userId = HeadGetter.getUserIdFromName(userName);
+                                // Create new cache object.
+                                cache = new HeadCache(userName, playerSkin.getKey(),
+                                        HeadGetter.createProfile(userName, playerSkin.getKey(), playerSkin.getValue()));
+                            } else {
+                                if (userId == null) {
+                                    // Use MojangAPI to get userId from userName.
+                                    userId = HeadGetter.getUserIdFromName(userName);
+                                }
+
+                                // Create new cache object.
+                                cache = new HeadCache(userName, userId,
+                                        HeadGetter.createProfile(userName, userId,
+                                                HeadGetter.getTextureFromUUID(userId)));
                             }
-
-                            // Create new cache object.
-                            cache = new HeadCache(userName, userId,
-                                    HeadGetter.createProfile(userName, userId, HeadGetter.getTextureFromUUID(userId)));
                         }
 
                         // Save in cache. A failed lookup must not evict a texture we already
@@ -207,6 +254,38 @@ public class HeadGetter {
                 }
             }
         }, 0, plugin.getSettings().getTicksBetweenCalls());
+    }
+
+    /**
+     * Asks the server to complete a player profile for the given name/UUID. Paper resolves
+     * this through its own session-service client, which caches the profile of every player
+     * who has logged in, so for known players this returns instantly with no web request of
+     * our own. For unknown premium names it performs the Mojang lookup on our behalf,
+     * respecting the server's rate limiting.
+     * <p>
+     * Must be called from an async thread — profile completion may block on I/O.
+     *
+     * @param userName name of the player.
+     * @param userId UUID of the player, if known.
+     * @return a cache entry with a usable texture, or null if the server could not provide one.
+     * @since 3.22.3
+     */
+    private static @Nullable HeadCache getFromServer(@NonNull String userName, @Nullable UUID userId) {
+        try {
+            PlayerProfile profile = Bukkit.createPlayerProfile(userId, userName).update()
+                    .get(10, TimeUnit.SECONDS);
+
+            if (profile.getTextures().getSkin() != null) {
+                UUID resolvedId = profile.getUniqueId() != null ? profile.getUniqueId() : userId;
+                return new HeadCache(userName, resolvedId, profile);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            // Server could not complete the profile - fall back to the web-based lookups.
+        }
+
+        return null;
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/util/heads/HeadGetterTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/heads/HeadGetterTest.java
@@ -1,0 +1,122 @@
+package world.bentobox.bentobox.util.heads;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.profile.PlayerTextures;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.panels.PanelItem;
+
+/**
+ * Tests the online-player fast path of {@link HeadGetter#getHead}.
+ * @author tastybento
+ */
+class HeadGetterTest extends CommonTestSetup {
+
+    @Mock
+    private HeadRequester requester;
+    @Mock
+    private PanelItem panelItem;
+    @Mock
+    private PlayerProfile profile;
+    @Mock
+    private PlayerTextures textures;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        when(itemFactory.getItemMeta(any())).thenReturn(mock(SkullMeta.class));
+
+        when(mockPlayer.getPlayerProfile()).thenReturn(profile);
+        when(profile.getTextures()).thenReturn(textures);
+    }
+
+    /**
+     * An online player with a textured profile must be delivered synchronously from the
+     * server's own profile - no queuing, no web lookup.
+     */
+    @Test
+    void testGetHeadOnlinePlayerDeliversSynchronously() throws Exception {
+        URL skin = new URI("https://textures.minecraft.net/texture/test-online").toURL();
+        when(textures.getSkin()).thenReturn(skin);
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_online");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_online")).thenReturn(mockPlayer);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        verify(panelItem).setHead(any(ItemStack.class));
+        verify(requester).setHead(panelItem);
+    }
+
+    /**
+     * An online player whose live profile has no skin texture must not short-circuit -
+     * the request falls through to the async resolver queue.
+     */
+    @Test
+    void testGetHeadOnlinePlayerWithoutTextureIsQueued() {
+        when(textures.getSkin()).thenReturn(null);
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_no_texture");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_no_texture")).thenReturn(mockPlayer);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        verify(panelItem, never()).setHead(any());
+        verify(requester, never()).setHead(any());
+    }
+
+    /**
+     * An offline player cannot be resolved synchronously and must be queued.
+     */
+    @Test
+    void testGetHeadOfflinePlayerIsQueued() {
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_offline");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        verify(panelItem, never()).setHead(any());
+        verify(requester, never()).setHead(any());
+    }
+
+    /**
+     * Once the fast path has run, a second request for the same name is served from the
+     * head cache.
+     */
+    @Test
+    void testGetHeadSecondRequestServedFromCache() throws Exception {
+        URL skin = new URI("https://textures.minecraft.net/texture/test-cached").toURL();
+        when(textures.getSkin()).thenReturn(skin);
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_cached");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_cached")).thenReturn(mockPlayer);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        // Player logs off; the cache must still serve the head.
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_cached")).thenReturn(null);
+
+        HeadRequester secondRequester = mock(HeadRequester.class);
+        HeadGetter.getHead(panelItem, secondRequester);
+
+        verify(secondRequester).setHead(panelItem);
+    }
+}


### PR DESCRIPTION
## Motivation

A server admin reported that TopBlock panels consistently show default heads. TopBlock requests heads by player name through `HeadGetter`, which always resolved textures via the web (mc-heads or the Mojang API) — even for players the server already knows about. Those lookups get rate limited (HTTP 429) and the panel keeps its default Steve head. A patched TopBlock that used Paper's `SkullMeta`/`PlayerProfile` API directly showed heads immediately, confirming the server-side data is the better source.

Since BentoBox is now Paper-only, the head resolver can ask the server first.

## Changes

**Fast path for online players** — `HeadGetter.getHead()` now short-circuits on the main thread when the requested player is online: `Player#getPlayerProfile()` is already complete with textures, so the head is cached and delivered synchronously. This also removes the async-callback race where the head update could land on a GUI that had since been redrawn.

**Server-mediated resolution for everyone else** — the async worker first tries `Bukkit.createPlayerProfile(uuid, name).update()`. Paper completes this through its own session-service client, which caches the profile of every player who has logged in and rate-limits Mojang lookups properly. The existing mc-heads (`use-cache-server`) and Mojang HTTP paths remain untouched as fallbacks for names the server cannot resolve (e.g. non-premium names on offline-mode servers).

No API changes — `HeadGetter`, `HeadCache`, and `HeadRequester` signatures are unchanged, so addons need no recompile.

## Testing

New `HeadGetterTest` covers the synchronous delivery for an online textured player, the fall-through to the queue for untextured/offline players, and cache reuse after the player logs off. Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018whk2Jwzd7iqEKFnwWqgQY