### PR TITLE
Release 3.22.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArt
 group = "world.bentobox" // From <groupId>
 
 // Base properties from <properties>
-val buildVersion = "3.22.3"
+val buildVersion = "3.22.4"
 val buildNumberDefault = "-LOCAL" // Local build identifier
 val snapshotSuffix = "-SNAPSHOT"  // Indicates development/snapshot version
 

--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -551,7 +551,7 @@ public class Settings implements ConfigObject {
     @ConfigComment("existing servers keep their current behaviour.")
     @ConfigComment("Note: capping can undercount the historical-members placeholder once old")
     @ConfigComment("JOINED entries are dropped off the front.")
-    @ConfigEntry(path = "island.history.max-entries", since = "3.22.3")
+    @ConfigEntry(path = "island.history.max-entries", since = "3.22.4")
     private int islandHistoryMaxEntries = 0;
 
     /* WORLD */
@@ -1849,7 +1849,7 @@ public class Settings implements ConfigObject {
      * Gets the maximum number of history entries kept per island.
      *
      * @return the cap; 0 or less means unlimited
-     * @since 3.22.3
+     * @since 3.22.4
      */
     public int getIslandHistoryMaxEntries() {
         return islandHistoryMaxEntries;
@@ -1859,7 +1859,7 @@ public class Settings implements ConfigObject {
      * Sets the maximum number of history entries kept per island.
      *
      * @param islandHistoryMaxEntries the cap; 0 or less means unlimited
-     * @since 3.22.3
+     * @since 3.22.4
      */
     public void setIslandHistoryMaxEntries(int islandHistoryMaxEntries) {
         this.islandHistoryMaxEntries = islandHistoryMaxEntries;

--- a/src/main/java/world/bentobox/bentobox/Settings.java
+++ b/src/main/java/world/bentobox/bentobox/Settings.java
@@ -544,6 +544,16 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "island.obsidian-scooping-lava-tip-duration", since = "3.14.0")
     private int obsidianScoopingLavaTipDuration = 5;
 
+    @ConfigComment("Maximum number of history (log) entries kept per island. The oldest entries")
+    @ConfigComment("are dropped first once the cap is reached, so long-lived islands do not grow")
+    @ConfigComment("without bound in memory and in the database.")
+    @ConfigComment("Set to 0 (or a negative value) for unlimited history. This is the default so")
+    @ConfigComment("existing servers keep their current behaviour.")
+    @ConfigComment("Note: capping can undercount the historical-members placeholder once old")
+    @ConfigComment("JOINED entries are dropped off the front.")
+    @ConfigEntry(path = "island.history.max-entries", since = "3.22.3")
+    private int islandHistoryMaxEntries = 0;
+
     /* WORLD */
     @ConfigComment("Vanilla structures disabled by default in EVERY BentoBox game mode world")
     @ConfigComment("(overworld, nether and end). List the structure keys to stop generating and to")
@@ -1833,6 +1843,26 @@ public class Settings implements ConfigObject {
      */
     public void setObsidianScoopingLavaTipDuration(int obsidianScoopingLavaTipDuration) {
         this.obsidianScoopingLavaTipDuration = obsidianScoopingLavaTipDuration;
+    }
+
+    /**
+     * Gets the maximum number of history entries kept per island.
+     *
+     * @return the cap; 0 or less means unlimited
+     * @since 3.22.3
+     */
+    public int getIslandHistoryMaxEntries() {
+        return islandHistoryMaxEntries;
+    }
+
+    /**
+     * Sets the maximum number of history entries kept per island.
+     *
+     * @param islandHistoryMaxEntries the cap; 0 or less means unlimited
+     * @since 3.22.3
+     */
+    public void setIslandHistoryMaxEntries(int islandHistoryMaxEntries) {
+        this.islandHistoryMaxEntries = islandHistoryMaxEntries;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
+++ b/src/main/java/world/bentobox/bentobox/api/addons/AddonClassLoader.java
@@ -6,6 +6,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -157,11 +158,11 @@ public class AddonClassLoader extends URLClassLoader {
 
         String depend = data.getString("depend");
         if (depend != null) {
-            builder.dependencies(Arrays.asList(depend.split("\\s*+,\\s*+")));
+            builder.dependencies(splitCommaSeparated(depend));
         }
         String softDepend = data.getString("softdepend");
         if (softDepend != null) {
-            builder.softDependencies(Arrays.asList(softDepend.split("\\s*+,\\s*+")));
+            builder.softDependencies(splitCommaSeparated(softDepend));
         }
         Material icon = Material.getMaterial(data.getString("icon", "PAPER").toUpperCase(Locale.ENGLISH));
         if (icon == null) {
@@ -185,6 +186,15 @@ public class AddonClassLoader extends URLClassLoader {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Splits a comma-separated list, trimming whitespace around each entry.
+     * Splitting on the literal comma and stripping afterwards avoids the
+     * super-linear {@code \s*,\s*} regex scan (Sonar S8786).
+     */
+    private static List<String> splitCommaSeparated(String value) {
+        return Arrays.stream(value.split(",")).map(String::strip).toList();
     }
 
     /* (non-Javadoc)

--- a/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/CompositeCommand.java
@@ -407,10 +407,11 @@ public abstract class CompositeCommand extends Command implements PluginIdentifi
                 if (sub.isEmpty()) {
                     return subCommand;
                 }
-                // Step down one
+                // Step down one. The label the player actually typed is derived from
+                // args by the caller; it must never be written onto the shared command
+                // object, or every player's tab completion and help would start showing
+                // whichever alias was typed last (#3075).
                 subCommand = sub.orElse(subCommand);
-                // Set the label
-                subCommand.setLabel(arg);
             } else {
                 // We are at the end of the walk
                 return subCommand;

--- a/src/main/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/DelayedTeleportCommand.java
@@ -10,6 +10,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -94,6 +95,20 @@ public abstract class DelayedTeleportCommand extends CompositeCommand implements
         }
     }
 
+
+    /**
+     * Cancels and removes any pending delayed command when the player quits,
+     * otherwise the entry would remain in the monitor map forever.
+     *
+     * @param e Player quit event
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        DelayedCommand delayed = toBeMonitored.remove(e.getPlayer().getUniqueId());
+        if (delayed != null) {
+            delayed.task().cancel();
+        }
+    }
 
     /**
      * Top level command

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommand.java
@@ -2,16 +2,26 @@ package world.bentobox.bentobox.api.commands.admin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.commands.island.IslandGoCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.IslandInfo;
 import world.bentobox.bentobox.util.Util;
 
+/**
+ * Shows admin info about an island.
+ * <p>
+ * {@code /[admin] info} shows the island the admin is standing on.
+ * {@code /[admin] info <player>} shows every island the player has in this world.
+ * {@code /[admin] info <player> <island name>} shows just that island; island names
+ * and home names are resolved the same way as {@code /[admin] tp}.
+ */
 public class AdminInfoCommand extends CompositeCommand {
 
     public AdminInfoCommand(CompositeCommand parent) {
@@ -28,7 +38,7 @@ public class AdminInfoCommand extends CompositeCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        if (args.size() > 1 || (args.isEmpty() && !user.isPlayer())) {
+        if (args.isEmpty() && !user.isPlayer()) {
             // Show help
             showHelp(this, user);
             return false;
@@ -45,15 +55,29 @@ public class AdminInfoCommand extends CompositeCommand {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.getFirst());
             return false;
         }
-        // Show info for this player
-        Island island = getIslands().getIsland(getWorld(), targetUUID);
-        if (island != null) {
-            new IslandInfo(island).showAdminInfo(user, getAddon());
-            return true;
-        } else {
+        List<Island> islands = getIslands().getIslands(getWorld(), targetUUID);
+        if (islands.isEmpty()) {
             user.sendMessage("general.errors.player-has-no-island");
             return false;
         }
+        if (args.size() == 1) {
+            // Show info for every island this player has in this world
+            islands.forEach(island -> new IslandInfo(island).showAdminInfo(user, getAddon()));
+            return true;
+        }
+        // They named the island they want info on
+        Map<String, IslandGoCommand.IslandInfo> names = IslandGoCommand.getNameIslandMap(User.getInstance(targetUUID), getWorld());
+        final String typed = String.join(" ", args.subList(1, args.size()));
+        final String name = IslandGoCommand.resolveName(typed, names.keySet());
+        if (name == null) {
+            user.sendMessage("commands.island.go.unknown-home");
+            user.sendMessage("commands.island.sethome.homes-are");
+            names.keySet()
+                    .forEach(n -> user.sendMessage("commands.island.sethome.home-list-syntax", TextVariables.NAME, n));
+            return false;
+        }
+        new IslandInfo(names.get(name).island()).showAdminInfo(user, getAddon());
+        return true;
     }
 
     @Override
@@ -63,7 +87,16 @@ public class AdminInfoCommand extends CompositeCommand {
             // Don't show every player on the server. Require at least the first letter
             return Optional.empty();
         }
-        List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
+        if (args.size() == 1) {
+            List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
+            return Optional.of(Util.tabLimit(options, lastArg));
+        }
+        // Offer the target player's island and home names
+        UUID targetUUID = Util.getUUID(args.getFirst());
+        if (targetUUID == null) {
+            return Optional.empty();
+        }
+        List<String> options = new ArrayList<>(IslandGoCommand.getNameIslandMap(User.getInstance(targetUUID), getWorld()).keySet());
         return Optional.of(Util.tabLimit(options, lastArg));
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/blueprints/AdminBlueprintCommand.java
@@ -9,6 +9,9 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Particle;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
@@ -18,7 +21,7 @@ import world.bentobox.bentobox.blueprints.BlueprintClipboard;
 import world.bentobox.bentobox.managers.BlueprintsManager;
 import world.bentobox.bentobox.panels.BlueprintManagementPanel;
 
-public class AdminBlueprintCommand extends ConfirmableCommand {
+public class AdminBlueprintCommand extends ConfirmableCommand implements Listener {
     // Clipboards
     private Map<UUID, BlueprintClipboard> clipboards;
 
@@ -39,6 +42,7 @@ public class AdminBlueprintCommand extends ConfirmableCommand {
 
         clipboards = new HashMap<>();
         displayClipboards = new HashMap<>();
+        Bukkit.getPluginManager().registerEvents(this, getPlugin());
 
         // Sub commands
         new AdminBlueprintLoadCommand(this);
@@ -62,6 +66,17 @@ public class AdminBlueprintCommand extends ConfirmableCommand {
 
     protected Map<UUID, BlueprintClipboard> getClipboards() {
         return clipboards;
+    }
+
+    /**
+     * Releases the quitting player's clipboard. A clipboard can hold a full copied
+     * island (tens of thousands of block objects), so it must not outlive the player.
+     *
+     * @param e Player quit event
+     */
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent e) {
+        clipboards.remove(e.getPlayer().getUniqueId());
     }
 
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandDeletehomeCommand.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNull;
+
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -65,7 +67,7 @@ public class IslandDeletehomeCommand extends ConfirmableCommand {
      * </ul>
      */
     @Override
-    public boolean canExecute(User user, String label, List<String> args) {
+    public boolean canExecute(@NonNull User user, String label, List<String> args) {
         if (args.isEmpty()) {
             this.showHelp(this, user);
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandExpelCommand.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -156,7 +157,7 @@ public class IslandExpelCommand extends CompositeCommand {
      * </ul>
      */
     @Override
-    public boolean execute(User user, String label, List<String> args) {
+    public boolean execute(@NonNull User user, String label, List<String> args) {
         // Finished error checking - expel player
         Island island = getIslands().getIsland(getWorld(), user);
         // Fire event

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandGoCommand.java
@@ -256,7 +256,7 @@ public class IslandGoCommand extends DelayedTeleportCommand {
      * @param names the valid destination names
      * @return the canonical destination name to use, or {@code null} if none matched confidently
      */
-    static String resolveName(String typed, Set<String> names) {
+    public static String resolveName(String typed, Set<String> names) {
         // 1. Exact match wins and preserves the original behaviour
         if (names.contains(typed)) {
             return typed;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandLockCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandLockCommand.java
@@ -2,6 +2,7 @@ package world.bentobox.bentobox.api.commands.island;
 
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -55,7 +56,7 @@ public class IslandLockCommand extends CompositeCommand {
     }
 
     @Override
-    public boolean canExecute(User user, String label, List<String> args) {
+    public boolean canExecute(@NonNull User user, String label, List<String> args) {
         island = getIslands().getIsland(getWorld(), user);
         if (island == null) {
             user.sendMessage("general.errors.no-island");

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandRenamehomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandRenamehomeCommand.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.bukkit.conversations.ConversationFactory;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.BentoBox;
@@ -74,7 +75,7 @@ public class IslandRenamehomeCommand extends ConfirmableCommand {
      * </ul>
      */
     @Override
-    public boolean canExecute(User user, String label, List<String> args) {
+    public boolean canExecute(@NonNull User user, String label, List<String> args) {
         if (args.isEmpty()) {
             this.showHelp(this, user);
             return false;

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandResetCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandResetCommand.java
@@ -182,18 +182,22 @@ public class IslandResetCommand extends ConfirmableCommand {
      * @param name The blueprint bundle name to use
      * @return true if reset was successful
      */
-    private boolean resetIsland(User user, String name) {
+    private boolean resetIsland(@NonNull User user, String name) {
         if (!checkCost(user, name, false)) {
             return false;
         }
         // Get the player's old island
         Island oldIsland = getIslands().getIsland(getWorld(), user);
+        if (oldIsland == null) {
+            // Should not happen, but the player has no island to reset
+            user.sendMessage("general.errors.no-island");
+            return false;
+        }
         deleteOldIsland(user, oldIsland);
 
         user.sendMessage("commands.island.create.creating-island");
         // Create new island and then delete the old one
         try {
-            assert oldIsland != null;
             Builder builder = NewIsland.builder().player(user).reason(Reason.RESET).addon(getAddon())
                     .oldIsland(oldIsland).name(name);
             if (noPaste)
@@ -233,7 +237,7 @@ public class IslandResetCommand extends ConfirmableCommand {
      * @param user The user resetting their island
      * @param oldIsland The island being reset
      */
-    private void deleteOldIsland(User user, Island oldIsland) {
+    private void deleteOldIsland(@NonNull User user, @NonNull Island oldIsland) {
         // Fire island preclear event
         IslandEvent.builder().involvedPlayer(user.getUniqueId()).reason(Reason.PRECLEAR).island(oldIsland)
                 .oldIsland(oldIsland).location(oldIsland.getCenter()).build();

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandResetnameCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandResetnameCommand.java
@@ -3,6 +3,8 @@ package world.bentobox.bentobox.api.commands.island;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNull;
+
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -53,7 +55,7 @@ public class IslandResetnameCommand extends CompositeCommand {
      * </ul>
      */
     @Override
-    public boolean canExecute(User user, String label, List<String> args)
+    public boolean canExecute(@NonNull User user, String label, List<String> args)
     {
         Island island = getIslands().getIsland(getWorld(), user);
 

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSethomeCommand.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.api.commands.island;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -66,7 +67,7 @@ public class IslandSethomeCommand extends ConfirmableCommand {
      * </ul>
      */
     @Override
-    public boolean canExecute(User user, String label, List<String> args) {
+    public boolean canExecute(@NonNull User user, String label, List<String> args) {
         island = getIslands().getIsland(getWorld(), user);
         // Check island
         if (island == null || island.getOwner() == null) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/IslandSetnameCommand.java
@@ -3,6 +3,8 @@ package world.bentobox.bentobox.api.commands.island;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNull;
+
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.events.island.IslandEvent;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -64,7 +66,7 @@ public class IslandSetnameCommand extends CompositeCommand {
      * </ul>
      */
     @Override
-    public boolean canExecute(User user, String label, List<String> args)
+    public boolean canExecute(@NonNull User user, String label, List<String> args)
     {
         // Explain command
         if (args.isEmpty()) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamGUI.java
@@ -518,8 +518,9 @@ public class IslandTeamGUI {
     }
 
     private void leave(User clickingUser, User target) {
+        // Objects.equals: getUniqueId() is null for non-player users and must not NPE
         if (clickingUser.hasPermission(parent.getLeaveCommand().getPermission()) && target.equals(clickingUser)
-                && !clickingUser.getUniqueId().equals(island.getOwner())) {
+                && !Objects.equals(clickingUser.getUniqueId(), island.getOwner())) {
             plugin.log("Leave: " + clickingUser.getName() + " trying to leave island at " + island.getCenter());
             clickingUser.closeInventory();
             if (parent.getLeaveCommand().leave(clickingUser)) {

--- a/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/island/team/IslandTeamLeaveCommand.java
@@ -3,6 +3,8 @@ package world.bentobox.bentobox.api.commands.island.team;
 import java.util.List;
 import java.util.UUID;
 
+import org.eclipse.jdt.annotation.NonNull;
+
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
 import world.bentobox.bentobox.api.events.IslandBaseEvent;
@@ -69,7 +71,7 @@ public class IslandTeamLeaveCommand extends ConfirmableCommand {
 
     }
 
-    protected boolean leave(User user) {
+    protected boolean leave(@NonNull User user) {
         Island island = getIslands().getIsland(getWorld(), user);
         if (island == null) {
             user.sendMessage("general.errors.no-island");

--- a/src/main/java/world/bentobox/bentobox/api/flags/FlagListener.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/FlagListener.java
@@ -1,7 +1,9 @@
 package world.bentobox.bentobox.api.flags;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -33,6 +35,16 @@ import world.bentobox.bentobox.util.Util;
 public abstract class FlagListener implements Listener {
 
     private static final String WHY = "Why: ";
+
+    /**
+     * Cache of per-world why-debug metadata keys to avoid rebuilding the string
+     * on every protection check.
+     */
+    private static final Map<String, String> WHY_DEBUG_KEYS = new ConcurrentHashMap<>();
+
+    private static String whyDebugKey(String worldName) {
+        return worldName == null ? "null_why_debug" : WHY_DEBUG_KEYS.computeIfAbsent(worldName, n -> n + "_why_debug");
+    }
 
     /**
      * Reason for why flag was allowed or disallowed
@@ -175,13 +187,12 @@ public abstract class FlagListener implements Listener {
         }
 
         // Protection flag
-        // Ops or "bypass everywhere" moderators can do anything unless they have switched it off
-        if (hasBypassEverywhere(loc, flag)) {
-            report(user, e, loc, flag, user.isOp() ? Why.OP : Why.BYPASS_EVERYWHERE);
-            return true;
-        }
         // Check if the island is deleted - if so, then nothing is allowed by default
         if (isDeletedIsland(island)) {
+            // Ops or "bypass everywhere" moderators can do anything unless they have switched it off
+            if (checkBypassEverywhere(e, loc, flag)) {
+                return true;
+            }
             report(user, e, loc, flag, Why.ISLAND_DELETED);
             noGo(e, flag, silent, WORLD_PROTECTED);
             return false;
@@ -203,8 +214,25 @@ public abstract class FlagListener implements Listener {
             report(user, e, loc, flag, Why.ALLOWED_IN_WORLD);
             return true;
         }
+        // Ops or "bypass everywhere" moderators can do anything unless they have switched it off
+        if (checkBypassEverywhere(e, loc, flag)) {
+            return true;
+        }
         report(user, e, loc, flag, Why.NOT_ALLOWED_IN_WORLD);
         noGo(e, flag, silent, WORLD_PROTECTED);
+        return false;
+    }
+
+    /**
+     * Checks the bypass-everywhere permissions and reports if they apply. Only called on
+     * the deny path so the common allow path skips the permission lookups entirely.
+     * @return true if the user may bypass protection everywhere
+     */
+    private boolean checkBypassEverywhere(@NonNull Event e, @NonNull Location loc, @NonNull Flag flag) {
+        if (hasBypassEverywhere(loc, flag)) {
+            report(user, e, loc, flag, user.isOp() ? Why.OP : Why.BYPASS_EVERYWHERE);
+            return true;
+        }
         return false;
     }
 
@@ -213,9 +241,12 @@ public abstract class FlagListener implements Listener {
     }
 
     private boolean hasBypassEverywhere(Location loc, Flag flag) {
-        return !user.getMetaData(AdminSwitchCommand.META_TAG).map(MetaDataValue::asBoolean).orElse(false)
-                && (user.hasPermission(getIWM().getPermissionPrefix(loc.getWorld()) + "mod.bypassprotect")
-                        || user.hasPermission(getIWM().getPermissionPrefix(loc.getWorld()) + "mod.bypass." + flag.getID() + ".everywhere"));
+        if (user.getMetaData(AdminSwitchCommand.META_TAG).map(MetaDataValue::asBoolean).orElse(false)) {
+            return false;
+        }
+        String prefix = getIWM().getPermissionPrefix(loc.getWorld());
+        return user.hasPermission(prefix + "mod.bypassprotect")
+                || user.hasPermission(prefix + "mod.bypass." + flag.getID() + ".everywhere");
     }
 
     private boolean processBypass(@NonNull Flag flag, Island island, @NonNull Event e, @NonNull Location loc, boolean silent) {
@@ -224,7 +255,12 @@ public abstract class FlagListener implements Listener {
         if (island.isAllowed(user, flag)) {
             report(user, e, loc, flag,  Why.RANK_ALLOWED);
             return true;
-        } else if (!user.getMetaData(AdminSwitchCommand.META_TAG).map(MetaDataValue::asBoolean).orElse(false)
+        }
+        // Ops or "bypass everywhere" moderators can do anything unless they have switched it off
+        if (checkBypassEverywhere(e, loc, flag)) {
+            return true;
+        }
+        if (!user.getMetaData(AdminSwitchCommand.META_TAG).map(MetaDataValue::asBoolean).orElse(false)
                 && (user.hasPermission(getIWM().getPermissionPrefix(loc.getWorld()) + "mod.bypass." + flag.getID() + ".island"))) {
             report(user, e, loc, flag,  Why.BYPASS_ISLAND);
             return true;
@@ -239,6 +275,10 @@ public abstract class FlagListener implements Listener {
             report(user, e, loc, flag,  Why.ALLOWED_IN_WORLD);
             return true;
         }
+        // Ops or "bypass everywhere" moderators can do anything unless they have switched it off
+        if (checkBypassEverywhere(e, loc, flag)) {
+            return true;
+        }
         report(user, e, loc, flag,  Why.NOT_ALLOWED_IN_WORLD);
         noGo(e, flag, silent, WORLD_PROTECTED);
         return false;
@@ -247,11 +287,13 @@ public abstract class FlagListener implements Listener {
     private boolean processSetting(@NonNull Flag flag, Optional<Island> island, @NonNull Event e, @NonNull Location loc) {
         // If the island exists, return the setting, otherwise return the default setting for this flag
         if (island.isPresent()) {
-            report(user, e, loc, flag,  island.map(x -> x.isAllowed(flag)).orElse(false) ? Why.SETTING_ALLOWED_ON_ISLAND : Why.SETTING_NOT_ALLOWED_ON_ISLAND);
-        } else {
-            report(user, e, loc, flag,  flag.isSetForWorld(loc.getWorld()) ? Why.SETTING_ALLOWED_IN_WORLD : Why.SETTING_NOT_ALLOWED_IN_WORLD);
+            boolean allowed = island.get().isAllowed(flag);
+            report(user, e, loc, flag,  allowed ? Why.SETTING_ALLOWED_ON_ISLAND : Why.SETTING_NOT_ALLOWED_ON_ISLAND);
+            return allowed;
         }
-        return island.map(x -> x.isAllowed(flag)).orElseGet(() -> flag.isSetForWorld(loc.getWorld()));
+        boolean allowed = flag.isSetForWorld(loc.getWorld());
+        report(user, e, loc, flag,  allowed ? Why.SETTING_ALLOWED_IN_WORLD : Why.SETTING_NOT_ALLOWED_IN_WORLD);
+        return allowed;
     }
 
     /**
@@ -264,7 +306,12 @@ public abstract class FlagListener implements Listener {
      */
     protected void report(@Nullable User user, @NonNull Event e, @NonNull Location loc, @NonNull Flag flag, @NonNull Why why) {
         // A quick way to debug flag listener unit tests is to add this line here: System.out.println(why.name()); NOSONAR
-        if (user != null && user.isPlayer() && user.getPlayer().getMetadata(loc.getWorld().getName() + "_why_debug").stream()
+        if (user == null || !user.isPlayer()) {
+            return;
+        }
+        // hasMetadata is a cheap map hit - avoids the metadata list + stream allocations on every check
+        String whyDebugKey = whyDebugKey(loc.getWorld().getName());
+        if (user.getPlayer().hasMetadata(whyDebugKey) && user.getPlayer().getMetadata(whyDebugKey).stream()
                 .filter(p -> p.getOwningPlugin().equals(getPlugin())).findFirst().map(MetadataValue::asBoolean).orElse(false)) {
             String whyEvent = WHY + e.getEventName() + " in world " + loc.getWorld().getName() + " at " + Util.xyz(loc.toVector());
             String whyBypass = WHY + user.getName() + " " + flag.getID() + " - " + why.name();

--- a/src/main/java/world/bentobox/bentobox/api/flags/FlagListener.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/FlagListener.java
@@ -162,7 +162,7 @@ public abstract class FlagListener implements Listener {
      * @return true if the check is okay, false if it was disallowed
      */
     public boolean checkIsland(@NonNull Event e, @Nullable Player player, @Nullable Location loc, @NonNull Flag flag, boolean silent) {
-        
+
         // Set user
         user = player == null ? null : User.getInstance(player);
         if (loc == null) {
@@ -180,7 +180,7 @@ public abstract class FlagListener implements Listener {
 
         // Get the island and if present
         Optional<Island> island = getIslands().getProtectedIslandAt(loc);
-        
+
         // Handle Settings Flag
         if (flag.getType().equals(Flag.Type.SETTING)) {
             return processSetting(flag, island, e, loc);
@@ -374,8 +374,9 @@ public abstract class FlagListener implements Listener {
         String prefix = addon != null ? "[" + addon.getDescription().getName() + "] " : "";
         String whyMessage = WHY + prefix + message + " - " + reason.name() + " in world "
                 + loc.getWorld().getName() + " at " + Util.xyz(loc.toVector());
+        String whyDebugKey = whyDebugKey(loc.getWorld().getName());
         Bukkit.getOnlinePlayers().stream()
-                .filter(p -> p.getMetadata(loc.getWorld().getName() + "_why_debug").stream()
+                .filter(p -> p.hasMetadata(whyDebugKey) && p.getMetadata(whyDebugKey).stream()
                         .filter(m -> m.getOwningPlugin().equals(getPlugin()))
                         .findFirst().map(MetadataValue::asBoolean).orElse(false))
                 .forEach(p -> {

--- a/src/main/java/world/bentobox/bentobox/api/flags/clicklisteners/CycleClick.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/clicklisteners/CycleClick.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.api.flags.clicklisteners;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.bukkit.Bukkit;
@@ -8,7 +9,6 @@ import org.bukkit.World;
 import org.bukkit.event.inventory.ClickType;
 
 import world.bentobox.bentobox.BentoBox;
-import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.flags.FlagProtectionChangeEvent;
 import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -159,16 +159,20 @@ public class CycleClick implements PanelItem.ClickHandler {
     }
 
     private void leftShiftClick(Flag flag, World world) {
-        if (!plugin.getIWM().getHiddenFlags(world).contains(flag.getID())) {
-            plugin.getIWM().getHiddenFlags(world).add(flag.getID());
-            user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
-        } else {
-            plugin.getIWM().getHiddenFlags(world).remove(flag.getID());
-            user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 1F, 1F);
-        }
-        // Save changes
-        plugin.getIWM().getAddon(world).ifPresent(GameModeAddon::saveWorldSettings);
-
+        // Mutate the game mode's live list - IWM#getHiddenFlags returns an immutable
+        // empty list when the world is not a game world (java:S6322)
+        plugin.getIWM().getAddon(world).ifPresent(gameModeAddon -> {
+            List<String> hiddenFlags = gameModeAddon.getWorldSettings().getHiddenFlags();
+            if (!hiddenFlags.contains(flag.getID())) {
+                hiddenFlags.add(flag.getID());
+                user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
+            } else {
+                hiddenFlags.remove(flag.getID());
+                user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 1F, 1F);
+            }
+            // Save changes
+            gameModeAddon.saveWorldSettings();
+        });
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/flags/clicklisteners/IslandToggleClick.java
+++ b/src/main/java/world/bentobox/bentobox/api/flags/clicklisteners/IslandToggleClick.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.api.flags.clicklisteners;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.bukkit.Bukkit;
@@ -7,7 +8,6 @@ import org.bukkit.Sound;
 import org.bukkit.event.inventory.ClickType;
 
 import world.bentobox.bentobox.BentoBox;
-import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.events.flags.FlagSettingChangeEvent;
 import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -123,18 +123,22 @@ public class IslandToggleClick implements ClickHandler {
     }
 
     private void shiftLeftClick(User user, Flag flag) {
-        if (!plugin.getIWM().getHiddenFlags(user.getWorld()).contains(flag.getID()))
-        {
-            plugin.getIWM().getHiddenFlags(user.getWorld()).add(flag.getID());
-            user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
-        }
-        else
-        {
-            plugin.getIWM().getHiddenFlags(user.getWorld()).remove(flag.getID());
-            user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 1F, 1F);
-        }
-        // Save changes
-        plugin.getIWM().getAddon(user.getWorld()).ifPresent(GameModeAddon::saveWorldSettings);
-
+        // Mutate the game mode's live list - IWM#getHiddenFlags returns an immutable
+        // empty list when the world is not a game world (java:S6322)
+        plugin.getIWM().getAddon(user.getWorld()).ifPresent(gameModeAddon -> {
+            List<String> hiddenFlags = gameModeAddon.getWorldSettings().getHiddenFlags();
+            if (!hiddenFlags.contains(flag.getID()))
+            {
+                hiddenFlags.add(flag.getID());
+                user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
+            }
+            else
+            {
+                hiddenFlags.remove(flag.getID());
+                user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 1F, 1F);
+            }
+            // Save changes
+            gameModeAddon.saveWorldSettings();
+        });
     }
 }

--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -1035,10 +1035,12 @@ public class User implements MetaDataAble {
     }
 
     /**
-     * Closes the user's inventory
+     * Closes the user's inventory. Does nothing if the user is not a player.
      */
     public void closeInventory() {
-        player.closeInventory();
+        if (player != null) {
+            player.closeInventory();
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/api/user/User.java
+++ b/src/main/java/world/bentobox/bentobox/api/user/User.java
@@ -79,10 +79,12 @@ public class User implements MetaDataAble {
 
     // Used for particle validation
     private static final Map<Particle, Class<?>> VALIDATION_CHECK;
+    // Resolved once - the enum lookup chain is too costly to run per spawned particle
+    private static final Particle DUST_PARTICLE = Enums.getIfPresent(Particle.class, "DUST")
+            .or(Enums.getIfPresent(Particle.class, "REDSTONE").or(Particle.FLAME));
     static {
         Map<Particle, Class<?>> v = new EnumMap<>(Particle.class);
-        v.put(Enums.getIfPresent(Particle.class, "DUST")
-                .or(Enums.getIfPresent(Particle.class, "REDSTONE").or(Particle.FLAME)), Particle.DustOptions.class);
+        v.put(DUST_PARTICLE, Particle.DustOptions.class);
         if (Enums.getIfPresent(Particle.class, "ITEM").isPresent()) {
             // 1.20.6 Particles
             v.put(Particle.ITEM, ItemStack.class);
@@ -110,7 +112,7 @@ public class User implements MetaDataAble {
 
     /**
      * Gets an instance of User from a CommandSender
-     * 
+     *
      * @param sender - command sender, e.g. console
      * @return user - user
      */
@@ -125,7 +127,7 @@ public class User implements MetaDataAble {
 
     /**
      * Gets an instance of User from a Player object.
-     * 
+     *
      * @param player - the player
      * @return user - user
      */
@@ -140,7 +142,7 @@ public class User implements MetaDataAble {
     /**
      * Gets an instance of User from a UUID. This will always return a user object.
      * If the player is offline then the getPlayer value will be null.
-     * 
+     *
      * @param uuid - UUID
      * @return user - user
      */
@@ -155,7 +157,7 @@ public class User implements MetaDataAble {
 
     /**
      * Gets an instance of User from an OfflinePlayer
-     * 
+     *
      * @param offlinePlayer offline Player
      * @return user
      * @since 1.3.0
@@ -170,7 +172,7 @@ public class User implements MetaDataAble {
 
     /**
      * Removes this player from the User cache and player manager cache
-     * 
+     *
      * @param player the player
      */
     public static void removePlayer(Player player) {
@@ -222,7 +224,7 @@ public class User implements MetaDataAble {
 
     /**
      * Used for testing
-     * 
+     *
      * @param p - plugin
      */
     public static void setPlugin(BentoBox p) {
@@ -235,7 +237,7 @@ public class User implements MetaDataAble {
 
     /**
      * Get the user's inventory
-     * 
+     *
      * @return player's inventory
      */
     @NonNull
@@ -245,7 +247,7 @@ public class User implements MetaDataAble {
 
     /**
      * Get the user's location
-     * 
+     *
      * @return location
      */
     @NonNull
@@ -257,7 +259,7 @@ public class User implements MetaDataAble {
 
     /**
      * Get the user's name
-     * 
+     *
      * @return player's name
      */
     @NonNull
@@ -267,7 +269,7 @@ public class User implements MetaDataAble {
 
     /**
      * Get the user's display name
-     * 
+     *
      * @return player's display name if the player is online otherwise just their
      *         name
      * @since 1.22.1
@@ -280,7 +282,7 @@ public class User implements MetaDataAble {
 
     /**
      * Get the user's display name as a text Component
-     * 
+     *
      * @return player's display name if the player is online otherwise just their
      *         name
      * @since 3.4.0
@@ -291,7 +293,7 @@ public class User implements MetaDataAble {
 
     /**
      * Check if the User is a player before calling this method. {@link #isPlayer()}
-     * 
+     *
      * @return the player
      */
     @NonNull
@@ -308,7 +310,7 @@ public class User implements MetaDataAble {
 
     /**
      * Use {@link #isOfflinePlayer()} before calling this method
-     * 
+     *
      * @return the offline player
      * @since 1.3.0
      */
@@ -345,7 +347,7 @@ public class User implements MetaDataAble {
 
     /**
      * Removes permission from user
-     * 
+     *
      * @param name - Name of the permission to remove
      * @return true if successful
      * @since 1.5.0
@@ -366,7 +368,7 @@ public class User implements MetaDataAble {
 
     /**
      * Add a permission to user
-     * 
+     *
      * @param name - Name of the permission to attach
      * @return The PermissionAttachment that was just created
      * @since 1.5.0
@@ -382,7 +384,7 @@ public class User implements MetaDataAble {
 
     /**
      * Checks if user is Op
-     * 
+     *
      * @return true if user is Op
      */
     public boolean isOp() {
@@ -399,7 +401,7 @@ public class User implements MetaDataAble {
      * Get the maximum value of a numerical permission setting. If a player is given
      * an explicit negative number then this is treated as "unlimited" and returned
      * immediately.
-     * 
+     *
      * @param permissionPrefix the start of the perm, e.g.,
      *                         {@code plugin.mypermission}
      * @param defaultValue     the default value; the result may be higher or lower
@@ -467,7 +469,7 @@ public class User implements MetaDataAble {
 
     /**
      * Gets a translation for a specific world
-     * 
+     *
      * @param world     - world of translation
      * @param reference - reference found in a locale file
      * @param variables - variables to insert into translated string. Variables go
@@ -488,7 +490,7 @@ public class User implements MetaDataAble {
      * Gets a translation of this reference for this user with colors converted.
      * Translations may be overridden by Addons by using the same reference prefixed
      * by the addon name (from the Addon Description) in lower case.
-     * 
+     *
      * @param reference - reference found in a locale file
      * @param variables - variables to insert into translated string. Variables go
      *                  in pairs, for example "[name]", "tastybento"
@@ -596,7 +598,7 @@ public class User implements MetaDataAble {
      * Gets a translation of this reference for this user without colors translated.
      * Translations may be overridden by Addons by using the same reference prefixed
      * by the addon name (from the Addon Description) in lower case.
-     * 
+     *
      * @param reference - reference found in a locale file
      * @param variables - variables to insert into translated string. Variables go
      *                  in pairs, for example "[name]", "tastybento"
@@ -704,7 +706,7 @@ public class User implements MetaDataAble {
 
     /**
      * Gets a translation of this reference for this user.
-     * 
+     *
      * @param reference - reference found in a locale file
      * @param variables - variables to insert into translated string. Variables go
      *                  in pairs, for example "[name]", "tastybento"
@@ -718,7 +720,7 @@ public class User implements MetaDataAble {
 
     /**
      * Send a message to sender if message is not empty.
-     * 
+     *
      * @param reference - language file reference
      * @param variables - CharSequence target, replacement pairs
      */
@@ -967,7 +969,7 @@ public class User implements MetaDataAble {
     /**
      * Sends a message to sender if message is not empty and if the same wasn't sent
      * within the previous Notifier.NOTIFICATION_DELAY seconds.
-     * 
+     *
      * @param reference - language file reference
      * @param variables - CharSequence target, replacement pairs
      *
@@ -983,7 +985,7 @@ public class User implements MetaDataAble {
     /**
      * Sends a message to sender if message is not empty and if the same wasn't sent
      * within the previous Notifier.NOTIFICATION_DELAY seconds.
-     * 
+     *
      * @param world     - the world the translation should come from
      * @param reference - language file reference
      * @param variables - CharSequence target, replacement pairs
@@ -1000,7 +1002,7 @@ public class User implements MetaDataAble {
 
     /**
      * Sets the user's game mode
-     * 
+     *
      * @param mode - GameMode
      */
     public void setGameMode(GameMode mode) {
@@ -1012,7 +1014,7 @@ public class User implements MetaDataAble {
     /**
      * Teleports user to this location. If the user is in a vehicle, they will exit
      * first.
-     * 
+     *
      * @param location - the location
      */
     public void teleport(Location location) {
@@ -1023,7 +1025,7 @@ public class User implements MetaDataAble {
 
     /**
      * Gets the current world this entity resides in
-     * 
+     *
      * @return World - world
      */
     @NonNull
@@ -1041,7 +1043,7 @@ public class User implements MetaDataAble {
 
     /**
      * Get the user's locale
-     * 
+     *
      * @return Locale
      */
     public Locale getLocale() {
@@ -1078,7 +1080,7 @@ public class User implements MetaDataAble {
 
     /**
      * Performs a command as the player
-     * 
+     *
      * @param command - command to execute
      * @return true if the command was successful, otherwise false
      */
@@ -1097,7 +1099,7 @@ public class User implements MetaDataAble {
 
     /**
      * Checks if a user is in one of the game worlds
-     * 
+     *
      * @return true if user is, false if not
      */
     public boolean inWorld() {
@@ -1107,7 +1109,7 @@ public class User implements MetaDataAble {
     /**
      * Spawn particles to the player. They are only displayed if they are within the
      * server's view distance.
-     * 
+     *
      * @param particle    Particle to display.
      * @param dustOptions Particle.DustOptions for the particle to display.
      * @param x           X coordinate of the particle to display.
@@ -1126,11 +1128,19 @@ public class User implements MetaDataAble {
                     + " must be provided when using Particle." + particle + " as particle.");
         }
 
-        // Check if this particle is beyond the viewing distance of the server
-        if (this.player != null && this.player.getLocation().toVector().distanceSquared(new Vector(x, y,
-                z)) < (Bukkit.getServer().getViewDistance() * 256 * Bukkit.getServer().getViewDistance())) {
-            if (particle.equals(Enums.getIfPresent(Particle.class, "DUST")
-                    .or(Enums.getIfPresent(Particle.class, "REDSTONE").or(Particle.FLAME)))) {
+        // Check if this particle is beyond the viewing distance of the server.
+        // Plain coordinate math can run hundreds of times per tick when
+        // range/clipboard displays are active, so avoid vector allocations.
+        if (this.player == null) {
+            return;
+        }
+        Location l = this.player.getLocation();
+        double dx = l.getX() - x;
+        double dy = l.getY() - y;
+        double dz = l.getZ() - z;
+        if (dx * dx + dy * dy + dz * dz < (Bukkit.getServer().getViewDistance() * 256
+                * Bukkit.getServer().getViewDistance())) {
+            if (particle.equals(DUST_PARTICLE)) {
                 player.spawnParticle(particle, x, y, z, 1, 0, 0, 0, 1, dustOptions);
             } else if (dustOptions != null) {
                 player.spawnParticle(particle, x, y, z, 1, dustOptions);
@@ -1145,7 +1155,7 @@ public class User implements MetaDataAble {
     /**
      * Spawn particles to the player. They are only displayed if they are within the
      * server's view distance. Compatibility method for older usages.
-     * 
+     *
      * @param particle    Particle to display.
      * @param dustOptions Particle.DustOptions for the particle to display.
      * @param x           X coordinate of the particle to display.
@@ -1159,7 +1169,7 @@ public class User implements MetaDataAble {
     /**
      * Spawn particles to the player. They are only displayed if they are within the
      * server's view distance.
-     * 
+     *
      * @param particle    Particle to display.
      * @param dustOptions Particle.DustOptions for the particle to display.
      * @param x           X coordinate of the particle to display.
@@ -1172,7 +1182,7 @@ public class User implements MetaDataAble {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -1185,7 +1195,7 @@ public class User implements MetaDataAble {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -1207,7 +1217,7 @@ public class User implements MetaDataAble {
 
     /**
      * Set the addon context when a command is executed
-     * 
+     *
      * @param addon - the addon executing the command
      */
     public void setAddon(Addon addon) {
@@ -1216,7 +1226,7 @@ public class User implements MetaDataAble {
 
     /**
      * Get all the metadata for this user
-     * 
+     *
      * @return the metaData
      * @since 1.15.4
      */

--- a/src/main/java/world/bentobox/bentobox/blueprints/BlueprintClipboard.java
+++ b/src/main/java/world/bentobox/bentobox/blueprints/BlueprintClipboard.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -160,14 +161,16 @@ public class BlueprintClipboard {
             }
             copying = true;
             NamespacedKey key = new NamespacedKey(BentoBox.getInstance(), "associatedDisplayEntity");
+            // Index the world's entities by block position once per tick instead of scanning
+            // the full entity list for every copied block
+            Map<Vector, List<Entity>> entitiesByBlock = world.getEntities().stream()
+                    .filter(Objects::nonNull)
+                    .filter(e -> !(e instanceof Player))
+                    .filter(e -> !e.getPersistentDataContainer().has(key, PersistentDataType.STRING)) // Do not copy hidden display entities
+                    .collect(Collectors.groupingBy(e -> new Vector(e.getLocation().getBlockX(),
+                            e.getLocation().getBlockY(), e.getLocation().getBlockZ())));
             vectorsToCopy.stream().skip(index).limit(speed).forEach(v -> {
-                List<Entity> ents = world.getEntities().stream()
-                        .filter(Objects::nonNull)
-                        .filter(e -> !(e instanceof Player))
-                        .filter(e -> !e.getPersistentDataContainer().has(key, PersistentDataType.STRING)) // Do not copy hidden display entities
-                        .filter(e -> new Vector(e.getLocation().getBlockX(), e.getLocation().getBlockY(),
-                                e.getLocation().getBlockZ()).equals(v))
-                        .toList();
+                List<Entity> ents = entitiesByBlock.getOrDefault(v, List.of());
                 if (copyBlock(v.toLocation(world), copyAir, copyBiome, ents, noWater)) {
                     count++;
                 }

--- a/src/main/java/world/bentobox/bentobox/database/json/adapters/PairTypeAdapter.java
+++ b/src/main/java/world/bentobox/bentobox/database/json/adapters/PairTypeAdapter.java
@@ -11,6 +11,9 @@ import com.google.gson.stream.JsonWriter;
 import world.bentobox.bentobox.util.Pair;
 
 public class PairTypeAdapter<X, Z> extends TypeAdapter<Pair<X, Z>> {
+    // Gson construction is expensive and this adapter runs per field on every database load
+    private static final Gson GSON = new Gson();
+
     private final Type xType;
     private final Type zType;
 
@@ -23,10 +26,9 @@ public class PairTypeAdapter<X, Z> extends TypeAdapter<Pair<X, Z>> {
     public void write(JsonWriter out, Pair<X, Z> pair) throws IOException {
         out.beginObject();
         out.name("x");
-        Gson gson = new Gson();
-        gson.toJson(pair.getKey(), xType, out);
+        GSON.toJson(pair.getKey(), xType, out);
         out.name("z");
-        gson.toJson(pair.getValue(), zType, out);
+        GSON.toJson(pair.getValue(), zType, out);
         out.endObject();
     }
 
@@ -39,9 +41,9 @@ public class PairTypeAdapter<X, Z> extends TypeAdapter<Pair<X, Z>> {
         while (in.hasNext()) {
             String name = in.nextName();
             if (name.equals("x")) {
-                x = new Gson().fromJson(in, xType);
+                x = GSON.fromJson(in, xType);
             } else if (name.equals("z")) {
-                z = new Gson().fromJson(in, zType);
+                z = GSON.fromJson(in, zType);
             }
         }
         in.endObject();

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -410,7 +410,14 @@ public class Island implements DataObject, MetaDataAble {
      * @return flag value
      */
     public int getFlag(@NonNull Flag flag) {
-        return flags.computeIfAbsent(flag.getID(), k -> flag.getDefaultRank());
+        // Plain get first - computeIfAbsent allocates a capturing lambda on every
+        // call and this runs on every protection check
+        Integer rank = flags.get(flag.getID());
+        if (rank == null) {
+            rank = flag.getDefaultRank();
+            flags.put(flag.getID(), rank);
+        }
+        return rank;
     }
 
     /**
@@ -493,7 +500,7 @@ public class Island implements DataObject, MetaDataAble {
      * @return the minProtectedX
      */
     public int getMinProtectedX() {
-        return Math.max(getMinX(), getProtectionCenter().getBlockX() - this.getProtectionRange());
+        return Math.max(getMinX(), rawProtectionCenter().getBlockX() - this.getProtectionRange());
     }
 
     /**
@@ -514,7 +521,18 @@ public class Island implements DataObject, MetaDataAble {
      * @return the minProtectedZ
      */
     public int getMinProtectedZ() {
-        return Math.max(getMinZ(), getProtectionCenter().getBlockZ() - this.getProtectionRange());
+        return Math.max(getMinZ(), rawProtectionCenter().getBlockZ() - this.getProtectionRange());
+    }
+
+    /**
+     * Read-only access to the protection center without the defensive clone that
+     * {@link #getProtectionCenter()} makes. For internal coordinate reads only -
+     * callers must not mutate the returned location.
+     */
+    @NonNull
+    private Location rawProtectionCenter() {
+        return location == null ? Objects.requireNonNull(center, "Island getCenter requires a non-null center")
+                : location;
     }
 
     /**
@@ -612,8 +630,13 @@ public class Island implements DataObject, MetaDataAble {
      * @see #getRange()
      */
     public int getProtectionRange() {
-        return Math.min(this.getRange(),
-                getRawProtectionRange() + this.getBonusRanges().stream().mapToInt(BonusRangeRecord::getRange).sum());
+        // Plain loop - this is called several times per protection event and the
+        // stream pipeline allocates even when there are no bonus ranges
+        int bonus = 0;
+        for (BonusRangeRecord r : getBonusRanges()) {
+            bonus += r.getRange();
+        }
+        return Math.min(this.getRange(), getRawProtectionRange() + bonus);
     }
 
     /**
@@ -947,14 +970,23 @@ public class Island implements DataObject, MetaDataAble {
      *         {@code false} otherwise.
      */
     public boolean onIsland(@NonNull Location target) {
-        return Util.sameWorld(this.world, target.getWorld())
-                && (target.getWorld().getEnvironment().equals(Environment.NORMAL)
-                        || this.getPlugin().getIWM().isIslandNether(target.getWorld())
-                        || this.getPlugin().getIWM().isIslandEnd(target.getWorld()))
-                && target.getBlockX() >= this.getMinProtectedX()
-                && target.getBlockX() < (this.getMinProtectedX() + this.getProtectionRange() * 2)
-                && target.getBlockZ() >= this.getMinProtectedZ()
-                && target.getBlockZ() < (this.getMinProtectedZ() + this.getProtectionRange() * 2);
+        // Cheapest checks first: int coordinate compares before any world resolution
+        int x = target.getBlockX();
+        int minProtectedX = this.getMinProtectedX();
+        int protectedSide = this.getProtectionRange() * 2;
+        if (x < minProtectedX || x >= minProtectedX + protectedSide) {
+            return false;
+        }
+        int z = target.getBlockZ();
+        int minProtectedZ = this.getMinProtectedZ();
+        if (z < minProtectedZ || z >= minProtectedZ + protectedSide) {
+            return false;
+        }
+        World targetWorld = target.getWorld();
+        return Util.sameWorld(this.world, targetWorld)
+                && (targetWorld.getEnvironment() == Environment.NORMAL
+                        || this.getPlugin().getIWM().isIslandNether(targetWorld)
+                        || this.getPlugin().getIWM().isIslandEnd(targetWorld));
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -190,7 +190,7 @@ public class Island implements DataObject, MetaDataAble {
      * Maximum number of {@link LogEntry} kept in {@link #history}. Oldest entries are
      * dropped first. Prevents unbounded per-island memory and database growth.
      */
-    private static final int MAX_HISTORY_SIZE = 500;
+    private static final int MAX_HISTORY_SIZE = 100;
 
     @Adapter(LogEntryListAdapter.class)
     @Expose

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -186,11 +186,6 @@ public class Island implements DataObject, MetaDataAble {
     private Map<String, Integer> flags = new HashMap<>();
 
     //// Island History ////
-    /**
-     * Maximum number of {@link LogEntry} kept in {@link #history}. Oldest entries are
-     * dropped first. Prevents unbounded per-island memory and database growth.
-     */
-    private static final int MAX_HISTORY_SIZE = 100;
 
     @Adapter(LogEntryListAdapter.class)
     @Expose
@@ -511,7 +506,7 @@ public class Island implements DataObject, MetaDataAble {
      * @since 1.5.2
      */
     public int getMaxProtectedX() {
-        return Math.min(getMaxX(), getProtectionCenter().getBlockX() + this.getProtectionRange());
+        return Math.min(getMaxX(), rawProtectionCenter().getBlockX() + this.getProtectionRange());
     }
 
     /**
@@ -543,7 +538,7 @@ public class Island implements DataObject, MetaDataAble {
      * @since 1.5.2
      */
     public int getMaxProtectedZ() {
-        return Math.min(getMaxZ(), getProtectionCenter().getBlockZ() + this.getProtectionRange());
+        return Math.min(getMaxZ(), rawProtectionCenter().getBlockZ() + this.getProtectionRange());
     }
 
     /**
@@ -1475,16 +1470,19 @@ public class Island implements DataObject, MetaDataAble {
 
     /**
      * Adds a {@link LogEntry} to the history of this island.
-     * History is capped at {@link #MAX_HISTORY_SIZE} entries; the oldest entry is
-     * dropped when the cap is reached so long-lived islands do not grow without bound
-     * in memory and in the database.
+     * History is capped at the {@code island.history.max-entries} config setting; the
+     * oldest entry is dropped when the cap is reached so long-lived islands do not grow
+     * without bound in memory and in the database. A cap of 0 or less means unlimited.
      *
      * @param logEntry the LogEntry to add.
      */
     public void log(LogEntry logEntry) {
         history.add(logEntry);
-        while (history.size() > MAX_HISTORY_SIZE) {
-            history.remove(0);
+        int max = BentoBox.getInstance().getSettings().getIslandHistoryMaxEntries();
+        if (max > 0) {
+            while (history.size() > max) {
+                history.remove(0);
+            }
         }
         setChanged();
     }

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -272,10 +272,7 @@ public class Island implements DataObject, MetaDataAble {
     public Island(Island island) {
         this.center = island.getCenter().clone();
         this.createdDate = island.getCreatedDate();
-        Optional.ofNullable(island.getCommandRanks()).ifPresent(cr -> {
-            this.commandRanks = new HashMap<>();
-            this.commandRanks.putAll(cr);
-        });
+        this.commandRanks = island.getCommandRanks() == null ? null : new HashMap<>(island.getCommandRanks());
         Optional.ofNullable(island.getCooldowns()).ifPresent(c -> {
             this.cooldowns = new HashMap<>();
             this.cooldowns.putAll(c);
@@ -293,10 +290,7 @@ public class Island implements DataObject, MetaDataAble {
         this.maxHomes = island.getMaxHomes();
         this.maxMembers = new HashMap<>(island.getMaxMembers());
         this.members.putAll(island.getMembers());
-        island.getMetaData().ifPresent(m -> {
-            this.metaData = new HashMap<>();
-            this.metaData.putAll(m);
-        });
+        this.metaData = island.getMetaData().<Map<String, MetaDataValue>>map(HashMap::new).orElse(null);
         this.name = island.getName();
         this.owner = island.getOwner();
         this.protectionRange = island.getProtectionRange();
@@ -304,7 +298,7 @@ public class Island implements DataObject, MetaDataAble {
         this.range = island.getRange();
         this.reserved = island.isReserved();
         this.spawn = island.isSpawn();
-        island.getSpawnPoint().forEach((k, v) -> island.spawnPoint.put(k, v.clone()));
+        island.getSpawnPoint().forEach((k, v) -> this.spawnPoint.put(k, v.clone()));
         this.uniqueId = island.getUniqueId();
         this.updatedDate = island.getUpdatedDate();
         this.world = island.getWorld();

--- a/src/main/java/world/bentobox/bentobox/database/objects/Island.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/Island.java
@@ -186,6 +186,12 @@ public class Island implements DataObject, MetaDataAble {
     private Map<String, Integer> flags = new HashMap<>();
 
     //// Island History ////
+    /**
+     * Maximum number of {@link LogEntry} kept in {@link #history}. Oldest entries are
+     * dropped first. Prevents unbounded per-island memory and database growth.
+     */
+    private static final int MAX_HISTORY_SIZE = 500;
+
     @Adapter(LogEntryListAdapter.class)
     @Expose
     private List<LogEntry> history = new LinkedList<>();
@@ -1437,11 +1443,17 @@ public class Island implements DataObject, MetaDataAble {
 
     /**
      * Adds a {@link LogEntry} to the history of this island.
-     * 
+     * History is capped at {@link #MAX_HISTORY_SIZE} entries; the oldest entry is
+     * dropped when the cap is reached so long-lived islands do not grow without bound
+     * in memory and in the database.
+     *
      * @param logEntry the LogEntry to add.
      */
     public void log(LogEntry logEntry) {
         history.add(logEntry);
+        while (history.size() > MAX_HISTORY_SIZE) {
+            history.remove(0);
+        }
         setChanged();
     }
 

--- a/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
+++ b/src/main/java/world/bentobox/bentobox/database/objects/IslandDeletion.java
@@ -218,7 +218,8 @@ public class IslandDeletion implements DataObject {
     }
 
     public boolean inBounds(int x, int z) {
-        return box.contains(new Vector(x, 0, z));
+        // Called per block during deletion scans - avoid allocating a vector
+        return box.contains(x, 0, z);
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/listeners/PrimaryIslandListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/PrimaryIslandListener.java
@@ -36,8 +36,13 @@ public class PrimaryIslandListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerMove(final PlayerMoveEvent event) {
-        if (!event.getFrom().toVector().equals(event.getTo().toVector())) {
-            setIsland(event.getPlayer(), event.getTo());
+        // Island bounds are block-based, so only a block change can alter the result.
+        // Compare raw coordinates to avoid allocating vectors on every move event.
+        Location from = event.getFrom();
+        Location to = event.getTo();
+        if (from.getBlockX() != to.getBlockX() || from.getBlockY() != to.getBlockY()
+                || from.getBlockZ() != to.getBlockZ()) {
+            setIsland(event.getPlayer(), to);
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/StandardSpawnProtectionListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/StandardSpawnProtectionListener.java
@@ -10,7 +10,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
-import org.bukkit.util.Vector;
+import org.bukkit.util.NumberConversions;
 import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.BentoBox;
@@ -123,13 +123,15 @@ public class StandardSpawnProtectionListener implements Listener {
             // If end portals are active, there is no common spawn
             return false;
         }
-        Vector p = location.toVector().multiply(new Vector(1, 0, 1));
-        Vector spawn = location.getWorld().getSpawnLocation().toVector().multiply(new Vector(1, 0, 1));
         int radius = env == World.Environment.THE_END
                 ? plugin.getIWM().getEndSpawnRadius(gameWorld)
                 : plugin.getIWM().getNetherSpawnRadius(gameWorld);
-        Vector diff = p.subtract(spawn);
-        return Math.abs(diff.getBlockX()) <= radius && Math.abs(diff.getBlockZ()) <= radius;
+        // Plain coordinate math runs per block event, so it avoid vector allocations.
+        // floor() keeps the exact semantics of the previous Vector#getBlockX comparison.
+        Location spawn = location.getWorld().getSpawnLocation();
+        int diffX = NumberConversions.floor(location.getX() - spawn.getX());
+        int diffZ = NumberConversions.floor(location.getZ() - spawn.getZ());
+        return Math.abs(diffX) <= radius && Math.abs(diffZ) <= radius;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClick.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClick.java
@@ -1,11 +1,12 @@
 package world.bentobox.bentobox.listeners.flags.clicklisteners;
 
+import java.util.List;
+
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.event.inventory.ClickType;
 
 import world.bentobox.bentobox.BentoBox;
-import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem.ClickHandler;
 import world.bentobox.bentobox.api.user.User;
@@ -72,16 +73,20 @@ public class CommandCycleClick implements ClickHandler {
      */
     private void leftShiftClick(User user) {
         String configSetting = COMMAND_RANK_PREFIX + command;
-        if (!plugin.getIWM().getHiddenFlags(user.getWorld()).contains(configSetting)) {
-            plugin.getIWM().getHiddenFlags(user.getWorld()).add(configSetting);
-            user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
-        } else {
-            plugin.getIWM().getHiddenFlags(user.getWorld()).remove(configSetting);
-            user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 1F, 1F);
-        }
-        // Save changes
-        plugin.getIWM().getAddon(user.getWorld()).ifPresent(GameModeAddon::saveWorldSettings);
-
+        // Mutate the game mode's live list - IWM#getHiddenFlags returns an immutable
+        // empty list when the world is not a game world (java:S6322)
+        plugin.getIWM().getAddon(user.getWorld()).ifPresent(gameModeAddon -> {
+            List<String> hiddenFlags = gameModeAddon.getWorldSettings().getHiddenFlags();
+            if (!hiddenFlags.contains(configSetting)) {
+                hiddenFlags.add(configSetting);
+                user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_GLASS_BREAK, 1F, 1F);
+            } else {
+                hiddenFlags.remove(configSetting);
+                user.getPlayer().playSound(user.getLocation(), Sound.BLOCK_NOTE_BLOCK_CHIME, 1F, 1F);
+            }
+            // Save changes
+            gameModeAddon.saveWorldSettings();
+        });
     }
 
 }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTab.java
@@ -14,7 +14,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.BentoBox;
-import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.panels.Panel;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.PanelItem.ClickHandler;
@@ -92,23 +91,22 @@ public class GeoMobLimitTab implements Tab, ClickHandler {
         // Convert the slot and active page to an index
         int index = tp.getActivePage() * 36 + slot - 9;
         EntityType c = getEntityTypes().get(index);
-        if (type == EntityLimitTabType.MOB_LIMIT) {
-            if (plugin.getIWM().getMobLimitSettings(world).contains(c.name())) {
-                plugin.getIWM().getMobLimitSettings(world).remove(c.name());
+        // Mutate the game mode's live list - the IWM getters return an immutable
+        // empty list when the world is not a game world (java:S6322)
+        plugin.getIWM().getAddon(Util.getWorld(world)).ifPresent(gameModeAddon -> {
+            List<String> settings = type == EntityLimitTabType.MOB_LIMIT
+                    ? gameModeAddon.getWorldSettings().getMobLimitSettings()
+                    : gameModeAddon.getWorldSettings().getGeoLimitSettings();
+            if (settings.contains(c.name())) {
+                settings.remove(c.name());
             } else {
-                plugin.getIWM().getMobLimitSettings(world).add(c.name());
+                settings.add(c.name());
             }
-        } else {
-            if (plugin.getIWM().getGeoLimitSettings(world).contains(c.name())) {
-                plugin.getIWM().getGeoLimitSettings(world).remove(c.name());
-            } else {
-                plugin.getIWM().getGeoLimitSettings(world).add(c.name());
-            }
-        }
+            // Save settings
+            gameModeAddon.saveWorldSettings();
+        });
         // Apply change to panel
         panel.getInventory().setItem(slot, getPanelItem(c, user).getItem());
-        // Save settings
-        plugin.getIWM().getAddon(Util.getWorld(world)).ifPresent(GameModeAddon::saveWorldSettings);
         return true;
     }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
@@ -112,14 +112,21 @@ public class LockAndBanListener extends FlagListener {
         if (e.getFrom().getBlockX() - e.getTo().getBlockX() == 0 && e.getFrom().getBlockZ() - e.getTo().getBlockZ() == 0) {
             return;
         }
-        // For each Player in the vehicle
-        Optional<Island> island = getIslands().getProtectedIslandAt(e.getTo());
+        // For each Player in the vehicle. Resolve the island lazily on the first Player
+        // passenger so unmanned/mob-ridden vehicles pay no grid lookup, and reuse it for
+        // any further player passengers (the rare multi-player case).
+        Optional<Island> island = null;
         for (Entity passenger : e.getVehicle().getPassengers()) {
-            if (passenger instanceof Player p && !checkAndNotify(p, e.getTo(), island).isAllowed()) {
-                p.leaveVehicle();
-                p.teleport(e.getFrom());
-                e.getVehicle().getWorld().playSound(e.getFrom(), Sound.BLOCK_ANVIL_HIT, 1F, 1F);
-                eject(p);
+            if (passenger instanceof Player p) {
+                if (island == null) {
+                    island = getIslands().getProtectedIslandAt(e.getTo());
+                }
+                if (!checkAndNotify(p, e.getTo(), island).isAllowed()) {
+                    p.leaveVehicle();
+                    p.teleport(e.getFrom());
+                    e.getVehicle().getWorld().playSound(e.getFrom(), Sound.BLOCK_ANVIL_HIT, 1F, 1F);
+                    eject(p);
+                }
             }
         }
     }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
@@ -1,12 +1,14 @@
 package world.bentobox.bentobox.listeners.flags.protection;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -111,14 +113,15 @@ public class LockAndBanListener extends FlagListener {
             return;
         }
         // For each Player in the vehicle
-        e.getVehicle().getPassengers().stream().filter(Player.class::isInstance).map(Player.class::cast).forEach(p -> {
-            if (!checkAndNotify(p, e.getTo()).isAllowed()) {
+        Optional<Island> island = getIslands().getProtectedIslandAt(e.getTo());
+        for (Entity passenger : e.getVehicle().getPassengers()) {
+            if (passenger instanceof Player p && !checkAndNotify(p, e.getTo(), island).isAllowed()) {
                 p.leaveVehicle();
                 p.teleport(e.getFrom());
                 e.getVehicle().getWorld().playSound(e.getFrom(), Sound.BLOCK_ANVIL_HIT, 1F, 1F);
                 eject(p);
             }
-        });
+        }
     }
 
     // Login check
@@ -145,6 +148,19 @@ public class LockAndBanListener extends FlagListener {
      */
     private CheckResult check(@NonNull Player player, Location loc)
     {
+        return check(player, loc, this.getIslands().getProtectedIslandAt(loc));
+    }
+
+    /**
+     * Check if a player is banned or the island is locked, using an already-resolved island
+     * to avoid repeated island lookups for the same location.
+     * @param player - player
+     * @param loc - location to check
+     * @param island - island at the location, if any
+     * @return CheckResult LOCKED, BANNED or OPEN. If an island is locked, that will take priority over banned
+     */
+    private CheckResult check(@NonNull Player player, Location loc, Optional<Island> island)
+    {
         // Ops or NPC's are allowed everywhere
         if (player.isOp() || player.hasMetadata("NPC"))
         {
@@ -152,7 +168,7 @@ public class LockAndBanListener extends FlagListener {
         }
 
         // See if the island is locked to non-members or player is banned
-        return this.getIslands().getProtectedIslandAt(loc).
+        return island.
                 map(is ->
                 {
                     if (is.isBanned(player.getUniqueId()))
@@ -181,7 +197,19 @@ public class LockAndBanListener extends FlagListener {
      */
     private CheckResult checkAndNotify(@NonNull Player player, Location loc)
     {
-        CheckResult result = this.check(player, loc);
+        return checkAndNotify(player, loc, this.getIslands().getProtectedIslandAt(loc));
+    }
+
+    /**
+     * Same as {@link #checkAndNotify(Player, Location)} but reuses an already-resolved island.
+     * @param player - player
+     * @param loc - location to check
+     * @param island - island at the location, if any
+     * @return CheckResult
+     */
+    private CheckResult checkAndNotify(@NonNull Player player, Location loc, Optional<Island> island)
+    {
+        CheckResult result = this.check(player, loc, island);
         if (result == CheckResult.OPEN) {
             // Player is in an open area, clear notification state
             notifiedPlayers.remove(player.getUniqueId());
@@ -195,7 +223,7 @@ public class LockAndBanListener extends FlagListener {
                 User.getInstance(player).notify("protection.locked-island-bypass");
             }
         }
-        notifyIfDeletable(player, loc);
+        notifyIfDeletable(player, island);
         return result;
     }
 
@@ -208,13 +236,12 @@ public class LockAndBanListener extends FlagListener {
      * <p>Fires at most once per entry, using the same "move out to reset"
      * pattern as the lock notification.
      */
-    private void notifyIfDeletable(@NonNull Player player, Location loc) {
+    private void notifyIfDeletable(@NonNull Player player, Optional<Island> island) {
         if (!player.isOp()) {
             deletableNotified.remove(player.getUniqueId());
             return;
         }
-        boolean deletable = getIslands().getProtectedIslandAt(loc)
-                .map(Island::isDeletable).orElse(false);
+        boolean deletable = island.map(Island::isDeletable).orElse(false);
         if (deletable) {
             if (deletableNotified.add(player.getUniqueId())) {
                 User.getInstance(player).notify("protection.deletable-island-admin");

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListener.java
@@ -115,11 +115,13 @@ public class LockAndBanListener extends FlagListener {
         // For each Player in the vehicle. Resolve the island lazily on the first Player
         // passenger so unmanned/mob-ridden vehicles pay no grid lookup, and reuse it for
         // any further player passengers (the rare multi-player case).
-        Optional<Island> island = null;
+        Optional<Island> island = Optional.empty();
+        boolean islandResolved = false;
         for (Entity passenger : e.getVehicle().getPassengers()) {
             if (passenger instanceof Player p) {
-                if (island == null) {
+                if (!islandResolved) {
                     island = getIslands().getProtectedIslandAt(e.getTo());
+                    islandResolved = true;
                 }
                 if (!checkAndNotify(p, e.getTo(), island).isAllowed()) {
                     p.leaveVehicle();

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/settings/MobSpawnListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/settings/MobSpawnListener.java
@@ -96,8 +96,10 @@ public class MobSpawnListener extends FlagListener
      */
     void onMobSpawn(CreatureSpawnEvent e)
     {
+        // Entity#getLocation allocates a new Location on every call, so fetch it once
+        Location location = e.getLocation();
         // If not in the right world, or spawning is not natural return
-        if (!this.getIWM().inWorld(e.getEntity().getLocation()))
+        if (!this.getIWM().inWorld(location))
         {
             return;
         }
@@ -109,7 +111,7 @@ public class MobSpawnListener extends FlagListener
                  RAID, REINFORCEMENTS, SILVERFISH_BLOCK, TRAP, VILLAGE_DEFENSE, VILLAGE_INVASION ->
             {
                 boolean cancelNatural = this.shouldCancel(e.getEntity(),
-                    e.getLocation(),
+                    location,
                     Flags.ANIMAL_NATURAL_SPAWN,
                     Flags.MONSTER_NATURAL_SPAWN);
                 e.setCancelled(cancelNatural);
@@ -118,7 +120,7 @@ public class MobSpawnListener extends FlagListener
             case SPAWNER, TRIAL_SPAWNER ->
             {
                 boolean cancelSpawners = this.shouldCancel(e.getEntity(),
-                    e.getLocation(),
+                    location,
                     Flags.ANIMAL_SPAWNERS_SPAWN,
                     Flags.MONSTER_SPAWNERS_SPAWN);
                 e.setCancelled(cancelSpawners);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/settings/PVPListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/settings/PVPListener.java
@@ -145,8 +145,9 @@ public class PVPListener extends FlagListener {
                 return;
             }
             // Run through affected entities and cancel the splash for protected players
+            Flag flag = getFlag(e.getEntity().getWorld());
             for (LivingEntity le : e.getAffectedEntities()) {
-                if (!le.getUniqueId().equals(user.getUniqueId()) && blockPVP(user, le, e, getFlag(e.getEntity().getWorld()))) {
+                if (!le.getUniqueId().equals(user.getUniqueId()) && blockPVP(user, le, e, flag)) {
                     e.setIntensity(le, 0);
                 }
             }
@@ -222,7 +223,8 @@ public class PVPListener extends FlagListener {
         if (thrownPotions.containsKey(e.getEntity().getEntityId())) {
             User user = User.getInstance(thrownPotions.get(e.getEntity().getEntityId()));
             // Run through affected entities and delete them if they are safe
-            e.getAffectedEntities().removeIf(le -> !le.getUniqueId().equals(user.getUniqueId()) && blockPVP(user, le, e, getFlag(e.getEntity().getWorld())));
+            Flag flag = getFlag(e.getEntity().getWorld());
+            e.getAffectedEntities().removeIf(le -> !le.getUniqueId().equals(user.getUniqueId()) && blockPVP(user, le, e, flag));
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
@@ -1,6 +1,8 @@
 package world.bentobox.bentobox.listeners.flags.worldsettings;
 
+import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Queue;
 
 import org.bukkit.Bukkit;
@@ -11,7 +13,6 @@ import org.bukkit.World.Environment;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.world.ChunkLoadEvent;
-import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.scheduler.BukkitTask;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -55,6 +56,12 @@ public class CleanSuperFlatListener extends FlagListener {
 
     private WorldRegenerator regenerator;
 
+    /**
+     * Per-world cache of whether a default world generator exists, so the addon
+     * lookup does not run for every superflat chunk load.
+     */
+    private final Map<String, Boolean> hasGenerator = new HashMap<>();
+
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onBentoBoxReady(BentoBoxReadyEvent e) {
         this.regenerator = Util.getRegenerator();
@@ -75,9 +82,10 @@ public class CleanSuperFlatListener extends FlagListener {
             return;
         }
         
-        ChunkGenerator cg = plugin.getAddonsManager().getDefaultWorldGenerator(world.getName(), "");
-        
-        if (cg == null) 
+        boolean cg = hasGenerator.computeIfAbsent(world.getName(),
+                name -> plugin.getAddonsManager().getDefaultWorldGenerator(name, "") != null);
+
+        if (!cg)
         {
             Flags.CLEAN_SUPER_FLAT.setSetting(world, false);
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/CleanSuperFlatListener.java
@@ -64,6 +64,8 @@ public class CleanSuperFlatListener extends FlagListener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onBentoBoxReady(BentoBoxReadyEvent e) {
+        // Clear the generator cache so a reload picks up newly assigned/registered generators.
+        hasGenerator.clear();
         this.regenerator = Util.getRegenerator();
         if (regenerator == null) {
             plugin.logError("Could not start CleanSuperFlat because of NMS error");

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/EnterExitListener.java
@@ -7,7 +7,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -24,7 +23,6 @@ import world.bentobox.bentobox.lists.Flags;
  */
 public class EnterExitListener extends FlagListener {
 
-    private static final Vector XZ = new Vector(1,0,1);
     private static final String ISLAND_MESSAGE = "protection.flags.ENTER_EXIT_MESSAGES.island";
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -39,9 +37,11 @@ public class EnterExitListener extends FlagListener {
 
     private void handleEnterExit(@NonNull User user, @NonNull Location from, @Nullable Location to,
             @NonNull PlayerMoveEvent e) {
-        // Only process if there is a change in X or Z coords
+        // Only process if there is a change in X or Z coords. Island protection bounds
+        // are block-based, so same-block moves cannot change the result; comparing block
+        // coordinates avoids allocating vectors on every move event.
         if (from.getWorld() != null && to != null && from.getWorld().equals(to.getWorld())
-                && from.toVector().multiply(XZ).equals(to.toVector().multiply(XZ))) {
+                && from.getBlockX() == to.getBlockX() && from.getBlockZ() == to.getBlockZ()) {
             return;
         }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/GeoLimitMobsListener.java
@@ -1,9 +1,11 @@
 package world.bentobox.bentobox.listeners.flags.worldsettings;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.WeakHashMap;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
@@ -32,13 +34,20 @@ public class GeoLimitMobsListener extends FlagListener {
      */
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPluginReady(BentoBoxReadyEvent event) {
-        // Kick off the task to remove entities that go outside island boundaries
+        // Kick off the task to remove entities that go outside island boundaries.
+        // This runs every second, so avoid stream allocations
         Bukkit.getScheduler().runTaskTimer(getPlugin(), () -> {
-            mobSpawnTracker.entrySet().stream()
-            .filter(e -> !e.getValue().onIsland(e.getKey().getLocation()))
-            .map(Map.Entry::getKey)
-            .forEach(Entity::remove);
-            mobSpawnTracker.keySet().removeIf(e -> e == null || e.isDead());
+            Iterator<Map.Entry<Entity, Island>> it = mobSpawnTracker.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<Entity, Island> entry = it.next();
+                Entity mob = entry.getKey();
+                if (mob == null || mob.isDead()) {
+                    it.remove();
+                } else if (!entry.getValue().onIsland(mob.getLocation())) {
+                    mob.remove();
+                    it.remove();
+                }
+            }
         }, 20L, 20L);
     }
 
@@ -48,9 +57,11 @@ public class GeoLimitMobsListener extends FlagListener {
      */
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onMobSpawn(CreatureSpawnEvent e) {
-        if (getIWM().inWorld(e.getLocation())
-                && getIWM().getGeoLimitSettings(e.getLocation().getWorld()).contains(e.getEntityType().name())) {
-            getIslands().getIslandAt(e.getLocation()).ifPresent(i -> mobSpawnTracker.put(e.getEntity(), i));
+        // Entity#getLocation allocates a new Location on every call, so fetch it once
+        Location location = e.getLocation();
+        if (getIWM().inWorld(location)
+                && getIWM().getGeoLimitSettings(location.getWorld()).contains(e.getEntityType().name())) {
+            getIslands().getIslandAt(location).ifPresent(i -> mobSpawnTracker.put(e.getEntity(), i));
         }
     }
 
@@ -68,9 +79,11 @@ public class GeoLimitMobsListener extends FlagListener {
      */
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onProjectileLaunch(final ProjectileLaunchEvent e) {
-        if (getIWM().inWorld(e.getEntity().getLocation())
-                && getIWM().getGeoLimitSettings(e.getEntity().getLocation().getWorld()).contains(e.getEntityType().name())) {
-            getIslands().getIslandAt(e.getEntity().getLocation()).ifPresent(i -> mobSpawnTracker.put(e.getEntity(), i));
+        // Entity#getLocation allocates a new Location on every call, so fetch it once
+        Location location = e.getEntity().getLocation();
+        if (getIWM().inWorld(location)
+                && getIWM().getGeoLimitSettings(location.getWorld()).contains(e.getEntityType().name())) {
+            getIslands().getIslandAt(location).ifPresent(i -> mobSpawnTracker.put(e.getEntity(), i));
         }
     }
 

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
@@ -3,6 +3,7 @@ package world.bentobox.bentobox.listeners.flags.worldsettings;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -28,6 +29,7 @@ import world.bentobox.bentobox.api.panels.PanelItem.ClickHandler;
 import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 import world.bentobox.bentobox.util.teleport.SafeSpotTeleport;
 
@@ -156,13 +158,14 @@ public class InvincibleVisitorsListener extends FlagListener implements ClickHan
         e.setCancelled(true);
         // Handle the void - teleport player back to island in a safe spot
         if(e.getCause().equals(DamageCause.VOID)) {
-            if (getIslands().getIslandAt(p.getLocation()).isPresent()) {
-                getIslands().getIslandAt(p.getLocation()).ifPresent(island ->
+            // Single lookup - getIslandAt walks the grid and getLocation copies, no need to do either twice
+            Optional<Island> island = getIslands().getIslandAt(p.getLocation());
+            if (island.isPresent()) {
                 // Teleport
                 new SafeSpotTeleport.Builder(getPlugin())
                 .entity(p)
-                .location(island.getProtectionCenter().toVector().toLocation(p.getWorld()))
-                .build());
+                .location(island.get().getProtectionCenter().toVector().toLocation(p.getWorld()))
+                .build();
             } else if (getIslands().hasIsland(p.getWorld(), p.getUniqueId())) {
                 // No island in this location - if the player has an island try to teleport them back
                 getIslands().homeTeleportAsync(p.getWorld(), p);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/InvincibleVisitorsListener.java
@@ -159,7 +159,8 @@ public class InvincibleVisitorsListener extends FlagListener implements ClickHan
         // Handle the void - teleport player back to island in a safe spot
         if(e.getCause().equals(DamageCause.VOID)) {
             // Single lookup - getIslandAt walks the grid and getLocation copies, no need to do either twice
-            Optional<Island> island = getIslands().getIslandAt(p.getLocation());
+            // requireNonNull: Bukkit guarantees a live player's location is non-null (java:S2637)
+            Optional<Island> island = getIslands().getIslandAt(Objects.requireNonNull(p.getLocation()));
             if (island.isPresent()) {
                 // Teleport
                 new SafeSpotTeleport.Builder(getPlugin())

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/LimitMobsListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/LimitMobsListener.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.listeners.flags.worldsettings;
 
+import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -28,7 +29,9 @@ public class LimitMobsListener extends FlagListener {
     }
 
     private void check(CreatureSpawnEvent e, EntityType type) {
-        if (getIWM().inWorld(e.getLocation()) && getIWM().getMobLimitSettings(e.getLocation().getWorld()).contains(type.name())) {
+        // Entity#getLocation allocates a new Location on every call, so fetch it once
+        Location location = e.getLocation();
+        if (getIWM().inWorld(location) && getIWM().getMobLimitSettings(location.getWorld()).contains(type.name())) {
             e.setCancelled(true);
         }
     }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListener.java
@@ -26,19 +26,20 @@ public class LiquidsFlowingOutListener extends FlagListener {
         Block from = e.getBlock();
         Block to = e.getToBlock();
 
-        if (!getIWM().inWorld(from.getLocation()) || Flags.LIQUIDS_FLOWING_OUT.isSetForWorld(from.getWorld())) {
-            // We do not want to run any check if this is not the right world or if it is allowed.
-            return;
-        }
-
         // https://github.com/BentoBoxWorld/BentoBox/issues/511#issuecomment-460040287
         if (to.getY() != from.getY()) {
             // We do not run any checks if this is a vertical flow - would be too much resource consuming.
             return;
         }
 
+        Location fromLocation = from.getLocation();
+        if (!getIWM().inWorld(fromLocation) || Flags.LIQUIDS_FLOWING_OUT.isSetForWorld(from.getWorld())) {
+            // We do not want to run any check if this is not the right world or if it is allowed.
+            return;
+        }
+
         // Only prevent if it is flowing into the area between islands or into another island.
-        Optional<Island> fromIsland = getIslands().getProtectedIslandAt(from.getLocation());
+        Optional<Island> fromIsland = getIslands().getProtectedIslandAt(fromLocation);
         Optional<Island> toIsland = getIslands().getProtectedIslandAt(to.getLocation());
         if (toIsland.isEmpty() || (fromIsland.isPresent() && !fromIsland.equals(toIsland))) {
             e.setCancelled(true);

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListener.java
@@ -32,8 +32,7 @@ public class LiquidsFlowingOutListener extends FlagListener {
         }
 
         // https://github.com/BentoBoxWorld/BentoBox/issues/511#issuecomment-460040287
-        // Time to do some maths! We've got the vector FromTo, let's check if its y coordinate is different from zero.
-        if (to.getLocation().toVector().subtract(from.getLocation().toVector()).getY() != 0) {
+        if (to.getY() != from.getY()) {
             // We do not run any checks if this is a vertical flow - would be too much resource consuming.
             return;
         }

--- a/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/NaturalSpawningOutsideRangeListener.java
+++ b/src/main/java/world/bentobox/bentobox/listeners/flags/worldsettings/NaturalSpawningOutsideRangeListener.java
@@ -1,5 +1,6 @@
 package world.bentobox.bentobox.listeners.flags.worldsettings;
 
+import org.bukkit.Location;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -17,13 +18,15 @@ public class NaturalSpawningOutsideRangeListener extends FlagListener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onCreatureSpawn(CreatureSpawnEvent e) {
-        if (!getIWM().inWorld(e.getLocation()) || Flags.NATURAL_SPAWNING_OUTSIDE_RANGE.isSetForWorld(e.getLocation().getWorld())) {
+        // Entity#getLocation allocates a new Location on every call, so fetch it once
+        Location location = e.getLocation();
+        if (!getIWM().inWorld(location) || Flags.NATURAL_SPAWNING_OUTSIDE_RANGE.isSetForWorld(location.getWorld())) {
             // We do not want to run any check if this is not the right world or if it is allowed.
             return;
         }
 
         // If it is a natural spawn and there is no protected island at the location, block the spawn.
-        if (e.getSpawnReason() == CreatureSpawnEvent.SpawnReason.NATURAL && getIslands().getProtectedIslandAt(e.getLocation()).isEmpty()) {
+        if (e.getSpawnReason() == CreatureSpawnEvent.SpawnReason.NATURAL && getIslands().getProtectedIslandAt(location).isEmpty()) {
             e.setCancelled(true);
         }
     }

--- a/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
+++ b/src/main/java/world/bentobox/bentobox/managers/PurgeRegionsService.java
@@ -16,8 +16,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -224,8 +227,11 @@ public class PurgeRegionsService {
      * along with any island database entries, island cache entries, and
      * orphaned player data files that correspond to them.
      *
-     * <p>Runs synchronously on the calling thread and performs disk I/O.
-     * Callers must invoke this from an async task. Callers are also
+     * <p>Performs disk I/O on the calling thread and should be invoked from
+     * an async task. The final bookkeeping — firing {@link IslandEvent}s and
+     * removing islands from the cache and database — is hopped onto the main
+     * thread and awaited before this method returns, because Paper only
+     * allows {@link IslandEvent} to be fired synchronously. Callers are also
      * responsible for flushing in-memory chunk state by calling
      * {@code World.save()} on the main thread <b>before</b> dispatching
      * this method — {@code World.save()} is not safe to invoke from an
@@ -252,8 +258,13 @@ public class PurgeRegionsService {
             affectedIds.addAll(islandIDs);
         }
 
-        int islandsRemoved = 0;
+        // Phase 1 (calling thread, disk I/O): decide which islands are fully
+        // reaped and delete their orphaned player data. No Bukkit events or
+        // cache/DB mutations happen here — this method is normally invoked
+        // from an async task and IslandEvent may only be fired on the main
+        // thread (Paper enforces this and throws IllegalStateException).
         int islandsDeferred = 0;
+        List<Island> toFinalize = new ArrayList<>();
         for (String islandID : affectedIds) {
             Optional<Island> opt = plugin.getIslands().getIslandById(islandID);
             if (opt.isEmpty()) {
@@ -294,28 +305,14 @@ public class PurgeRegionsService {
                     continue;
                 }
                 deletePlayerFromWorldFolder(scan.world(), islandID, scan.deletableRegions(), scan.days());
-                // For the age sweep, DELETED may never have fired (the island was
-                // pruned by age, not by an explicit /is reset). Fire it now so addons
-                // (Level, OneBlock, etc.) can clean up their per-island data.
-                if (!island.isDeletable()) {
-                    IslandEvent.builder()
-                            .island(island)
-                            .reason(Reason.DELETED)
-                            .build();
-                }
-                plugin.getIslands().getIslandCache().deleteIslandFromCache(islandID);
-                if (plugin.getIslands().deleteIslandId(islandID)) {
-                    plugin.log("Island ID " + islandID + " deleted from cache and database");
-                    islandsRemoved++;
-                    // Fire PURGED so addons that track physical storage state know
-                    // the region files and DB row are both gone.
-                    IslandEvent.builder()
-                            .island(island)
-                            .reason(Reason.PURGED)
-                            .build();
-                }
+                toFinalize.add(island);
             }
         }
+
+        // Phase 2 (main thread): fire events and remove the islands from the
+        // cache and database. Blocks the calling thread until done so the
+        // return value and the summary log below reflect the final state.
+        int islandsRemoved = toFinalize.isEmpty() ? 0 : runOnMainThread(() -> finalizeIslands(toFinalize));
         plugin.log("Purge complete for world " + scan.world().getName()
                 + ": " + scan.deletableRegions().size() + " region(s), "
                 + islandsRemoved + " island(s) removed, "
@@ -364,6 +361,76 @@ public class PurgeRegionsService {
      */
     public Set<String> getPendingDeletions() {
         return Collections.unmodifiableSet(pendingDeletions);
+    }
+
+    /**
+     * Removes each fully-reaped island from the cache and database, firing
+     * {@link Reason#DELETED} first if the island was never soft-deleted and
+     * {@link Reason#PURGED} once the row is gone. <b>Main thread only</b>:
+     * {@link IslandEvent} is a synchronous event.
+     *
+     * @param islands islands whose region files and player data are already gone
+     * @return the number of islands actually removed from the database
+     */
+    private int finalizeIslands(List<Island> islands) {
+        int removed = 0;
+        for (Island island : islands) {
+            String islandID = island.getUniqueId();
+            // For the age sweep, DELETED may never have fired (the island was
+            // pruned by age, not by an explicit /is reset). Fire it now so addons
+            // (Level, OneBlock, etc.) can clean up their per-island data.
+            if (!island.isDeletable()) {
+                IslandEvent.builder()
+                        .island(island)
+                        .reason(Reason.DELETED)
+                        .build();
+            }
+            plugin.getIslands().getIslandCache().deleteIslandFromCache(islandID);
+            if (plugin.getIslands().deleteIslandId(islandID)) {
+                plugin.log("Island ID " + islandID + " deleted from cache and database");
+                removed++;
+                // Fire PURGED so addons that track physical storage state know
+                // the region files and DB row are both gone.
+                IslandEvent.builder()
+                        .island(island)
+                        .reason(Reason.PURGED)
+                        .build();
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Runs {@code task} on the main server thread and waits for its result.
+     * If already on the main thread the task runs inline.
+     *
+     * @param task work that must run on the main thread
+     * @return the task's result
+     * @throws IllegalStateException if the task could not be scheduled or failed
+     */
+    private <T> T runOnMainThread(Supplier<T> task) {
+        if (Bukkit.isPrimaryThread()) {
+            return task.get();
+        }
+        CompletableFuture<T> done = new CompletableFuture<>();
+        try {
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                try {
+                    done.complete(task.get());
+                } catch (Exception e) {
+                    done.completeExceptionally(e);
+                }
+            });
+        } catch (RuntimeException e) {
+            // Typically IllegalPluginAccessException: the plugin is disabling and
+            // the scheduler will not accept new tasks.
+            throw new IllegalStateException("Could not schedule purge finalization on the main thread", e);
+        }
+        try {
+            return done.join();
+        } catch (CompletionException e) {
+            throw new IllegalStateException("Purge finalization failed on the main thread", e.getCause());
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
@@ -265,10 +265,11 @@ public class IslandCache {
      */
     public boolean isIslandAt(@NonNull Location location) {
         World w = Util.getWorld(location.getWorld());
-        if (w == null || !grids.containsKey(w)) {
+        if (w == null) {
             return false;
         }
-        return grids.get(w).isIslandAt(location.getBlockX(), location.getBlockZ());
+        IslandGrid grid = grids.get(w);
+        return grid != null && grid.isIslandAt(location.getBlockX(), location.getBlockZ());
     }
 
     /**
@@ -281,10 +282,11 @@ public class IslandCache {
     @Nullable
     public Island getIslandAt(@NonNull Location location) {
         World w = Util.getWorld(location.getWorld());
-        if (w == null || !grids.containsKey(w)) {
+        if (w == null) {
             return null;
         }
-        return grids.get(w).getIslandAt(location.getBlockX(), location.getBlockZ());
+        IslandGrid grid = grids.get(w);
+        return grid == null ? null : grid.getIslandAt(location.getBlockX(), location.getBlockZ());
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
+++ b/src/main/java/world/bentobox/bentobox/managers/island/IslandCache.java
@@ -48,7 +48,9 @@ public class IslandCache {
     private final Map<@NonNull UUID, Set<String>> islandsByUUID;
 
     @NonNull
-    private final Map<@NonNull World, @NonNull IslandGrid> grids;
+    // No @NonNull on the value type: Map#get returns null for worlds that have no grid
+    // yet, and a non-null value annotation makes those null checks look impossible (java:S2583)
+    private final Map<World, IslandGrid> grids;
     private final @NonNull Database<Island> handler;
 
     public IslandCache(@NonNull Database<Island> handler) {

--- a/src/main/java/world/bentobox/bentobox/util/IslandInfo.java
+++ b/src/main/java/world/bentobox/bentobox/util/IslandInfo.java
@@ -50,6 +50,9 @@ public class IslandInfo {
     public void showAdminInfo(User user, Addon addon) {
         user.sendMessage("commands.admin.info.title");
         user.sendMessage("commands.admin.info.island-uuid", TextVariables.UUID, island.getUniqueId());
+        if (island.getName() != null && !island.getName().isBlank()) {
+            user.sendMessage("commands.admin.info.island-name", TextVariables.NAME, island.getName());
+        }
         if (owner == null) {
             user.sendMessage("commands.admin.info.unowned");
         } else {

--- a/src/main/java/world/bentobox/bentobox/util/PlaceholderGrouper.java
+++ b/src/main/java/world/bentobox/bentobox/util/PlaceholderGrouper.java
@@ -143,6 +143,8 @@ public final class PlaceholderGrouper {
      * </p>
      */
     static String stripTrailingHashNumber(String description) {
-        return description.replaceAll("\\s*+#\\d++", "").trim();
+        // Bounded whitespace prefix (\s?+) keeps the scan linear; an unbounded \s*+
+        // prefix is re-tried at every position of a whitespace run (Sonar S8786)
+        return description.replaceAll("\\s?+#\\d++", "").trim();
     }
 }

--- a/src/main/java/world/bentobox/bentobox/util/Util.java
+++ b/src/main/java/world/bentobox/bentobox/util/Util.java
@@ -8,10 +8,12 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -332,17 +334,31 @@ public class Util {
             // matches nothing
             return false;
         }
+        // Same instance is the overwhelmingly common case on the event path
+        if (world == world2) {
+            return true;
+        }
         return stripName(world).equals(stripName(world2));
     }
 
+    /**
+     * Cache of world name -> name with any _nether/_the_end suffix stripped.
+     * The mapping is a pure function of the name, so it never needs invalidation.
+     */
+    private static final Map<String, String> STRIPPED_NAMES = new ConcurrentHashMap<>();
+
     private static String stripName(World world) {
-        if (world.getName().endsWith(NETHER)) {
-            return world.getName().substring(0, world.getName().length() - NETHER.length());
+        return STRIPPED_NAMES.computeIfAbsent(world.getName(), Util::stripSuffix);
+    }
+
+    private static String stripSuffix(String name) {
+        if (name.endsWith(NETHER)) {
+            return name.substring(0, name.length() - NETHER.length());
         }
-        if (world.getName().endsWith(THE_END)) {
-            return world.getName().substring(0, world.getName().length() - THE_END.length());
+        if (name.endsWith(THE_END)) {
+            return name.substring(0, name.length() - THE_END.length());
         }
-        return world.getName();
+        return name;
     }
 
     /**
@@ -350,12 +366,23 @@ public class Util {
      * @param world - world
      * @return over world or null if world is null or a world cannot be found
      */
+    /**
+     * Cache of world name -> overworld name (suffixes replaced). Pure string
+     * function, so entries never go stale. The World itself is still resolved
+     * live via {@link Bukkit#getWorld(String)}.
+     */
+    private static final Map<String, String> OVERWORLD_NAMES = new ConcurrentHashMap<>();
+
     @Nullable
     public static World getWorld(@Nullable World world) {
         if (world == null) {
             return null;
         }
-        return world.getEnvironment().equals(Environment.NORMAL) ? world : Bukkit.getWorld(world.getName().replace(NETHER, "").replace(THE_END, ""));
+        if (world.getEnvironment() == Environment.NORMAL) {
+            return world;
+        }
+        return Bukkit.getWorld(OVERWORLD_NAMES.computeIfAbsent(world.getName(),
+                n -> n.replace(NETHER, "").replace(THE_END, "")));
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -31,7 +31,7 @@ import world.bentobox.bentobox.util.Pair;
 
 /**
  * This class manages getting player heads for requester.
- * 
+ *
  * @author tastybento, BONNe1704
  */
 public class HeadGetter {
@@ -52,6 +52,9 @@ public class HeadGetter {
             TimeUnit.SECONDS);
 
     private static final String TEXTURES = "textures";
+
+    // Gson construction is expensive, don't rebuild it per head lookup
+    private static final Gson GSON = new Gson();
 
     private static final String NAME = "name";
 
@@ -151,7 +154,7 @@ public class HeadGetter {
     /**
      * This method allows to add HeadCache object into local cache. It will provide
      * addons to use HeadGetter cache directly.
-     * 
+     *
      * @param cache Cache object that need to be added into local cache.
      * @since 1.14.1
      */
@@ -290,7 +293,7 @@ public class HeadGetter {
 
     /**
      * This method gets and returns userId from mojang web API based on user name.
-     * 
+     *
      * @param name user which Id must be returned.
      * @return String value for user Id.
      * @since 1.14.1
@@ -299,10 +302,8 @@ public class HeadGetter {
         UUID userId;
 
         try {
-            Gson gsonReader = new Gson();
-
             // Get mojang user-id from given nickname
-            JsonObject jsonObject = gsonReader.fromJson(
+            JsonObject jsonObject = GSON.fromJson(
                     HeadGetter.getURLContent("https://api.mojang.com/users/profiles/minecraft/" + name),
                     JsonObject.class);
             /*
@@ -335,10 +336,8 @@ public class HeadGetter {
      */
     private static @Nullable String getTextureFromUUID(UUID userId) {
         try {
-            Gson gsonReader = new Gson();
-
             // Get user encoded texture value.
-            JsonObject jsonObject = gsonReader.fromJson(
+            JsonObject jsonObject = GSON.fromJson(
                     HeadGetter.getURLContent(
                             "https://sessionserver.mojang.com/session/minecraft/profile/" + userId.toString()),
                     JsonObject.class);
@@ -379,13 +378,11 @@ public class HeadGetter {
      */
     private static @NonNull Pair<UUID, String> getTextureFromName(String userName, @Nullable UUID userId) {
         try {
-            Gson gsonReader = new Gson();
-
             // Get user encoded texture value.
             // mc-heads returns correct skin with providing just a name, unlike mojang api,
             // which
             // requires UUID.
-            JsonObject jsonObject = gsonReader.fromJson(HeadGetter.getURLContent(
+            JsonObject jsonObject = GSON.fromJson(HeadGetter.getURLContent(
                     "https://mc-heads.net/minecraft/profile/" + (userId == null ? userName : userId.toString())),
                     JsonObject.class);
 
@@ -449,7 +446,7 @@ public class HeadGetter {
          */
         try {
             String decoded = new String(Base64.getDecoder().decode(base64));
-            JsonObject json = new Gson().fromJson(decoded, JsonObject.class);
+            JsonObject json = GSON.fromJson(decoded, JsonObject.class);
             String url = json.getAsJsonObject(TEXTURES).getAsJsonObject("SKIN").get("url").getAsString();
             return new URI(url).toURL();
         } catch (Exception e) {

--- a/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
+++ b/src/main/java/world/bentobox/bentobox/util/heads/HeadGetter.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.profile.PlayerProfile;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -100,10 +101,50 @@ public class HeadGetter {
                 || System.currentTimeMillis() - cache.getTimestamp() <= cacheTimeout)) {
             panelItem.setHead(cachedHeads.get(panelItem.getPlayerHeadName()).getPlayerHead());
             requester.setHead(panelItem);
-        } else {
-            // Get the name
-            headRequesters.computeIfAbsent(panelItem.getPlayerHeadName(), k -> new HashSet<>()).add(requester);
-            names.add(new Pair<>(panelItem.getPlayerHeadName(), panelItem));
+            return;
+        }
+
+        // If the player is online, the server already holds their completed profile,
+        // textures included, so the head can be delivered synchronously with no web
+        // lookup. This also avoids the async callback racing a GUI that has since been
+        // redrawn. The player list may only be read from the primary thread.
+        if (Bukkit.isPrimaryThread()) {
+            HeadCache live = getFromOnlinePlayer(panelItem.getPlayerHeadName());
+
+            if (live != null) {
+                cachedHeads.put(live.getUserName(), live);
+                panelItem.setHead(live.getPlayerHead());
+                requester.setHead(panelItem);
+                return;
+            }
+        }
+
+        // Queue for the async resolver
+        headRequesters.computeIfAbsent(panelItem.getPlayerHeadName(), k -> new HashSet<>()).add(requester);
+        names.add(new Pair<>(panelItem.getPlayerHeadName(), panelItem));
+    }
+
+    /**
+     * Builds a head cache entry from an online player's live profile, if the player is
+     * online and their profile carries a skin texture.
+     *
+     * @param userName exact name of the player.
+     * @return a cache entry with a usable texture, or null if unavailable.
+     * @since 3.22.3
+     */
+    private static @Nullable HeadCache getFromOnlinePlayer(String userName) {
+        Player player = Bukkit.getPlayerExact(userName);
+
+        if (player == null) {
+            return null;
+        }
+
+        try {
+            HeadCache cache = new HeadCache(userName, player.getUniqueId(), player.getPlayerProfile());
+            return cache.hasTexture() ? cache : null;
+        } catch (Exception e) {
+            // An unreadable profile just means we fall back to the async resolver.
+            return null;
         }
     }
 
@@ -156,24 +197,30 @@ public class HeadGetter {
                             userId = null;
                         }
 
-                        HeadCache cache;
+                        // Ask the server first: Paper completes profiles through its own
+                        // session-service cache, so this is free for anyone who has
+                        // logged in recently and avoids hand-rolled HTTP entirely.
+                        HeadCache cache = HeadGetter.getFromServer(userName, userId);
 
-                        if (plugin.getSettings().isUseCacheServer()) {
-                            // Cache server has an implementation to get a skin just from player name.
-                            Pair<UUID, String> playerSkin = HeadGetter.getTextureFromName(userName, userId);
+                        if (cache == null) {
+                            if (plugin.getSettings().isUseCacheServer()) {
+                                // Cache server has an implementation to get a skin just from player name.
+                                Pair<UUID, String> playerSkin = HeadGetter.getTextureFromName(userName, userId);
 
-                            // Create new cache object.
-                            cache = new HeadCache(userName, playerSkin.getKey(),
-                                    HeadGetter.createProfile(userName, playerSkin.getKey(), playerSkin.getValue()));
-                        } else {
-                            if (userId == null) {
-                                // Use MojangAPI to get userId from userName.
-                                userId = HeadGetter.getUserIdFromName(userName);
+                                // Create new cache object.
+                                cache = new HeadCache(userName, playerSkin.getKey(),
+                                        HeadGetter.createProfile(userName, playerSkin.getKey(), playerSkin.getValue()));
+                            } else {
+                                if (userId == null) {
+                                    // Use MojangAPI to get userId from userName.
+                                    userId = HeadGetter.getUserIdFromName(userName);
+                                }
+
+                                // Create new cache object.
+                                cache = new HeadCache(userName, userId,
+                                        HeadGetter.createProfile(userName, userId,
+                                                HeadGetter.getTextureFromUUID(userId)));
                             }
-
-                            // Create new cache object.
-                            cache = new HeadCache(userName, userId,
-                                    HeadGetter.createProfile(userName, userId, HeadGetter.getTextureFromUUID(userId)));
                         }
 
                         // Save in cache. A failed lookup must not evict a texture we already
@@ -207,6 +254,38 @@ public class HeadGetter {
                 }
             }
         }, 0, plugin.getSettings().getTicksBetweenCalls());
+    }
+
+    /**
+     * Asks the server to complete a player profile for the given name/UUID. Paper resolves
+     * this through its own session-service client, which caches the profile of every player
+     * who has logged in, so for known players this returns instantly with no web request of
+     * our own. For unknown premium names it performs the Mojang lookup on our behalf,
+     * respecting the server's rate limiting.
+     * <p>
+     * Must be called from an async thread — profile completion may block on I/O.
+     *
+     * @param userName name of the player.
+     * @param userId UUID of the player, if known.
+     * @return a cache entry with a usable texture, or null if the server could not provide one.
+     * @since 3.22.3
+     */
+    private static @Nullable HeadCache getFromServer(@NonNull String userName, @Nullable UUID userId) {
+        try {
+            PlayerProfile profile = Bukkit.createPlayerProfile(userId, userName).update()
+                    .get(10, TimeUnit.SECONDS);
+
+            if (profile.getTextures().getSkin() != null) {
+                UUID resolvedId = profile.getUniqueId() != null ? profile.getUniqueId() : userId;
+                return new HeadCache(userName, resolvedId, profile);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            // Server could not complete the profile - fall back to the web-based lookups.
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/java/world/bentobox/bentobox/util/teleport/ClosestSafeSpotTeleport.java
+++ b/src/main/java/world/bentobox/bentobox/util/teleport/ClosestSafeSpotTeleport.java
@@ -345,10 +345,12 @@ public class ClosestSafeSpotTeleport
 
                 for (int y = Math.max(minY, startY - this.range); y < Math.min(maxY, startY + this.range); y++)
                 {
-                    Vector positionVector = new Vector(chunkX + x, y, chunkZ + z);
-                    if (this.boundingBox.contains(positionVector))
+                    // Raw-coordinate bounds check first and only allocate a vector for
+                    // positions actually inside the search area
+                    if (this.boundingBox.contains(chunkX + x, y, chunkZ + z))
                     {
                         // Process positions that are inside bounding box of search area.
+                        Vector positionVector = new Vector(chunkX + x, y, chunkZ + z);
 
                         PositionData positionData = new PositionData(
                                 positionVector,

--- a/src/main/java/world/bentobox/bentobox/util/teleport/ClosestSafeSpotTeleport.java
+++ b/src/main/java/world/bentobox/bentobox/util/teleport/ClosestSafeSpotTeleport.java
@@ -347,7 +347,7 @@ public class ClosestSafeSpotTeleport
                 {
                     // Raw-coordinate bounds check first and only allocate a vector for
                     // positions actually inside the search area
-                    if (this.boundingBox.contains(chunkX + x, y, chunkZ + z))
+                    if (this.boundingBox.contains((double) chunkX + x, y, (double) chunkZ + z))
                     {
                         // Process positions that are inside bounding box of search area.
                         Vector positionVector = new Vector(chunkX + x, y, chunkZ + z);

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -291,11 +291,12 @@ commands:
         specify-island-location: '<red>Určete [prefix_island] Umístění ve formátu X, Y, Z</red>'
         player-has-more-than-one-island: '<red>Hráč má více než jeden [prefix_island]. Zadejte, který z nich.</red>'
     info:
-      parameters: <Player>
+      parameters: <Player> [název ostrova]
       description: získat info, kde se nacházíš ty nebo hráčův ostrov
       no-island: '<red>Právě nejsi na žádném ostrovu...</red>'
       title: '========== Info o ostrovu ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Název: [name]'
       owner: 'Vlastník: [owner] ([uuid])'
       last-login: 'Naposledy spatřen: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -313,11 +313,12 @@ commands:
         specify-island-location: '<red>Gib den Inselstandort im x,y,z Format an</red>'
         player-has-more-than-one-island: '<red>Spieler hat mehr als eine Insel. Gib an welche.</red>'
     info:
-      parameters: <spieler>
+      parameters: <spieler> [Inselname]
       description: Informationen über deinen Standort oder die Spielerinsel erhalten
       no-island: '<red>Du bist im Moment nicht auf einer Insel...</red>'
       title: '========== Insel Info ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Name: [name]'
       owner: 'Besitzer: [owner] ([uuid])'
       last-login: 'Letzter Login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -278,11 +278,12 @@ commands:
         player-has-more-than-one-island: '<red>Player has more than one [prefix_island].
           Specify which one.</red>'
     info:
-      parameters: <player>
+      parameters: <player> [island name]
       description: get info on where you are or player's [prefix_island]
       no-island: '<red>You are not on [prefix_an-island] right now...</red>'
       title: ========== [prefix_Island] Info ============
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Name: [name]'
       owner: 'Owner: [owner] ([uuid])'
       last-login: 'Last login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -299,11 +299,12 @@ commands:
         specify-island-location: '<red>Especifica la ubicación de [prefix_island] en formato x,y,z</red>'
         player-has-more-than-one-island: '<red>El jugador tiene más de un [prefix_island]. Especifica cuál.</red>'
     info:
-      parameters: <jugador>
+      parameters: <jugador> [nombre de la isla]
       description: Obtén información sobre dónde estás o la isla del jugador.
       no-island: '<red>No estás en una isla en este momento...</red>'
       title: '========== Info de la Isla ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nombre: [name]'
       owner: 'Propietario: [owner] ([uuid])'
       last-login: 'Último acceso: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -319,13 +319,14 @@ commands:
         specify-island-location: '<red>Spécifiez l''emplacement de [prefix_island] au format x,y,z</red>'
         player-has-more-than-one-island: '<red>Le joueur a plus d''un [prefix_island]. Veuillez spécifier lequel.</red>'
     info:
-      parameters: <joueur>
+      parameters: <joueur> [nom de l'île]
       description: >-
         obtenir des informations sur l'endroit où vous êtes ou sur l'île du
         joueur
       no-island: '<red>Vous n''êtes pas sur une île en ce moment...</red>'
       title: '========== Informations sur l''île ============'
       island-uuid: 'UUID : [uuid]'
+      island-name: 'Nom : [name]'
       owner: '<red>Propriétaire : [owner]</red>'
       last-login: 'Dernière connexion : [date]'
       last-login-date-time-format: EEE MMM jj HH:mm:ss zzz aaaa

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -299,11 +299,12 @@ commands:
         specify-island-location: '<red>Specificirajte [prefix_island] lokaciju u x,y,z formatu</red>'
         player-has-more-than-one-island: '<red>Igrač ima više od jednog [prefix_island]. Odredite koji.</red>'
     info:
-      parameters: <igrač>
+      parameters: <igrač> [ime otoka]
       description: dobiti informacije o tome gdje se nalazite ili igračev otok
       no-island: '<red>Trenutno nisi na otoku...</red>'
       title: '========== Informacije o otoku ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Ime: [name]'
       owner: 'Vlasnik: [owner] ([uuid])'
       last-login: 'Zadnja prijava: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -319,11 +319,12 @@ commands:
           <red>A játékosnak több [prefix_island] van. Kérlek, jelöld meg,</red>
           melyiket.
     info:
-      parameters: <játékos>
+      parameters: <játékos> [sziget neve]
       description: információkat kaphat a tartózkodási helyéről vagy a játékos szigetéről
       no-island: '<red>Jelenleg nem vagy szigeten...</red>'
       title: '========== [prefix_Island] információ ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Név: [name]'
       owner: 'Tulajdonos: [owner] ([uuid])'
       last-login: 'Utolsó bejelentkezés: [date]'
       last-login-date-time-format: EEE HMM nn ÓÓ:pp:ss zzz éééé

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -304,11 +304,12 @@ commands:
           <red>Pemain memiliki lebih dari satu [prefix_island]. Tentukan yang</red>
           mana.
     info:
-      parameters: <player>
+      parameters: <player> [nama pulau]
       description: dapatkan info di mana Anda berada atau pulau pemain
       no-island: '<red>Anda tidak berada di pulau saat ini...</red>'
       title: '========== Info Pulau ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nama: [name]'
       owner: 'Pemilik: [owner] ([uuid])'
       last-login: 'Login terakhir: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -306,13 +306,14 @@ commands:
         specify-island-location: '<red>Specifica la posizione di [prefix_island] nel formato x,y,z</red>'
         player-has-more-than-one-island: '<red>Il giocatore ha più di un [prefix_island]. Specifica quale.</red>'
     info:
-      parameters: <giocatore>
+      parameters: <giocatore> [nome isola]
       description: >-
         ottieni informazioni riguardo l'isola del giocatore o riguardo quella in
         cui sei
       no-island: '<red>Al momento non ti trovi su un''isola...</red>'
       title: '========== Info Isola ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nome: [name]'
       owner: 'Proprietario: [owner] ([uuid])'
       last-login: 'Ultimo login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -262,11 +262,12 @@ commands:
         specify-island-location: '<red>x、y、z形式の[prefix_island]を指定します</red>'
         player-has-more-than-one-island: '<red>プレーヤーには複数の[prefix_island]があります。どれを指定します。</red>'
     info:
-      parameters: <プレーヤー>
+      parameters: <プレーヤー> [島の名前]
       description: あなたがどこにいるか、プレイヤーの島に関する情報を取得する
       no-island: '<red>あなたは今、島にいません...</red>'
       title: ' ========== 島情報 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '名前: [name]'
       owner: '所有者: [owner] ([uuid])'
       last-login: '最終ログイン: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -279,11 +279,12 @@ commands:
         specify-island-location: '<red>[prefix_island] 위치를 x,y,z 형식으로 지정하세요</red>'
         player-has-more-than-one-island: '<red>플레이어가 하나 이상의 [prefix_island]를 가지고 있습니다. 어느 것을 지정하세요.</red>'
     info:
-      parameters: <플레이어>
+      parameters: <플레이어> [섬 이름]
       description: 현재 위치에 있는 섬이나 플레이어의 섬의 정보를 봅니다
       no-island: '<red>당신은 섬에 있지 않습니다...</red>'
       title: '========== 섬 정보 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '이름: [name]'
       owner: '주인: [owner] ([uuid])'
       last-login: '마지막 로그인: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -306,11 +306,12 @@ commands:
           <red>Spēlētājam ir vairāk nekā viens [prefix_island]. Lūdzu, norādiet,</red>
           kuru.
     info:
-      parameters: <spēlētājs>
+      parameters: <spēlētājs> [salas nosaukums]
       description: atgriež informāciju par spēlētāja salu vai esošo pozīciju
       no-island: '<red>Tu neesi uz salas šobrīd...</red>'
       title: '========== Salas informācija ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nosaukums: [name]'
       owner: 'Īpašnieks: [owner] ([uuid])'
       last-login: 'Pēdējā pieslēgšanās: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -312,11 +312,12 @@ commands:
         specify-island-location: '<red>Geef de locatie van [prefix_island] op in x,y,z formaat</red>'
         player-has-more-than-one-island: '<red>Speler heeft meer dan één [prefix_island]. Geef aan welke.</red>'
     info:
-      parameters: <speler>
+      parameters: <speler> [eilandnaam]
       description: informatie krijgen over waar je bent of over het eiland van de speler
       no-island: '<red>Je bent nu niet op een eiland ...</red>'
       title: '========== Eilandinformatie ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Naam: [name]'
       owner: 'Eigenaar: [owner] ([uuid])'
       last-login: 'Laatste login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -302,11 +302,12 @@ commands:
         specify-island-location: '<red>Określ lokalizację [prefix_island] w formacie x,y,z</red>'
         player-has-more-than-one-island: '<red>Gracz ma więcej niż jeden [prefix_island]. Wskaź, który.</red>'
     info:
-      parameters: <gracz>
+      parameters: <gracz> [nazwa wyspy]
       description: zdobądź informacje o tym, gdzie jesteś lub wyspie gracza
       no-island: '<red>Nie jesteś teraz na wyspie...</red>'
       title: '======= Informacje o wyspie ========='
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nazwa: [name]'
       owner: 'Lider: [owner] ([uuid])'
       last-login: 'Ostatnie logowanie: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -298,11 +298,12 @@ commands:
         specify-island-location: '<red>Especifique a localização de [prefix_island] no formato x,y,z</red>'
         player-has-more-than-one-island: '<red>O jogador tem mais de um [prefix_island]. Especifique qual.</red>'
     info:
-      parameters: <jogador>
+      parameters: <jogador> [nome da ilha]
       description: obter informações de onde você está ou da ilha de um jogador
       no-island: '<red>Você não está em uma ilha no momento...</red>'
       title: '========== Informações da Ilha ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nome: [name]'
       owner: 'Dono: [owner] ([uuid])'
       last-login: 'Último login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -305,11 +305,12 @@ commands:
         specify-island-location: '<red>Especifique a localização de [prefix_island] no formato x,y,z</red>'
         player-has-more-than-one-island: '<red>O jogador tem mais de um [prefix_island]. Especifique qual.</red>'
     info:
-      parameters: <jogador>
+      parameters: <jogador> [nome da ilha]
       description: obtenha informações sobre onde você está ou a ilha do jogador
       no-island: '<red>Você não está em uma ilha agora...</red>'
       title: '========== Informações da Ilha ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nome: [name]'
       owner: 'Dono: [owner] ([uuid])'
       last-login: 'Ultimo login: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz aaaa

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -309,11 +309,12 @@ commands:
         specify-island-location: '<red>Specificați locația insulei în format x,y,z</red>'
         player-has-more-than-one-island: '<red>Player are mai multe insule. Specificați care dintre ele.</red>'
     info:
-      parameters: <player>
+      parameters: <player> [numele insulei]
       description: obțineți informații despre locul dvs. sau insula jucătorului
       no-island: '<red>Nu vă aflați într-o insulă acum ...</red>'
       title: '========== Informații despre insulă ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Nume: [name]'
       owner: 'Proprietar: [owner] ([uuid])'
       last-login: 'Ultima autentificare: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz aaaa

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -304,11 +304,12 @@ commands:
         player-has-more-than-one-island: <red>Игрок имеет более одного [prefix_island].
           Укажите, какой именно.</red>
     info:
-      parameters: <игрок>
+      parameters: <игрок> [название острова]
       description: получите информацию где вы или на чьем вы острове
       no-island: <red>Вы не на острове в данный момент...</red>
       title: ========== Информация об острове ============
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Название: [name]'
       owner: 'Владелец: [owner] ([uuid])'
       last-login: 'Последний вход: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -300,11 +300,12 @@ commands:
           <red>Oyuncunun birden fazla [prefix_island] var. Hangisini seçeceğinizi</red>
           belirtin.
     info:
-      parameters: <player>
+      parameters: <player> [ada adı]
       description: Ada hakkında bilgi verir
       no-island: '<dark_red>Herhangi bir adada degilsin...</dark_red>'
       title: '<yellow>Ada Bilgileri</yellow>'
       island-uuid: '<dark_purple>UUID: [uuid]</dark_purple>'
+      island-name: '<dark_purple>Ad: [name]</dark_purple>'
       owner: '<aqua>Sahibi: </aqua><dark_purple>[owner] ([uuid])</dark_purple>'
       last-login: '<aqua>Son giris: </aqua><dark_purple>[date]</dark_purple>'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -272,11 +272,12 @@ commands:
         specify-island-location: '<red>Вкажіть локацію [prefix_island] у форматі x,y,z</red>'
         player-has-more-than-one-island: '<red>У гравця більше ніж один [prefix_island]. Уточніть який.</red>'
     info:
-      parameters: <гравець>
+      parameters: <гравець> [назва острова]
       description: отримати інформацію про місце розташування або [prefix_island] гравця
       no-island: '<red>Зараз ви не на [prefix_an-island]...</red>'
       title: ========== Інфо про [prefix_Island] ============
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Назва: [name]'
       owner: 'Власник: [owner] ([uuid])'
       last-login: 'Останній вхід: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -299,11 +299,12 @@ commands:
           <red>Người chơi có nhiều hơn một [prefix_island]. Vui lòng chỉ rõ cái</red>
           nào.
     info:
-      parameters: <người chơi>
+      parameters: <người chơi> [tên đảo]
       description: xem thông tin đảo bạn đang đứng
       no-island: '<red>Bạn không có ở đảo nào...</red>'
       title: '========== Thông Tin Đảo ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: 'Tên: [name]'
       owner: 'Chủ: [owner] ([uuid])'
       last-login: 'Lần đăng nhập cuối: [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -270,11 +270,12 @@ commands:
         specify-island-location: '<red>以x,y,z格式选定岛屿位置</red>'
         player-has-more-than-one-island: '<red>玩家拥有多个岛屿, 请指定一个岛屿.</red>'
     info:
-      parameters: <玩家>
+      parameters: <玩家> [岛屿名称]
       description: 获取当前岛屿或指定玩家的岛屿信息
       no-island: '<red>你当前没有岛屿...</red>'
       title: '========== 岛屿信息 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '名称: [name]'
       owner: '岛主: [owner] ([uuid])'
       last-login: '最后登录: [date]'
       last-login-date-time-format: yyyy-MM-dd HH:mm:ss zzz

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -271,11 +271,12 @@ commands:
         specify-island-location: 指定[prefix_island] x，y，z格式的位置
         player-has-more-than-one-island: 玩家有多個[prefix_island]。指定哪一個。
     info:
-      parameters: <player>
+      parameters: <player> [島嶼名稱]
       description: 獲得您當前所在或者指定玩家的島嶼信息
       no-island: '<red>您當前不在一座島上......</red>'
       title: '========== 島嶼信息 ============'
       island-uuid: 'UUID: [uuid]'
+      island-name: '名稱: [name]'
       owner: 島主：[owner] ([uuid])
       last-login: 最後登錄：[date]
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -14,7 +14,7 @@ meta:
   authors:
   - tastybento
   - Poslovitch
-  banner: WHITE_BANNER:1:STRIPE_SMALL:RED:SQUARE_TOP_RIGHT:CYAN:SQUARE_TOP_RIGHT:BLUE
+  banner: RED_BANNER:1:SQUARE_TOP_RIGHT:BLUE
 
 prefixes:
   bentobox: <gold>BentoBox </gold><gray><bold>> </bold></gray>

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -14,7 +14,7 @@ meta:
   authors:
   - tastybento
   - Poslovitch
-  banner: RED_BANNER:1:SQUARE_TOP_RIGHT:BLUE
+  banner: WHITE_BANNER:1:STRIPE_SMALL:RED:SQUARE_TOP_RIGHT:CYAN:SQUARE_TOP_RIGHT:BLUE
 
 prefixes:
   bentobox: <gold>BentoBox </gold><gray><bold>> </bold></gray>

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -253,11 +253,12 @@ commands:
         specify-island-location: <red>請以 x,y,z 格式指定[prefix_island]的位置。</red>
         player-has-more-than-one-island: <red>該玩家擁有多座[prefix_islands]，請指定要解除註冊的島嶼。</red>
     info:
-      parameters: <玩家>
+      parameters: <玩家> [島嶼名稱]
       description: 查看目前所在或指定玩家的[prefix_island]資訊
       no-island: <red>你目前不在[prefix_an-island]上……</red>
       title: ========== [prefix_Island]資訊 ==========
       island-uuid: 'UUID： [uuid]'
+      island-name: '名稱： [name]'
       owner: '島主： [owner]（[uuid]）'
       last-login: '最後登入： [date]'
       last-login-date-time-format: EEE MMM dd HH:mm:ss zzz yyyy

--- a/src/test/java/world/bentobox/bentobox/api/commands/SubCommandAliasLabelTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/SubCommandAliasLabelTest.java
@@ -1,0 +1,115 @@
+package world.bentobox.bentobox.api.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.managers.CommandsManager;
+
+/**
+ * Regression test for <a href="https://github.com/BentoBoxWorld/BentoBox/issues/3075">#3075</a>.
+ * <p>
+ * Walking the typed arguments to find a sub-command used to call
+ * {@code setLabel(arg)} on the shared sub-command object. After any player
+ * typed {@code /island h}, every other player's tab completion advertised
+ * {@code h} in place of {@code go}. The label must stay the primary one however
+ * the command is addressed.
+ *
+ * @author tastybento
+ */
+class SubCommandAliasLabelTest extends CommonTestSetup {
+
+    private TopCommand top;
+    private CommandSender sender;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        when(plugin.getCommandsManager()).thenReturn(mock(CommandsManager.class));
+        top = new TopCommand();
+        sender = mock(CommandSender.class);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void testTabCompleteViaAliasKeepsPrimaryLabel() {
+        // Brigadier calls tabComplete on every keystroke, so merely typing the alias
+        // used to be enough to rename the command for everyone.
+        top.tabComplete(sender, "island", new String[] { "h", "" });
+        assertEquals("go", top.go.getLabel());
+
+        List<String> options = top.tabComplete(sender, "island", new String[] { "" });
+        assertTrue(options.contains("go"), options.toString());
+        assertFalse(options.contains("h"), options.toString());
+        assertFalse(options.contains("home"), options.toString());
+    }
+
+    @Test
+    void testExecuteViaAliasKeepsPrimaryLabelButPassesTypedAlias() {
+        assertTrue(top.execute(sender, "island", new String[] { "home" }));
+        assertEquals("home", top.go.labelUsed, "sub-command should still learn which alias was typed");
+        assertEquals("go", top.go.getLabel(), "shared command object must not be renamed");
+
+        assertTrue(top.execute(sender, "island", new String[] { "h" }));
+        assertEquals("h", top.go.labelUsed);
+        assertEquals("go", top.go.getLabel());
+
+        assertEquals("/island go", top.go.getUsage());
+    }
+
+    class TopCommand extends CompositeCommand {
+
+        GoCommand go;
+
+        TopCommand() {
+            super("island");
+        }
+
+        @Override
+        public void setup() {
+            go = new GoCommand(this);
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            return true;
+        }
+    }
+
+    class GoCommand extends CompositeCommand {
+
+        String labelUsed;
+
+        GoCommand(CompositeCommand parent) {
+            super(parent, "go", "home", "h");
+        }
+
+        @Override
+        public void setup() {
+            // No permission, so any sender may run it
+        }
+
+        @Override
+        public boolean execute(User user, String label, List<String> args) {
+            labelUsed = label;
+            return true;
+        }
+    }
+}

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminInfoCommandTest.java
@@ -8,11 +8,13 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -99,6 +101,7 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
         Optional<Island> optionalIsland = Optional.of(testIsland);
         when(im.getIslandAt(any())).thenReturn(optionalIsland);
         when(im.getIsland(any(), any(UUID.class))).thenReturn(testIsland);
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of(testIsland));
 
         // Players manager
         when(plugin.getPlayers()).thenReturn(pm);
@@ -120,12 +123,57 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
     }
 
     /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.island.AdminInfoCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} with an island name that does not exist.
      */
     @Test
-    void testExecuteUserStringListOfStringTooManyArgs() {
-        assertFalse(iic.execute(user, "", Arrays.asList("hdhh", "hdhdhd")));
-        verify(user).sendMessage("commands.help.header", "[label]", "commands.help.console");
+    void testExecuteUserStringListOfStringUnknownIslandName() {
+        testIsland.setName("myisland");
+        assertFalse(iic.execute(user, "", Arrays.asList("tastybento", "nosuchisland")));
+        verify(user).sendMessage("commands.island.go.unknown-home");
+        verify(user).sendMessage("commands.island.sethome.homes-are");
+        verify(user).sendMessage("commands.island.sethome.home-list-syntax", "[name]", "myisland");
+        verify(user, never()).sendMessage("commands.admin.info.title");
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} with an exact island name.
+     */
+    @Test
+    void testExecuteUserStringListOfStringIslandName() {
+        testIsland.setName("myisland");
+        Island other = new Island(location, user.getUniqueId(), 100);
+        other.setName("other");
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of(testIsland, other));
+        assertTrue(iic.execute(user, "", Arrays.asList("tastybento", "other")));
+        verify(user, times(1)).sendMessage("commands.admin.info.title");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "other");
+        verify(user, never()).sendMessage("commands.admin.info.island-name", "[name]", "myisland");
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} with a multi-word, case-insensitive island name.
+     */
+    @Test
+    void testExecuteUserStringListOfStringIslandNameForgiving() {
+        testIsland.setName("My Big Island");
+        assertTrue(iic.execute(user, "", Arrays.asList("tastybento", "my", "big", "island")));
+        verify(user).sendMessage("commands.admin.info.title");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "My Big Island");
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#execute(User, String, List)} when the player has several islands.
+     */
+    @Test
+    void testExecuteUserStringListOfStringArgsMultipleIslands() {
+        testIsland.setName("first");
+        Island second = new Island(location, user.getUniqueId(), 100);
+        second.setName("second");
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of(testIsland, second));
+        assertTrue(iic.execute(user, "", Collections.singletonList("tastybento")));
+        verify(user, times(2)).sendMessage("commands.admin.info.title");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "first");
+        verify(user).sendMessage("commands.admin.info.island-name", "[name]", "second");
     }
 
     /**
@@ -206,7 +254,7 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
      */
     @Test
     void testExecuteUserStringListOfStringArgsNoIsland() {
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(null);
+        when(im.getIslands(any(), any(UUID.class))).thenReturn(List.of());
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.player-has-no-island");
     }
@@ -220,6 +268,25 @@ class AdminInfoCommandTest extends RanksManagerTestSetup {
         assertFalse(iic.execute(user, "", Collections.singletonList("tastybento")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
 
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#tabComplete(User, String, List)} - second arg offers island names.
+     */
+    @Test
+    void testTabCompleteIslandNames() {
+        testIsland.setName("myisland");
+        Optional<List<String>> result = iic.tabComplete(user, "", Arrays.asList("tastybento", "my"));
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("myisland"));
+    }
+
+    /**
+     * Test method for {@link AdminInfoCommand#tabComplete(User, String, List)} - no args gives nothing.
+     */
+    @Test
+    void testTabCompleteNoArgs() {
+        assertTrue(iic.tabComplete(user, "", Collections.emptyList()).isEmpty());
     }
 
 }

--- a/src/test/java/world/bentobox/bentobox/api/flags/FlagListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/FlagListenerTest.java
@@ -44,6 +44,7 @@ class FlagListenerTest extends CommonTestSetup {
         when(location.toVector()).thenReturn(new Vector(10, 64, 20));
 
         // Enable why-debug on mockPlayer for this world, issuer is the same player (uuid)
+        when(mockPlayer.hasMetadata("bskyblock_world_why_debug")).thenReturn(true);
         when(mockPlayer.getMetadata("bskyblock_world_why_debug"))
                 .thenReturn(Collections.singletonList(new FixedMetadataValue(plugin, true)));
         when(mockPlayer.getMetadata("bskyblock_world_why_debug_issuer"))

--- a/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/CycleClickTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/flags/clicklisteners/CycleClickTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mock;
 
 import world.bentobox.bentobox.RanksManagerTestSetup;
 import world.bentobox.bentobox.Settings;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.events.flags.FlagProtectionChangeEvent;
 import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.api.panels.TabbedPanel;
@@ -189,6 +191,12 @@ class CycleClickTest extends RanksManagerTestSetup {
         // Hidden flags
         hiddenFlags = new ArrayList<>();
         when(iwm.getHiddenFlags(world)).thenReturn(hiddenFlags);
+        // Shift-click mutates the live world settings list via the game mode addon
+        GameModeAddon gma = mock(GameModeAddon.class);
+        WorldSettings ws = mock(WorldSettings.class);
+        when(gma.getWorldSettings()).thenReturn(ws);
+        when(ws.getHiddenFlags()).thenReturn(hiddenFlags);
+        when(iwm.getAddon(any())).thenReturn(Optional.of(gma));
     }
 
     @Override

--- a/src/test/java/world/bentobox/bentobox/listeners/StandardSpawnProtectionListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/StandardSpawnProtectionListenerTest.java
@@ -81,6 +81,8 @@ class StandardSpawnProtectionListenerTest extends CommonTestSetup {
         mockedUtil.when(() -> Util.getWorld(any())).thenReturn(world);
         // Location
         when(location.toVector()).thenReturn(new Vector(5,5,5));
+        when(location.getX()).thenReturn(5D);
+        when(location.getZ()).thenReturn(5D);
         when(location.getWorld()).thenReturn(nether);
         when(spawnLocation.toVector()).thenReturn(new Vector(0,0,0));
         when(spawnLocation.getWorld()).thenReturn(nether);
@@ -286,11 +288,7 @@ class StandardSpawnProtectionListenerTest extends CommonTestSetup {
         blockList.add(block);
         blockList.add(block);
         // Make some inside and outside spawn
-        when(location.toVector()).thenReturn(new Vector(0,0,0),
-                new Vector(0,0,0),
-                new Vector(0,0,0),
-                new Vector(0,0,0),
-                new Vector(10000,0,0));
+        when(location.getX()).thenReturn(0D, 0D, 0D, 0D, 10000D);
         EntityExplodeEvent e = getExplodeEvent(mockPlayer, location, blockList);
         ssp.onExplosion(e);
         // 4 blocks inside the spawn should be removed, leaving one
@@ -311,11 +309,7 @@ class StandardSpawnProtectionListenerTest extends CommonTestSetup {
         blockList.add(block);
         blockList.add(block);
         // Make some inside and outside spawn
-        when(location.toVector()).thenReturn(new Vector(0,0,0),
-                new Vector(0,0,0),
-                new Vector(0,0,0),
-                new Vector(0,0,0),
-                new Vector(10000,0,0));
+        when(location.getX()).thenReturn(0D, 0D, 0D, 0D, 10000D);
         EntityExplodeEvent e = getExplodeEvent(mockPlayer, location, blockList);
         ssp.onExplosion(e);
         // No blocks should be removed
@@ -344,11 +338,7 @@ class StandardSpawnProtectionListenerTest extends CommonTestSetup {
         blockList.add(block);
         blockList.add(block);
         // Make some inside and outside spawn
-        when(location.toVector()).thenReturn(new Vector(0, 0, 0),
-                new Vector(0, 0, 0),
-                new Vector(0, 0, 0),
-                new Vector(0, 0, 0),
-                new Vector(10000, 0, 0));
+        when(location.getX()).thenReturn(0D, 0D, 0D, 0D, 10000D);
         EntityExplodeEvent e = getExplodeEvent(mockPlayer, location, blockList);
         // Should not throw NullPointerException
         ssp.onExplosion(e);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClickTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/CommandCycleClickTest.java
@@ -30,6 +30,7 @@ import org.mockito.stubbing.Answer;
 import world.bentobox.bentobox.RanksManagerTestSetup;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TabbedPanel;
 import world.bentobox.bentobox.api.user.User;
@@ -73,6 +74,11 @@ class CommandCycleClickTest extends RanksManagerTestSetup {
         when(iwm.getAddon(any())).thenReturn(Optional.of(gma));
         when(iwm.getPermissionPrefix(world)).thenReturn("oneblock.");
         when(iwm.getHiddenFlags(any())).thenReturn(new ArrayList<>());
+        // Shift-click mutates the live world settings list via the game mode addon;
+        // delegate to the iwm stub so per-test re-stubbing keeps working
+        WorldSettings ws = mock(WorldSettings.class);
+        when(gma.getWorldSettings()).thenReturn(ws);
+        when(ws.getHiddenFlags()).thenAnswer(invocation -> iwm.getHiddenFlags(world));
         // Panel
         when(panel.getInventory()).thenReturn(inv);
         when(panel.getWorld()).thenReturn(Optional.of(world));

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/clicklisteners/GeoMobLimitTabTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,6 +27,7 @@ import org.mockito.stubbing.Answer;
 
 import world.bentobox.bentobox.CommonTestSetup;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.TabbedPanel;
 import world.bentobox.bentobox.api.user.User;
@@ -62,6 +64,11 @@ class GeoMobLimitTabTest extends CommonTestSetup {
         list.add("COW");
         when(iwm.getMobLimitSettings(any())).thenReturn(list);
         when(iwm.getGeoLimitSettings(any())).thenReturn(list);
+        // The click handler mutates the live world settings lists via the game mode addon
+        WorldSettings ws = mock(WorldSettings.class);
+        when(gma.getWorldSettings()).thenReturn(ws);
+        when(ws.getMobLimitSettings()).thenReturn(list);
+        when(ws.getGeoLimitSettings()).thenReturn(list);
         // Panel
         when(panel.getInventory()).thenReturn(inv);
         // User

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/protection/LockAndBanListenerTest.java
@@ -264,6 +264,39 @@ class LockAndBanListenerTest extends CommonTestSetup {
     }
 
     @Test
+    void testVehicleMoveNoPlayerPassengersSkipsIslandLookup() {
+        // A vehicle carrying only non-player entities (e.g. a mob-ridden horse or an
+        // empty minecart) must not trigger an island lookup when it crosses a boundary.
+        Vehicle vehicle = mock(Vehicle.class);
+        Entity mob = mock(Entity.class); // not a Player
+        List<Entity> passengers = new ArrayList<>();
+        passengers.add(mob);
+        when(vehicle.getPassengers()).thenReturn(passengers);
+        // Horizontal move across a block boundary
+        listener.onVehicleMove(new VehicleMoveEvent(vehicle, outside, inside));
+        // Lazy lookup: no player passenger, so the grid is never queried
+        verify(im, never()).getProtectedIslandAt(any());
+    }
+
+    @Test
+    void testVehicleMoveResolvesIslandOnceForMultiplePlayers() {
+        // Two players in one vehicle should share a single island lookup, not one each.
+        when(mockPlayer.getUniqueId()).thenReturn(uuid);
+        Vehicle vehicle = mock(Vehicle.class);
+        Player player2 = mock(Player.class);
+        when(player2.isOp()).thenReturn(false);
+        when(player2.hasPermission(anyString())).thenReturn(false);
+        List<Entity> passengers = new ArrayList<>();
+        passengers.add(mockPlayer);
+        passengers.add(player2);
+        when(vehicle.getPassengers()).thenReturn(passengers);
+        // Horizontal move across a block boundary into an open island
+        listener.onVehicleMove(new VehicleMoveEvent(vehicle, outside, inside));
+        // Resolved lazily on the first player and reused for the second
+        verify(im, org.mockito.Mockito.times(1)).getProtectedIslandAt(inside);
+    }
+
+    @Test
     void testPlayerMoveIntoBannedIsland() {
         // Make player
         when(mockPlayer.getUniqueId()).thenReturn(uuid);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/LiquidsFlowingOutListenerTest.java
@@ -120,8 +120,9 @@ class LiquidsFlowingOutListenerTest extends CommonTestSetup {
     @Test
     void testLiquidFlowsVertically() {
         // "To" is at (1,0,0)
-        // Set "from" at (1,1,0) so that the vector's y coordinate != 0, which means the liquid flows vertically.
+        // Set "from" at (1,1,0) so that the y coordinates differ, which means the liquid flows vertically.
         when(from.getLocation()).thenReturn(new Location(world, 1, 1, 0));
+        when(from.getY()).thenReturn(1);
 
         // Run
         new LiquidsFlowingOutListener().onLiquidFlow(event);

--- a/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/VisitorKeepInventoryListenerTest.java
+++ b/src/test/java/world/bentobox/bentobox/listeners/flags/worldsettings/VisitorKeepInventoryListenerTest.java
@@ -62,6 +62,7 @@ class VisitorKeepInventoryListenerTest extends CommonTestSetup {
         when(location.getWorld()).thenReturn(world);
         when(location.toVector()).thenReturn(new Vector(1,2,3));
         // Turn on why for player
+        when(mockPlayer.hasMetadata("bskyblock_world_why_debug")).thenReturn(true);
         when(mockPlayer.getMetadata("bskyblock_world_why_debug")).thenReturn(Collections.singletonList(new FixedMetadataValue(plugin, true)));
         when(mockPlayer.getMetadata("bskyblock_world_why_debug_issuer")).thenReturn(Collections.singletonList(new FixedMetadataValue(plugin, uuid.toString())));
         User.getInstance(mockPlayer);

--- a/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
+++ b/src/test/java/world/bentobox/bentobox/managers/PurgeRegionsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -27,13 +28,18 @@ import java.util.UUID;
 
 import com.google.common.collect.ImmutableSet;
 
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.events.island.IslandEvent;
+import world.bentobox.bentobox.api.events.island.IslandEvent.Reason;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.PurgeRegionsService.FilterStats;
 import world.bentobox.bentobox.managers.PurgeRegionsService.PurgeScanResult;
@@ -82,6 +88,10 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
 
         when(im.getIslandCache()).thenReturn(islandCache);
         when(world.getWorldFolder()).thenReturn(tempDir.toFile());
+
+        // Most tests exercise delete() as if called on the main thread so the
+        // finalization phase runs inline. The async-path tests override this.
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
 
         service = new PurgeRegionsService(plugin);
     }
@@ -708,5 +718,92 @@ class PurgeRegionsServiceTest extends CommonTestSetup {
         // Age sweep: immediate deletion, not deferred.
         verify(im, times(1)).deleteIslandId("tiny");
         assertTrue(service.getPendingDeletions().isEmpty());
+    }
+
+    /**
+     * Regression for the async purge crash: {@code delete()} is dispatched
+     * from an async task by both the purge command and housekeeping, but
+     * {@link IslandEvent} may only be fired on the main thread (Paper throws
+     * {@code IllegalStateException: IslandEvent may only be triggered
+     * synchronously}). When not on the primary thread, the event/cache/DB
+     * finalization must be hopped onto the main thread via the scheduler and
+     * awaited, and the events must still fire.
+     */
+    @Test
+    void testDeleteOffMainThreadFinalizesViaScheduler() throws IOException {
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
+        // Simulate the scheduler running the main-thread task.
+        doAnswer(inv -> {
+            inv.getArgument(1, Runnable.class).run();
+            return null;
+        }).when(sch).runTask(eq(plugin), any(Runnable.class));
+
+        Island tiny = mock(Island.class);
+        when(tiny.getUniqueId()).thenReturn("tiny");
+        // Never soft-deleted: DELETED must fire before PURGED.
+        when(tiny.isDeletable()).thenReturn(false);
+        when(tiny.getMemberSet()).thenReturn(ImmutableSet.<UUID>of());
+        when(tiny.getMinProtectedX()).thenReturn(0);
+        when(tiny.getMaxProtectedX()).thenReturn(100);
+        when(tiny.getMinProtectedZ()).thenReturn(0);
+        when(tiny.getMaxProtectedZ()).thenReturn(100);
+        when(im.getIslandById("tiny")).thenReturn(Optional.of(tiny));
+        when(im.deleteIslandId("tiny")).thenReturn(true);
+
+        Path regionDir = Files.createDirectories(tempDir.resolve("region"));
+        Files.write(regionDir.resolve("r.0.0.mca"), new byte[0]);
+
+        Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
+        regions.put(new Pair<>(0, 0), Set.of("tiny"));
+        PurgeScanResult scan = new PurgeScanResult(world, 30, regions, false, false,
+                new FilterStats(0, 0, 0, 0), Set.of());
+
+        boolean ok = service.delete(scan);
+        assertTrue(ok);
+
+        // Finalization was routed through the scheduler, not run inline.
+        verify(sch, times(1)).runTask(eq(plugin), any(Runnable.class));
+        verify(islandCache, times(1)).deleteIslandFromCache("tiny");
+        verify(im, times(1)).deleteIslandId("tiny");
+
+        // Each build() fires the generic IslandEvent plus a reason-specific
+        // subclass; check the generic ones for order.
+        ArgumentCaptor<Event> events = ArgumentCaptor.forClass(Event.class);
+        verify(pim, times(4)).callEvent(events.capture());
+        List<Reason> reasons = events.getAllValues().stream()
+                .filter(e -> e.getClass() == IslandEvent.class)
+                .map(IslandEvent.class::cast)
+                .map(IslandEvent::getReason)
+                .toList();
+        assertEquals(List.of(Reason.DELETED, Reason.PURGED), reasons);
+    }
+
+    /**
+     * When there is nothing to finalize (deleted sweep defers DB rows to
+     * shutdown) the service must not touch the scheduler at all, even when
+     * called off the main thread.
+     */
+    @Test
+    void testDeleteOffMainThreadDeletedSweepDoesNotSchedule() throws IOException {
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
+
+        Island del = mock(Island.class);
+        when(del.getUniqueId()).thenReturn("del");
+        when(del.isDeletable()).thenReturn(true);
+        when(del.getMemberSet()).thenReturn(ImmutableSet.<UUID>of());
+        when(im.getIslandById("del")).thenReturn(Optional.of(del));
+
+        Path regionDir = Files.createDirectories(tempDir.resolve("region"));
+        Files.write(regionDir.resolve("r.0.0.mca"), new byte[0]);
+
+        Map<Pair<Integer, Integer>, Set<String>> regions = new HashMap<>();
+        regions.put(new Pair<>(0, 0), Set.of("del"));
+        PurgeScanResult scan = new PurgeScanResult(world, 0, regions, false, false,
+                new FilterStats(0, 0, 0, 0), Set.of());
+
+        assertTrue(service.delete(scan));
+        verify(sch, never()).runTask(eq(plugin), any(Runnable.class));
+        verify(pim, never()).callEvent(any());
+        assertTrue(service.getPendingDeletions().contains("del"));
     }
 }

--- a/src/test/java/world/bentobox/bentobox/util/heads/HeadGetterTest.java
+++ b/src/test/java/world/bentobox/bentobox/util/heads/HeadGetterTest.java
@@ -1,0 +1,122 @@
+package world.bentobox.bentobox.util.heads;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.profile.PlayerTextures;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+
+import world.bentobox.bentobox.CommonTestSetup;
+import world.bentobox.bentobox.api.panels.PanelItem;
+
+/**
+ * Tests the online-player fast path of {@link HeadGetter#getHead}.
+ * @author tastybento
+ */
+class HeadGetterTest extends CommonTestSetup {
+
+    @Mock
+    private HeadRequester requester;
+    @Mock
+    private PanelItem panelItem;
+    @Mock
+    private PlayerProfile profile;
+    @Mock
+    private PlayerTextures textures;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        when(itemFactory.getItemMeta(any())).thenReturn(mock(SkullMeta.class));
+
+        when(mockPlayer.getPlayerProfile()).thenReturn(profile);
+        when(profile.getTextures()).thenReturn(textures);
+    }
+
+    /**
+     * An online player with a textured profile must be delivered synchronously from the
+     * server's own profile - no queuing, no web lookup.
+     */
+    @Test
+    void testGetHeadOnlinePlayerDeliversSynchronously() throws Exception {
+        URL skin = new URI("https://textures.minecraft.net/texture/test-online").toURL();
+        when(textures.getSkin()).thenReturn(skin);
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_online");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_online")).thenReturn(mockPlayer);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        verify(panelItem).setHead(any(ItemStack.class));
+        verify(requester).setHead(panelItem);
+    }
+
+    /**
+     * An online player whose live profile has no skin texture must not short-circuit -
+     * the request falls through to the async resolver queue.
+     */
+    @Test
+    void testGetHeadOnlinePlayerWithoutTextureIsQueued() {
+        when(textures.getSkin()).thenReturn(null);
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_no_texture");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_no_texture")).thenReturn(mockPlayer);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        verify(panelItem, never()).setHead(any());
+        verify(requester, never()).setHead(any());
+    }
+
+    /**
+     * An offline player cannot be resolved synchronously and must be queued.
+     */
+    @Test
+    void testGetHeadOfflinePlayerIsQueued() {
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_offline");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        verify(panelItem, never()).setHead(any());
+        verify(requester, never()).setHead(any());
+    }
+
+    /**
+     * Once the fast path has run, a second request for the same name is served from the
+     * head cache.
+     */
+    @Test
+    void testGetHeadSecondRequestServedFromCache() throws Exception {
+        URL skin = new URI("https://textures.minecraft.net/texture/test-cached").toURL();
+        when(textures.getSkin()).thenReturn(skin);
+        when(panelItem.getPlayerHeadName()).thenReturn("hg_cached");
+        mockedBukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_cached")).thenReturn(mockPlayer);
+
+        HeadGetter.getHead(panelItem, requester);
+
+        // Player logs off; the cache must still serve the head.
+        mockedBukkit.when(() -> Bukkit.getPlayerExact("hg_cached")).thenReturn(null);
+
+        HeadRequester secondRequester = mock(HeadRequester.class);
+        HeadGetter.getHead(panelItem, secondRequester);
+
+        verify(secondRequester).setHead(panelItem);
+    }
+}


### PR DESCRIPTION
Release 3.22.4 — bug fix and performance release.

* Fix purge crash `IslandEvent may only be triggered synchronously` (#3077)
* Stop renaming sub-commands to the alias a player typed (#3076, fixes #3075)
* `/[admin] info <player>` shows every island, adds `[island name]` argument (#3074)
* Performance improvements and new `island.history.max-entries` config option (#3073)
* Use server-provided player profiles for heads (#3070)
* SonarCloud / SAST reliability fixes

Draft release notes: https://github.com/BentoBoxWorld/BentoBox/releases (tag 3.22.4, draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZRwXXfTUJLJFwSnzSgeRb
