### PR TITLE
Stop renaming sub-commands to the alias a player typed (#3075)

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -407,10 +407,11 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
                 if (sub.isEmpty()) {
                     return subCommand;
                 }
-                // Step down one
+                // Step down one. The label the player actually typed is derived from
+                // args by the caller; it must never be written onto the shared command
+                // object, or every player's tab completion and help would start showing
+                // whichever alias was typed last (#3075).
                 subCommand = sub.orElse(subCommand);
-                // Set the label
-                subCommand.setLabel(arg);
             } else {
                 // We are at the end of the walk
                 return subCommand;

--- a/src/test/java/world/bentobox/bentobox/api/commands/SubCommandAliasLabelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/SubCommandAliasLabelTest.java
@@ -1,0 +1,115 @@
+package world.bentobox.bentobox.api.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * Regression test for <a href="https://github.com/BentoBoxWorld/BentoBox/issues/3075">#3075</a>.
+ * <p>
+ * Walking the typed arguments to find a sub-command used to call
+ * {@code setLabel(arg)} on the shared sub-command object. After any player
+ * typed {@code /island h}, every other player's tab completion advertised
+ * {@code h} in place of {@code go}. The label must stay the primary one however
+ * the command is addressed.
+ *
+ * @author tastybento
+ */
+class SubCommandAliasLabelTest extends CommonTestSetup {
+
+    private TopCommand top;
+    private CommandSender sender;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        when(plugin.getCommandsManager()).thenReturn(mock(CommandsManager.class));
+        top = new TopCommand();
+        sender = mock(CommandSender.class);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testTabCompleteViaAliasKeepsPrimaryLabel() {
+        // Brigadier calls tabComplete on every keystroke, so merely typing the alias
+        // used to be enough to rename the command for everyone.
+        top.tabComplete(sender, "island", new String[] { "h", "" });
+        assertEquals("go", top.go.getLabel());
+
+        List<String> options = top.tabComplete(sender, "island", new String[] { "" });
+        assertTrue(options.contains("go"), options.toString());
+        assertFalse(options.contains("h"), options.toString());
+        assertFalse(options.contains("home"), options.toString());
+    }
+
+    @Test
+    void testExecuteViaAliasKeepsPrimaryLabelButPassesTypedAlias() {
+        assertTrue(top.execute(sender, "island", new String[] { "home" }));
+        assertEquals("home", top.go.labelUsed, "sub-command should still learn which alias was typed");
+        assertEquals("go", top.go.getLabel(), "shared command object must not be renamed");
+
+        assertTrue(top.execute(sender, "island", new String[] { "h" }));
+        assertEquals("h", top.go.labelUsed);
+        assertEquals("go", top.go.getLabel());
+
+        assertEquals("/island go", top.go.getUsage());
+    }
+
+    class TopCommand extends CompositeCommand {
+
+        GoCommand go;
+
+        TopCommand() {
+            super("island");
+        }
+
+        @Override
+        public void setup() {
+            go = new GoCommand(this);
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    class GoCommand extends CompositeCommand {
+
+        String labelUsed;
+
+        GoCommand(CompositeCommand parent) {
+            super(parent, "go", "home", "h");
+        }
+
+        @Override
+        public void setup() {
+            // No permission, so any sender may run it
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            labelUsed = label;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3075

## What was happening

`/ob go` has the aliases `home` and `h`. `CompositeCommand.getCommandFromArgs` walked the typed arguments and called `setLabel(arg)` on the **shared** sub-command object, so after any player typed `/ob h` the go command's label became `h` for everyone. Tab completion advertises sub-commands by `getLabel()`, which is why the reporter saw `/ob h` where `/ob go` should be, and why it "reverted" seemingly at random: it followed whichever alias anyone had used most recently.

Brigadier registration (3.22.0) made this much more visible. The greedy-argument suggestion provider calls `tabComplete` on every keystroke, so merely *typing* `/ob h` was enough to rename the command. It also broke the registrar's literal de-duplication, which compares `sub.getLabel()` against the advertised literal names, so the alias was pushed to clients as an extra suggestion.

The same mutated label leaked into `ConfirmableCommand` (confirmations are keyed by label) and `DefaultHelpCommand`.

## The fix

`execute()` already derives the typed alias from the args array and hands it to `call(user, cmdLabel, cmdArgs)`, so the mutation was redundant. This PR removes the `setLabel(arg)` call and adds `SubCommandAliasLabelTest`, which:

- tab-completes via `h` and asserts the label stays `go` and the completion list offers `go`, not `h` or `home`
- executes via `home` and `h` and asserts the sub-command still receives the typed alias while its own label and usage stay `go`

Not changed, on purpose: the `home`/`h` aliases and the `island.home` permission name the reporter suggested removing or renaming. They are long-standing public behaviour and the display was the only thing wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTSR5y1ScxFzCqcXiAXXFT
