### PR TITLE
Fire purge IslandEvents on the main thread

### DIFF
--- a/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
@@ -16,8 +16,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -224,8 +227,11 @@ public class PurgeRegionsService {
      * along with any island database entries, island cache entries, and
      * orphaned player data files that correspond to them.
      *
-     * <p>Runs synchronously on the calling thread and performs disk I/O.
-     * Callers must invoke this from an async task. Callers are also
+     * <p>Performs disk I/O on the calling thread and should be invoked from
+     * an async task. The final bookkeeping — firing {@link IslandEvent}s and
+     * removing islands from the cache and database — is hopped onto the main
+     * thread and awaited before this method returns, because Paper only
+     * allows {@link IslandEvent} to be fired synchronously. Callers are also
      * responsible for flushing in-memory chunk state by calling
      * {@code World.save()} on the main thread <b>before</b> dispatching
      * this method — {@code World.save()} is not safe to invoke from an
@@ -252,8 +258,13 @@ public class PurgeRegionsService {
             affectedIds.addAll(islandIDs);
         }
 
-        int islandsRemoved = 0;
+        // Phase 1 (calling thread, disk I/O): decide which islands are fully
+        // reaped and delete their orphaned player data. No Bukkit events or
+        // cache/DB mutations happen here — this method is normally invoked
+        // from an async task and IslandEvent may only be fired on the main
+        // thread (Paper enforces this and throws IllegalStateException).
         int islandsDeferred = 0;
+        List<Island> toFinalize = new ArrayList<>();
         for (String islandID : affectedIds) {
             Optional<Island> opt = plugin.getIslands().getIslandById(islandID);
             if (opt.isEmpty()) {
@@ -294,28 +305,14 @@ public class PurgeRegionsService {
                     continue;
                 }
                 deletePlayerFromWorldFolder(scan.world(), islandID, scan.deletableRegions(), scan.days());
-                // For the age sweep, DELETED may never have fired (the island was
-                // pruned by age, not by an explicit /is reset). Fire it now so addons
-                // (Level, OneBlock, etc.) can clean up their per-island data.
-                if (!island.isDeletable()) {
-                    IslandEvent.builder()
-                            .island(island)
-                            .reason(Reason.DELETED)
-                            .build();
-                }
-                plugin.getIslands().getIslandCache().deleteIslandFromCache(islandID);
-                if (plugin.getIslands().deleteIslandId(islandID)) {
-                    plugin.log("Island ID " + islandID + " deleted from cache and database");
-                    islandsRemoved++;
-                    // Fire PURGED so addons that track physical storage state know
-                    // the region files and DB row are both gone.
-                    IslandEvent.builder()
-                            .island(island)
-                            .reason(Reason.PURGED)
-                            .build();
-                }
+                toFinalize.add(island);
             }
         }
+
+        // Phase 2 (main thread): fire events and remove the islands from the
+        // cache and database. Blocks the calling thread until done so the
+        // return value and the summary log below reflect the final state.
+        int islandsRemoved = toFinalize.isEmpty() ? 0 : runOnMainThread(() -> finalizeIslands(toFinalize));
         plugin.log("Purge complete for world " + scan.world().getName()
                 + ": " + scan.deletableRegions().size() + " region(s), "
                 + islandsRemoved + " island(s) removed, "
@@ -364,6 +361,76 @@ public class PurgeRegionsService {
      */
     public Set<String> getPendingDeletions() {
         return Collections.unmodifiableSet(pendingDeletions);
+    }
+
+    /**
+     * Removes each fully-reaped island from the cache and database, firing
+     * {@link Reason#DELETED} first if the island was never soft-deleted and
+     * {@link Reason#PURGED} once the row is gone. <b>Main thread only</b>:
+     * {@link IslandEvent} is a synchronous event.
+     *
+     * @param islands islands whose region files and player data are already gone
+     * @return the number of islands actually removed from the database
+     */
+    private int finalizeIslands(List<Island> islands) {
+        int removed = 0;
+        for (Island island : islands) {
+            String islandID = island.getUniqueId();
+            // For the age sweep, DELETED may never have fired (the island was
+            // pruned by age, not by an explicit /is reset). Fire it now so addons
+            // (Level, OneBlock, etc.) can clean up their per-island data.
+            if (!island.isDeletable()) {
+                IslandEvent.builder()
+                        .island(island)
+                        .reason(Reason.DELETED)
+                        .build();
+            }
+            plugin.getIslands().getIslandCache().deleteIslandFromCache(islandID);
+            if (plugin.getIslands().deleteIslandId(islandID)) {
+                plugin.log("Island ID " + islandID + " deleted from cache and database");
+                removed++;
+                // Fire PURGED so addons that track physical storage state know
+                // the region files and DB row are both gone.
+                IslandEvent.builder()
+                        .island(island)
+                        .reason(Reason.PURGED)
+                        .build();
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Runs {@code task} on the main server thread and waits for its result.
+     * If already on the main thread the task runs inline.
+     *
+     * @param task work that must run on the main thread
+     * @return the task's result
+     * @throws IllegalStateException if the task could not be scheduled or failed
+     */
+    private <T> T runOnMainThread(Supplier<T> task) {
+        if (Bukkit.isPrimaryThread()) {
+            return task.get();
+        }
+        CompletableFuture<T> done = new CompletableFuture<>();
+        try {
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                try {
+                    done.complete(task.get());
+                } catch (Exception e) {
+                    done.completeExceptionally(e);
+                }
+            });
+        } catch (RuntimeException e) {
+            // Typically IllegalPluginAccessException: the plugin is disabling and
+            // the scheduler will not accept new tasks.
+            throw new IllegalStateException("Could not schedule purge finalization on the main thread", e);
+        }
+        try {
+            return done.join();
+        } catch (CompletionException e) {
+            throw new IllegalStateException("Purge finalization failed on the main thread", e.getCause());
+        }
     }
 
     /**

--- a/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -27,13 +28,18 @@ import java.util.UUID;
 
 import com.google.common.collect.ImmutableSet;
 
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
+import world.bentobox.bentobox.api.events.island.IslandEvent.Reason;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.PurgeRegionsService.FilterStats;
 import world.bentobox.bentobox.managers.PurgeRegionsService.PurgeScanResult;
@@ -82,6 +88,10 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
 
         when(im.getIslandCache()).thenReturn(islandCache);
         when(world.getWorldFolder()).thenReturn(tempDir.toFile());
+
+        // Most tests exercise delete() as if called on the main thread so the
+        // finalization phase runs inline. The async-path tests override this.
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
 
         service = new PurgeRegionsService(plugin);
     }
@@ -708,5 +718,92 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         // Age sweep: immediate deletion, not deferred.
         verify(im, times(1)).deleteIslandId("tiny");
         assertTrue(service.getPendingDeletions().isEmpty());
+    }
+
+    /**
+     * Regression for the async purge crash: {@code delete()} is dispatched
+     * from an async task by both the purge command and housekeeping, but
+     * {@link IslandEvent} may only be fired on the main thread (Paper throws
+     * {@code IllegalStateException: IslandEvent may only be triggered
+     * synchronously}). When not on the primary thread, the event/cache/DB
+     * finalization must be hopped onto the main thread via the scheduler and
+     * awaited, and the events must still fire.
+     */
+    @Test
+    void testDeleteOffMainThreadFinalizesViaScheduler() throws IOException {
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
+        // Simulate the scheduler running the main-thread task.
+        doAnswer(inv -> {
+            inv.getArgument(1, Runnable.class).run();
+            return null;
+        }).when(sch).runTask(eq(plugin), any(Runnable.class));
+
+        Island tiny = mock(Island.class);
+        when(tiny.getUniqueId()).thenReturn("tiny");
+        // Never soft-deleted: DELETED must fire before PURGED.
+        when(tiny.isDeletable()).thenReturn(false);
+        when(tiny.getMemberSet()).thenReturn(ImmutableSet.<UUID>of());
+        when(tiny.getMinProtectedX()).thenReturn(0);
+        when(tiny.getMaxProtectedX()).thenReturn(100);
+        when(tiny.getMinProtectedZ()).thenReturn(0);
+        when(tiny.getMaxProtectedZ()).thenReturn(100);
+        when(im.getIslandById("tiny")).thenReturn(Optional.of(tiny));
+        when(im.deleteIslandId("tiny")).thenReturn(true);
+
+        Path regionDir = Files.createDirectories(tempDir.resolve("region"));
+        Files.write(regionDir.resolve("r.0.0.mca"), new byte[0]);
+
+        Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
+        regions.put(new Pair<>(0, 0), Set.of("tiny"));
+        PurgeScanResult scan = new PurgeScanResult(world, 30, regions, false, false,
+                new FilterStats(0, 0, 0, 0), Set.of());
+
+        boolean ok = service.delete(scan);
+        assertTrue(ok);
+
+        // Finalization was routed through the scheduler, not run inline.
+        verify(sch, times(1)).runTask(eq(plugin), any(Runnable.class));
+        verify(islandCache, times(1)).deleteIslandFromCache("tiny");
+        verify(im, times(1)).deleteIslandId("tiny");
+
+        // Each build() fires the generic IslandEvent plus a reason-specific
+        // subclass; check the generic ones for order.
+        ArgumentCaptor<Event> events = ArgumentCaptor.forClass(Event.class);
+        verify(pim, times(4)).callEvent(events.capture());
+        List<Reason> reasons = events.getAllValues().stream()
+                .filter(e -> e.getClass() == IslandEvent.class)
+                .map(IslandEvent.class::cast)
+                .map(IslandEvent::getReason)
+                .toList();
+        assertEquals(List.of(Reason.DELETED, Reason.PURGED), reasons);
+    }
+
+    /**
+     * When there is nothing to finalize (deleted sweep defers DB rows to
+     * shutdown) the service must not touch the scheduler at all, even when
+     * called off the main thread.
+     */
+    @Test
+    void testDeleteOffMainThreadDeletedSweepDoesNotSchedule() throws IOException {
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
+
+        Island del = mock(Island.class);
+        when(del.getUniqueId()).thenReturn("del");
+        when(del.isDeletable()).thenReturn(true);
+        when(del.getMemberSet()).thenReturn(ImmutableSet.<UUID>of());
+        when(im.getIslandById("del")).thenReturn(Optional.of(del));
+
+        Path regionDir = Files.createDirectories(tempDir.resolve("region"));
+        Files.write(regionDir.resolve("r.0.0.mca"), new byte[0]);
+
+        Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
+        regions.put(new Pair<>(0, 0), Set.of("del"));
+        PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
+                new FilterStats(0, 0, 0, 0), Set.of());
+
+        assertTrue(service.delete(scan));
+        verify(sch, never()).runTask(eq(plugin), any(Runnable.class));
+        verify(pim, never()).callEvent(any());
+        assertTrue(service.getPendingDeletions().contains("del"));
     }
 }


### PR DESCRIPTION
## Problem

Reported on Discord by a server admin running BentoBox 3.22.3 on Paper 26.2: `/sgadmin purge confirm` fails with

```
java.lang.IllegalStateException: IslandEvent may only be triggered synchronously.
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:42)
        at world.bentobox.bentobox.api.events.island.IslandEvent$IslandEventBuilder.build(IslandEvent.java:410)
        at world.bentobox.bentobox.managers.PurgeRegionsService.delete(PurgeRegionsService.java:304)
        at world.bentobox.bentobox.api.commands.admin.purge.AbstractPurgeCommand.lambda$deleteEverything$0(AbstractPurgeCommand.java:89)
        at org.bukkit.craftbukkit.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
```

Logs: https://mclo.gs/uGuzB8F, https://mclo.gs/rSn4KGX

`PurgeRegionsService.delete()` is dispatched from an async task by both `AbstractPurgeCommand.deleteEverything()` and `HousekeepingManager`, but it fired the `DELETED` / `PURGED` `IslandEvent`s straight from that thread. Paper enforces that synchronous events are only fired on the main thread. Because the region files are deleted *before* the island loop, the crash left the region files gone but the island DB rows and cache entries intact, and the command reported the purge as failed.

## Fix

`delete()` is now two phases:

1. **Calling (async) thread** – region file deletion, residual-region check, orphaned player-data cleanup. Islands that are fully reaped are collected.
2. **Main thread** – `finalizeIslands()` fires `DELETED` (if the island was never soft-deleted) and `PURGED`, and removes the island from the cache and database. This is scheduled with `runTask` and awaited via a `CompletableFuture`, so the boolean return and the "Purge complete" summary log still reflect the final state. When already on the main thread it runs inline.

The deleted sweep (`days == 0`) still defers DB rows to shutdown and never touches the scheduler.

## Tests

- `testDeleteOffMainThreadFinalizesViaScheduler` – with `isPrimaryThread()` false, verifies finalization goes through the scheduler, the cache/DB are cleaned, and `DELETED` then `PURGED` fire in order.
- `testDeleteOffMainThreadDeletedSweepDoesNotSchedule` – deleted sweep off-thread never schedules or fires events.
- Existing `PurgeRegionsServiceTest` cases now stub `isPrimaryThread()` true to keep exercising the inline path.

Full suite: 3484 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZRwXXfTUJLJFwSnzSgeRb
