### PR TITLE
fix: give zh-TW its own locale banner instead of the US flag

### DIFF
--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -14,7 +14,7 @@ meta:
   authors:
   - tastybento
   - Poslovitch
-  banner: WHITE_BANNER:1:STRIPE_SMALL:RED:SQUARE_TOP_RIGHT:CYAN:SQUARE_TOP_RIGHT:BLUE
+  banner: RED_BANNER:1:SQUARE_TOP_RIGHT:BLUE
 
 prefixes:
   bentobox: <gold>BentoBox </gold><gray><bold>> </bold></gray>


### PR DESCRIPTION
## Summary
The language selection panel shows the **US flag** for 中文（台灣） (zh-TW). `zh-TW.yml` was created from a copy of `en-US.yml` (its header still says so) and the `meta.banner` was never changed — it is byte-for-byte the en-US banner:

```yaml
banner: WHITE_BANNER:1:STRIPE_SMALL:RED:SQUARE_TOP_RIGHT:CYAN:SQUARE_TOP_RIGHT:BLUE
```

## Fix
```yaml
banner: RED_BANNER:1:SQUARE_TOP_RIGHT:BLUE
```

A red field with a blue canton — the closest banner-pattern approximation of the ROC flag (the white sun cannot be placed in a corner with banner patterns). Uses the same corner convention as the en-US canton.

I checked all 24 locale files: every other locale has its own flag design; zh-TW was the only en-US copy.

Reported by a zh-TW user via AOneBlock testing (the addon defines no banners, so the panel takes core's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtmXKNJ5fSZ9sEumeFDEBc