### PR TITLE
feat(admin): show every island in /[admin] info <player>, add [island name] arg

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommand.java
@@ -2,16 +2,26 @@ package world.bentobox.bentobox.api.commands.admin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.island.IslandGoCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.IslandInfo;
 import world.bentobox.bentobox.util.Util;
 
+/**
+ * Shows admin info about an island.
+ * <p>
+ * {@code /[admin] info} shows the island the admin is standing on.
+ * {@code /[admin] info <player>} shows every island the player has in this world.
+ * {@code /[admin] info <player> <island name>} shows just that island; island names
+ * and home names are resolved the same way as {@code /[admin] tp}.
+ */
 public class AdminInfoCommand extends CompositeCommand {
 
     public AdminInfoCommand(CompositeCommand parent) {
@@ -28,7 +38,7 @@ public class AdminInfoCommand extends CompositeCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        if (args.size() > 1 || (args.isEmpty() && !user.isPlayer())) {
+        if (args.isEmpty() && !user.isPlayer()) {
             // Show help
             showHelp(this, user);
             return false;
@@ -45,15 +55,29 @@ public class AdminInfoCommand extends CompositeCommand {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.getFirst());
             return false;
         }
-        // Show info for this player
-        Island island = getIslands().getIsland(getWorld(), targetUUID);
-        if (island != null) {
-            new IslandInfo(island).showAdminInfo(user, getAddon());
-            return true;
-        } else {
+        List<Island> islands = getIslands().getIslands(getWorld(), targetUUID);
+        if (islands.isEmpty()) {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         }
+        if (args.size() == 1) {
+            // Show info for every island this player has in this world
+            islands.forEach(island -> new IslandInfo(island).showAdminInfo(user, getAddon()));
+            return true;
+        }
+        // They named the island they want info on
+        Map<String, IslandGoCommand.IslandInfo> names = IslandGoCommand.getNameIslandMap(User.getInstance(targetUUID), getWorld());
+        final String typed = String.join(" ", args.subList(1, args.size()));
+        final String name = IslandGoCommand.resolveName(typed, names.keySet());
+        if (name == null) {
+            user.sendMessage("commands.island.go.unknown-home");
+            user.sendMessage("commands.island.sethome.homes-are");
+            names.keySet()
+                    .forEach(n -> user.sendMessage("commands.island.sethome.home-list-syntax", TextVariables.NAME, n));
+            return false;
+        }
+        new IslandInfo(names.get(name).island()).showAdminInfo(user, getAddon());
+        return true;
     }
 
     @Override
@@ -63,7 +87,16 @@ public class AdminInfoCommand extends CompositeCommand {
             // Don't show every player on the server. Require at least the first letter
             return Optional.empty();
         }
-        List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
+        if (args.size() == 1) {
+            List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
+            return Optional.of(Util.tabLimit(options, lastArg));
+        }
+        // Offer the target player's island and home names
+        UUID targetUUID = Util.getUUID(args.getFirst());
+        if (targetUUID == null) {
+            return Optional.empty();
+        }
+        List<String> options = new ArrayList<>(IslandGoCommand.getNameIslandMap(User.getInstance(targetUUID), getWorld()).keySet());
         return Optional.of(Util.tabLimit(options, lastArg));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
@@ -256,7 +256,7 @@ public class IslandGoCommand extends DelayedTeleportCommand {
      * @param names the valid destination names
      * @return the canonical destination name to use, or {@code null} if none matched confidently
      */
-    static String resolveName(String typed, Set<String> names) {
+    public static String resolveName(String typed, Set<String> names) {
         // 1. Exact match wins and preserves the original behaviour
         if (names.contains(typed)) {
             return typed;

--- a/src/main/java/world/bentobox/bentobox/util/IslandInfo.java
+++ b/src/main/java/world/bentobox/bentobox/util/IslandInfo.java
@@ -50,6 +50,9 @@ public class IslandInfo {
     public void showAdminInfo(User user, Addon addon) {
         user.sendMessage("commands.admin.info.title");
         user.sendMessage("commands.admin.info.island-uuid", TextVariables.UUID, island.getUniqueId());
+        if (island.getName() != null && !island.getName().isBlank()) {
+            user.sendMessage("commands.admin.info.island-name", TextVariables.NAME, island.getName());
+        }
         if (owner == null) {
             user.sendMessage("commands.admin.info.unowned");
         } else {

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -291,11 +291,12 @@ commands:
         specify-island-location: '<red>Určete [prefix_island] Umístění ve formátu X, Y, Z</red>'
         player-has-more-than-one-island: '<red>Hráč má více než jeden [prefix_island]. Zadejte, který z nich.</red>'
     info:
-      parameters: <Player>
+      parameters: <Player> [název ostrova]
       description: získat info, kde se nacházíš ty nebo hráčův ostrov
       no-island: '<red>Právě nejsi na žádném ostrovu...</red>'
       title: '========== Info o ostrovu ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Název: [name]'
       owner: 'Vlastník: [owner] ([uuid])'
       last-login: 'Naposledy spatřen: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -313,11 +313,12 @@ commands:
         specify-island-location: '<red>Gib den Inselstandort im x,y,z Format an</red>'
         player-has-more-than-one-island: '<red>Spieler hat mehr als eine Insel. Gib an welche.</red>'
     info:
-      parameters: <spieler>
+      parameters: <spieler> [Inselname]
       description: Informationen über deinen Standort oder die Spielerinsel erhalten
       no-island: '<red>Du bist im Moment nicht auf einer Insel...</red>'
       title: '========== Insel Info ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Name: [name]'
       owner: 'Besitzer: [owner] ([uuid])'
       last-login: 'Letzter Login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -278,11 +278,12 @@ commands:
         player-has-more-than-one-island: '<red>Player has more than one [prefix_island].
           Specify which one.</red>'
     info:
-      parameters: <player>
+      parameters: <player> [island name]
       description: get info on where you are or player's [prefix_island]
       no-island: '<red>You are not on [prefix_an-island] right now...</red>'
       title: ========== [prefix_Island] Info ============
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Name: [name]'
       owner: 'Owner: [owner] ([uuid])'
       last-login: 'Last login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -299,11 +299,12 @@ commands:
         specify-island-location: '<red>Especifica la ubicación de [prefix_island] en formato x,y,z</red>'
         player-has-more-than-one-island: '<red>El jugador tiene más de un [prefix_island]. Especifica cuál.</red>'
     info:
-      parameters: <jugador>
+      parameters: <jugador> [nombre de la isla]
       description: Obtén información sobre dónde estás o la isla del jugador.
       no-island: '<red>No estás en una isla en este momento...</red>'
       title: '========== Info de la Isla ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nombre: [name]'
       owner: 'Propietario: [owner] ([uuid])'
       last-login: 'Último acceso: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -319,13 +319,14 @@ commands:
         specify-island-location: '<red>Spécifiez l''emplacement de [prefix_island] au format x,y,z</red>'
         player-has-more-than-one-island: '<red>Le joueur a plus d''un [prefix_island]. Veuillez spécifier lequel.</red>'
     info:
-      parameters: <joueur>
+      parameters: <joueur> [nom de l'île]
       description: >-
         obtenir des informations sur l'endroit où vous êtes ou sur l'île du
         joueur
       no-island: '<red>Vous n''êtes pas sur une île en ce moment...</red>'
       title: '========== Informations sur l''île ============'
       island-uuid: 'UUID : [uuid]'
+      island-name: 'Nom : [name]'
       owner: '<red>Propriétaire : [owner]</red>'
       last-login: 'Dernière connexion : [date]'
       last-login-date-time-format: EEE MMM jj HH:mm:ss zzz aaaa

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -299,11 +299,12 @@ commands:
         specify-island-location: '<red>Specificirajte [prefix_island] lokaciju u x,y,z formatu</red>'
         player-has-more-than-one-island: '<red>Igrač ima više od jednog [prefix_island]. Odredite koji.</red>'
     info:
-      parameters: <igrač>
+      parameters: <igrač> [ime otoka]
       description: dobiti informacije o tome gdje se nalazite ili igračev otok
       no-island: '<red>Trenutno nisi na otoku...</red>'
       title: '========== Informacije o otoku ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Ime: [name]'
       owner: 'Vlasnik: [owner] ([uuid])'
       last-login: 'Zadnja prijava: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -319,11 +319,12 @@ commands:
           <red>A játékosnak több [prefix_island] van. Kérlek, jelöld meg,</red>
           melyiket.
     info:
-      parameters: <játékos>
+      parameters: <játékos> [sziget neve]
       description: információkat kaphat a tartózkodási helyéről vagy a játékos szigetéről
       no-island: '<red>Jelenleg nem vagy szigeten...</red>'
       title: '========== [prefix_Island] információ ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Név: [name]'
       owner: 'Tulajdonos: [owner] ([uuid])'
       last-login: 'Utolsó bejelentkezés: [date]'
       last-login-date-time-format: EEE HMM nn ÓÓ:pp:ss zzz éééé

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -304,11 +304,12 @@ commands:
           <red>Pemain memiliki lebih dari satu [prefix_island]. Tentukan yang</red>
           mana.
     info:
-      parameters: <player>
+      parameters: <player> [nama pulau]
       description: dapatkan info di mana Anda berada atau pulau pemain
       no-island: '<red>Anda tidak berada di pulau saat ini...</red>'
       title: '========== Info Pulau ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nama: [name]'
       owner: 'Pemilik: [owner] ([uuid])'
       last-login: 'Login terakhir: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -306,13 +306,14 @@ commands:
         specify-island-location: '<red>Specifica la posizione di [prefix_island] nel formato x,y,z</red>'
         player-has-more-than-one-island: '<red>Il giocatore ha più di un [prefix_island]. Specifica quale.</red>'
     info:
-      parameters: <giocatore>
+      parameters: <giocatore> [nome isola]
       description: >-
         ottieni informazioni riguardo l'isola del giocatore o riguardo quella in
         cui sei
       no-island: '<red>Al momento non ti trovi su un''isola...</red>'
       title: '========== Info Isola ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nome: [name]'
       owner: 'Proprietario: [owner] ([uuid])'
       last-login: 'Ultimo login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -262,11 +262,12 @@ commands:
         specify-island-location: '<red>x、y、z形式の[prefix_island]を指定します</red>'
         player-has-more-than-one-island: '<red>プレーヤーには複数の[prefix_island]があります。どれを指定します。</red>'
     info:
-      parameters: <プレーヤー>
+      parameters: <プレーヤー> [島の名前]
       description: あなたがどこにいるか、プレイヤーの島に関する情報を取得する
       no-island: '<red>あなたは今、島にいません...</red>'
       title: ' ========== 島情報 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '名前: [name]'
       owner: '所有者: [owner] ([uuid])'
       last-login: '最終ログイン: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -279,11 +279,12 @@ commands:
         specify-island-location: '<red>[prefix_island] 위치를 x,y,z 형식으로 지정하세요</red>'
         player-has-more-than-one-island: '<red>플레이어가 하나 이상의 [prefix_island]를 가지고 있습니다. 어느 것을 지정하세요.</red>'
     info:
-      parameters: <플레이어>
+      parameters: <플레이어> [섬 이름]
       description: 현재 위치에 있는 섬이나 플레이어의 섬의 정보를 봅니다
       no-island: '<red>당신은 섬에 있지 않습니다...</red>'
       title: '========== 섬 정보 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '이름: [name]'
       owner: '주인: [owner] ([uuid])'
       last-login: '마지막 로그인: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -306,11 +306,12 @@ commands:
           <red>Spēlētājam ir vairāk nekā viens [prefix_island]. Lūdzu, norādiet,</red>
           kuru.
     info:
-      parameters: <spēlētājs>
+      parameters: <spēlētājs> [salas nosaukums]
       description: atgriež informāciju par spēlētāja salu vai esošo pozīciju
       no-island: '<red>Tu neesi uz salas šobrīd...</red>'
       title: '========== Salas informācija ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nosaukums: [name]'
       owner: 'Īpašnieks: [owner] ([uuid])'
       last-login: 'Pēdējā pieslēgšanās: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -312,11 +312,12 @@ commands:
         specify-island-location: '<red>Geef de locatie van [prefix_island] op in x,y,z formaat</red>'
         player-has-more-than-one-island: '<red>Speler heeft meer dan één [prefix_island]. Geef aan welke.</red>'
     info:
-      parameters: <speler>
+      parameters: <speler> [eilandnaam]
       description: informatie krijgen over waar je bent of over het eiland van de speler
       no-island: '<red>Je bent nu niet op een eiland ...</red>'
       title: '========== Eilandinformatie ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Naam: [name]'
       owner: 'Eigenaar: [owner] ([uuid])'
       last-login: 'Laatste login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -302,11 +302,12 @@ commands:
         specify-island-location: '<red>Określ lokalizację [prefix_island] w formacie x,y,z</red>'
         player-has-more-than-one-island: '<red>Gracz ma więcej niż jeden [prefix_island]. Wskaź, który.</red>'
     info:
-      parameters: <gracz>
+      parameters: <gracz> [nazwa wyspy]
       description: zdobądź informacje o tym, gdzie jesteś lub wyspie gracza
       no-island: '<red>Nie jesteś teraz na wyspie...</red>'
       title: '======= Informacje o wyspie ========='
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nazwa: [name]'
       owner: 'Lider: [owner] ([uuid])'
       last-login: 'Ostatnie logowanie: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -298,11 +298,12 @@ commands:
         specify-island-location: '<red>Especifique a localização de [prefix_island] no formato x,y,z</red>'
         player-has-more-than-one-island: '<red>O jogador tem mais de um [prefix_island]. Especifique qual.</red>'
     info:
-      parameters: <jogador>
+      parameters: <jogador> [nome da ilha]
       description: obter informações de onde você está ou da ilha de um jogador
       no-island: '<red>Você não está em uma ilha no momento...</red>'
       title: '========== Informações da Ilha ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nome: [name]'
       owner: 'Dono: [owner] ([uuid])'
       last-login: 'Último login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -305,11 +305,12 @@ commands:
         specify-island-location: '<red>Especifique a localização de [prefix_island] no formato x,y,z</red>'
         player-has-more-than-one-island: '<red>O jogador tem mais de um [prefix_island]. Especifique qual.</red>'
     info:
-      parameters: <jogador>
+      parameters: <jogador> [nome da ilha]
       description: obtenha informações sobre onde você está ou a ilha do jogador
       no-island: '<red>Você não está em uma ilha agora...</red>'
       title: '========== Informações da Ilha ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nome: [name]'
       owner: 'Dono: [owner] ([uuid])'
       last-login: 'Ultimo login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz aaaa

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -309,11 +309,12 @@ commands:
         specify-island-location: '<red>Specificați locația insulei în format x,y,z</red>'
         player-has-more-than-one-island: '<red>Player are mai multe insule. Specificați care dintre ele.</red>'
     info:
-      parameters: <player>
+      parameters: <player> [numele insulei]
       description: obțineți informații despre locul dvs. sau insula jucătorului
       no-island: '<red>Nu vă aflați într-o insulă acum ...</red>'
       title: '========== Informații despre insulă ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nume: [name]'
       owner: 'Proprietar: [owner] ([uuid])'
       last-login: 'Ultima autentificare: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz aaaa

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -304,11 +304,12 @@ commands:
         player-has-more-than-one-island: <red>Игрок имеет более одного [prefix_island].
           Укажите, какой именно.</red>
     info:
-      parameters: <игрок>
+      parameters: <игрок> [название острова]
       description: получите информацию где вы или на чьем вы острове
       no-island: <red>Вы не на острове в данный момент...</red>
       title: ========== Информация об острове ============
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Название: [name]'
       owner: 'Владелец: [owner] ([uuid])'
       last-login: 'Последний вход: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -300,11 +300,12 @@ commands:
           <red>Oyuncunun birden fazla [prefix_island] var. Hangisini seçeceğinizi</red>
           belirtin.
     info:
-      parameters: <player>
+      parameters: <player> [ada adı]
       description: Ada hakkında bilgi verir
       no-island: '<dark_red>Herhangi bir adada degilsin...</dark_red>'
       title: '<yellow>Ada Bilgileri</yellow>'
       island-uuid: '<dark_purple>UUID: [uuid]</dark_purple>'
+      island-name: '<dark_purple>Ad: [name]</dark_purple>'
       owner: '<aqua>Sahibi: </aqua><dark_purple>[owner] ([uuid])</dark_purple>'
       last-login: '<aqua>Son giris: </aqua><dark_purple>[date]</dark_purple>'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -272,11 +272,12 @@ commands:
         specify-island-location: '<red>Вкажіть локацію [prefix_island] у форматі x,y,z</red>'
         player-has-more-than-one-island: '<red>У гравця більше ніж один [prefix_island]. Уточніть який.</red>'
     info:
-      parameters: <гравець>
+      parameters: <гравець> [назва острова]
       description: отримати інформацію про місце розташування або [prefix_island] гравця
       no-island: '<red>Зараз ви не на [prefix_an-island]...</red>'
       title: ========== Інфо про [prefix_Island] ============
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Назва: [name]'
       owner: 'Власник: [owner] ([uuid])'
       last-login: 'Останній вхід: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -299,11 +299,12 @@ commands:
           <red>Người chơi có nhiều hơn một [prefix_island]. Vui lòng chỉ rõ cái</red>
           nào.
     info:
-      parameters: <người chơi>
+      parameters: <người chơi> [tên đảo]
       description: xem thông tin đảo bạn đang đứng
       no-island: '<red>Bạn không có ở đảo nào...</red>'
       title: '========== Thông Tin Đảo ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Tên: [name]'
       owner: 'Chủ: [owner] ([uuid])'
       last-login: 'Lần đăng nhập cuối: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -270,11 +270,12 @@ commands:
         specify-island-location: '<red>以x,y,z格式选定岛屿位置</red>'
         player-has-more-than-one-island: '<red>玩家拥有多个岛屿, 请指定一个岛屿.</red>'
     info:
-      parameters: <玩家>
+      parameters: <玩家> [岛屿名称]
       description: 获取当前岛屿或指定玩家的岛屿信息
       no-island: '<red>你当前没有岛屿...</red>'
       title: '========== 岛屿信息 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '名称: [name]'
       owner: '岛主: [owner] ([uuid])'
       last-login: '最后登录: [date]'
       last-login-date-time-format: yyyy-MM-dd HH:mm:ss zzz

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -271,11 +271,12 @@ commands:
         specify-island-location: 指定[prefix_island] x，y，z格式的位置
         player-has-more-than-one-island: 玩家有多個[prefix_island]。指定哪一個。
     info:
-      parameters: <player>
+      parameters: <player> [島嶼名稱]
       description: 獲得您當前所在或者指定玩家的島嶼信息
       no-island: '<red>您當前不在一座島上......</red>'
       title: '========== 島嶼信息 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '名稱: [name]'
       owner: 島主：[owner] ([uuid])
       last-login: 最後登錄：[date]
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -253,11 +253,12 @@ commands:
         specify-island-location: <red>請以 x,y,z 格式指定[prefix_island]的位置。</red>
         player-has-more-than-one-island: <red>該玩家擁有多座[prefix_islands]，請指定要解除註冊的島嶼。</red>
     info:
-      parameters: <玩家>
+      parameters: <玩家> [島嶼名稱]
       description: 查看目前所在或指定玩家的[prefix_island]資訊
       no-island: <red>你目前不在[prefix_an-island]上……</red>
       title: ========== [prefix_Island]資訊 ==========
       island-uuid: 'UUID： [uuid]'
+      island-name: '名稱： [name]'
       owner: '島主： [owner]（[uuid]）'
       last-login: '最後登入： [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
@@ -8,11 +8,13 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -99,6 +101,7 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
         Optional<Island> optionalIsland = Optional.of(testIsland);
         when(im.getIslandAt(any())).thenReturn(optionalIsland);
         when(im.getIsland(any(), any(UUID.class))).thenReturn(testIsland);
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of(testIsland));
 
         // Players manager
         when(plugin.getPlayers()).thenReturn(pm);
@@ -120,12 +123,57 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
     }
 
     /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} with an island name that does not exist.
      */
     @Test
-    void testExecuteUserStringListOfStringTooManyArgs() {
-        assertFalse(iic.execute(user, "", Arrays.asList("hdhh", "hdhdhd")));
-        verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
+    void testExecuteUserStringListOfStringUnknownIslandName() {
+        testIsland.setName("myisland");
+        assertFalse(iic.execute(user, "", Arrays.asList("tastybento", "nosuchisland")));
+        verify(user).sendMessage("commands.island.go.unknown-home");
+        verify(user).sendMessage("commands.island.sethome.homes-are");
+        verify(user).sendMessage("commands.island.sethome.home-list-syntax", "[name]", "myisland");
+        verify(user, never()).sendMessage("commands.admin.info.title");
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} with an exact island name.
+     */
+    @Test
+    void testExecuteUserStringListOfStringIslandName() {
+        testIsland.setName("myisland");
+        Island other = new Island(location, user.getUniqueId(), 100);
+        other.setName("other");
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of(testIsland, other));
+        assertTrue(iic.execute(user, "", Arrays.asList("tastybento", "other")));
+        verify(user, times(1)).sendMessage("commands.admin.info.title");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "other");
+        verify(user, never()).sendMessage("commands.admin.info.island-name", "[name]", "myisland");
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} with a multi-word, case-insensitive island name.
+     */
+    @Test
+    void testExecuteUserStringListOfStringIslandNameForgiving() {
+        testIsland.setName("My Big Island");
+        assertTrue(iic.execute(user, "", Arrays.asList("tastybento", "my", "big", "island")));
+        verify(user).sendMessage("commands.admin.info.title");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "My Big Island");
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} when the player has several islands.
+     */
+    @Test
+    void testExecuteUserStringListOfStringArgsMultipleIslands() {
+        testIsland.setName("first");
+        Island second = new Island(location, user.getUniqueId(), 100);
+        second.setName("second");
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of(testIsland, second));
+        assertTrue(iic.execute(user, "", Collections.singletonList("tastybento")));
+        verify(user, times(2)).sendMessage("commands.admin.info.title");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "first");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "second");
     }
 
     /**
@@ -206,7 +254,7 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
      */
     @Test
     void testExecuteUserStringListOfStringArgsNoIsland() {
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of());
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
     }
@@ -220,6 +268,25 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
 
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#tabComplete(User, String, List)} - second arg offers island names.
+     */
+    @Test
+    void testTabCompleteIslandNames() {
+        testIsland.setName("myisland");
+        Optional<List<String>> result = iic.tabComplete(user, "", Arrays.asList("tastybento", "my"));
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("myisland"));
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#tabComplete(User, String, List)} - no args gives nothing.
+     */
+    @Test
+    void testTabCompleteNoArgs() {
+        assertTrue(iic.tabComplete(user, "", Collections.emptyList()).isEmpty());
     }
 
 }


### PR DESCRIPTION
## Problem

An admin asked for a way to get all the info on a player, but `/[admin] info <player>` only ever reports **one** island when the player has several. The command used `IslandsManager.getIsland(world, uuid)`, which returns just the primary/active island, and there was no other admin command to enumerate a player's islands.

## Changes

- **`/[admin] info <player>`** now loops over `getIslands(world, uuid)` and prints the admin info block for every island the player has in the world (owned and team islands — the same set `/[admin] tp <player> <name>` treats as reachable).
- **New optional argument** `/[admin] info <player> [island name]` shows a single island. Island and home names are resolved via `IslandGoCommand.getNameIslandMap` with the same forgiving matching as `/[player] go` (exact → case/space-insensitive → unique prefix); multi-word names work without quotes. An unknown name lists the valid ones, exactly like `/[admin] tp` does.
- **Tab completion** on the second argument offers the target player's island and home names.
- The admin info block now prints the **island name** (new locale key `commands.admin.info.island-name`) so multiple blocks can be told apart. Translated into all 24 bundled locales; `parameters` updated everywhere to advertise `[island name]`.
- `IslandGoCommand.resolveName` made `public` so admin commands can reuse it (additive, binary-compatible).

## Tests

`AdminInfoCommandTest`: added multi-island, exact-name, forgiving-name, unknown-name and tab-complete cases; `no-island` case now goes through `getIslands`. Full suite: 3478 tests, 0 failures.

## Follow-up

`docs/BentoBox/About/AdminTools.md` lists `/[admin] info <player>`; I'll update it to mention `[island name]` in the docs repo once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjU4tEg1H9fbcdErGLATAj
