### PR TITLE
Make admin setrank a full console team-rank tool

### DIFF
--- a/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommand.java
+++ b/src/main/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommand.java
@@ -1,10 +1,15 @@
 package world.bentobox.bentobox.api.commands.admin;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.bukkit.Location;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -16,14 +21,30 @@ import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 
 /**
- * @author tastybento
+ * Sets a player's rank on an island directly, which covers both promotion and demotion.
+ * <p>
+ * Unlike the player-facing {@code /island team promote} and {@code demote} commands, this does
+ * not step one rank at a time and does not depend on the rank of the admin running it. It is
+ * intentionally not restricted to in-game players so that server staff can manage teams from the
+ * console. The island is identified in one of three ways:
+ * <ul>
+ * <li>nothing - the island the target is a team member of, if there is exactly one</li>
+ * <li>the name of the island's owner</li>
+ * <li>the island's centre as {@code x,y,z}</li>
+ * </ul>
+ * Any rank between visitor and owner may be set, so this also grants or revokes coop and trusted
+ * status. Owner rank is refused - ownership is transferred with {@code setowner}, which keeps the
+ * island's owner field and the rank map in step.
  *
+ * @author tastybento
  */
 public class AdminSetrankCommand extends CompositeCommand {
 
+    private static final String RANK_PREFIX = "ranks.";
+
     private int rankValue;
     private @Nullable UUID targetUUID;
-    private @Nullable UUID ownerUUID;
+    private @Nullable Island island;
 
     public AdminSetrankCommand(CompositeCommand adminCommand) {
         super(adminCommand, "setrank");
@@ -39,113 +60,197 @@ public class AdminSetrankCommand extends CompositeCommand {
 
     @Override
     public boolean canExecute(User user, String label, List<String> args) {
+        // Syntax: <player> <rank> [island owner | x,y,z]
         if (args.size() != 2 && args.size() != 3) {
-            // Show help
             showHelp(this, user);
             return false;
         }
-        // Get target player
+        // Target
         targetUUID = Util.getUUID(args.getFirst());
         if (targetUUID == null) {
             user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.getFirst());
             return false;
         }
-        // Get rank
-        rankValue = RanksManager.getInstance().getRanks().entrySet().stream()
-                .filter(r -> user.getTranslation(r.getKey()).equalsIgnoreCase(args.get(1))).findFirst()
-                .map(Map.Entry::getValue).orElse(-999);
-        if (rankValue < RanksManager.BANNED_RANK) {
-            user.sendMessage("commands.admin.setrank.unknown-rank");
+        // Rank
+        Optional<Integer> rank = parseRank(user, args.get(1));
+        if (rank.isEmpty()) {
+            user.sendMessage("commands.admin.setrank.unknown-rank", TextVariables.RANK, args.get(1), "[ranks]",
+                    String.join(", ", getAllowedRankNames()));
             return false;
         }
+        rankValue = rank.get();
         if (rankValue <= RanksManager.VISITOR_RANK) {
             user.sendMessage("commands.admin.setrank.not-possible");
             return false;
         }
-
-        if (args.size() == 2) {
-            // We want to change the player's rank on the island he is part of.
-
-            // Check if the target is part of an island
-            if (!getIslands().hasIsland(getWorld(), targetUUID) && !getPlugin().getIslands().inTeam(getWorld(), targetUUID)) {
-                user.sendMessage("general.errors.player-has-no-island");
-                return false;
-            }
-        } else {
-            // We want to change the player's rank on the island of the specified owner.
-
-            ownerUUID = getPlayers().getUUID(args.get(2));
-            if (ownerUUID == null) {
-                user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(2));
-                return false;
-            }
-
-            if (!getPlugin().getIslands().hasIsland(getWorld(), ownerUUID)) {
-                user.sendMessage("general.errors.player-is-not-owner", TextVariables.NAME, args.get(2));
-                return false;
-            }
+        if (rankValue >= RanksManager.OWNER_RANK) {
+            user.sendMessage("commands.admin.setrank.cannot-set-owner");
+            return false;
         }
-
+        // Island
+        island = args.size() == 2 ? findTargetIsland(user) : findNamedIsland(user, args.get(2));
+        if (island == null) {
+            return false;
+        }
+        if (targetUUID.equals(island.getOwner())) {
+            user.sendMessage("commands.admin.setrank.cannot-set-owner");
+            return false;
+        }
+        if (island.getRank(targetUUID) == rankValue) {
+            user.sendMessage("commands.admin.setrank.already-rank", TextVariables.NAME, args.getFirst(),
+                    TextVariables.RANK, user.getTranslation(RanksManager.getInstance().getRank(rankValue)));
+            return false;
+        }
         return true;
     }
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        assert targetUUID != null;
+        Objects.requireNonNull(island);
+        Objects.requireNonNull(targetUUID);
         User target = User.getInstance(targetUUID);
-        Island island;
-        if (ownerUUID != null) {
-            island = getIslands().getIsland(getWorld(), ownerUUID);
-        } else {
-            island = getIslands().getIsland(getWorld(), targetUUID);
-        }
-        if (island == null) {
-            user.sendMessage("general.errors.player-has-no-island");
-            return false;
-        }
-        int currentRank = island.getRank(target);
-        island.setRank(target, rankValue);
-        IslandEvent.builder()
-        .island(island)
-        .involvedPlayer(targetUUID)
-        .admin(true)
-        .reason(IslandEvent.Reason.RANK_CHANGE)
-        .rankChange(currentRank, rankValue)
-        .build();
+        int currentRank = island.getRank(targetUUID);
+        String ownerName = getPlayers().getName(island.getOwner());
 
-        String ownerName;
-        if (ownerUUID != null) {
-            ownerName = getPlayers().getName(ownerUUID);
-        } else {
-            ownerName = target.getName();
+        island.setRank(targetUUID, rankValue);
+        IslandEvent.builder().island(island).involvedPlayer(targetUUID).admin(true)
+                .reason(IslandEvent.Reason.RANK_CHANGE).rankChange(currentRank, rankValue).build();
+
+        user.sendMessage("commands.admin.setrank.rank-set", "[from]",
+                user.getTranslation(RanksManager.getInstance().getRank(currentRank)), "[to]",
+                user.getTranslation(RanksManager.getInstance().getRank(rankValue)), TextVariables.NAME, ownerName);
+        if (target.isOnline()) {
+            target.sendMessage("commands.admin.setrank.admin-changed-rank", TextVariables.RANK,
+                    target.getTranslation(RanksManager.getInstance().getRank(rankValue)), TextVariables.NAME,
+                    ownerName);
         }
-        user.sendMessage("commands.admin.setrank.rank-set",
-                "[from]", user.getTranslation(RanksManager.getInstance().getRank(currentRank)), "[to]",
-                user.getTranslation(RanksManager.getInstance().getRank(rankValue)),
-                TextVariables.NAME, ownerName);
         return true;
     }
 
+    /**
+     * Resolves a rank argument. Accepts the rank keyword ({@code member}, {@code sub-owner}, or any
+     * addon-registered rank's reference without the {@code ranks.} prefix), the rank's translated
+     * name in the caller's locale, or the numeric rank value.
+     * @return the rank value, if the argument names any known rank
+     */
+    private Optional<Integer> parseRank(User user, String arg) {
+        String wanted = arg.toLowerCase(Locale.ROOT);
+        for (Map.Entry<String, Integer> en : RanksManager.getInstance().getRanks().entrySet()) {
+            String translated = Util.stripColor(user.getTranslation(en.getKey())).toLowerCase(Locale.ROOT);
+            if (wanted.equals(keyword(en.getKey())) || wanted.equals(translated)
+                    || wanted.equals(String.valueOf(en.getValue()))) {
+                return Optional.of(en.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static String keyword(String reference) {
+        String key = reference.startsWith(RANK_PREFIX) ? reference.substring(RANK_PREFIX.length()) : reference;
+        return key.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * @return the keywords of every rank this command can set, lowest first
+     */
+    private static List<String> getAllowedRankNames() {
+        return RanksManager.getInstance().getRanks().entrySet().stream()
+                .filter(en -> en.getValue() > RanksManager.VISITOR_RANK && en.getValue() < RanksManager.OWNER_RANK)
+                .sorted(Map.Entry.comparingByValue()).map(en -> keyword(en.getKey())).toList();
+    }
+
+    /**
+     * No island was named: use the one team island the target belongs to but does not own.
+     */
+    private @Nullable Island findTargetIsland(User user) {
+        List<Island> memberOf = getIslands().getIslands(getWorld(), targetUUID).stream()
+                .filter(i -> !Objects.equals(targetUUID, i.getOwner())).toList();
+        if (memberOf.isEmpty()) {
+            if (getIslands().hasIsland(getWorld(), targetUUID)) {
+                user.sendMessage("commands.admin.setrank.cannot-set-owner");
+            } else {
+                user.sendMessage("general.errors.player-has-no-island");
+            }
+            return null;
+        }
+        if (memberOf.size() > 1) {
+            user.sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
+            memberOf.forEach(i -> user.sendMessage("commands.admin.unregister.errors.specify-island-location",
+                    TextVariables.XYZ, Util.xyz(i.getCenter().toVector())));
+            return null;
+        }
+        return memberOf.getFirst();
+    }
+
+    /**
+     * An island was named, either by its x,y,z centre or by the name of its owner.
+     */
+    private @Nullable Island findNamedIsland(User user, String name) {
+        Optional<Location> coords = parseXYZ(name);
+        if (coords.isPresent()) {
+            Optional<Island> at = getIslands().getIslandAt(coords.get());
+            if (at.isEmpty()) {
+                user.sendMessage("commands.admin.unregister.errors.unknown-island-location");
+                return null;
+            }
+            return at.get();
+        }
+        UUID ownerUUID = Util.getUUID(name);
+        if (ownerUUID == null) {
+            user.sendMessage("general.errors.unknown-player", TextVariables.NAME, name);
+            return null;
+        }
+        List<Island> owned = getIslands().getIslands(getWorld(), ownerUUID).stream()
+                .filter(i -> ownerUUID.equals(i.getOwner())).toList();
+        if (owned.isEmpty()) {
+            user.sendMessage("general.errors.player-is-not-owner", TextVariables.NAME, name);
+            return null;
+        }
+        if (owned.size() > 1) {
+            // Concurrent islands: the owner alone is ambiguous, so ask for the centre
+            user.sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
+            owned.forEach(i -> user.sendMessage("commands.admin.unregister.errors.specify-island-location",
+                    TextVariables.XYZ, Util.xyz(i.getCenter().toVector())));
+            return null;
+        }
+        return owned.getFirst();
+    }
+
+    /**
+     * @return a location in this command's world if the argument is in {@code x,y,z} form
+     */
+    private Optional<Location> parseXYZ(String arg) {
+        String[] parts = arg.split(",");
+        if (parts.length != 3) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(new Location(getWorld(), Integer.parseInt(parts[0].trim()),
+                    Integer.parseInt(parts[1].trim()), Integer.parseInt(parts[2].trim())));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
     @Override
-    public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
-        // Return the player names
+    public Optional<List<String>> tabComplete(User user, String alias, @NonNull List<String> args) {
+        String lastArg = !args.isEmpty() ? args.getLast() : "";
+        if (args.size() == 1) {
+            return Optional.of(Util.getOnlinePlayerList(user));
+        }
         if (args.size() == 2) {
-            return Optional.of(Util.getOnlinePlayerList(user));
+            return Optional.of(Util.tabLimit(getAllowedRankNames(), lastArg));
         }
-
-        // Return the ranks
         if (args.size() == 3) {
-            return Optional.of(RanksManager.getInstance().getRanks()
-                    .entrySet().stream()
-                    .filter(entry -> entry.getValue() > RanksManager.VISITOR_RANK)
-                    .map(entry -> user.getTranslation(entry.getKey())).toList());
+            // Island owners, plus the centres of the islands the target already belongs to
+            List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
+            UUID targetId = getPlayers().getUUID(args.getFirst());
+            if (targetId != null) {
+                getIslands().getIslands(getWorld(), targetId).stream().map(i -> Util.xyz(i.getCenter().toVector()))
+                        .forEach(options::add);
+            }
+            return Optional.of(Util.tabLimit(options, lastArg));
         }
-
-        // Return the player names again for the optional island owner argument
-        if (args.size() == 4) {
-            return Optional.of(Util.getOnlinePlayerList(user));
-        }
-
         return Optional.empty();
     }
 }

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -383,13 +383,14 @@ commands:
       description: získat hodnost hráče na jejich ostrově nebo na ostrově vlastníka
       rank-is: '<green>Hodnost je </green><aqua>[rank] </aqua><green>na ostrově </green><aqua>[name]</aqua><green>.</green>'
     setrank:
-      parameters: <player> <rank> [island owner]
-      description: nastavit hodnot hráče na jejich ostrově nebo na ostrově vlastníka
-      unknown-rank: '<red>Neznámá hodnost!</red>'
+      parameters: <hráč> <hodnost> [vlastník [prefix_island]u | x,y,z]
+      description: 'povýší nebo degraduje hráče na hodnost na jeho týmovém [prefix_island]u, nebo na [prefix_island]u určeném jménem vlastníka či středem x,y,z'
+      unknown-rank: '<red>Neznámá hodnost [rank]. Vyberte jednu z: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Hodnost musí být vyšší, než visitor.</red>'
-      rank-set: >-
-        <green>Hodnost nastavena z </green><aqua>[from] </aqua><green>na </green><aqua>[to] </aqua><green>na ostrově </green><aqua>[name]</aqua><green></green>
-        .
+      cannot-set-owner: '<red>Hodnost vlastníka nelze nastavit ani změnit. Použijte </red><yellow>setowner</yellow><red> k převodu vlastnictví.</red>'
+      already-rank: '<red>[name] už má hodnost [rank] na tomto [prefix_island]u.</red>'
+      rank-set: '<green>Hodnost nastavena z </green><aqua>[from] </aqua><green>na </green><aqua>[to] </aqua><green>na ostrově </green><aqua>[name]</aqua><green></green> .'
+      admin-changed-rank: '<gold>Admin nastavil tvou hodnost na [prefix_island]u hráče </gold><aqua>[name]</aqua><gold> na </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z souřadnice]'
       description: >-

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -407,13 +407,14 @@ commands:
       description: Den Rang eines Spielers auf seiner Insel erhalten
       rank-is: '<green>Der Rang ist [rank] auf ihrer Insel.</green>'
     setrank:
-      parameters: <player> <rank> [Insels Besitzer]
-      description: >-
-        Den Rang eines Spielers auf seiner Insel oder der Insel des Besitzers
-        festlegen
-      unknown-rank: '<red>Unbekannter Rang!</red>'
+      parameters: <Spieler> <Rang> [[prefix_island]-Besitzer | x,y,z]
+      description: 'befördert oder degradiert einen Spieler auf einen Rang auf seiner Team-[prefix_island] oder auf der [prefix_island], die über den Besitzer oder das x,y,z-Zentrum angegeben wird'
+      unknown-rank: '<red>Unbekannter Rang [rank]. Wähle einen von: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Der Rang muss höher sein als Besucher.</red>'
+      cannot-set-owner: '<red>Der Rang des Besitzers kann nicht gesetzt oder geändert werden. Nutze </red><yellow>setowner</yellow><red>, um das Eigentum zu übertragen.</red>'
+      already-rank: '<red>[name] hat auf dieser [prefix_island] bereits den Rang [rank].</red>'
       rank-set: '<green>Rang von</green><aqua>[from]</aqua><green>auf</green><aqua>[to]</aqua><green>gesetzt für</green><aqua>[name]</aqua><green>''s Insel.</green>'
+      admin-changed-rank: '<gold>Ein Admin hat deinen Rang auf der [prefix_island] von </gold><aqua>[name]</aqua><gold> auf </gold><aqua>[rank]</aqua><gold> gesetzt.</gold>'
     setprotectionlocation:
       parameters: '[x y z Koordinaten]'
       description: >-

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -362,12 +362,15 @@ commands:
         of the owner
       rank-is: '<green>Rank is </green><aqua>[rank] </aqua><green>on </green><aqua>[name]</aqua><green>''s [prefix_island].</green>'
     setrank:
-      parameters: <player> <rank> [[prefix_island] owner]
-      description: set a player's rank on their [prefix_island] or the [prefix_island]
-        of the owner
-      unknown-rank: '<red>Unknown rank!</red>'
+      parameters: <player> <rank> [[prefix_island] owner | x,y,z]
+      description: >-
+        promote or demote a player to a rank on their team [prefix_island], or on the [prefix_island] named by its owner or x,y,z centre
+      unknown-rank: '<red>Unknown rank [rank]. Choose one of: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Rank must be higher than visitor.</red>'
+      cannot-set-owner: '<red>You cannot set or change the owner''s rank. Use </red><yellow>setowner</yellow><red> to transfer ownership instead.</red>'
+      already-rank: '<red>[name] is already [rank] on this [prefix_island].</red>'
       rank-set: '<green>Rank set from </green><aqua>[from] </aqua><green>to </green><aqua>[to] </aqua><green>on </green><aqua>[name]</aqua><green>''s [prefix_island].</green>'
+      admin-changed-rank: '<gold>An admin set your rank on </gold><aqua>[name]</aqua><gold>''s [prefix_island] to </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z coords]'
       description: set current location or [x y z] as center of [prefix_island]'s

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -391,11 +391,14 @@ commands:
       description: conseguir el rango de un jugador en su isla
       rank-is: '<green>El Rango es [rank] en su isla.</green>'
     setrank:
-      parameters: <player> <rank>
-      description: Establecer el rango de un jugador en su isla
-      unknown-rank: '<red>Rango desconocido!</red>'
+      parameters: <jugador> <rango> [dueño de la [prefix_island] | x,y,z]
+      description: 'asciende o degrada a un jugador a un rango en la [prefix_island] de su equipo, o en la [prefix_island] indicada por su dueño o centro x,y,z'
+      unknown-rank: '<red>Rango desconocido [rank]. Elige uno de: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Rank debe ser más alto que el visitante</red>'
+      cannot-set-owner: '<red>No puedes establecer ni cambiar el rango del dueño. Usa </red><yellow>setowner</yellow><red> para transferir la propiedad.</red>'
+      already-rank: '<red>[name] ya es [rank] en esta [prefix_island].</red>'
       rank-set: '<green>Rango establecido desde [from] a [to].</green>'
+      admin-changed-rank: '<gold>Un administrador ha puesto tu rango en la [prefix_island] de </gold><aqua>[name]</aqua><gold> a </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[coordenadas x y z]'
       description: >-

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -423,11 +423,14 @@ commands:
       description: obtenir le rang d'un joueur sur son île ou sur l'île du propriétaire
       rank-is: '<green>Le rang du joueur est </green><aqua>[rank] </aqua><green>sur l''île de </green><aqua>[name]</aqua><green>.</green>'
     setrank:
-      parameters: <player> <rank> [propriétaire de l'île]
-      description: définir le rang d'un joueur sur son île ou sur celle du propriétaire
-      unknown-rank: '<red>Rang inconnu!</red>'
+      parameters: <joueur> <rang> [propriétaire de l’[prefix_island] | x,y,z]
+      description: 'promouvoir ou rétrograder un joueur à un rang sur l’[prefix_island] de son équipe, ou sur l’[prefix_island] désignée par son propriétaire ou son centre x,y,z'
+      unknown-rank: '<red>Rang inconnu [rank]. Choisissez parmi : </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Le classement doit être supérieur à celui du visiteur.</red>'
+      cannot-set-owner: '<red>Vous ne pouvez pas définir ni changer le rang du propriétaire. Utilisez </red><yellow>setowner</yellow><red> pour transférer la propriété.</red>'
+      already-rank: '<red>[name] est déjà [rank] sur cette [prefix_island].</red>'
       rank-set: '<green>Rang défini de </green><aqua>[from] </aqua><green>à </green><aqua>[to] </aqua><green>sur l''île de </green><aqua>[name]</aqua><green>.</green>'
+      admin-changed-rank: '<gold>Un administrateur a défini votre rang sur l’[prefix_island] de </gold><aqua>[name]</aqua><gold> à </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[coordonnées x y z]'
       description: >-

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -391,11 +391,14 @@ commands:
       description: dobiti rang igrača na svom otoku ili otoku vlasnika
       rank-is: '<green>Rang je </green><aqua>[rank] </aqua><green>na </green><aqua>[name]</aqua><green>otoku.</green>'
     setrank:
-      parameters: <igrač> <rang> [vlasnik otoka]
-      description: postaviti rang igrača na njegovom otoku ili otoku vlasnika
-      unknown-rank: '<red>Nepoznat rang!</red>'
+      parameters: <igrač> <rang> [vlasnik [prefix_island]a | x,y,z]
+      description: 'promakni ili degradiraj igrača na rang na njegovom timskom [prefix_island]u, ili na [prefix_island]u navedenom po vlasniku ili središtu x,y,z'
+      unknown-rank: '<red>Nepoznat rang [rank]. Odaberi jedan od: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Rang mora biti viši od posjetitelja.</red>'
+      cannot-set-owner: '<red>Ne možeš postaviti ni promijeniti rang vlasnika. Koristi </red><yellow>setowner</yellow><red> za prijenos vlasništva.</red>'
+      already-rank: '<red>[name] je već [rank] na ovom [prefix_island]u.</red>'
       rank-set: '<green>Rang postavljen od </green><aqua>[from] </aqua><green>do </green><aqua>[to] </aqua><green>na </green><aqua>[name]</aqua><green>otoku.</green>'
+      admin-changed-rank: '<gold>Admin je postavio tvoj rang na [prefix_island]u igrača </gold><aqua>[name]</aqua><gold> na </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z koordinate]'
       description: >-

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -417,13 +417,14 @@ commands:
       description: kap egy játékos rangot a szigetén vagy a tulajdonos szigetén
       rank-is: 'Az <green>Rank </green><aqua>[rank] </aqua><green></green><aqua>[name]</aqua><green>szigetén.</green>'
     setrank:
-      parameters: <játékos> <rang> [szigettulajdonos]
-      description: állítsanak be egy játékos rangot a szigetükön vagy a tulajdonos szigetén
-      unknown-rank: '<red>Ismeretlen rang!</red>'
+      parameters: <játékos> <rang> [[prefix_island] tulajdonosa | x,y,z]
+      description: 'játékos előléptetése vagy lefokozása egy rangra a csapata [prefix_island]án, vagy a tulajdonos nevével vagy x,y,z középponttal megadott [prefix_island]on'
+      unknown-rank: '<red>Ismeretlen rang: [rank]. Válassz egyet: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>A rangnak magasabbnak kell lennie, mint a látogatóé.</red>'
-      rank-set: >-
-        Az <green>rangsor beállítva </green><aqua>-től [from] </aqua><green>-ig </green><aqua>-ig [to] </aqua><green>-ig </green><aqua>[name]</aqua><green></green>
-        szigetén.
+      cannot-set-owner: '<red>A tulajdonos rangját nem lehet beállítani vagy megváltoztatni. Használd a </red><yellow>setowner</yellow><red> parancsot a tulajdonjog átadásához.</red>'
+      already-rank: '<red>[name] már [rank] ezen a [prefix_island]on.</red>'
+      rank-set: 'Az <green>rangsor beállítva </green><aqua>-től [from] </aqua><green>-ig </green><aqua>-ig [to] </aqua><green>-ig </green><aqua>[name]</aqua><green></green> szigetén.'
+      admin-changed-rank: '<gold>Egy admin a rangodat </gold><aqua>[name]</aqua><gold> [prefix_island]án </gold><aqua>[rank]</aqua><gold> rangra állította.</gold>'
     setprotectionlocation:
       parameters: '[x y z koordináta]'
       description: >-

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -400,13 +400,14 @@ commands:
       description: mendapatkan peringkat pemain di pulau mereka atau pulau pemiliknya
       rank-is: '<green>Peringkat adalah </green><aqua>[rank] </aqua><green>di pulau </green><aqua>[name]</aqua><green>.</green>'
     setrank:
-      parameters: <pemain> <peringkat> [pemilik pulau]
-      description: mengatur peringkat pemain di pulau mereka atau pulau pemiliknya
-      unknown-rank: '<red>Peringkat tidak diketahui!</red>'
+      parameters: <pemain> <peringkat> [pemilik [prefix_island] | x,y,z]
+      description: 'naikkan atau turunkan peringkat pemain di [prefix_island] timnya, atau di [prefix_island] yang disebutkan berdasarkan pemilik atau pusat x,y,z'
+      unknown-rank: '<red>Peringkat [rank] tidak dikenal. Pilih salah satu: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Peringkat harus lebih tinggi dari pengunjung.</red>'
-      rank-set: >-
-        <green>Peringkat ditetapkan dari </green><aqua>[from] </aqua><green>ke </green><aqua>[to] </aqua><green>di pulau </green><aqua></aqua>
-        [name]<green>.</green>
+      cannot-set-owner: '<red>Kamu tidak dapat mengatur atau mengubah peringkat pemilik. Gunakan </red><yellow>setowner</yellow><red> untuk memindahkan kepemilikan.</red>'
+      already-rank: '<red>[name] sudah [rank] di [prefix_island] ini.</red>'
+      rank-set: '<green>Peringkat ditetapkan dari </green><aqua>[from] </aqua><green>ke </green><aqua>[to] </aqua><green>di pulau </green><aqua></aqua> [name]<green>.</green>'
+      admin-changed-rank: '<gold>Admin mengatur peringkatmu di [prefix_island] milik </gold><aqua>[name]</aqua><gold> menjadi </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[koord x y z]'
       description: >-

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -406,11 +406,14 @@ commands:
       description: ottieni il rango di un giocatore nella sua isola
       rank-is: '<green>Il rango è [rank] nella sua isola.</green>'
     setrank:
-      parameters: <player> <rank>
-      description: imposta il rango di un player nella sua isola
-      unknown-rank: '<red>Rango sconosciuto!</red>'
+      parameters: <giocatore> <grado> [proprietario dell’[prefix_island] | x,y,z]
+      description: 'promuove o degrada un giocatore a un grado sull’[prefix_island] del suo team, o sull’[prefix_island] indicata dal proprietario o dal centro x,y,z'
+      unknown-rank: '<red>Grado sconosciuto [rank]. Scegli uno tra: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Il rank deve essere maggiore di quello del visitatore</red>'
+      cannot-set-owner: '<red>Non puoi impostare o cambiare il grado del proprietario. Usa </red><yellow>setowner</yellow><red> per trasferire la proprietà.</red>'
+      already-rank: '<red>[name] è già [rank] su questa [prefix_island].</red>'
       rank-set: '<green>Rango impostato da [from] a [to].</green>'
+      admin-changed-rank: '<gold>Un admin ha impostato il tuo grado sull’[prefix_island] di </gold><aqua>[name]</aqua><gold> a </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[coordinate x y z]'
       description: >-

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -348,11 +348,14 @@ commands:
       description: プレイヤーの島でのランクを見る。
       rank-is: プレーヤーのランクは [rank]である。
     setrank:
-      parameters: ＜プレーヤー＞　＜ランク＞
-      description: プレイヤーのランクを設定する
-      unknown-rank: '<red>不明ランク!</red>'
+      parameters: <プレイヤー> <ランク> [[prefix_island]の所有者 | x,y,z]
+      description: 'プレイヤーをチームの[prefix_island]、または所有者名か中心座標 x,y,z で指定した[prefix_island]で、指定のランクに昇格または降格します'
+      unknown-rank: '<red>不明なランク [rank] です。次から選んでください: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>ランクは訪問者より高くなければなりません</red>'
+      cannot-set-owner: '<red>所有者のランクは設定・変更できません。所有権を移すには </red><yellow>setowner</yellow><red> を使用してください。</red>'
+      already-rank: '<red>[name] はこの[prefix_island]ですでに [rank] です。</red>'
       rank-set: '<dark_green>[from] から [to] に設定されたランク。</dark_green>'
+      admin-changed-rank: '<gold>管理者が </gold><aqua>[name]</aqua><gold> の[prefix_island]でのあなたのランクを </gold><aqua>[rank]</aqua><gold> に設定しました。</gold>'
     setprotectionlocation:
       parameters: '[x y z coords]'
       description: 現在地または[x y z]を島の保護地域の中心として設定します

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -365,11 +365,14 @@ commands:
       description: 자신이나 소유자의 섬의 랭크를 가져옵니다
       rank-is: '<green></green><aqua>[name]의 </aqua><green>섬에서의 순위는 </green><aqua>[rank]</aqua><green>입니다</green>'
     setrank:
-      parameters: <player> <rank> [island owner]
-      description: 섬의 플레이어의 랭크를 설정합니다
-      unknown-rank: '<red>알수없는 랭크입니다</red>'
+      parameters: <플레이어> <등급> [[prefix_island] 소유자 | x,y,z]
+      description: '플레이어를 자신의 팀 [prefix_island], 또는 소유자 이름이나 중심 x,y,z로 지정한 [prefix_island]에서 지정한 등급으로 승급 또는 강등합니다'
+      unknown-rank: '<red>알 수 없는 등급 [rank]입니다. 다음 중 하나를 선택하세요: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>랭크는 방문자보다 높아야합니다.</red>'
+      cannot-set-owner: '<red>소유자의 등급은 설정하거나 변경할 수 없습니다. 소유권을 이전하려면 </red><yellow>setowner</yellow><red>를 사용하세요.</red>'
+      already-rank: '<red>[name]님은 이미 이 [prefix_island]에서 [rank]입니다.</red>'
       rank-set: '<green>랭크를 </green><aqua>[from] </aqua><green>에서 </green><aqua>[to] </aqua><green>로 </green><aqua>[name]</aqua><green>의 섬에서 설정했습니다</green>'
+      admin-changed-rank: '<gold>관리자가 </gold><aqua>[name]</aqua><gold>님의 [prefix_island]에서 당신의 등급을 </gold><aqua>[rank]</aqua><gold>(으)로 설정했습니다.</gold>'
     setprotectionlocation:
       parameters: '[x y z 좌표]'
       description: 현재 위치 또는 [x y z]를 [prefix_island]의 보호 지역 중심으로 설정합니다.

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -396,11 +396,14 @@ commands:
       description: atgriež spēlētāja rangu komandā
       rank-is: '<green>Spēlētājam ir [rank] rangs uz viņa salas.</green>'
     setrank:
-      parameters: <spēlētājs> <rangs>
-      description: uzstāda spēlētājam rangu uz viņa salas
-      unknown-rank: '<red>Nezināms rangs!</red>'
+      parameters: <spēlētājs> <rangs> [[prefix_island] īpašnieks | x,y,z]
+      description: 'paaugstina vai pazemina spēlētāju uz rangu viņa komandas [prefix_island] vai [prefix_island], kas norādīta pēc īpašnieka vai centra x,y,z'
+      unknown-rank: '<red>Nezināms rangs [rank]. Izvēlies vienu no: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Rangam ir jābūt lielākam par apmeklētāju</red>'
+      cannot-set-owner: '<red>Īpašnieka rangu nevar iestatīt vai mainīt. Izmanto </red><yellow>setowner</yellow><red>, lai nodotu īpašumtiesības.</red>'
+      already-rank: '<red>[name] jau ir [rank] šajā [prefix_island].</red>'
       rank-set: '<green>Spēlētājam nomainīts rangs no [from] uz [to].</green>'
+      admin-changed-rank: '<gold>Administrators iestatīja tavu rangu </gold><aqua>[name]</aqua><gold> [prefix_island] uz </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z koordinātas]'
       description: >-

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -414,15 +414,14 @@ commands:
         eigenaar
       rank-is: '<green>rang is </green><aqua>[rank] </aqua><green>op </green><aqua>[name] </aqua><green>''s eiland.</green>'
     setrank:
-      parameters: <speler> <rank> [eilandeigenaar]
-      description: >-
-        bepaal de rang van een speler op zijn of haar eiland of op het eiland
-        van de eigenaar
-      unknown-rank: '<red>Onbekende rang!</red>'
+      parameters: <speler> <rang> [[prefix_island] eigenaar | x,y,z]
+      description: 'promoveer of degradeer een speler naar een rang op het [prefix_island] van zijn team, of op het [prefix_island] aangeduid met de eigenaar of het x,y,z-middelpunt'
+      unknown-rank: '<red>Onbekende rang [rank]. Kies uit: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Rang moet hoger zijn dan bezoeker.</red>'
-      rank-set: >-
-        <green>Rang ingesteld van </green><aqua>[from] </aqua><green>naar </green><aqua>[to] </aqua><green>op </green><aqua>[name] </aqua><green>'s</green>
-        eiland.
+      cannot-set-owner: '<red>Je kunt de rang van de eigenaar niet instellen of wijzigen. Gebruik </red><yellow>setowner</yellow><red> om het eigendom over te dragen.</red>'
+      already-rank: '<red>[name] is al [rank] op dit [prefix_island].</red>'
+      rank-set: '<green>Rang ingesteld van </green><aqua>[from] </aqua><green>naar </green><aqua>[to] </aqua><green>op </green><aqua>[name] </aqua><green>''s</green> eiland.'
+      admin-changed-rank: '<gold>Een admin heeft je rang op het [prefix_island] van </gold><aqua>[name]</aqua><gold> ingesteld op </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z coördinaten]'
       description: >-

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -398,11 +398,14 @@ commands:
       description: zdobądź role gracza na jego wyspie
       rank-is: '<green>Rola [rank] na jego wyspie.</green>'
     setrank:
-      parameters: <gracz> <rola>
-      description: ustawia role gracza na swojej wyspie
-      unknown-rank: '<red>Nieznana rola!</red>'
+      parameters: <gracz> <ranga> [właściciel [prefix_island] | x,y,z]
+      description: 'awansuje lub degraduje gracza do rangi na [prefix_island] jego drużyny, lub na [prefix_island] wskazanej przez właściciela lub środek x,y,z'
+      unknown-rank: '<red>Nieznana ranga [rank]. Wybierz jedną z: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Ranga musi być wyższa niż ranga gościa.</red>'
+      cannot-set-owner: '<red>Nie możesz ustawić ani zmienić rangi właściciela. Użyj </red><yellow>setowner</yellow><red>, aby przenieść własność.</red>'
+      already-rank: '<red>[name] ma już rangę [rank] na tej [prefix_island].</red>'
       rank-set: '<green>Rola ustawiona z [from] na [to].</green>'
+      admin-changed-rank: '<gold>Administrator ustawił twoją rangę na [prefix_island] gracza </gold><aqua>[name]</aqua><gold> na </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z współrzędne]'
       description: >-

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -392,15 +392,14 @@ commands:
       description: ver o cargo de um jogador em sua ilha ou na ilha de outro
       rank-is: '<green>Cargo é </green><aqua>[rank] </aqua><green>na ilha de </green><aqua>[name]</aqua><green>.</green>'
     setrank:
-      parameters: <jogador> <cargo> [dono da ilha]
-      description: >-
-        alterar o cargo de um jogador em sua própria ilha ou na ilha do jogador
-        especificado
-      unknown-rank: '<red>Cargo desconhecido!</red>'
+      parameters: <jogador> <cargo> [dono da [prefix_island] | x,y,z]
+      description: 'promove ou rebaixa um jogador para um cargo na [prefix_island] da sua equipe, ou na [prefix_island] indicada pelo dono ou centro x,y,z'
+      unknown-rank: '<red>Cargo desconhecido [rank]. Escolha um de: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>O cargo deve ser maior que visitante.</red>'
-      rank-set: >-
-        <green>Cargo alterado de </green><aqua>[from] </aqua><green>para </green><aqua>[to] </aqua><green>na ilha de </green><aqua></aqua>
-        [name]<green>.</green>
+      cannot-set-owner: '<red>Você não pode definir nem mudar o cargo do dono. Use </red><yellow>setowner</yellow><red> para transferir a propriedade.</red>'
+      already-rank: '<red>[name] já é [rank] nesta [prefix_island].</red>'
+      rank-set: '<green>Cargo alterado de </green><aqua>[from] </aqua><green>para </green><aqua>[to] </aqua><green>na ilha de </green><aqua></aqua> [name]<green>.</green>'
+      admin-changed-rank: '<gold>Um admin definiu seu cargo na [prefix_island] de </gold><aqua>[name]</aqua><gold> como </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: As coordenadas [x y z]
       description: >-

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -397,13 +397,14 @@ commands:
       description: obter o cargo de um jogador em sua ilha ou na ilha do dono
       rank-is: '<green>Cargo é </green><aqua>[rank] </aqua><green>na ilha de </green><aqua>[name]</aqua><green>.</green>'
     setrank:
-      parameters: <jogador> <classificação> [dono da ilha]
-      description: definir o cargo de um jogador em sua ilha ou na ilha do dono
-      unknown-rank: '<red>Cargo desconhecido!</red>'
+      parameters: <jogador> <cargo> [dono da [prefix_island] | x,y,z]
+      description: 'promove ou despromove um jogador para um cargo na [prefix_island] da sua equipa, ou na [prefix_island] indicada pelo dono ou centro x,y,z'
+      unknown-rank: '<red>Cargo desconhecido [rank]. Escolhe um de: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>O cargo deve ser maior que visitante.</red>'
-      rank-set: >-
-        <green>Cargo definido de </green><aqua>[from] </aqua><green>para </green><aqua>[to] </aqua><green>na ilha de </green><aqua></aqua>
-        [name]<green>.</green>
+      cannot-set-owner: '<red>Não podes definir nem mudar o cargo do dono. Usa </red><yellow>setowner</yellow><red> para transferir a propriedade.</red>'
+      already-rank: '<red>[name] já é [rank] nesta [prefix_island].</red>'
+      rank-set: '<green>Cargo definido de </green><aqua>[from] </aqua><green>para </green><aqua>[to] </aqua><green>na ilha de </green><aqua></aqua> [name]<green>.</green>'
+      admin-changed-rank: '<gold>Um admin definiu o teu cargo na [prefix_island] de </gold><aqua>[name]</aqua><gold> como </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[coordenadas x y z]'
       description: >-

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -405,11 +405,14 @@ commands:
       description: obține rangul unui jucător pe insula lor sau pe insula proprietarului
       rank-is: '<green>Rank este </green><aqua>[rank] </aqua><green>pe insula </green><aqua>[name] </aqua><green>.</green>'
     setrank:
-      parameters: <player> <rank> [proprietarul insulei]
-      description: stabiliți rangul unui jucător pe insula lor sau pe insula proprietarului
-      unknown-rank: '<red>Rang necunoscut!</red>'
+      parameters: <jucător> <rang> [proprietarul [prefix_island] | x,y,z]
+      description: 'promovează sau retrogradează un jucător la un rang pe [prefix_island] echipei sale, sau pe [prefix_island] indicată prin proprietar sau centrul x,y,z'
+      unknown-rank: '<red>Rang necunoscut [rank]. Alege unul dintre: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Rank trebuie să fie mai mare decât vizitatorul.</red>'
+      cannot-set-owner: '<red>Nu poți seta sau schimba rangul proprietarului. Folosește </red><yellow>setowner</yellow><red> pentru a transfera proprietatea.</red>'
+      already-rank: '<red>[name] este deja [rank] pe această [prefix_island].</red>'
       rank-set: '<green>Rang setat de la </green><aqua>[from] </aqua><green>la </green><aqua>[to] </aqua><green>pe insula </green><aqua>[name] </aqua><green>.</green>'
+      admin-changed-rank: '<gold>Un admin ți-a setat rangul pe [prefix_island] lui </gold><aqua>[name]</aqua><gold> la </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[ coordonatele x y z ]'
       description: >-

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -395,12 +395,14 @@ commands:
       description: отображает ранг игрока на его острове или острове владельца
       rank-is: <green>Ранг <aqua>[rank] </aqua>на острове игрока <aqua>[name]</aqua>.</green>
     setrank:
-      parameters: <игрок> <ранг> [владелец [prefix_island]а]
-      description: устанавливает ранг игрока на их острове или острове владельца
-      unknown-rank: <red>Неизвестный ранг!</red>
-      not-possible: <red>Ранг должен быть больше чем у посетителя.</red>
-      rank-set: <green>Ранг установлен между <aqua>[from] </aqua>и <aqua>[to] </aqua>на
-        острове игрока <aqua>[name]</aqua>.</green>
+      parameters: <игрок> <ранг> [владелец [prefix_island]а | x,y,z]
+      description: 'повысить или понизить игрока до ранга на [prefix_island]е его команды, либо на [prefix_island]е, указанном по владельцу или центру x,y,z'
+      unknown-rank: '<red>Неизвестный ранг [rank]. Выберите один из: </red><yellow>[ranks]</yellow>'
+      not-possible: '<red>Ранг должен быть больше чем у посетителя.</red>'
+      cannot-set-owner: '<red>Нельзя установить или изменить ранг владельца. Используйте </red><yellow>setowner</yellow><red>, чтобы передать владение.</red>'
+      already-rank: '<red>[name] уже имеет ранг [rank] на этом [prefix_island]е.</red>'
+      rank-set: '<green>Ранг установлен между <aqua>[from] </aqua>и <aqua>[to] </aqua>на острове игрока <aqua>[name]</aqua>.</green>'
+      admin-changed-rank: '<gold>Администратор установил ваш ранг на [prefix_island]е игрока </gold><aqua>[name]</aqua><gold>: </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z координаты]'
       description: устанавливает текущую локацию или координаты [x y z] как центральную

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -394,11 +394,14 @@ commands:
       description: Olduğun ada üstündeki oyuncunun rankını gösterir.
       rank-is: '<green>Ada üstündeki yetkisi: </green><yellow>[rank].</yellow>'
     setrank:
-      parameters: <player> <rank>
-      description: Olduğun ada üstündeki oyuncuya yetkisini ayarlar
-      unknown-rank: '<dark_red>Bilinmeyen rütbe!</dark_red>'
+      parameters: <oyuncu> <rütbe> [[prefix_island] sahibi | x,y,z]
+      description: 'bir oyuncuyu takımının [prefix_island] üzerinde veya sahibiyle ya da x,y,z merkeziyle belirtilen [prefix_island] üzerinde bir rütbeye yükseltir veya düşürür'
+      unknown-rank: '<red>Bilinmeyen rütbe [rank]. Şunlardan birini seçin: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Rütbe türü ziyaretçiden yüksek olmalıdır.</red>'
+      cannot-set-owner: '<red>Sahibin rütbesini ayarlayamaz veya değiştiremezsiniz. Sahipliği aktarmak için </red><yellow>setowner</yellow><red> kullanın.</red>'
+      already-rank: '<red>[name] bu [prefix_island] üzerinde zaten [rank].</red>'
       rank-set: '<green>Rütbe </green><red>[from]</red><green>''dan </green><yellow>[to] </yellow><green>yükseltildi.</green>'
+      admin-changed-rank: '<gold>Bir yönetici </gold><aqua>[name]</aqua><gold> adlı oyuncunun [prefix_island] üzerindeki rütbeni </gold><aqua>[rank]</aqua><gold> olarak ayarladı.</gold>'
     setprotectionlocation:
       parameters: '[x y z koordinatları]'
       description: >-

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -356,11 +356,14 @@ commands:
       description: отримати ранг гравця на його [prefix_island] або на [prefix_island] власника
       rank-is: '<green>Ранг </green><aqua>[rank] </aqua><green>на [prefix_island] гравця </green><aqua>[name]</aqua><green>.</green>'
     setrank:
-      parameters: <гравець> <rank> [[prefix_island] owner]
-      description: встановити ранг гравцю на його [prefix_island] або на [prefix_island] власника
-      unknown-rank: '<red>Невідомий ранг!</red>'
+      parameters: <гравець> <ранг> [власник [prefix_island]а | x,y,z]
+      description: 'підвищити або понизити гравця до рангу на [prefix_island]і його команди, або на [prefix_island]і, вказаному за власником чи центром x,y,z'
+      unknown-rank: '<red>Невідомий ранг [rank]. Виберіть один із: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Ранг має бути вищий за «відвідувач».</red>'
+      cannot-set-owner: '<red>Не можна встановити чи змінити ранг власника. Використайте </red><yellow>setowner</yellow><red>, щоб передати власність.</red>'
+      already-rank: '<red>[name] уже має ранг [rank] на цьому [prefix_island]і.</red>'
       rank-set: '<green>Ранг змінено з </green><aqua>[from] </aqua><green>на </green><aqua>[to] </aqua><green>на [prefix_island] </green><aqua>[name]</aqua><green>.</green>'
+      admin-changed-rank: '<gold>Адміністратор встановив ваш ранг на [prefix_island]і гравця </gold><aqua>[name]</aqua><gold>: </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[x y z coords]'
       description: встановити поточну локацію або [x y z] центром зони захисту [prefix_island]

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -395,11 +395,14 @@ commands:
       description: xem hạng của người chơi trên đảo của họ hoặc đảo của chủ
       rank-is: '<green>Hạng là </green><aqua>[rank] </aqua><green>trên đảo của </green><aqua>[name]</aqua><green>.</green>'
     setrank:
-      parameters: <người chơi> <hạng> [chủ đảo]
-      description: đặt hạng của người chơi trên đảo c��a họ hoặc đảo của chủ
-      unknown-rank: '<red>Hạng không xác định!</red>'
+      parameters: <người chơi> <cấp bậc> [chủ [prefix_island] | x,y,z]
+      description: 'thăng hoặc giáng cấp một người chơi lên một cấp bậc trên [prefix_island] của đội họ, hoặc trên [prefix_island] được chỉ định theo chủ sở hữu hoặc tâm x,y,z'
+      unknown-rank: '<red>Cấp bậc không xác định [rank]. Chọn một trong: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>Hạng phải cao hơn khách tham quan.</red>'
+      cannot-set-owner: '<red>Bạn không thể đặt hoặc thay đổi cấp bậc của chủ đảo. Dùng </red><yellow>setowner</yellow><red> để chuyển quyền sở hữu.</red>'
+      already-rank: '<red>[name] đã là [rank] trên [prefix_island] này.</red>'
       rank-set: '<green>Đã đặt hạng t�� </green><aqua>[from] </aqua><green>thành </green><aqua>[to] </aqua><green>trên đảo của </green><aqua>[name]</aqua><green>.</green>'
+      admin-changed-rank: '<gold>Quản trị viên đã đặt cấp bậc của bạn trên [prefix_island] của </gold><aqua>[name]</aqua><gold> thành </gold><aqua>[rank]</aqua><gold>.</gold>'
     setprotectionlocation:
       parameters: '[toạ độ x y z]'
       description: đặt vị trí hiện tại hoặc [x y z] là điểm giữa khu vực bảo vệ

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -356,11 +356,14 @@ commands:
       description: 获取指定玩家的身份等级
       rank-is: '<green>玩家</green><aqua>[name]</aqua><green>在岛屿上的身份等级为: </green><aqua>[rank]</aqua><green>.</green>'
     setrank:
-      parameters: <player> <rank> [island owner]
-      description: 设置指定玩家的身份等级
-      unknown-rank: '<red>未知的身份等级!</red>'
+      parameters: <玩家> <等级> [[prefix_island]岛主 | x,y,z]
+      description: '将玩家在其团队[prefix_island]上、或在通过岛主名称或中心 x,y,z 指定的[prefix_island]上提升或降低到指定等级'
+      unknown-rank: '<red>未知的身份等级 [rank]。请选择以下之一: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>身份等级必须比</red><aqua>访客</aqua><red>高.</red>'
+      cannot-set-owner: '<red>无法设置或更改岛主的身份等级。请使用 </red><yellow>setowner</yellow><red> 转移所有权。</red>'
+      already-rank: '<red>[name] 在此[prefix_island]上已经是 [rank]。</red>'
       rank-set: '<green>已将玩家</green><aqua>[name]</aqua><green>的身份等级从</green><aqua>[from]</aqua><green>设置为</green><aqua>[to]</aqua><green>.</green>'
+      admin-changed-rank: '<gold>管理员已将你在 </gold><aqua>[name]</aqua><gold> 的[prefix_island]上的身份等级设置为 </gold><aqua>[rank]</aqua><gold>。</gold>'
     setprotectionlocation:
       parameters: '<gray>[x y z coords]</gray>'
       description: 将当前位置或指定坐标作为岛屿保护的中心点

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -357,11 +357,14 @@ commands:
       description: 得到玩家在他們的島嶼上的階銜
       rank-is: '<green>在他們的島嶼上的階銜是 [rank]。</green>'
     setrank:
-      parameters: <player> <rank>
-      description: 設置玩家在他們島嶼上的階銜
-      unknown-rank: '<red>未知階銜!</red>'
+      parameters: <玩家> <等級> [[prefix_island]島主 | x,y,z]
+      description: '將玩家在其團隊[prefix_island]上、或在透過島主名稱或中心 x,y,z 指定的[prefix_island]上提升或降低到指定等級'
+      unknown-rank: '<red>未知的身份等級 [rank]。請選擇以下之一: </red><yellow>[ranks]</yellow>'
       not-possible: '<red>要設置的階銜必須比 “訪客” 高。</red>'
+      cannot-set-owner: '<red>無法設定或更改島主的身份等級。請使用 </red><yellow>setowner</yellow><red> 轉移擁有權。</red>'
+      already-rank: '<red>[name] 在此[prefix_island]上已經是 [rank]。</red>'
       rank-set: '<green>階銜由 [from] 設置為 [to]。</green>'
+      admin-changed-rank: '<gold>管理員已將你在 </gold><aqua>[name]</aqua><gold> 的[prefix_island]上的身份等級設定為 </gold><aqua>[rank]</aqua><gold>。</gold>'
     setprotectionlocation:
       parameters: '[x y z (坐標)]'
       description: 將所處位置或給定坐標設置為島嶼保護區的中心點

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -331,11 +331,14 @@ commands:
       description: 查詢玩家在自己的[prefix_island]或指定島主[prefix_island]中的權限等級
       rank-is: <green>權限等級為 </green><aqua>[rank] </aqua><green>（</green><aqua>[name]</aqua><green> 的[prefix_island]）。</green>
     setrank:
-      parameters: <玩家> <權限等級> [[prefix_island]島主]
-      description: 設定玩家在自己的[prefix_island]或指定島主[prefix_island]中的權限等級
-      unknown-rank: <red>未知的權限等級！</red>
-      not-possible: <red>權限等級必須高於訪客。</red>
-      rank-set: <green>已將 </green><aqua>[name]</aqua><green> 的[prefix_island]權限等級從 </green><aqua>[from] </aqua><green>變更為 </green><aqua>[to]</aqua><green>。</green>
+      parameters: <玩家> <等級> [[prefix_island]島主 | x,y,z]
+      description: '將玩家在其團隊[prefix_island]上、或在透過島主名稱或中心 x,y,z 指定的[prefix_island]上提升或降低到指定等級'
+      unknown-rank: '<red>未知的身份等級 [rank]。請選擇以下之一: </red><yellow>[ranks]</yellow>'
+      not-possible: '<red>權限等級必須高於訪客。</red>'
+      cannot-set-owner: '<red>無法設定或更改島主的身份等級。請使用 </red><yellow>setowner</yellow><red> 轉移擁有權。</red>'
+      already-rank: '<red>[name] 在此[prefix_island]上已經是 [rank]。</red>'
+      rank-set: '<green>已將 </green><aqua>[name]</aqua><green> 的[prefix_island]權限等級從 </green><aqua>[from] </aqua><green>變更為 </green><aqua>[to]</aqua><green>。</green>'
+      admin-changed-rank: '<gold>管理員已將你在 </gold><aqua>[name]</aqua><gold> 的[prefix_island]上的身份等級設定為 </gold><aqua>[rank]</aqua><gold>。</gold>'
     setprotectionlocation:
       parameters: '[x y z 座標]'
       description: 將目前位置或指定的 [x y z] 座標設為[prefix_island]的保護區域中心

--- a/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
+++ b/src/test/java/world/bentobox/bentobox/api/commands/admin/AdminSetrankCommandTest.java
@@ -5,17 +5,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.bukkit.entity.Player;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -23,6 +26,7 @@ import org.mockito.stubbing.Answer;
 
 import world.bentobox.bentobox.RanksManagerTestSetup;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.PlayersManager;
@@ -35,167 +39,330 @@ import world.bentobox.bentobox.util.Util;
  */
 class AdminSetrankCommandTest extends RanksManagerTestSetup {
 
+    private static final String TARGET = "target";
+    private static final String OWNER = "owner";
+    private static final String XYZ = "0,0,0";
+    private static final String XYZ2 = "100,64,100";
+
     @Mock
     private CompositeCommand ac;
     @Mock
     private User user;
     @Mock
     private PlayersManager pm;
+    @Mock
+    private Island island2;
 
     private AdminSetrankCommand c;
 
     private UUID targetUUID;
+    private UUID ownerUUID;
 
- @Override
+    @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         Util.setPlugin(plugin);
+        User.setPlugin(plugin);
+
+        when(ac.getWorld()).thenReturn(world);
 
         // Players Manager
         when(plugin.getPlayers()).thenReturn(pm);
-
-        // Target
         targetUUID = UUID.randomUUID();
-        Player p = mock(Player.class);
-        when(p.getUniqueId()).thenReturn(targetUUID);
-        User.getInstance(p);
+        ownerUUID = UUID.randomUUID();
+        when(pm.getUUID(TARGET)).thenReturn(targetUUID);
+        when(pm.getUUID(OWNER)).thenReturn(ownerUUID);
+        when(pm.getName(ownerUUID)).thenReturn(OWNER);
+
+        // island2 is a team island owned by "owner"; the target is a plain member of it
+        when(island2.getOwner()).thenReturn(ownerUUID);
+        when(island2.getCenter()).thenReturn(location);
+        when(location.toVector()).thenReturn(new Vector(0, 0, 0));
+        when(island2.getRank(targetUUID)).thenReturn(RanksManager.MEMBER_RANK);
+        when(im.getIslands(world, targetUUID)).thenReturn(List.of(island2));
+        when(im.getIslands(world, ownerUUID)).thenReturn(List.of(island2));
 
         // Online players
         mockedUtil.when(() -> Util.getOnlinePlayerList(any())).thenReturn(Collections.singletonList("tastybento"));
         mockedUtil.when(() -> Util.getUUID(anyString())).thenCallRealMethod();
+        mockedUtil.when(() -> Util.xyz(any())).thenCallRealMethod();
+        mockedUtil.when(() -> Util.tabLimit(any(), any())).thenCallRealMethod();
+        mockedUtil.when(() -> Util.stripColor(anyString())).thenCallRealMethod();
 
         // Translations
         when(user.getTranslation(anyString()))
                 .thenAnswer((Answer<String>) invocation -> invocation.getArgument(0, String.class));
 
+        // Ranks: the mocked manager returns the reference for each value
+        when(rm.getRank(RanksManager.MEMBER_RANK)).thenReturn(RanksManager.MEMBER_RANK_REF);
+        when(rm.getRank(RanksManager.SUB_OWNER_RANK)).thenReturn(RanksManager.SUB_OWNER_RANK_REF);
+        when(rm.getRank(RanksManager.TRUSTED_RANK)).thenReturn(RanksManager.TRUSTED_RANK_REF);
+
         // Command
         c = new AdminSetrankCommand(ac);
-
     }
 
     /**
-     * Test method for
-     * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#AdminSetrankCommand(world.bentobox.bentobox.api.commands.CompositeCommand)}.
+     * Adds a second team island that the target is also a member of.
      */
+    private void addSecondIsland(UUID owner) {
+        when(island.getOwner()).thenReturn(owner);
+        Location loc2 = mock(Location.class);
+        when(loc2.toVector()).thenReturn(new Vector(100, 64, 100));
+        when(island.getCenter()).thenReturn(loc2);
+        when(island.getRank(targetUUID)).thenReturn(RanksManager.SUB_OWNER_RANK);
+        when(im.getIslands(world, targetUUID)).thenReturn(List.of(island, island2));
+        when(im.getIslands(world, owner)).thenReturn(List.of(island, island2));
+    }
+
     @Test
     void testAdminSetrankCommand() {
         assertEquals("setrank", c.getLabel());
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#setup()}.
-     */
     @Test
     void testSetup() {
         assertEquals("admin.setrank", c.getPermission());
         assertFalse(c.isOnlyPlayer());
         assertEquals("commands.admin.setrank.parameters", c.getParameters());
         assertEquals("commands.admin.setrank.description", c.getDescription());
-
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
     @Test
     void testCanExecuteNoArgs() {
         assertFalse(c.canExecute(user, "", Collections.emptyList()));
-        verify(user).getTranslation("commands.help.console");
+        verify(user).getTranslation("commands.admin.setrank.description");
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
     @Test
     void testCanExecuteOneArg() {
         assertFalse(c.canExecute(user, "", Collections.singletonList("test")));
-        verify(user).getTranslation("commands.help.console");
+        verify(user).getTranslation("commands.admin.setrank.description");
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
+    @Test
+    void testCanExecuteTooManyArgs() {
+        assertFalse(c.canExecute(user, "", List.of("a", "b", "c", "d")));
+        verify(user).getTranslation("commands.admin.setrank.description");
+    }
+
     @Test
     void testCanExecuteUnknownPlayer() {
-        assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "member")));
+        assertFalse(c.canExecute(user, "", List.of("tastybento", "member")));
         verify(user).sendMessage("general.errors.unknown-player", "[name]", "tastybento");
     }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
     @Test
-    void testCanExecuteKnownPlayerNoIsland() {
-        when(pm.getUUID(any())).thenReturn(targetUUID);
-        assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "ranks.member")));
-        verify(user).sendMessage("general.errors.player-has-no-island");
+    void testCanExecuteUnknownRank() {
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "xxx")));
+        verify(user).sendMessage("commands.admin.setrank.unknown-rank", TextVariables.RANK, "xxx", "[ranks]",
+                "coop, trusted, member, sub-owner");
     }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
     @Test
-    void testCanExecuteKnownPlayerHasIslandUnknownRank() {
-        when(pm.getUUID(any())).thenReturn(targetUUID);
-        when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
-        assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "xxx")));
-        verify(user).sendMessage("commands.admin.setrank.unknown-rank");
-    }
-
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
-    @Test
-    void testCanExecuteKnownPlayerHasIslandTooLowRank() {
-        when(pm.getUUID(any())).thenReturn(targetUUID);
-        when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
-        assertFalse(c.canExecute(user, "", Arrays.asList("tastybento", "ranks.visitor")));
+    void testCanExecuteTooLowRank() {
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "visitor")));
         verify(user).sendMessage("commands.admin.setrank.not-possible");
     }
 
-    /**
-     * Test method for {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
     @Test
-    void testCanExecuteKnownPlayerHasIslandSuccess() {
-        when(pm.getUUID(any())).thenReturn(targetUUID);
-        when(im.hasIsland(any(), any(UUID.class))).thenReturn(true);
-        assertTrue(c.canExecute(user, "", Arrays.asList("tastybento", "ranks.member")));
+    void testCanExecuteBannedRank() {
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "banned")));
+        verify(user).sendMessage("commands.admin.setrank.not-possible");
+    }
+
+    @Test
+    void testCanExecuteOwnerRankRefused() {
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "owner")));
+        verify(user).sendMessage("commands.admin.setrank.cannot-set-owner");
+    }
+
+    @Test
+    void testCanExecuteAdminRankRefused() {
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "admin")));
+        verify(user).sendMessage("commands.admin.setrank.cannot-set-owner");
     }
 
     /**
-     * Test method for
-     * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
+     * The legacy form - the rank's locale reference - still works because the mocked translation
+     * returns the reference itself.
      */
     @Test
-    void testExecuteUserStringListOfString() {
-        // Set the target
-        testCanExecuteKnownPlayerHasIslandSuccess();
-        Island island = mock(Island.class);
-        when(island.getRank(any(User.class))).thenReturn(RanksManager.SUB_OWNER_RANK);
-        when(im.getIsland(any(), any(UUID.class))).thenReturn(island);
-        when(island.getCenter()).thenReturn(location);
-        assertTrue(c.execute(user, "", Arrays.asList("tastybento", "member")));
-        verify(user).sendMessage("commands.admin.setrank.rank-set", "[from]", "", "[to]", "", "[name]", null);
+    void testCanExecuteRankByReference() {
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "ranks.sub-owner")));
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.bentobox.api.commands.admin.AdminSetrankCommand#tabComplete(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
-     */
     @Test
-    void testTabCompleteUserStringListOfString() {
-        Optional<List<String>> result = c.tabComplete(user, "", Arrays.asList("setrank", ""));
-        assertTrue(result.isPresent());
-        result.ifPresent(list -> {
-            assertEquals(1, list.size());
-            assertEquals("tastybento", list.getFirst());
+    void testCanExecuteRankByTranslatedName() {
+        when(user.getTranslation(RanksManager.SUB_OWNER_RANK_REF)).thenReturn("§bSous-Chef");
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "SOUS-chef")));
+    }
+
+    @Test
+    void testCanExecuteRankByNumber() {
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "900")));
+    }
+
+    @Test
+    void testCanExecuteNoIslandKnownPlayer() {
+        when(im.getIslands(world, targetUUID)).thenReturn(List.of());
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "member")));
+        verify(user).sendMessage("general.errors.player-has-no-island");
+    }
+
+    @Test
+    void testCanExecuteTargetOnlyOwnsIsland() {
+        when(island2.getOwner()).thenReturn(targetUUID);
+        when(im.hasIsland(world, targetUUID)).thenReturn(true);
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "member")));
+        verify(user).sendMessage("commands.admin.setrank.cannot-set-owner");
+    }
+
+    @Test
+    void testCanExecuteAlreadyRank() {
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "member")));
+        verify(user).sendMessage("commands.admin.setrank.already-rank", TextVariables.NAME, TARGET,
+                TextVariables.RANK, RanksManager.MEMBER_RANK_REF);
+    }
+
+    @Test
+    void testCanExecuteSingleIslandSuccess() {
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "sub-owner")));
+    }
+
+    @Test
+    void testCanExecuteMultipleIslandsRequiresIsland() {
+        addSecondIsland(UUID.randomUUID());
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "sub-owner")));
+        verify(user).sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
+        verify(user).sendMessage("commands.admin.unregister.errors.specify-island-location", TextVariables.XYZ, XYZ);
+        verify(user).sendMessage("commands.admin.unregister.errors.specify-island-location", TextVariables.XYZ, XYZ2);
+    }
+
+    @Test
+    void testCanExecuteIslandByOwner() {
+        addSecondIsland(UUID.randomUUID());
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "sub-owner", OWNER)));
+        assertTrue(c.execute(user, "", List.of(TARGET, "sub-owner", OWNER)));
+        verify(island2).setRank(targetUUID, RanksManager.SUB_OWNER_RANK);
+        verify(island, never()).setRank(any(UUID.class), any(Integer.class));
+    }
+
+    @Test
+    void testCanExecuteIslandByOwnerUnknownPlayer() {
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "sub-owner", "stranger")));
+        verify(user).sendMessage("general.errors.unknown-player", TextVariables.NAME, "stranger");
+    }
+
+    @Test
+    void testCanExecuteIslandByOwnerNotOwner() {
+        when(im.getIslands(world, ownerUUID)).thenReturn(List.of());
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "sub-owner", OWNER)));
+        verify(user).sendMessage("general.errors.player-is-not-owner", TextVariables.NAME, OWNER);
+    }
+
+    @Test
+    void testCanExecuteIslandByOwnerWithConcurrentIslands() {
+        addSecondIsland(ownerUUID);
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "sub-owner", OWNER)));
+        verify(user).sendMessage("commands.admin.unregister.errors.player-has-more-than-one-island");
+        verify(user, times(2)).sendMessage(eq("commands.admin.unregister.errors.specify-island-location"),
+                eq(TextVariables.XYZ), any());
+    }
+
+    @Test
+    void testCanExecuteIslandByXyz() {
+        addSecondIsland(ownerUUID);
+        when(im.getIslandAt(any())).thenAnswer(inv -> {
+            Location l = inv.getArgument(0);
+            return l.getBlockX() == 100 ? Optional.of(island) : Optional.of(island2);
         });
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "member", XYZ2)));
+        assertTrue(c.execute(user, "", List.of(TARGET, "member", XYZ2)));
+        verify(island).setRank(targetUUID, RanksManager.MEMBER_RANK);
+        verify(island2, never()).setRank(any(UUID.class), any(Integer.class));
     }
 
+    @Test
+    void testCanExecuteIslandByXyzUnknown() {
+        when(im.getIslandAt(any())).thenReturn(Optional.empty());
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "member", "9,9,9")));
+        verify(user).sendMessage("commands.admin.unregister.errors.unknown-island-location");
+    }
+
+    @Test
+    void testCanExecuteIslandByXyzTargetIsOwner() {
+        when(island2.getOwner()).thenReturn(targetUUID);
+        when(im.getIslandAt(any())).thenReturn(Optional.of(island2));
+        assertFalse(c.canExecute(user, "", List.of(TARGET, "member", XYZ)));
+        verify(user).sendMessage("commands.admin.setrank.cannot-set-owner");
+    }
+
+    /**
+     * Granting a rank on an island the target has no standing on yet, e.g. making them trusted.
+     */
+    @Test
+    void testExecuteGrantTrustedOnOwnersIsland() {
+        when(im.getIslands(world, targetUUID)).thenReturn(List.of());
+        when(island2.getRank(targetUUID)).thenReturn(RanksManager.VISITOR_RANK);
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "trusted", OWNER)));
+        assertTrue(c.execute(user, "", List.of(TARGET, "trusted", OWNER)));
+        verify(island2).setRank(targetUUID, RanksManager.TRUSTED_RANK);
+    }
+
+    @Test
+    void testExecutePromote() {
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "sub-owner")));
+        assertTrue(c.execute(user, "", List.of(TARGET, "sub-owner")));
+        verify(island2).setRank(targetUUID, RanksManager.SUB_OWNER_RANK);
+        verify(user).sendMessage("commands.admin.setrank.rank-set", "[from]", RanksManager.MEMBER_RANK_REF, "[to]",
+                RanksManager.SUB_OWNER_RANK_REF, TextVariables.NAME, OWNER);
+        // IslandEvent.build fires the generic IslandEvent plus the specific rank change event
+        verify(pim, times(2)).callEvent(any());
+    }
+
+    @Test
+    void testExecuteDemote() {
+        when(island2.getRank(targetUUID)).thenReturn(RanksManager.SUB_OWNER_RANK);
+        assertTrue(c.canExecute(user, "", List.of(TARGET, "member")));
+        assertTrue(c.execute(user, "", List.of(TARGET, "member")));
+        verify(island2).setRank(targetUUID, RanksManager.MEMBER_RANK);
+        verify(user).sendMessage("commands.admin.setrank.rank-set", "[from]", RanksManager.SUB_OWNER_RANK_REF, "[to]",
+                RanksManager.MEMBER_RANK_REF, TextVariables.NAME, OWNER);
+        verify(pim, times(2)).callEvent(any());
+    }
+
+    @Test
+    void testTabCompletePlayer() {
+        Optional<List<String>> result = c.tabComplete(user, "", List.of(""));
+        assertTrue(result.isPresent());
+        assertEquals(List.of("tastybento"), result.get());
+    }
+
+    @Test
+    void testTabCompleteRank() {
+        Optional<List<String>> result = c.tabComplete(user, "", List.of(TARGET, ""));
+        assertTrue(result.isPresent());
+        assertEquals(List.of("coop", "trusted", "member", "sub-owner"), result.get());
+    }
+
+    @Test
+    void testTabCompleteRankPartial() {
+        Optional<List<String>> result = c.tabComplete(user, "", List.of(TARGET, "s"));
+        assertTrue(result.isPresent());
+        assertEquals(List.of("sub-owner"), result.get());
+    }
+
+    @Test
+    void testTabCompleteIsland() {
+        Optional<List<String>> result = c.tabComplete(user, "", List.of(TARGET, "member", ""));
+        assertTrue(result.isPresent());
+        assertTrue(result.get().containsAll(List.of("tastybento", XYZ)));
+    }
+
+    @Test
+    void testTabCompleteTooManyArgs() {
+        assertTrue(c.tabComplete(user, "", List.of(TARGET, "member", OWNER, "")).isEmpty());
+    }
 }


### PR DESCRIPTION
## Summary

Admins want to promote and demote team members from the console without logging in. Rather than add a second command, this turns the existing console-capable `/[admin] setrank <player> <rank> [island owner]` into something reliable enough for that job.

**Syntax is now** `/[admin] setrank <player> <rank> [island owner | x,y,z]` and is backwards compatible.

### Fixes and improvements

- **Rank argument**: previously only the rank's *translated display name* matched. Now `member`, `sub-owner`, `trusted`, `coop` (or any addon rank reference without the `ranks.` prefix), the translated name, or the numeric value all work, case-insensitively. The error lists the valid choices.
- **Owner/mod/admin ranks refused**: setting `owner` rank in the member map without moving the owner field left the island inconsistent. These are now refused with a message pointing at `setowner`.
- **Island selection without an argument**: the target's *primary* island was used even when they owned it, so the command could demote an owner into a member. Now the island the target is a member of (but does not own) is used; if they are on several team islands the centres are listed so one can be chosen.
- **Island by `x,y,z`**: the island can be named by its centre as well as by owner. Needed when an owner has concurrent islands.
- **Tab completion** was off by one (players offered for the rank slot, ranks for the owner slot) and now completes the right argument.
- The affected player is told their rank changed, and a no-op change is reported instead of silently succeeding.

### Locale changes

New keys under `commands.admin.setrank` in every bundled locale: `cannot-set-owner`, `already-rank`, `admin-changed-rank`. `unknown-rank` gained `[rank]` and `[ranks]` placeholders, and `parameters`/`description` were updated.

## Test plan

- [x] `AdminSetrankCommandTest` rewritten: 34 tests covering rank parsing (keyword, translated, numeric, reference), rank range refusals, island resolution (none / owner / xyz / ambiguous), owner guard, no-op guard, promote and demote execution, events, tab completion.
- [x] Full suite: 3507 tests, 0 failures.
- [ ] Manual check on a server: `setrank Alice sub-owner` from the console with Alice on one team island; `setrank Alice member Bob` and `setrank Alice member 0,64,0` with Alice on two islands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146MpZW6KGnu5E4qkcR5NXV